### PR TITLE
feat(discord): atomic button confirmations for tool approvals

### DIFF
--- a/packages/channels/src/__tests__/discord.test.ts
+++ b/packages/channels/src/__tests__/discord.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { generateKeyPairSync, sign as cryptoSign, type KeyObject } from 'node:crypto'
 import { createDiscordAdapter } from '../discord/adapter.js'
+import { respondToInteraction } from '../discord/api.js'
 import { verifyDiscordSignature, isPingInteraction } from '../discord/verify.js'
 import { markdownToDiscord } from '../discord/markdown.js'
 
@@ -300,5 +301,106 @@ describe('[COMP:channels/discord] markdownToDiscord', () => {
   it('passes native markdown (bold, italic, links, lists) through unchanged', () => {
     const md = '**bold** *italic* [link](https://x.com)\n- one\n- two'
     expect(markdownToDiscord(md)).toBe(md)
+  })
+})
+
+// ── Confirmation buttons: outbound components ──────────────────
+
+type CapturedCall = { url: string; init: RequestInit }
+
+function mockFetch(captured: CapturedCall[], status = 200, json: unknown = { id: 'msg-1', channel_id: 'C1' }) {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+    captured.push({ url: String(url), init: init ?? {} })
+    return status === 204
+      ? new Response(null, { status: 204 })
+      : new Response(JSON.stringify(json), { status, headers: { 'content-type': 'application/json' } })
+  })
+}
+
+describe('[COMP:channels/discord] sendMessage confirmation buttons', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('renders OutgoingAction[] as one action row of custom_id buttons', async () => {
+    const calls: CapturedCall[] = []
+    mockFetch(calls)
+    const adapter = createDiscordAdapter({ token: 't' })
+    await adapter.sendMessage('C1', {
+      text: 'Allow this action?',
+      actions: [
+        { id: 'allow', label: 'Allow', data: 'mcp_confirm:tc1:allow' },
+        { id: 'deny', label: 'Deny', data: 'mcp_confirm:tc1:deny' },
+        { id: 'always', label: 'Always Allow', data: 'mcp_confirm:tc1:always_allow' },
+        { id: 'never', label: 'Always Deny', data: 'mcp_confirm:tc1:always_deny' },
+      ],
+    })
+    expect(calls).toHaveLength(1)
+    const body = JSON.parse(String(calls[0].init.body))
+    expect(body.components).toEqual([
+      {
+        type: 1,
+        components: [
+          { type: 2, style: 3, label: 'Allow', custom_id: 'mcp_confirm:tc1:allow' },
+          { type: 2, style: 4, label: 'Deny', custom_id: 'mcp_confirm:tc1:deny' },
+          { type: 2, style: 1, label: 'Always Allow', custom_id: 'mcp_confirm:tc1:always_allow' },
+          { type: 2, style: 2, label: 'Always Deny', custom_id: 'mcp_confirm:tc1:always_deny' },
+        ],
+      },
+    ])
+  })
+
+  it('omits components when no actions are present', async () => {
+    const calls: CapturedCall[] = []
+    mockFetch(calls)
+    const adapter = createDiscordAdapter({ token: 't' })
+    await adapter.sendMessage('C1', { text: 'plain reply' })
+    const body = JSON.parse(String(calls[0].init.body))
+    expect(body.components).toBeUndefined()
+  })
+
+  it('maps a web_app action to a Discord link button', async () => {
+    const calls: CapturedCall[] = []
+    mockFetch(calls)
+    const adapter = createDiscordAdapter({ token: 't' })
+    await adapter.sendMessage('C1', {
+      text: 'open',
+      actions: [{ kind: 'web_app', label: 'Open', url: 'https://x.test' }],
+    })
+    const body = JSON.parse(String(calls[0].init.body))
+    expect(body.components[0].components[0]).toEqual({ type: 2, style: 5, label: 'Open', url: 'https://x.test' })
+  })
+
+  it('clears buttons on editMessage when actions is an empty array', async () => {
+    const calls: CapturedCall[] = []
+    mockFetch(calls)
+    const adapter = createDiscordAdapter({ token: 't' })
+    await adapter.editMessage('C1', 'M1', { text: 'Tool action: Allowed', actions: [] })
+    const body = JSON.parse(String(calls[0].init.body))
+    expect(body.components).toEqual([])
+  })
+})
+
+// ── Confirmation buttons: interaction ack ──────────────────────
+
+describe('[COMP:channels/discord] respondToInteraction', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('POSTs a type-7 callback to the interaction endpoint with no bot auth', async () => {
+    const calls: CapturedCall[] = []
+    mockFetch(calls, 204)
+    await respondToInteraction('IID', 'ITOKEN', {
+      type: 7,
+      data: { content: 'Tool action: Allowed', components: [] },
+    })
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe('https://discord.com/api/v10/interactions/IID/ITOKEN/callback')
+    expect((calls[0].init.headers as Record<string, string>).Authorization).toBeUndefined()
+    const body = JSON.parse(String(calls[0].init.body))
+    expect(body.type).toBe(7)
+    expect(body.data.components).toEqual([])
+  })
+
+  it('throws on a non-2xx callback (e.g. already acknowledged)', async () => {
+    mockFetch([], 400, { message: 'already acked', code: 40060 })
+    await expect(respondToInteraction('IID', 'ITOKEN', { type: 6 })).rejects.toThrow()
   })
 })

