### PR TITLE
fix(app-web): show brain graph when it has nodes but list is empty

### DIFF
--- a/apps/app-web/src/app/w/[workspaceId]/brain/page.tsx
+++ b/apps/app-web/src/app/w/[workspaceId]/brain/page.tsx
@@ -357,11 +357,23 @@ function BrainPageInner() {
   };
 
   const loading = rows === null;
+  // The graph is a SEPARATE data source from the `/list` rows: `/list` searches
+  // the CRM (contact/company/deal) + memory/file/task scopes, while the graph
+  // surfaces knowledge-graph ENTITIES (person/company/project/… in `entities`).
+  // A workspace can have graph entities but zero list rows — so "pristine" must
+  // consider BOTH, else a brain with only entity nodes (e.g. one extracted
+  // person) renders the empty nudge and hides the populated graph. Treat the
+  // graph as still-loading (null) as "not yet empty" to avoid a nudge flash
+  // before it arrives.
+  const graphLoading = graph === null;
+  const graphHasNodes = (graph?.nodes.length ?? 0) > 0;
   // The pristine nudge counts skills too — a workspace whose only brain
   // content is a skill isn't pristine.
   const showNoData =
     !loading &&
+    !graphLoading &&
     rows.length === 0 &&
+    !graphHasNodes &&
     (skills?.length ?? 0) === 0 &&
     !search &&
     primitives.length === 0 &&


### PR DESCRIPTION
## Problem
The Brain page showed **"Your brain is empty"** even when the workspace's knowledge graph had entities. Reproduced with a single extracted `person` entity ("Jack"):

- `GET /api/brain/graph` → returns the node.
- `GET /api/brain/list` → returns `{"results":[]}`.

These are **separate data sources**: `/list` searches the CRM (`contact`/`company`/`deal`) + `memory`/`file`/`task` scopes, while the graph surfaces knowledge-graph entities (`person`/`company`/`project`/… from the `entities` table). The page computed its empty-state flag (`showNoData`) from `/list` rows only, so a brain with only entity nodes flipped `showNoData` true and rendered the pristine-brain nudge **instead of** the populated graph — even though graph mode is the default surface.

## Fix
Make `showNoData` graph-aware: the brain is "empty" only when **both** the `/list` rows and the graph nodes are empty. A still-loading graph (`null`) is treated as not-yet-empty to avoid a nudge flash before it arrives.

## Scope
Single-file, frontend-only (`apps/app-web/.../brain/page.tsx`). No API or schema change. `pnpm --filter app-web typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)