--- a/packages/channels/src/discord/adapter.ts
+++ b/packages/channels/src/discord/adapter.ts
@@ -1,6 +1,6 @@
-import type { ChannelAdapter, IncomingFile, IncomingMessage, OutgoingMessage } from '../types.js'
+import type { ChannelAdapter, IncomingFile, IncomingMessage, OutgoingAction, OutgoingMessage } from '../types.js'
 import { chunkText } from '../chunking.js'
-import { createDiscordApi, type DiscordAllowedMentions } from './api.js'
+import { createDiscordApi, type DiscordActionRow, type DiscordAllowedMentions, type DiscordButton } from './api.js'
 import { markdownToDiscord } from './markdown.js'
 
 // Discord's content limit is 2000 characters for bot messages (Nitro's 4000 is
@@ -82,6 +82,39 @@ function snowflakeToTimestamp(id: string): number {
   } catch {
     return Date.now()
   }
+}
+
+// ── Outgoing actions → Discord button components ───────────────
+
+// Visual style per callback action id (semantics live in the custom_id, not the
+// colour). allow → success (green), deny → danger (red), always_allow → primary,
+// else secondary (grey). Unknown ids fall back to secondary.
+const BUTTON_STYLE_BY_ID: Record<string, 1 | 2 | 3 | 4> = {
+  allow: 3, deny: 4, always: 1, always_allow: 1, never: 2, always_deny: 2,
+}
+
+// Discord limits: ≤5 buttons per action row, ≤5 action rows per message.
+const MAX_BUTTONS_PER_ROW = 5
+const MAX_ACTION_ROWS = 5
+
+/**
+ * Translate the channel-agnostic `OutgoingAction[]` into Discord action rows.
+ * A `callback` action becomes a button echoing `custom_id` (the connector
+ * relays the click back); a `web_app` action becomes a link button. Returns
+ * `undefined` when there are no actions so the message body omits `components`.
+ */
+function buildComponents(actions: OutgoingAction[]): DiscordActionRow[] | undefined {
+  if (actions.length === 0) return undefined
+  const buttons: DiscordButton[] = actions.map((a) =>
+    a.kind === 'web_app'
+      ? { type: 2, style: 5, label: a.label, url: a.url }
+      : { type: 2, style: BUTTON_STYLE_BY_ID[a.id] ?? 2, label: a.label, custom_id: a.data },
+  )
+  const rows: DiscordActionRow[] = []
+  for (let i = 0; i < buttons.length; i += MAX_BUTTONS_PER_ROW) {
+    rows.push({ type: 1, components: buttons.slice(i, i + MAX_BUTTONS_PER_ROW) })
+  }
+  return rows.slice(0, MAX_ACTION_ROWS)
 }
 
 // ── Attachment → IncomingMessage media mapping ─────────────────
@@ -292,6 +325,13 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): ChannelAda
       if (!response.text.trim()) return ''
       const text = response.format === 'markdown' ? markdownToDiscord(response.text) : response.text
       const chunks = chunkText(text, DISCORD_MAX_MESSAGE_LENGTH)
+      // Buttons attach to the last non-empty chunk so they sit beneath the full
+      // message rather than mid-way through a multi-part reply.
+      const components = response.actions ? buildComponents(response.actions) : undefined
+      let lastNonEmptyIndex = -1
+      for (let i = chunks.length - 1; i >= 0; i--) {
+        if (chunks[i].trim()) { lastNonEmptyIndex = i; break }
+      }
       let lastId = ''
 
       for (let i = 0; i < chunks.length; i++) {
@@ -306,6 +346,7 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): ChannelAda
           content: chunk,
           message_reference: reference,
           allowed_mentions: allowedMentions,
+          ...(components && i === lastNonEmptyIndex ? { components } : {}),
         })
         lastId = result.id
       }
@@ -316,8 +357,11 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): ChannelAda
     async editMessage(channelId: string, messageId: string, response: OutgoingMessage): Promise<void> {
       const raw = response.format === 'markdown' ? markdownToDiscord(response.text) : response.text
       const content = raw.slice(0, DISCORD_MAX_MESSAGE_LENGTH)
+      // When `actions` is supplied, replace the message's buttons (an empty array
+      // clears them); when omitted, leave existing components untouched.
+      const components = response.actions ? (buildComponents(response.actions) ?? []) : undefined
       try {
-        await api.editMessage(channelId, messageId, { content })
+        await api.editMessage(channelId, messageId, { content, ...(components ? { components } : {}) })
       } catch {
         // Edit failed (message too old, deleted, …) — fall back to a fresh send.
         await api.createMessage(channelId, { content, allowed_mentions: allowedMentions }).catch(() => {})

--- a/packages/channels/src/discord/api.ts
+++ b/packages/channels/src/discord/api.ts
@@ -72,12 +72,48 @@ export type DiscordMessageReference = {
   fail_if_not_exists?: boolean
 }
 
+// ── Message components (buttons) ───────────────────────────────
+//
+// Discord renders interactive buttons from a `components` array of action rows
+// (type 1), each holding up to 5 buttons (type 2). A button is either a callback
+// button (styles 1-4) carrying a `custom_id` echoed back on click, or a link
+// button (style 5) carrying a `url` and no custom_id. Styles: 1 primary, 2
+// secondary, 3 success (green), 4 danger (red), 5 link.
+export type DiscordButton =
+  | { type: 2; style: 1 | 2 | 3 | 4; label: string; custom_id: string }
+  | { type: 2; style: 5; label: string; url: string }
+
+export type DiscordActionRow = { type: 1; components: DiscordButton[] }
+
 export type DiscordCreateMessageBody = {
   content: string
   message_reference?: DiscordMessageReference
   allowed_mentions?: DiscordAllowedMentions
+  components?: DiscordActionRow[]
   flags?: number
 }
+
+export type DiscordEditMessageBody = {
+  content: string
+  components?: DiscordActionRow[]
+  allowed_mentions?: DiscordAllowedMentions
+}
+
+// ── Interaction responses ──────────────────────────────────────
+//
+// A component (button) interaction is acknowledged via the interaction-callback
+// endpoint. Type 6 (DEFERRED_UPDATE_MESSAGE) acks silently; type 7
+// (UPDATE_MESSAGE) acks and edits the message the button is attached to in the
+// same call. We use type 7 to morph the confirmation prompt into a result line
+// and clear its buttons atomically.
+export const InteractionCallbackType = { DEFERRED_UPDATE_MESSAGE: 6, UPDATE_MESSAGE: 7 } as const
+
+export type DiscordInteractionResponse =
+  | { type: 6 }
+  | {
+      type: 7
+      data: { content?: string; components?: DiscordActionRow[]; allowed_mentions?: DiscordAllowedMentions }
+    }
 
 export function createDiscordApi(options: DiscordApiOptions) {
   const base = options.baseUrl ?? 'https://discord.com/api/v10'
@@ -133,7 +169,7 @@ export function createDiscordApi(options: DiscordApiOptions) {
       call<DiscordRestMessage>('POST', `/channels/${channelId}/messages`, body),
 
     /** PATCH /channels/{channel.id}/messages/{message.id} */
-    editMessage: (channelId: string, messageId: string, body: { content: string }) =>
+    editMessage: (channelId: string, messageId: string, body: DiscordEditMessageBody) =>
       call<DiscordRestMessage>('PATCH', `/channels/${channelId}/messages/${messageId}`, body),
 
     /** DELETE /channels/{channel.id}/messages/{message.id} */
@@ -159,3 +195,33 @@ export function createDiscordApi(options: DiscordApiOptions) {
 }
 
 export type DiscordApi = ReturnType<typeof createDiscordApi>
+
+/**
+ * Acknowledge a component (button) interaction via
+ * `POST /interactions/{id}/{token}/callback`.
+ *
+ * This endpoint is authenticated by the interaction `token` in the URL, **not**
+ * by a bot token — so it is a plain `fetch` independent of any bot's
+ * credentials (the API layer can ack without re-deriving which bot owns the
+ * channel). Discord requires the ack within **3 seconds** of the interaction or
+ * the user sees "This interaction failed"; the caller must keep the round-trip
+ * tight. A first ack returns 204; a second ack for the same interaction returns
+ * 40060 ("interaction has already been acknowledged") — callers dedup upstream.
+ */
+export async function respondToInteraction(
+  interactionId: string,
+  interactionToken: string,
+  response: DiscordInteractionResponse,
+  opts?: { baseUrl?: string },
+): Promise<void> {
+  const base = opts?.baseUrl ?? 'https://discord.com/api/v10'
+  const res = await fetch(`${base}/interactions/${interactionId}/${interactionToken}/callback`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'User-Agent': USER_AGENT },
+    body: JSON.stringify(response),
+  })
+  if (!res.ok) {
+    const body = (await res.json().catch(() => undefined)) as DiscordErrorBody | undefined
+    throw new DiscordApiError('POST /interactions/:id/:token/callback', res.status, body)
+  }
+}

--- a/packages/channels/src/discord/index.ts
+++ b/packages/channels/src/discord/index.ts
@@ -1,7 +1,7 @@
 export { createDiscordAdapter } from './adapter.js'
 export type { DiscordAdapterOptions, DiscordAdapterConfig } from './adapter.js'
-export { createDiscordApi, DiscordApiError } from './api.js'
-export type { DiscordApi } from './api.js'
+export { createDiscordApi, DiscordApiError, respondToInteraction, InteractionCallbackType } from './api.js'
+export type { DiscordApi, DiscordActionRow, DiscordButton, DiscordInteractionResponse } from './api.js'
 export {
   verifyDiscordSignature,
   isPingInteraction,


### PR DESCRIPTION
Ports the discord channel adapter's atomic button-confirmation flow for tool approvals (ack the interaction before resuming the turn) into the open vertical's channels package, matching platform PR #164.

- `discord/adapter.ts`, `discord/api.ts`, `discord/index.ts` — button-confirmation send + interaction ack
- `__tests__/discord.test.ts` — +104 lines covering the new flow

`pnpm --filter @sidanclaw/channels build` clean; **158/158 channels tests pass**. No closed-code imports (adapter references only `../types`, `../chunking`, `./api`, `./markdown`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)