### PR TITLE
fix: serve brain-inbox from the open api + file preview/edit

### DIFF
--- a/apps/app-web/src/components/brain/detail-drawer.tsx
+++ b/apps/app-web/src/components/brain/detail-drawer.tsx
@@ -49,12 +49,14 @@ import {
 } from "@/lib/api/brain";
 import { getActiveAssistantId } from "@/lib/sidebar-cache";
 import { requestBrainRefresh } from "@/lib/brain-events";
+import { authFetch } from "@/lib/auth-fetch";
 import {
   type AdjustMemoryChanges,
   type BrainInboxRowDetail,
   type BrainPrimitive as InboxPrimitive,
   type ExplainContext,
   adjustBrainRow,
+  brainFileContentUrl,
   deleteBrainRow,
   explainBrainRow,
   fetchBrainRow,
@@ -1661,6 +1663,102 @@ type PrimitiveSectionProps = {
   onUpdated: (next: BrainInboxRowDetail) => void;
 };
 
+// ── File content preview (workspace_file) ────────────────────────
+//
+// Streams the file's bytes from the auth-gated brain-inbox content
+// endpoint (`brainFileContentUrl`) via `authFetch` — a plain <img src>
+// could not carry the bearer token. Images render inline, text/markdown
+// as text, everything else as a download link. Object URLs are revoked
+// on unmount / row change.
+function FileContentPreview({
+  workspaceId,
+  fileId,
+  mime,
+  name,
+}: {
+  workspaceId: string;
+  fileId: string;
+  mime: string;
+  name: string;
+}) {
+  const t = useT();
+  const fp = t.brainPage.detailDrawer.filePreview;
+  type PreviewState =
+    | { kind: "loading" }
+    | { kind: "image"; url: string }
+    | { kind: "text"; text: string }
+    | { kind: "download"; url: string }
+    | { kind: "error" };
+  const [state, setState] = useState<PreviewState>({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    let objectUrl: string | null = null;
+    setState({ kind: "loading" });
+    const isText =
+      mime.startsWith("text/") ||
+      mime === "application/json" ||
+      mime === "application/xml" ||
+      name.toLowerCase().endsWith(".md");
+    authFetch(brainFileContentUrl(workspaceId, fileId))
+      .then(async (res) => {
+        if (!res.ok) throw new Error(String(res.status));
+        if (mime.startsWith("image/")) {
+          const blob = await res.blob();
+          objectUrl = URL.createObjectURL(blob);
+          if (!cancelled) setState({ kind: "image", url: objectUrl });
+        } else if (isText) {
+          const text = await res.text();
+          if (!cancelled) setState({ kind: "text", text });
+        } else {
+          const blob = await res.blob();
+          objectUrl = URL.createObjectURL(blob);
+          if (!cancelled) setState({ kind: "download", url: objectUrl });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setState({ kind: "error" });
+      });
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [workspaceId, fileId, mime, name]);
+
+  if (state.kind === "loading") {
+    return <p className="text-xs text-muted-foreground">{fp.loading}</p>;
+  }
+  if (state.kind === "error") {
+    return <p className="text-xs text-muted-foreground">{fp.error}</p>;
+  }
+  if (state.kind === "image") {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element -- object URL, not an optimizable asset
+      <img
+        src={state.url}
+        alt={name}
+        className="max-h-80 w-auto rounded-md border border-border object-contain"
+      />
+    );
+  }
+  if (state.kind === "text") {
+    return (
+      <pre className="max-h-96 overflow-auto rounded-md border border-border bg-muted/30 p-3 text-[12px] leading-relaxed whitespace-pre-wrap break-words font-mono">
+        {state.text}
+      </pre>
+    );
+  }
+  return (
+    <a
+      href={state.url}
+      download={name}
+      className="inline-block w-max text-xs px-3 py-1.5 rounded-md border border-border hover:bg-muted"
+    >
+      {fp.download}
+    </a>
+  );
+}
+
 function PrimitiveSection({
   workspaceId,
   primitive,
@@ -1675,6 +1773,7 @@ function PrimitiveSection({
 
   const isMemory = primitive === "memory";
   const isCrm = primitive === "company" || primitive === "contact" || primitive === "deal";
+  const isFile = primitive === "workspace_file";
   const isVerified = Boolean(detail.verifiedAt);
   const summary = String(detail.body.summary ?? "");
   const memoryDetail = (detail.body.detail as string | null) ?? null;
@@ -1699,6 +1798,13 @@ function PrimitiveSection({
   const [draftDetail, setDraftDetail] = useState(memoryDetail ?? "");
   // CRM name draft — shared field for company/contact/deal edits.
   const [draftCrmName, setDraftCrmName] = useState(crmName);
+  // workspace_file tags draft — comma-separated for editing; the original
+  // set drives the change detection in `submitEdit`.
+  const fileTags: string[] = Array.isArray(detail.body.tags)
+    ? (detail.body.tags as unknown[]).filter((x): x is string => typeof x === "string")
+    : [];
+  const fileTagsJoined = fileTags.join(", ");
+  const [draftFileTags, setDraftFileTags] = useState(fileTagsJoined);
 
   const [whyDetailsOpen, setWhyDetailsOpen] = useState(false);
   const [whyLoading, setWhyLoading] = useState(true);
@@ -1731,10 +1837,11 @@ function PrimitiveSection({
     setDraftSummary(summary);
     setDraftDetail(memoryDetail ?? "");
     setDraftCrmName(crmName);
+    setDraftFileTags(fileTagsJoined);
     setDraftReason("");
     setMode("view");
     setError(null);
-  }, [detail.id, inferredScope, inferredSensitivity, summary, memoryDetail, crmName]);
+  }, [detail.id, inferredScope, inferredSensitivity, summary, memoryDetail, crmName, fileTagsJoined]);
 
   async function handleConfirm() {
     setBusy(true);
@@ -1774,6 +1881,7 @@ function PrimitiveSection({
     setDraftSensitivity(inferredSensitivity);
     setDraftSummary(summary);
     setDraftDetail(memoryDetail ?? "");
+    setDraftFileTags(fileTagsJoined);
     setDraftReason("");
     setError(null);
   }
@@ -1794,6 +1902,21 @@ function PrimitiveSection({
       if (draftSensitivity !== inferredSensitivity) {
         changes.sensitivity = draftSensitivity;
       }
+    } else if (isFile) {
+      // File edit shape — sensitivity + tags (rename is path-coupled and
+      // out of scope; the server's workspace_file adjust handler patches
+      // the metadata and stamps the row verified).
+      if (draftSensitivity !== inferredSensitivity) {
+        changes.sensitivity = draftSensitivity;
+      }
+      const parsedTags = draftFileTags
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      const tagsChanged =
+        parsedTags.length !== fileTags.length ||
+        parsedTags.some((tag, i) => tag !== fileTags[i]);
+      if (tagsChanged) changes.tags = parsedTags;
     } else {
       // Memory edit shape — scope/sensitivity/summary/detail.
       if (draftScope !== inferredScope) changes.scope = draftScope;
@@ -1815,7 +1938,9 @@ function PrimitiveSection({
     if (Object.keys(changes).length === 0 || (
       isCrm
         ? changes.display_name === undefined && changes.sensitivity === undefined
-        : false
+        : isFile
+          ? changes.sensitivity === undefined && changes.tags === undefined
+          : false
     )) {
       // Nothing to change — collapse the form. If the row was unverified,
       // also stamp it verified so the user's "no, this is right" intent
@@ -1892,7 +2017,7 @@ function PrimitiveSection({
               {review.confirm}
             </button>
           )}
-          {(isMemory || isCrm) && (
+          {(isMemory || isCrm || isFile) && (
             <button
               type="button"
               disabled={busy}
@@ -2196,31 +2321,117 @@ function PrimitiveSection({
             })}
           </p>
         </section>
+      ) : isFile && mode === "edit" ? (
+        <section className="flex flex-col gap-2">
+          <h3 className="text-xs uppercase tracking-wide text-muted-foreground">
+            {labels.detailsHeading}
+          </h3>
+          <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-2 text-sm items-start">
+            <div className="contents">
+              <dt className="text-xs text-muted-foreground uppercase tracking-wide pt-1.5">
+                {humaniseKey("sensitivity")}
+              </dt>
+              <dd>
+                <Select
+                  value={draftSensitivity}
+                  onValueChange={(v) => {
+                    if (v) setDraftSensitivity(v as Sensitivity);
+                  }}
+                  disabled={busy}
+                  items={{
+                    public: review.sensitivityPublic,
+                    internal: review.sensitivityInternal,
+                    confidential: review.sensitivityConfidential,
+                  }}
+                >
+                  <SelectTrigger className="text-xs w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent alignItemWithTrigger={false}>
+                    <SelectItem value="public">{review.sensitivityPublic}</SelectItem>
+                    <SelectItem value="internal">{review.sensitivityInternal}</SelectItem>
+                    <SelectItem value="confidential">{review.sensitivityConfidential}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </dd>
+            </div>
+            <div className="contents">
+              <dt className="text-xs text-muted-foreground uppercase tracking-wide pt-1.5">
+                {humaniseKey("tags")}
+              </dt>
+              <dd>
+                <input
+                  type="text"
+                  value={draftFileTags}
+                  onChange={(e) => setDraftFileTags(e.target.value)}
+                  placeholder={labels.filePreview.tagsPlaceholder}
+                  disabled={busy}
+                  className="text-xs px-2 py-1.5 rounded border border-border bg-background w-full"
+                />
+              </dd>
+            </div>
+            <div className="contents">
+              <dt className="text-xs text-muted-foreground uppercase tracking-wide pt-1.5">
+                {review.why}
+              </dt>
+              <dd>
+                <input
+                  type="text"
+                  value={draftReason}
+                  onChange={(e) => setDraftReason(e.target.value)}
+                  placeholder={review.reasonPlaceholder}
+                  disabled={busy}
+                  className="text-xs px-2 py-1.5 rounded border border-border bg-background w-full"
+                />
+              </dd>
+            </div>
+          </dl>
+          <p className="text-[11px] text-muted-foreground mt-1">
+            {format(labels.savedAt, {
+              date: new Date(detail.createdAt).toLocaleString(),
+            })}
+          </p>
+        </section>
       ) : (
-        fields.length > 0 && (
-          <section className="flex flex-col gap-2">
-            <h3 className="text-xs uppercase tracking-wide text-muted-foreground">
-              {labels.detailsHeading}
-            </h3>
-            <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1.5 text-sm">
-              {fields.map(([k, v]) => (
-                <div key={k} className="contents">
-                  <dt className="text-xs text-muted-foreground uppercase tracking-wide pt-0.5">
-                    {humaniseKey(k)}
-                  </dt>
-                  <dd className="break-words font-mono text-[12px] leading-relaxed">
-                    {v}
-                  </dd>
-                </div>
-              ))}
-            </dl>
-            <p className="text-[11px] text-muted-foreground mt-2">
-              {format(labels.savedAt, {
-                date: new Date(detail.createdAt).toLocaleString(),
-              })}
-            </p>
-          </section>
-        )
+        <>
+          {isFile && (
+            <section className="flex flex-col gap-2">
+              <h3 className="text-xs uppercase tracking-wide text-muted-foreground">
+                {labels.filePreview.heading}
+              </h3>
+              <FileContentPreview
+                workspaceId={workspaceId}
+                fileId={detail.id}
+                mime={String(detail.body.mime_type ?? "")}
+                name={String(detail.body.name ?? "file")}
+              />
+            </section>
+          )}
+          {fields.length > 0 && (
+            <section className="flex flex-col gap-2">
+              <h3 className="text-xs uppercase tracking-wide text-muted-foreground">
+                {labels.detailsHeading}
+              </h3>
+              <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1.5 text-sm">
+                {fields.map(([k, v]) => (
+                  <div key={k} className="contents">
+                    <dt className="text-xs text-muted-foreground uppercase tracking-wide pt-0.5">
+                      {humaniseKey(k)}
+                    </dt>
+                    <dd className="break-words font-mono text-[12px] leading-relaxed">
+                      {v}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+              <p className="text-[11px] text-muted-foreground mt-2">
+                {format(labels.savedAt, {
+                  date: new Date(detail.createdAt).toLocaleString(),
+                })}
+              </p>
+            </section>
+          )}
+        </>
       )}
 
       {crmEntity && <EmbeddedRollupSections rollup={crmEntity} />}

--- a/apps/app-web/src/lib/api/brain-inbox.ts
+++ b/apps/app-web/src/lib/api/brain-inbox.ts
@@ -168,8 +168,19 @@ export type AdjustMemoryChanges = {
   summary?: string;
   detail?: string;
   display_name?: string;
+  /** workspace_file adjust — replace the tag set. */
+  tags?: string[];
   reason?: string;
 };
+
+/**
+ * URL for a `workspace_file` row's raw bytes, used by the brain detail
+ * drawer's preview. The endpoint is auth-gated, so fetch it through
+ * `authFetch` (a plain `<img src>` would not carry the bearer token).
+ */
+export function brainFileContentUrl(workspaceId: string, rowId: string): string {
+  return `${API_URL}/api/brain-inbox/${encodeURIComponent(workspaceId)}/workspace_file/${encodeURIComponent(rowId)}/content`;
+}
 
 export async function adjustBrainRow(
   workspaceId: string,

--- a/apps/app-web/src/lib/i18n/dictionaries/en.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/en.ts
@@ -2561,6 +2561,13 @@ export const en = {
       provenanceHeading: "Source",
       savedBy: "Saved by {author}",
       savedAt: "Saved {date}",
+      filePreview: {
+        heading: "Preview",
+        loading: "Loading preview…",
+        error: "Couldn't load this file.",
+        download: "Download file",
+        tagsPlaceholder: "tag1, tag2",
+      },
       authorUser: "you",
       authorAssistant: "{name}",
       nameLabel: "Name",

--- a/apps/app-web/src/lib/i18n/dictionaries/ja.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/ja.ts
@@ -2385,6 +2385,13 @@ export const ja: Dictionary = {
       provenanceHeading: "出典",
       savedBy: "{author} が保存",
       savedAt: "保存日時: {date}",
+      filePreview: {
+        heading: "プレビュー",
+        loading: "プレビューを読み込んでいます…",
+        error: "このファイルを読み込めませんでした。",
+        download: "ファイルをダウンロード",
+        tagsPlaceholder: "タグ1, タグ2",
+      },
       authorUser: "あなた",
       authorAssistant: "{name}",
       nameLabel: "名前",

--- a/apps/app-web/src/lib/i18n/dictionaries/zh.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh.ts
@@ -2367,6 +2367,13 @@ export const zh: Dictionary = {
       provenanceHeading: "來源",
       savedBy: "由 {author} 儲存",
       savedAt: "儲存時間：{date}",
+      filePreview: {
+        heading: "預覽",
+        loading: "正在載入預覽…",
+        error: "無法載入此檔案。",
+        download: "下載檔案",
+        tagsPlaceholder: "標籤1, 標籤2",
+      },
       authorUser: "你",
       authorAssistant: "{name}",
       nameLabel: "名稱",

--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -92,6 +92,7 @@ import { createSmtpClient, createWorkspaceSmtpTransport } from './email/smtp-cli
 import { chatRoutes, runSessionResume, tryResolveLiveToolApproval } from './routes/chat.js'
 import { createSessionResumeReplay } from './routes/session-resume-replay.js'
 import { brainRoutes } from './routes/brain.js'
+import { brainInboxRoutes } from './routes/brain-inbox.js'
 import { homeRoutes } from './routes/home.js'
 import { homeDockRoutes } from './routes/home-dock.js'
 import { createDbHomeDockStore } from './db/home-dock-store.js'
@@ -1938,6 +1939,16 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
   app.use('/api/brain/stream', brainStreamRoutes({ workspaceStore, jwtSecret: env.JWT_SECRET }))
   startBrainStreamFanout()
   app.use('/api/brain', requireAuth(env.JWT_SECRET), brainRoutes({ entitiesStore, entityLinksStore, retrievalStore, knowledgeStore, workspaceSkillStore, connectorInstanceStore }))
+  // Brain inbox (verification surface). Open + hosted share this one mount: the
+  // route's deps are all open (brain-inbox-store / entities-store / crm / sessions /
+  // notify). `entityKindClassifier` is boot's own; `pendingClassificationStore` is
+  // an optional closed port (undefined in OSS → classify/pending endpoints no-op).
+  app.use('/api/brain-inbox', requireAuth(env.JWT_SECRET), brainInboxRoutes({
+    workspaceStore,
+    entityKindClassifier,
+    pendingClassificationStore: ports.pendingClassificationStore,
+    filesApi,
+  }))
   app.use('/api/home', requireAuth(env.JWT_SECRET), homeRoutes())
   app.use('/api/home-dock', requireAuth(env.JWT_SECRET), homeDockRoutes({
     homeDockStore,

--- a/packages/api/src/routes/__tests__/brain-inbox.test.ts
+++ b/packages/api/src/routes/__tests__/brain-inbox.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Brain-inbox route tests. The route lives in the OPEN package and is
+ * mounted by `bootOpenApi` (open + hosted share it) — see boot.ts
+ * `/api/brain-inbox`. Regression guard for the open-core wiring gap where
+ * the brain detail drawer hit `/api/brain-inbox/:ws/:primitive/:rowId` but
+ * the open API never mounted the route (the route was stranded in the closed
+ * `api-platform` package), so the open build returned a bare `Cannot GET` 404.
+ *
+ * [COMP:api/brain-inbox-route]
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import request from 'supertest'
+import { createTestApp } from './helpers.js'
+
+vi.mock('../../db/client.js', () => ({
+  query: vi.fn(),
+  queryWithRLS: vi.fn(),
+}))
+
+import { brainInboxRoutes } from '../brain-inbox.js'
+import { query } from '../../db/client.js'
+
+const mockQuery = vi.mocked(query)
+
+const WS = 'e1799b0e-9f64-46d5-8ed8-132a2194943d'
+const ROW = 'f4b30b32-1771-4c90-b5af-b1b42311f543'
+
+function makeApp(role: string | null = 'member') {
+  const workspaceStore = { getRole: vi.fn().mockResolvedValue(role) } as never
+  return createTestApp('/api/brain-inbox', brainInboxRoutes({ workspaceStore }), {
+    userId: 'u_caller',
+  })
+}
+
+describe('[COMP:api/brain-inbox-route] Brain inbox route', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('GET /:workspaceId/:primitive/:rowId returns a live memory row', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          primitive: 'memory',
+          id: ROW,
+          workspaceId: WS,
+          createdAt: new Date('2026-06-24T07:41:18Z'),
+          createdByAssistantId: 'a_1',
+          verifiedByUserId: null,
+          verifiedAt: null,
+          body: { summary: 'sandbox.md', sensitivity: 'confidential' },
+        },
+      ],
+    } as never)
+
+    const res = await request(makeApp()).get(`/api/brain-inbox/${WS}/memory/${ROW}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({ primitive: 'memory', id: ROW, workspaceId: WS })
+    expect(res.body.body.summary).toBe('sandbox.md')
+    // The detail SELECT must be workspace-scoped + liveness-filtered.
+    const sql = mockQuery.mock.calls[0][0] as string
+    expect(sql).toMatch(/FROM memories/)
+    expect(sql).toMatch(/valid_to IS NULL/)
+    expect(sql).toMatch(/retracted_at IS NULL/)
+  })
+
+  it('returns 404 when the row is absent (soft-deleted / retracted / wrong workspace)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never)
+    const res = await request(makeApp()).get(`/api/brain-inbox/${WS}/memory/${ROW}`)
+    expect(res.status).toBe(404)
+  })
+
+  it('rejects an unknown primitive with 400', async () => {
+    const res = await request(makeApp()).get(`/api/brain-inbox/${WS}/bogus/${ROW}`)
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects a non-member with 403', async () => {
+    const res = await request(makeApp(null)).get(`/api/brain-inbox/${WS}/memory/${ROW}`)
+    expect(res.status).toBe(403)
+  })
+
+  it('file content endpoint returns 501 when no files API is wired', async () => {
+    // makeApp() omits `filesApi`, mirroring an OSS boot without a blob client.
+    const res = await request(makeApp()).get(`/api/brain-inbox/${WS}/workspace_file/${ROW}/content`)
+    expect(res.status).toBe(501)
+  })
+
+  it('file adjust requires at least one of sensitivity / tags', async () => {
+    const res = await request(makeApp())
+      .post(`/api/brain-inbox/${WS}/workspace_file/${ROW}/adjust`)
+      .send({ reason: 'just a note, no field change' })
+    expect(res.status).toBe(400)
+  })
+
+  it('file adjust rejects an invalid sensitivity', async () => {
+    const res = await request(makeApp())
+      .post(`/api/brain-inbox/${WS}/workspace_file/${ROW}/adjust`)
+      .send({ sensitivity: 'top-secret' })
+    expect(res.status).toBe(400)
+  })
+})

--- a/packages/api/src/routes/brain-inbox.ts
+++ b/packages/api/src/routes/brain-inbox.ts
@@ -1,0 +1,1645 @@
+/**
+ * Brain inbox routes — workspace-scoped verification surface across
+ * every brain primitive carrying the universal `verified_by_user_id`
+ * column (mig 128 / WU-2.1). Generalises the per-assistant memory
+ * verify/adjust routes that lived in `memories.ts` to also cover
+ * entities, edges, tasks, CRM rows, and workspace files.
+ *
+ * Spec: [`docs/architecture/brain/corrections.md`](../../../../docs/architecture/brain/corrections.md).
+ *
+ * Mounted at `/api/brain-inbox` behind `requireAuth`.
+ *
+ * Routes:
+ *   GET    /:workspaceId                            — paginated unverified list
+ *   GET    /:workspaceId/count                      — total + per-primitive counts
+ *   POST   /:workspaceId/:primitive/:rowId/verify   — generic verify stamp
+ *   POST   /:workspaceId/:primitive/:rowId/adjust   — adjust (memory in v1; others 405)
+ *   DELETE /:workspaceId/:primitive/:rowId          — soft delete (valid_to)
+ *   GET    /:workspaceId/:primitive/:rowId/explain  — source-session context (no LLM)
+ *   POST   /:workspaceId/:primitive/:rowId/inspection-session — ephemeral chat session
+ *
+ * Legacy compatibility: `/api/workspaces/:id/memories/unverified` and
+ * `/api/assistants/:id/memories/:id/verify` stay mounted via thin
+ * shims that delegate here. Removed in a follow-up deploy cycle.
+ *
+ * [COMP:api/brain-inbox-route]
+ */
+
+import { Router } from 'express'
+import type { Response } from 'express'
+import { query } from '../db/client.js'
+import type { WorkspaceStore } from '../db/workspace-store.js'
+import {
+  listBrainInbox,
+  countBrainInbox,
+  getBrainInboxRow,
+  markVerifiedGeneric,
+  appendBrainVerification,
+  pruneDanglingEntityLinks,
+  primitiveToTable,
+  type BrainInboxPrimitive,
+} from '../db/brain-inbox-store.js'
+import { createInspectionSession } from '../db/sessions.js'
+import {
+  updateEntity,
+  reclassifyEntityKind,
+  promoteEntityToCrm,
+  addEntityAlias,
+  removeEntityAlias,
+  type PromoteEntityToCrmParams,
+} from '../db/entities-store.js'
+import { SYSTEM_ENTITY_KINDS } from '@sidanclaw/core'
+import { updateCompany, updateContact } from '../db/crm.js'
+import { updateWorkspaceFileMeta } from '../db/workspace-files.js'
+import type { FilesApi, FilesContext } from '@sidanclaw/core'
+import { notifyBrainInboxChange } from '../brain-stream/notify.js'
+
+type RouteOptions = {
+  workspaceStore: WorkspaceStore
+  /**
+   * Entity-kind classifier — when provided, exposes a `POST
+   * /:workspaceId/classify` suggestion endpoint that the web UI can
+   * call before submit to show "did you mean…" hints.
+   *
+   * Spec: docs/architecture/brain/classification/README.md
+   *   §B3 Brain inbox / web UI
+   */
+  entityKindClassifier?: import('@sidanclaw/core').Classifier<import('@sidanclaw/core').EntityKind>
+  /**
+   * Pending-classifications store — when provided, exposes
+   * `GET /:workspaceId/pending-classifications` (list unresolved) and
+   * `POST /:workspaceId/pending-classifications/:id/resolve` (accept /
+   * reject / dismiss). The web UI inbox surface reads from these.
+   *
+   * Spec: docs/architecture/brain/classification/README.md
+   *   §Pending-reclassification queue
+   */
+  pendingClassificationStore?: import('@sidanclaw/core').PendingClassificationStore
+  /**
+   * Files API — when provided, exposes `GET
+   * /:workspaceId/workspace_file/:rowId/content` so the brain detail
+   * drawer can preview a saved file's bytes (images inline, text/markdown
+   * as text, anything else as a download). Reads through `filesApi.readBytes`
+   * which is access-scoped (workspace + clearance). Absent → the endpoint
+   * returns 501 and the drawer falls back to a metadata-only card.
+   */
+  filesApi?: FilesApi | null
+}
+
+const VALID_PRIMITIVES: BrainInboxPrimitive[] = [
+  'memory',
+  'entity',
+  'entity_link',
+  'task',
+  'contact',
+  'company',
+  'deal',
+  'workspace_file',
+]
+
+function isValidPrimitive(s: string): s is BrainInboxPrimitive {
+  return (VALID_PRIMITIVES as string[]).includes(s)
+}
+
+export function brainInboxRoutes({
+  workspaceStore,
+  entityKindClassifier,
+  pendingClassificationStore,
+  filesApi,
+}: RouteOptions): Router {
+  const router = Router()
+
+  async function requireWorkspaceMember(
+    req: { userId?: string; params: { workspaceId: string } },
+    res: Response,
+  ): Promise<string | null> {
+    const userId = req.userId
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' })
+      return null
+    }
+    const role = await workspaceStore.getRole(userId, req.params.workspaceId)
+    if (!role) {
+      res.status(403).json({ error: 'Not a member of this workspace' })
+      return null
+    }
+    return role
+  }
+
+  // ── GET /:workspaceId — list ────────────────────────────────────
+
+  router.get('/:workspaceId', async (req, res) => {
+    const role = await requireWorkspaceMember(req as any, res)
+    if (!role) return
+
+    const { workspaceId } = req.params as { workspaceId: string }
+    const limit = Math.min(parseInt(req.query.limit as string) || 20, 100)
+    const cursor = req.query.cursor as string | undefined
+    const primitiveQuery = req.query.primitive as string | undefined
+    const includeExtracted = req.query.includeExtracted === 'true'
+
+    let primitive: BrainInboxPrimitive | undefined
+    if (primitiveQuery) {
+      if (!isValidPrimitive(primitiveQuery)) {
+        res.status(400).json({ error: `Unknown primitive '${primitiveQuery}'` })
+        return
+      }
+      primitive = primitiveQuery
+    }
+
+    try {
+      // Auto-prune dead relationships before listing when edges are in scope
+      // (the unscoped feed or an explicit entity_link fetch): a dangling edge
+      // points at a hard-deleted endpoint, so there's nothing to review. Soft-
+      // deleting them here keeps the queue + badge honest. Best-effort — a
+      // prune failure must not break the list (the list query also excludes
+      // dangling edges, so correctness doesn't depend on the prune landing).
+      if (!primitive || primitive === 'entity_link') {
+        try {
+          await pruneDanglingEntityLinks(workspaceId)
+        } catch (pruneErr) {
+          console.error('[brain-inbox] dangling-edge prune failed:', pruneErr)
+        }
+      }
+      const result = await listBrainInbox({
+        workspaceId,
+        primitive,
+        cursor,
+        limit,
+        includeExtracted,
+      })
+      res.json({ rows: result.rows, cursor: result.cursor })
+    } catch (err) {
+      console.error('[brain-inbox] list failed:', err)
+      res.status(500).json({ error: 'Failed to list brain inbox' })
+    }
+  })
+
+  // ── POST /:workspaceId/classify ─────────────────────────────────
+  //
+  // Suggestion endpoint for the web UI's "did you mean…" hint. Takes a
+  // candidate entity (display_name + optional canonical_id + optional
+  // attributes + optional proposed kind) and returns the classifier's
+  // decision, so the UI can guide the user before submit.
+  //
+  // No-op when no classifier wired (returns 200 with kind='no_signal').
+  //
+  // Spec: docs/architecture/brain/classification/README.md
+  //   §Decision semantics per boundary — B3 brain inbox / web UI
+  router.post('/:workspaceId/classify', async (req, res) => {
+    const role = await requireWorkspaceMember(req as any, res)
+    if (!role) return
+    if (!entityKindClassifier) {
+      res.json({ kind: 'no_signal' })
+      return
+    }
+    const body = (req.body ?? {}) as {
+      display_name?: unknown
+      canonical_id?: unknown
+      attributes?: unknown
+      proposed?: unknown
+    }
+    const displayName =
+      typeof body.display_name === 'string' && body.display_name.trim().length > 0
+        ? body.display_name.trim()
+        : null
+    if (!displayName) {
+      res.status(400).json({ error: 'display_name is required and must be a non-empty string' })
+      return
+    }
+    try {
+      const decision = entityKindClassifier.decide(
+        {
+          primary: displayName,
+          canonical_id: typeof body.canonical_id === 'string' ? body.canonical_id : null,
+          attributes:
+            body.attributes && typeof body.attributes === 'object' && !Array.isArray(body.attributes)
+              ? (body.attributes as Record<string, unknown>)
+              : undefined,
+          proposed: typeof body.proposed === 'string' ? body.proposed : undefined,
+        },
+        'inbox',
+      )
+      res.json(decision)
+    } catch (err) {
+      console.error('[brain-inbox] classify failed:', err)
+      res.status(500).json({ error: 'Classification failed' })
+    }
+  })
+
+  // ── GET /:workspaceId/pending-classifications ───────────────────
+  //
+  // List unresolved classifier suggestions for the workspace inbox UI.
+  // Newest-first, capped at 100. Returns 200 with empty array when
+  // pending_classifications isn't wired (older deployments).
+  router.get('/:workspaceId/pending-classifications', async (req, res) => {
+    const role = await requireWorkspaceMember(req as any, res)
+    if (!role) return
+    if (!pendingClassificationStore) {
+      res.json({ rows: [] })
+      return
+    }
+    const { workspaceId } = req.params as { workspaceId: string }
+    const userId = (req as { userId?: string }).userId
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' })
+      return
+    }
+    const limit = Math.min(parseInt((req.query.limit as string) ?? '50', 10) || 50, 100)
+    const primitiveKindRaw = req.query.primitive as string | undefined
+    try {
+      const rows = await pendingClassificationStore.listUnresolvedForWorkspace(
+        {
+          workspaceId,
+          userId,
+          assistantId: '',  // brain-inbox is workspace-scoped; no per-assistant filter
+          assistantKind: 'primary',
+        },
+        {
+          limit,
+          primitiveKind:
+            primitiveKindRaw === 'entity' ||
+            primitiveKindRaw === 'edge' ||
+            primitiveKindRaw === 'memory' ||
+            primitiveKindRaw === 'episode'
+              ? primitiveKindRaw
+              : undefined,
+        },
+      )
+      res.json({ rows })
+    } catch (err) {
+      console.error('[brain-inbox] pending-classifications list failed:', err)
+      res.status(500).json({ error: 'Failed to list pending classifications' })
+    }
+  })
+
+  // ── POST /:workspaceId/pending-classifications/:id/resolve ─────
+  //
+  // Resolve a single suggestion. Body: { resolution: 'accept' | 'reject' | 'dismiss' }.
+  // 'accept' is the UI affordance — it marks the queue row but DOES NOT
+  // apply the suggestion (the caller must invoke reclassifyEntityKind /
+  // promoteEntityToCrm separately, typically via the existing
+  // POST /:workspaceId/entity/:entityId/reclassify endpoint).
+  // 'reject' and 'dismiss' just flip the resolution state.
+  router.post('/:workspaceId/pending-classifications/:id/resolve', async (req, res) => {
+    const role = await requireWorkspaceMember(req as any, res)
+    if (!role) return
+    if (!pendingClassificationStore) {
+      res.status(404).json({ error: 'Pending classifications not enabled' })
+      return
+    }
+    const { id } = req.params as { id: string }
+    const userId = (req as { userId?: string }).userId
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' })
+      return
+    }
+    const { resolution } = (req.body ?? {}) as { resolution?: unknown }
+    if (resolution !== 'accept' && resolution !== 'reject' && resolution !== 'dismiss') {
+      res.status(400).json({ error: 'resolution must be one of: accept, reject, dismiss' })
+      return
+    }
+    try {
+      const resolved = await pendingClassificationStore.resolve(userId, id, resolution)
+      if (!resolved) {
+        res.status(404).json({ error: 'Pending classification not found or already resolved' })
+        return
+      }
+      res.json({ ok: true, row: resolved })
+    } catch (err) {
+      console.error('[brain-inbox] pending-classifications resolve failed:', err)
+      res.status(500).json({ error: 'Failed to resolve pending classification' })
+    }
+  })
+
+  // ── GET /:workspaceId/count ─────────────────────────────────────
+
+  router.get('/:workspaceId/count', async (req, res) => {
+    const role = await requireWorkspaceMember(req as any, res)
+    if (!role) return
+
+    const { workspaceId } = req.params as { workspaceId: string }
+    const includeExtracted = req.query.includeExtracted === 'true'
+    try {
+      const counts = await countBrainInbox(workspaceId, { includeExtracted })
+      res.json(counts)
+    } catch (err) {
+      console.error('[brain-inbox] count failed:', err)
+      res.status(500).json({ error: 'Failed to count brain inbox' })
+    }
+  })
+
+  // ── GET /:workspaceId/:primitive/:rowId — single-row detail ────
+  //
+  // Drives the per-primitive detail page. Unlike the inbox list, this
+  // includes already-verified rows (with the verifiedByUserId stamp in
+  // the response) so the page survives the user pressing Confirm and
+  // bookmarked / deep-linked URLs keep working. Soft-deleted /
+  // retracted rows still return 404 — those really are gone.
+
+  router.get('/:workspaceId/:primitive/:rowId', async (req, res) => {
+    const role = await requireWorkspaceMember(req as any, res)
+    if (!role) return
+
+    const { workspaceId, primitive: primitiveParam, rowId } = req.params as {
+      workspaceId: string
+      primitive: string
+      rowId: string
+    }
+    if (!isValidPrimitive(primitiveParam)) {
+      res.status(400).json({ error: `Unknown primitive '${primitiveParam}'` })
+      return
+    }
+
+    try {
+      const row = await getBrainInboxRow(workspaceId, primitiveParam, rowId)
+      if (!row) {
+        res.status(404).json({ error: 'Row not found' })
+        return
+      }
+      res.json({
+        primitive: row.primitive,
+        id: row.id,
+        workspaceId: row.workspaceId,
+        createdAt: row.createdAt,
+        createdByAssistantId: row.createdByAssistantId,
+        verifiedByUserId: row.verifiedByUserId,
+        verifiedAt: row.verifiedAt,
+        body: row.body,
+      })
+    } catch (err) {
+      // Log full pg error detail (message + code + position + where) so the
+      // next failure pinpoints the failing column / table. Stringifying the
+      // bare error object only prints `error: column "X"` and truncates.
+      const e = err as { message?: string; code?: string; position?: string; hint?: string; where?: string }
+      console.error(
+        `[brain-inbox] fetch row failed — workspaceId=${workspaceId} primitive=${primitiveParam} rowId=${rowId} ` +
+        `pgCode=${e?.code} msg=${e?.message} position=${e?.position} where=${e?.where} hint=${e?.hint}`,
+      )
+      res.status(500).json({ error: 'Failed to load brain row' })
+    }
+  })
+
+  // ── GET /:workspaceId/workspace_file/:rowId/content ─────────────
+  //
+  // Streams a saved file's bytes so the brain detail drawer can preview
+  // it (images inline, text/markdown as text, anything else offered as a
+  // download). Access-scoped through `filesApi.readBytes` (workspace +
+  // clearance) after the membership gate. 501 when no files API is wired
+  // (the row still renders as a metadata-only card). This is a 4-segment
+  // path with the literal `workspace_file`/`content` bookends, so it does
+  // not collide with the 3-segment `/:primitive/:rowId` detail route.
+
+  router.get('/:workspaceId/workspace_file/:rowId/content', async (req, res) => {
+    const role = await requireWorkspaceMember(req as any, res)
+    if (!role) return
+    if (!filesApi) {
+      res.status(501).json({ error: 'File preview is not available on this deployment' })
+      return
+    }
+    const { workspaceId, rowId } = req.params as { workspaceId: string; rowId: string }
+    const userId = (req as { userId?: string }).userId as string
+    try {
+      // Clearance is the read ceiling for the access-scoped byte read.
+      const member = await query<{ clearance: 'public' | 'internal' | 'confidential' }>(
+        `SELECT clearance FROM workspace_members WHERE workspace_id = $1 AND user_id = $2`,
+        [workspaceId, userId],
+      )
+      const clearance = member.rows[0]?.clearance ?? 'public'
+      const ctx: FilesContext = { workspaceId, userId, assistantId: null, clearance }
+      const result = await filesApi.readBytes(ctx, rowId)
+      if (!result.ok) {
+        res.status(404).json({ error: 'File not found' })
+        return
+      }
+      const { file, bytes } = result.value
+      res.setHeader('Content-Type', file.mime || 'application/octet-stream')
+      res.setHeader('Content-Length', String(bytes.length))
+      res.setHeader('Cache-Control', 'private, max-age=300')
+      // Inline so the drawer renders images / text / pdf in place; the
+      // filename is advisory for a save-as.
+      const safeName = (file.name || 'file').replace(/"/g, '')
+      res.setHeader('Content-Disposition', `inline; filename="${safeName}"`)
+      res.send(bytes)
+    } catch (err) {
+      console.error('[brain-inbox] file content failed:', err)
+      res.status(500).json({ error: 'Failed to load file content' })
+    }
+  })
+
+  // ── POST /:workspaceId/:primitive/:rowId/verify ─────────────────
+  //
+  // Generic verify stamp. Sets verified_by_user_id + verified_at on
+  // the active row + appends a brain_verifications audit row (or
+  // memory_verifications for the memory primitive — the existing
+  // evolution worker consumes that table specifically).
+
+  router.post('/:workspaceId/:primitive/:rowId/verify', async (req, res) => {
+    const role = await requireWorkspaceMember(req as any, res)
+    if (!role) return
+
+    const { workspaceId, primitive: primitiveParam, rowId } = req.params as {
+      workspaceId: string
+      primitive: string
+      rowId: string
+    }
+    if (!isValidPrimitive(primitiveParam)) {
+      res.status(400).json({ error: `Unknown primitive '${primitiveParam}'` })
+      return
+    }
+    const userId = (req as any).userId as string
+
+    try {
+      // Validate the row belongs to this workspace before stamping —
+      // primitiveToTable is closed-set so the table name is safe to
+      // interpolate.
+      const ownership = await query<{ workspace_id: string }>(
+        `SELECT workspace_id FROM ${primitiveToTable(primitiveParam)}
+         WHERE id = $1 AND valid_to IS NULL`,
+        [rowId],
+      )
+      if (ownership.rows.length === 0) {
+        res.status(404).json({ error: 'Row not found' })
+        return
+      }
+      if (ownership.rows[0].workspace_id !== workspaceId) {
+        res.status(403).json({ error: 'Row belongs to a different workspace' })
+        return
+      }
+
+      const stamped = await markVerifiedGeneric(primitiveParam, rowId, userId)
+      // Append audit. For memory we ride the existing memory_verifications
+      // shape; for other primitives we use the new polymorphic
+      // brain_verifications.
+      if (primitiveParam === 'memory') {
+        await query(
+          `INSERT INTO memory_verifications (memory_id, workspace_id, verified_by, action)
+           VALUES ($1, $2, $3, 'confirm')`,
+          [rowId, workspaceId, userId],
+        )
+      } else {
+        await appendBrainVerification({
+          targetKind: primitiveParam,
+          targetId: rowId,
+          workspaceId,
+          verifiedByUserId: userId,
+          action: 'confirm',
+        })
+      }
+
+      // Fire-and-forget realtime NOTIFY so open /brain pages on other tabs /
+      // devices repaint the now-verified row.
+      void notifyBrainInboxChange(workspaceId, primitiveParam, rowId, 'update')
+
+      res.json({ ok: true, stamped })
+    } catch (err) {
+      console.error('[brain-inbox] verify failed:', err)
+      res.status(500).json({ error: 'Failed to verify row' })
+    }
+  })
+
+  // ── POST /:workspaceId/:primitive/:rowId/adjust ─────────────────
+  //
+  // V1 implementation: memory uses the existing scope/sensitivity/
+  // summary/detail flow from the per-assistant memory route. Other
+  // primitives return 405 with a pointer to the detail page — the
+  // inbox card's "Edit" affordance for non-memory primitives links
+  // out, not inline. Generic per-primitive adjust is a follow-up.
+
+  router.post('/:workspaceId/:primitive/:rowId/adjust', async (req, res) => {
+    const role = await requireWorkspaceMember(req as any, res)
+    if (!role) return
+
+    const { workspaceId, primitive: primitiveParam, rowId } = req.params as {
+      workspaceId: string
+      primitive: string
+      rowId: string
+    }
+    if (!isValidPrimitive(primitiveParam)) {
+      res.status(400).json({ error: `Unknown primitive '${primitiveParam}'` })
+      return
+    }
+    const userId = (req as any).userId as string
+
+    if (primitiveParam === 'memory') {
+      // Memory adjust — delegate to the existing per-assistant route by
+      // returning a 308 redirect. The existing route requires the
+      // assistantId; we look it up from the memory row.
+      const assistantLookup = await query<{ assistantId: string }>(
+        `SELECT assistant_id as "assistantId" FROM memories WHERE id = $1 AND valid_to IS NULL`,
+        [rowId],
+      )
+      if (assistantLookup.rows.length === 0) {
+        res.status(404).json({ error: 'Memory not found' })
+        return
+      }
+      const assistantId = assistantLookup.rows[0].assistantId
+      res.redirect(
+        308,
+        `/api/assistants/${encodeURIComponent(assistantId)}/memories/${encodeURIComponent(rowId)}/adjust`,
+      )
+      return
+    }
+
+    if (primitiveParam === 'entity') {
+      // Entity adjust — v1 supports display_name + sensitivity only.
+      const { display_name, sensitivity, reason } = req.body as {
+        display_name?: unknown
+        sensitivity?: unknown
+        reason?: unknown
+      }
+
+      let nextDisplayName: string | undefined
+      if (display_name !== undefined) {
+        if (typeof display_name !== 'string' || display_name.trim().length === 0) {
+          res.status(400).json({ error: 'display_name must be a non-empty string' })
+          return
+        }
+        if (display_name.length > 200) {
+          res.status(400).json({ error: 'display_name must be 200 characters or less' })
+          return
+        }
+        nextDisplayName = display_name.trim()
+      }
+
+      let nextSensitivity: 'public' | 'internal' | 'confidential' | undefined
+      if (sensitivity !== undefined) {
+        if (
+          sensitivity !== 'public' &&
+          sensitivity !== 'internal' &&
+          sensitivity !== 'confidential'
+        ) {
+          res.status(400).json({ error: 'sensitivity must be public, internal, or confidential' })
+          return
+        }
+        nextSensitivity = sensitivity
+      }
+
+      if (nextDisplayName === undefined && nextSensitivity === undefined) {
+        res.status(400).json({
+          error: 'At least one field (display_name, sensitivity) is required',
+        })
+        return
+      }
+
+      try {
+        const before = await query<{
+          workspaceId: string
+          displayName: string
+          sensitivity: 'public' | 'internal' | 'confidential'
+        }>(
+          `SELECT workspace_id as "workspaceId",
+                  display_name as "displayName",
+                  sensitivity
+             FROM entities
+            WHERE id = $1 AND valid_to IS NULL`,
+          [rowId],
+        )
+        if (before.rows.length === 0) {
+          res.status(404).json({ error: 'Entity not found' })
+          return
+        }
+        if (before.rows[0].workspaceId !== workspaceId) {
+          res.status(403).json({ error: 'Entity belongs to a different workspace' })
+          return
+        }
+        const prev = before.rows[0]
+
+        const updated = await updateEntity(userId, rowId, {
+          displayName: nextDisplayName,
+          sensitivity: nextSensitivity,
+          verifiedByUserId: userId,
+          verifiedAt: new Date(),
+        })
+        if (!updated) {
+          res.status(404).json({ error: 'Entity not found' })
+          return
+        }
+
+        const reasonText = typeof reason === 'string' ? reason.slice(0, 500) : undefined
+        const writes: Promise<unknown>[] = []
+        if (nextDisplayName !== undefined && nextDisplayName !== prev.displayName) {
+          writes.push(
+            appendBrainVerification({
+              targetKind: 'entity',
+              targetId: rowId,
+              workspaceId,
+              verifiedByUserId: userId,
+              action: 'edit_summary',
+              modelValue: { display_name: prev.displayName },
+              userValue: { display_name: nextDisplayName },
+              reason: reasonText,
+            }),
+          )
+        }
+        if (nextSensitivity !== undefined && nextSensitivity !== prev.sensitivity) {
+          writes.push(
+            appendBrainVerification({
+              targetKind: 'entity',
+              targetId: rowId,
+              workspaceId,
+              verifiedByUserId: userId,
+              action: 'adjust_sensitivity',
+              modelValue: prev.sensitivity,
+              userValue: nextSensitivity,
+              reason: reasonText,
+            }),
+          )
+        }
+        await Promise.all(writes)
+
+        // Realtime repaint for the adjusted entity row.
+        void notifyBrainInboxChange(workspaceId, 'entity', rowId, 'update')
+
+        res.json({ ok: true, stamped: true })
+      } catch (err) {
+        console.error('[brain-inbox] entity adjust failed:', err)
+        res.status(500).json({ error: 'Failed to adjust entity' })
+      }
+      return
+    }
+
+    if (primitiveParam === 'company' || primitiveParam === 'contact' || primitiveParam === 'deal') {
+      // CRM-row adjust — supports `display_name` (mapped to the
+      // companies/contacts/deals `name` column) + `sensitivity` (which
+      // flows through the linked entity since that's the canonical
+      // source). For company-specific `domain` and other kind-specific
+      // fields, the chat tools (updateCompany / updateContact /
+      // updateDeal) remain the surface. Both row + entity updates
+      // happen so the list view (which reads the CRM row) and the
+      // graph view (which reads the entity row) stay in sync.
+      const { display_name, sensitivity, reason } = req.body as {
+        display_name?: unknown
+        sensitivity?: unknown
+        reason?: unknown
+      }
+
+      let nextName: string | undefined
+      if (display_name !== undefined) {
+        if (typeof display_name !== 'string' || display_name.trim().length === 0) {
+          res.status(400).json({ error: 'display_name must be a non-empty string' })
+          return
+        }
+        if (display_name.length > 200) {
+          res.status(400).json({ error: 'display_name must be 200 characters or less' })
+          return
+        }
+        nextName = display_name.trim()
+      }
+
+      let nextSensitivity: 'public' | 'internal' | 'confidential' | undefined
+      if (sensitivity !== undefined) {
+        if (
+          sensitivity !== 'public'
+          && sensitivity !== 'internal'
+          && sensitivity !== 'confidential'
+        ) {
+          res.status(400).json({ error: 'sensitivity must be public, internal, or confidential' })
+          return
+        }
+        nextSensitivity = sensitivity
+      }
+
+      if (nextName === undefined && nextSensitivity === undefined) {
+        res.status(400).json({
+          error: 'At least one field (display_name, sensitivity) is required',
+        })
+        return
+      }
+
+      try {
+        // Resolve the CRM row's current state + entity_id.
+        const table =
+          primitiveParam === 'company'
+            ? 'companies'
+            : primitiveParam === 'contact'
+              ? 'contacts'
+              : 'deals'
+        const before = await query<{
+          workspaceId: string
+          name: string | null
+          sensitivity: 'public' | 'internal' | 'confidential'
+          entityId: string | null
+        }>(
+          `SELECT workspace_id AS "workspaceId", name, sensitivity,
+                  entity_id AS "entityId"
+             FROM ${table}
+            WHERE id = $1 AND valid_to IS NULL`,
+          [rowId],
+        )
+        if (before.rows.length === 0) {
+          res.status(404).json({ error: 'Row not found' })
+          return
+        }
+        if (before.rows[0].workspaceId !== workspaceId) {
+          res.status(403).json({ error: 'Row belongs to a different workspace' })
+          return
+        }
+        const prev = before.rows[0]
+
+        // Update the CRM row's `name` (companies + contacts; deals has
+        // no `name` column — its label comes from the linked entity).
+        if (nextName !== undefined && primitiveParam !== 'deal') {
+          if (primitiveParam === 'company') {
+            await updateCompany(userId, rowId, { name: nextName })
+          } else {
+            await updateContact(userId, rowId, { name: nextName })
+          }
+        }
+
+        // Mirror name + sensitivity onto the linked entity so the
+        // graph view + brain-search stay in sync. Sensitivity has no
+        // CRM-row update path; the entity column is the canonical
+        // source per the data model.
+        if (prev.entityId && (nextName !== undefined || nextSensitivity !== undefined)) {
+          await updateEntity(userId, prev.entityId, {
+            ...(nextName !== undefined ? { displayName: nextName } : {}),
+            ...(nextSensitivity !== undefined ? { sensitivity: nextSensitivity } : {}),
+            verifiedByUserId: userId,
+            verifiedAt: new Date(),
+          })
+        }
+
+        const reasonText = typeof reason === 'string' ? reason.slice(0, 500) : undefined
+        const writes: Promise<unknown>[] = []
+        if (nextName !== undefined && nextName !== prev.name) {
+          writes.push(
+            appendBrainVerification({
+              targetKind: primitiveParam,
+              targetId: rowId,
+              workspaceId,
+              verifiedByUserId: userId,
+              action: 'edit_summary',
+              modelValue: { name: prev.name },
+              userValue: { name: nextName },
+              reason: reasonText,
+            }),
+          )
+        }
+        if (nextSensitivity !== undefined && nextSensitivity !== prev.sensitivity) {
+          writes.push(
+            appendBrainVerification({
+              targetKind: primitiveParam,
+              targetId: rowId,
+              workspaceId,
+              verifiedByUserId: userId,
+              action: 'adjust_sensitivity',
+              modelValue: prev.sensitivity,
+              userValue: nextSensitivity,
+              reason: reasonText,
+            }),
+          )
+        }
+        await Promise.all(writes)
+
+        // Realtime repaint: the CRM row itself, plus the linked entity when
+        // this adjust mirrored name / sensitivity onto it (the graph view +
+        // brain-search read the entity row, the list view reads the CRM row).
+        void notifyBrainInboxChange(workspaceId, primitiveParam, rowId, 'update')
+        if (prev.entityId && (nextName !== undefined || nextSensitivity !== undefined)) {
+          void notifyBrainInboxChange(workspaceId, 'entity', prev.entityId, 'update')
+        }
+
+        res.json({ ok: true, stamped: true })
+      } catch (err) {
+        console.error(`[brain-inbox] ${primitiveParam} adjust failed:`, err)
+        res.status(500).json({ error: `Failed to adjust ${primitiveParam}` })
+      }
+      return
+    }
+
+    if (primitiveParam === 'workspace_file') {
+      // File adjust — v1 supports `sensitivity` + `tags`. `name` is the
+      // path-coupled display name, so rename stays out of scope; substantive
+      // content edits route through supersession, not this metadata patch.
+      const { sensitivity, tags, reason } = req.body as {
+        sensitivity?: unknown
+        tags?: unknown
+        reason?: unknown
+      }
+
+      let nextSensitivity: 'public' | 'internal' | 'confidential' | undefined
+      if (sensitivity !== undefined) {
+        if (
+          sensitivity !== 'public'
+          && sensitivity !== 'internal'
+          && sensitivity !== 'confidential'
+        ) {
+          res.status(400).json({ error: 'sensitivity must be public, internal, or confidential' })
+          return
+        }
+        nextSensitivity = sensitivity
+      }
+
+      let nextTags: string[] | undefined
+      if (tags !== undefined) {
+        if (!Array.isArray(tags) || tags.some((t) => typeof t !== 'string')) {
+          res.status(400).json({ error: 'tags must be an array of strings' })
+          return
+        }
+        nextTags = (tags as string[]).map((t) => t.trim()).filter((t) => t.length > 0).slice(0, 50)
+      }
+
+      if (nextSensitivity === undefined && nextTags === undefined) {
+        res.status(400).json({ error: 'At least one field (sensitivity, tags) is required' })
+        return
+      }
+
+      try {
+        const before = await query<{
+          workspaceId: string
+          sensitivity: 'public' | 'internal' | 'confidential'
+          tags: string[]
+        }>(
+          `SELECT workspace_id AS "workspaceId", sensitivity, tags
+             FROM workspace_files
+            WHERE id = $1 AND valid_to IS NULL`,
+          [rowId],
+        )
+        if (before.rows.length === 0) {
+          res.status(404).json({ error: 'File not found' })
+          return
+        }
+        if (before.rows[0].workspaceId !== workspaceId) {
+          res.status(403).json({ error: 'File belongs to a different workspace' })
+          return
+        }
+        const prev = before.rows[0]
+
+        const updated = await updateWorkspaceFileMeta(userId, workspaceId, rowId, {
+          ...(nextSensitivity !== undefined ? { sensitivity: nextSensitivity } : {}),
+          ...(nextTags !== undefined ? { tags: nextTags } : {}),
+        })
+        if (!updated) {
+          res.status(404).json({ error: 'File not found' })
+          return
+        }
+        // Stamp verified — an explicit edit is an acknowledgement, so the row
+        // leaves the pending queue (matches the entity / CRM adjust branches).
+        await markVerifiedGeneric('workspace_file', rowId, userId)
+
+        const reasonText = typeof reason === 'string' ? reason.slice(0, 500) : undefined
+        const writes: Promise<unknown>[] = []
+        if (nextSensitivity !== undefined && nextSensitivity !== prev.sensitivity) {
+          writes.push(
+            appendBrainVerification({
+              targetKind: 'workspace_file',
+              targetId: rowId,
+              workspaceId,
+              verifiedByUserId: userId,
+              action: 'adjust_sensitivity',
+              modelValue: prev.sensitivity,
+              userValue: nextSensitivity,
+              reason: reasonText,
+            }),
+          )
+        }
+        if (nextTags !== undefined) {
+          writes.push(
+            appendBrainVerification({
+              targetKind: 'workspace_file',
+              targetId: rowId,
+              workspaceId,
+              verifiedByUserId: userId,
+              action: 'adjust_attributes',
+              modelValue: { tags: prev.tags },
+              userValue: { tags: nextTags },
+              reason: reasonText,
+            }),
+          )
+        }
+        await Promise.all(writes)
+
+        void notifyBrainInboxChange(workspaceId, 'workspace_file', rowId, 'update')
+        res.json({ ok: true, stamped: true })
+      } catch (err) {
+        console.error('[brain-inbox] workspace_file adjust failed:', err)
+        res.status(500).json({ error: 'Failed to adjust file' })
+      }
+      return
+    }
+
+    res.status(405).json({
+      error:
+        `Inline adjust not yet supported for primitive '${primitiveParam}'. ` +
+        `Use the detail page (e.g., /task/:id) to edit.`,
+    })
+  })
+
+  // ── GET /:workspaceId/entity/:entityId/crm-companion ───────────
+  //
+  // Lookup helper for the brain detail drawer (apps/web). When the
+  // user clicks a graph node with a CRM-specialized kind
+  // (person / company / deal), the node carries the entities.id —
+  // but the rich detail surface (with tags / domain / stage) lives
+  // in the CRM specialization table keyed on its own id with a
+  // `entity_id` FK back to entities. This endpoint resolves
+  // entities.id → { primitive, id } so the drawer can re-fetch
+  // through the existing CRM brain-inbox row path and get the same
+  // rich payload the list view shows. Returns `null` when the
+  // entity has no CRM specialization (non-CRM kinds, or a CRM-kind
+  // entity that's missing its companion row — a data-integrity
+  // surprise the UI silently falls back to the lean entity view).
+  router.get('/:workspaceId/entity/:entityId/crm-companion', async (req, res) => {
+    const role = await requireWorkspaceMember(req as any, res)
+    if (!role) return
+
+    const { workspaceId, entityId } = req.params as {
+      workspaceId: string
+      entityId: string
+    }
+    try {
+      const entityRes = await query<{ kind: string; workspaceId: string }>(
+        `SELECT kind, workspace_id AS "workspaceId"
+           FROM entities
+          WHERE id = $1 AND valid_to IS NULL`,
+        [entityId],
+      )
+      if (entityRes.rows.length === 0) {
+        res.status(404).json({ error: 'Entity not found' })
+        return
+      }
+      if (entityRes.rows[0].workspaceId !== workspaceId) {
+        res.status(403).json({ error: 'Entity belongs to a different workspace' })
+        return
+      }
+      const kind = entityRes.rows[0].kind
+      let table: 'companies' | 'contacts' | 'deals' | null = null
+      let primitive: 'company' | 'contact' | 'deal' | null = null
+      if (kind === 'company') { table = 'companies'; primitive = 'company' }
+      else if (kind === 'person') { table = 'contacts'; primitive = 'contact' }
+      else if (kind === 'deal') { table = 'deals'; primitive = 'deal' }
+
+      if (!table || !primitive) {
+        res.json({ companion: null })
+        return
+      }
+      // `valid_to IS NULL` filters out superseded rows so the drawer
+      // always lands on the current version of the CRM row.
+      const compRes = await query<{ id: string }>(
+        `SELECT id FROM ${table} WHERE entity_id = $1 AND valid_to IS NULL LIMIT 1`,
+        [entityId],
+      )
+      if (compRes.rows.length === 0) {
+        // CRM-kind entity with no companion row — possible after a
+        // soft-delete of the CRM row or a Q24-guard bypass. Surface
+        // null so the UI degrades to the lean entity view.
+        res.json({ companion: null })
+        return
+      }
+      res.json({
+        companion: { primitive, id: compRes.rows[0].id },
+      })
+    } catch (err) {
+      console.error('[brain-inbox] crm-companion lookup failed:', err)
+      res.status(500).json({ error: 'Failed to resolve CRM companion' })
+    }
+  })
+
+  // ── POST /:workspaceId/entity/:entityId/reclassify ─────────────
+  //
+  // Non-CRM kind change. Targets `product` / `project` / `event` /
+  // tenant.* — anything not in CRM_SPECIALIZED_KINDS. CRM targets are
+  // rejected here; they go through /promote-to-crm so the companion
+  // row is created in the same transaction. Stamps a brain_verification
+  // audit row with `action='reclassify_kind'`.
+  router.post('/:workspaceId/entity/:entityId/reclassify', async (req, res) => {
+    const role = await requireWorkspaceMember(req as any, res)
+    if (!role) return
+
+    const { workspaceId, entityId } = req.params as {
+      workspaceId: string
+      entityId: string
+    }
+    const userId = (req as { userId?: string }).userId
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' })
+      return
+    }
+    const { kind, reason } = req.body as { kind?: unknown; reason?: unknown }
+    if (typeof kind !== 'string' || kind.trim().length === 0) {
+      res.status(400).json({ error: 'kind must be a non-empty string' })
+      return
+    }
+    const targetKind = kind.trim()
+    const CRM_KINDS = new Set<string>(['person', 'company', 'deal'])
+    if (CRM_KINDS.has(targetKind)) {
+      res.status(400).json({
+        error:
+          `Reclassifying to '${targetKind}' requires the CRM companion row. Use POST /promote-to-crm.`,
+        useEndpoint: `/api/brain-inbox/${workspaceId}/entity/${entityId}/promote-to-crm`,
+      })
+      return
+    }
+    const systemKinds = new Set<string>(SYSTEM_ENTITY_KINDS as readonly string[])
+    if (!systemKinds.has(targetKind) && !targetKind.startsWith('tenant.')) {
+      res.status(400).json({
+        error: `Unknown entity kind '${targetKind}'. Allowed: project, product, or a tenant.* namespace.`,
+      })
+      return
+    }
+
+    try {
+      const before = await query<{ workspaceId: string; kind: string }>(
+        `SELECT workspace_id AS "workspaceId", kind
+           FROM entities
+          WHERE id = $1 AND valid_to IS NULL`,
+        [entityId],
+      )
+      if (before.rows.length === 0) {
+        res.status(404).json({ error: 'Entity not found' })
+        return
+      }
+      if (before.rows[0].workspaceId !== workspaceId) {
+        res.status(403).json({ error: 'Entity belongs to a different workspace' })
+        return
+      }
+      if (before.rows[0].kind === targetKind) {
+        // No-op — surface as success so the UI moves on.
+        res.json({ ok: true, kind: targetKind, idempotent: true })
+        return
+      }
+
+      const updated = await reclassifyEntityKind(userId, entityId, {
+        kind: targetKind,
+      })
+      if (!updated) {
+        res.status(404).json({ error: 'Entity not found' })
+        return
+      }
+      await appendBrainVerification({
+        targetKind: 'entity',
+        targetId: entityId,
+        workspaceId,
+        verifiedByUserId: userId,
+        action: 'reclassify_kind',
+        modelValue: { kind: before.rows[0].kind },
+        userValue: { kind: targetKind },
+        reason: typeof reason === 'string' ? reason.slice(0, 500) : undefined,
+      })
+      // Realtime repaint for the reclassified entity node.
+      void notifyBrainInboxChange(workspaceId, 'entity', entityId, 'update')
+      res.json({ ok: true, kind: targetKind })
+    } catch (err) {
+      console.error('[brain-inbox] entity reclassify failed:', err)
+      const message = err instanceof Error ? err.message : String(err)
+      res.status(500).json({ error: 'Failed to reclassify entity', detail: message })
+    }
+  })
+
+  // ── Alias mutators ────────────────────────────────────────────
+  //
+  // POST   /:workspaceId/entity/:entityId/aliases       — add alias
+  // DELETE /:workspaceId/entity/:entityId/aliases/:alias — remove alias
+  //
+  // Backs the entity-drawer's alias chips. Same RLS as the rest of
+  // the route group (workspace membership required). Add returns 409
+  // with the conflicting entity id when the alias is bound elsewhere
+  // in the workspace — the drawer surfaces that as a merge prompt.
+  router.post('/:workspaceId/entity/:entityId/aliases', async (req, res) => {
+    const role = await requireWorkspaceMember(req as any, res)
+    if (!role) return
+    const { workspaceId, entityId } = req.params as {
+      workspaceId: string
+      entityId: string
+    }
+    const userId = (req as { userId?: string }).userId
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' })
+      return
+    }
+    const { alias } = req.body as { alias?: unknown }
+    if (typeof alias !== 'string' || alias.trim().length === 0) {
+      res.status(400).json({ error: 'alias must be a non-empty string' })
+      return
+    }
+    if (alias.trim().length > 200) {
+      res.status(400).json({ error: 'alias must be <= 200 characters' })
+      return
+    }
+    try {
+      // Ownership check — RLS in addEntityAlias would already block
+      // cross-workspace, but a 404 here is friendlier than a not_found.
+      const owner = await query<{ workspaceId: string }>(
+        `SELECT workspace_id AS "workspaceId" FROM entities WHERE id = $1 AND valid_to IS NULL`,
+        [entityId],
+      )
+      if (owner.rows.length === 0) {
+        res.status(404).json({ error: 'Entity not found' })
+        return
+      }
+      if (owner.rows[0].workspaceId !== workspaceId) {
+        res.status(403).json({ error: 'Entity belongs to a different workspace' })
+        return
+      }
+      const result = await addEntityAlias(userId, entityId, alias)
+      if (result.kind === 'not_found') {
+        res.status(404).json({ error: 'Entity not found' })
+        return
+      }
+      if (result.kind === 'conflict') {
+        res.status(409).json({
+          error: 'Alias is already bound to another entity in this workspace',
+          conflictingEntityId: result.conflictingEntityId,
+        })
+        return
+      }
+      // Realtime repaint — alias chips are part of the entity card.
+      void notifyBrainInboxChange(workspaceId, 'entity', entityId, 'update')
+      res.json({ ok: true, aliases: result.entity.aliases })
+    } catch (err) {
+      console.error('[brain-inbox] alias add failed:', err)
+      const message = err instanceof Error ? err.message : String(err)
+      res.status(500).json({ error: 'Failed to add alias', detail: message })
+    }
+  })
+
+  router.delete('/:workspaceId/entity/:entityId/aliases/:alias', async (req, res) => {
+    const role = await requireWorkspaceMember(req as any, res)
+    if (!role) return
+    const { workspaceId, entityId, alias } = req.params as {
+      workspaceId: string
+      entityId: string
+      alias: string
+    }
+    const userId = (req as { userId?: string }).userId
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' })
+      return
+    }
+    try {
+      const owner = await query<{ workspaceId: string }>(
+        `SELECT workspace_id AS "workspaceId" FROM entities WHERE id = $1 AND valid_to IS NULL`,
+        [entityId],
+      )
+      if (owner.rows.length === 0) {
+        res.status(404).json({ error: 'Entity not found' })
+        return
+      }
+      if (owner.rows[0].workspaceId !== workspaceId) {
+        res.status(403).json({ error: 'Entity belongs to a different workspace' })
+        return
+      }
+      const updated = await removeEntityAlias(userId, entityId, decodeURIComponent(alias))
+      if (!updated) {
+        res.status(404).json({ error: 'Entity not found' })
+        return
+      }
+      // Realtime repaint — alias chips are part of the entity card.
+      void notifyBrainInboxChange(workspaceId, 'entity', entityId, 'update')
+      res.json({ ok: true, aliases: updated.aliases })
+    } catch (err) {
+      console.error('[brain-inbox] alias remove failed:', err)
+      const message = err instanceof Error ? err.message : String(err)
+      res.status(500).json({ error: 'Failed to remove alias', detail: message })
+    }
+  })
+
+  // ── POST /:workspaceId/entity/:entityId/promote-to-crm ──────────
+  //
+  // Atomic CRM promotion. Inserts the companion `contacts` /
+  // `companies` / `deals` row referencing the existing entity and
+  // flips `entities.kind` in one transaction. Required fields by kind:
+  //   - company: nothing extra (name defaults from display_name; domain optional)
+  //   - person : nothing extra (email/phone/companyId optional)
+  //   - deal   : stage REQUIRED ('lead'|'qualified'|'proposal'|'negotiation'|'won'|'lost')
+  router.post('/:workspaceId/entity/:entityId/promote-to-crm', async (req, res) => {
+    const role = await requireWorkspaceMember(req as any, res)
+    if (!role) return
+
+    const { workspaceId, entityId } = req.params as {
+      workspaceId: string
+      entityId: string
+    }
+    const userId = (req as { userId?: string }).userId
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' })
+      return
+    }
+    const body = (req.body ?? {}) as {
+      kind?: unknown
+      name?: unknown
+      tags?: unknown
+      domain?: unknown
+      email?: unknown
+      phone?: unknown
+      companyId?: unknown
+      stage?: unknown
+      amount?: unknown
+      closeDate?: unknown
+      contactId?: unknown
+      reason?: unknown
+    }
+    if (
+      body.kind !== 'person'
+      && body.kind !== 'company'
+      && body.kind !== 'deal'
+    ) {
+      res.status(400).json({
+        error: "kind must be one of: 'person', 'company', 'deal'",
+      })
+      return
+    }
+    const params: PromoteEntityToCrmParams = { kind: body.kind }
+    if (typeof body.name === 'string' && body.name.trim().length > 0) {
+      params.name = body.name.trim().slice(0, 200)
+    }
+    if (Array.isArray(body.tags)) {
+      params.tags = body.tags.filter((t): t is string => typeof t === 'string').slice(0, 20)
+    }
+    if (body.kind === 'company') {
+      if (typeof body.domain === 'string' && body.domain.trim().length > 0) {
+        params.domain = body.domain.trim()
+      }
+    } else if (body.kind === 'person') {
+      if (typeof body.email === 'string' && body.email.trim().length > 0) {
+        params.email = body.email.trim()
+      }
+      if (typeof body.phone === 'string' && body.phone.trim().length > 0) {
+        params.phone = body.phone.trim()
+      }
+      if (typeof body.companyId === 'string' && body.companyId.trim().length > 0) {
+        params.companyId = body.companyId.trim()
+      }
+    } else {
+      // deal — stage is required, validated against the enum.
+      const allowedStages = ['lead', 'qualified', 'proposal', 'negotiation', 'won', 'lost'] as const
+      type Stage = (typeof allowedStages)[number]
+      if (!allowedStages.includes(body.stage as Stage)) {
+        res.status(400).json({
+          error: `stage is required and must be one of: ${allowedStages.join(', ')}`,
+        })
+        return
+      }
+      params.stage = body.stage as Stage
+      if (typeof body.amount === 'number' && Number.isFinite(body.amount)) {
+        params.amount = body.amount
+      }
+      if (typeof body.closeDate === 'string') {
+        const d = new Date(body.closeDate)
+        if (!isNaN(d.getTime())) params.closeDate = d
+      }
+      if (typeof body.contactId === 'string' && body.contactId.trim().length > 0) {
+        params.contactId = body.contactId.trim()
+      }
+      if (typeof body.companyId === 'string' && body.companyId.trim().length > 0) {
+        params.companyId = body.companyId.trim()
+      }
+    }
+
+    try {
+      const before = await query<{ workspaceId: string; kind: string }>(
+        `SELECT workspace_id AS "workspaceId", kind
+           FROM entities
+          WHERE id = $1 AND valid_to IS NULL`,
+        [entityId],
+      )
+      if (before.rows.length === 0) {
+        res.status(404).json({ error: 'Entity not found' })
+        return
+      }
+      if (before.rows[0].workspaceId !== workspaceId) {
+        res.status(403).json({ error: 'Entity belongs to a different workspace' })
+        return
+      }
+
+      const result = await promoteEntityToCrm(userId, entityId, params)
+      await appendBrainVerification({
+        targetKind: 'entity',
+        targetId: entityId,
+        workspaceId,
+        verifiedByUserId: userId,
+        action: 'promote_to_crm',
+        modelValue: { kind: before.rows[0].kind },
+        userValue: { kind: params.kind, specializationId: result.specializationId },
+        reason: typeof body.reason === 'string' ? body.reason.slice(0, 500) : undefined,
+      })
+      // Realtime repaint: the new CRM companion row (a 'create') plus the
+      // entity itself whose kind just flipped (an 'update'). `params.kind`
+      // 'person' maps to the 'contact' inbox primitive.
+      const crmPrimitive = params.kind === 'person' ? 'contact' : params.kind
+      void notifyBrainInboxChange(workspaceId, crmPrimitive, result.specializationId, 'create')
+      void notifyBrainInboxChange(workspaceId, 'entity', entityId, 'update')
+      res.json({
+        ok: true,
+        kind: result.entity.kind,
+        entityId: result.entity.id,
+        specializationId: result.specializationId,
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.error('[brain-inbox] entity promote-to-crm failed:', message)
+      // Map known-message errors from the helper to 4xx so the UI can
+      // surface them cleanly.
+      if (
+        message.includes('already CRM-specialized')
+        || message.includes('requires a stage')
+        || message.includes('Cannot promote')
+      ) {
+        res.status(400).json({ error: message })
+      } else if (message === 'Entity not found or not live.') {
+        res.status(404).json({ error: message })
+      } else {
+        res.status(500).json({ error: 'Failed to promote entity', detail: message })
+      }
+    }
+  })
+
+  // ── DELETE /:workspaceId/:primitive/:rowId ──────────────────────
+  //
+  // Soft delete — sets valid_to = now() on the active version.
+  // Records the action in brain_verifications (or memory_verifications
+  // for memory).
+
+  router.delete('/:workspaceId/:primitive/:rowId', async (req, res) => {
+    const role = await requireWorkspaceMember(req as any, res)
+    if (!role) return
+
+    const { workspaceId, primitive: primitiveParam, rowId } = req.params as {
+      workspaceId: string
+      primitive: string
+      rowId: string
+    }
+    if (!isValidPrimitive(primitiveParam)) {
+      res.status(400).json({ error: `Unknown primitive '${primitiveParam}'` })
+      return
+    }
+    const userId = (req as any).userId as string
+
+    try {
+      // Validate ownership.
+      const ownership = await query<{ workspace_id: string }>(
+        `SELECT workspace_id FROM ${primitiveToTable(primitiveParam)}
+         WHERE id = $1 AND valid_to IS NULL`,
+        [rowId],
+      )
+      if (ownership.rows.length === 0) {
+        res.status(404).json({ error: 'Row not found' })
+        return
+      }
+      if (ownership.rows[0].workspace_id !== workspaceId) {
+        res.status(403).json({ error: 'Row belongs to a different workspace' })
+        return
+      }
+
+      // Soft delete.
+      await query(
+        `UPDATE ${primitiveToTable(primitiveParam)}
+            SET valid_to = now(), updated_at = now()
+          WHERE id = $1 AND valid_to IS NULL`,
+        [rowId],
+      )
+
+      // Audit. For memory ride memory_verifications.action='delete'; for
+      // others use brain_verifications.action='delete'.
+      if (primitiveParam === 'memory') {
+        await query(
+          `INSERT INTO memory_verifications (memory_id, workspace_id, verified_by, action)
+           VALUES ($1, $2, $3, 'delete')`,
+          [rowId, workspaceId, userId],
+        )
+      } else {
+        await appendBrainVerification({
+          targetKind: primitiveParam,
+          targetId: rowId,
+          workspaceId,
+          verifiedByUserId: userId,
+          action: 'delete',
+        })
+      }
+
+      // Realtime repaint so the deleted row drops off open /brain pages.
+      void notifyBrainInboxChange(workspaceId, primitiveParam, rowId, 'delete')
+
+      res.json({ ok: true })
+    } catch (err) {
+      console.error('[brain-inbox] delete failed:', err)
+      res.status(500).json({ error: 'Failed to delete row' })
+    }
+  })
+
+  // ── GET /:workspaceId/:primitive/:rowId/explain ─────────────────
+  //
+  // Returns the actual source-session context that motivated the save:
+  //   - The saving assistant's id + name
+  //   - Source-session id (link target for the frontend)
+  //   - Up to 6 surrounding session_messages (3 before, 3 after the
+  //     save's created_at) — these are what the user reads to verify
+  //     "is this an accurate read of what I said?"
+  //
+  // No LLM call. Cheap. The "Ask about this" drawer is where the
+  // model-mediated deliberation happens.
+
+  router.get('/:workspaceId/:primitive/:rowId/explain', async (req, res) => {
+    const role = await requireWorkspaceMember(req as any, res)
+    if (!role) return
+
+    const { workspaceId, primitive: primitiveParam, rowId } = req.params as {
+      workspaceId: string
+      primitive: string
+      rowId: string
+    }
+    if (!isValidPrimitive(primitiveParam)) {
+      res.status(400).json({ error: `Unknown primitive '${primitiveParam}'` })
+      return
+    }
+
+    try {
+      // Pull the universal-column fields we need. Every brain primitive
+      // carries created_by_assistant_id + source_episode_id; only some
+      // carry source_session_id (memory has it directly). We use the
+      // memory column when present; for other primitives we walk the
+      // source_episode_id to recover the originating session if any.
+      const targetTable = primitiveToTable(primitiveParam)
+      const sourceSessionCol = primitiveParam === 'memory' ? 'source_session_id' : 'NULL'
+      const meta = await query<{
+        workspace_id: string
+        created_at: Date
+        created_by_assistant_id: string | null
+        source_episode_id: string | null
+        source_session_id: string | null
+      }>(
+        `SELECT workspace_id, created_at, created_by_assistant_id,
+                source_episode_id, ${sourceSessionCol} AS source_session_id
+         FROM ${targetTable}
+         WHERE id = $1`,
+        [rowId],
+      )
+      if (meta.rows.length === 0) {
+        res.status(404).json({ error: 'Row not found' })
+        return
+      }
+      const row = meta.rows[0]
+      if (row.workspace_id !== workspaceId) {
+        res.status(403).json({ error: 'Row belongs to a different workspace' })
+        return
+      }
+
+      // Resolve the saving assistant's name.
+      let assistantName: string | null = null
+      if (row.created_by_assistant_id) {
+        const a = await query<{ name: string }>(
+          `SELECT name FROM assistants WHERE id = $1`,
+          [row.created_by_assistant_id],
+        )
+        assistantName = a.rows[0]?.name ?? null
+      }
+
+      // Resolve the source session if any. For non-memory primitives,
+      // attempt to walk episodes.content_ref for a 'web_chat' session
+      // pointer — if found, use it. Otherwise the explain response has
+      // no session messages, just the row metadata.
+      let sourceSessionId = row.source_session_id
+      if (!sourceSessionId && row.source_episode_id) {
+        const ep = await query<{ content_ref: { source_kind?: string; session_id?: string } }>(
+          `SELECT content_ref FROM episodes WHERE id = $1`,
+          [row.source_episode_id],
+        )
+        const ref = ep.rows[0]?.content_ref
+        if (ref?.source_kind === 'web_chat' && typeof ref.session_id === 'string') {
+          sourceSessionId = ref.session_id
+        }
+      }
+
+      // Pull up to 3 messages before + 3 after the row's created_at,
+      // ordered by created_at ASC for chronological reading.
+      let messages: Array<{
+        id: string
+        role: string
+        content: unknown
+        createdAt: Date
+      }> = []
+      if (sourceSessionId) {
+        const msgs = await query<{
+          id: string
+          role: string
+          content: unknown
+          createdAt: Date
+          rn: number
+        }>(
+          `WITH ordered AS (
+             SELECT id, role, content, created_at AS "createdAt",
+                    row_number() OVER (ORDER BY created_at ASC) AS rn,
+                    abs(extract(epoch FROM (created_at - $2))) AS dist
+             FROM session_messages
+             WHERE session_id = $1
+           ),
+           pivot AS (
+             SELECT rn FROM ordered ORDER BY dist ASC LIMIT 1
+           )
+           SELECT o.id, o.role, o.content, o."createdAt", o.rn
+           FROM ordered o, pivot p
+           WHERE o.rn BETWEEN GREATEST(p.rn - 3, 1) AND p.rn + 3
+           ORDER BY o."createdAt" ASC`,
+          [sourceSessionId, row.created_at],
+        )
+        messages = msgs.rows.map((m) => ({
+          id: m.id,
+          role: m.role,
+          content: m.content,
+          createdAt: m.createdAt,
+        }))
+      }
+
+      res.json({
+        savedAt: row.created_at,
+        savedByAssistantId: row.created_by_assistant_id,
+        savedByAssistantName: assistantName,
+        sourceSessionId,
+        sourceEpisodeId: row.source_episode_id,
+        messages,
+      })
+    } catch (err) {
+      console.error('[brain-inbox] explain failed:', err)
+      res.status(500).json({ error: 'Failed to load explain context' })
+    }
+  })
+
+  // ── POST /:workspaceId/:primitive/:rowId/inspection-session ─────
+  //
+  // Creates a transient session bound to the workspace's primary
+  // assistant (fallback: most-recent assistant). The frontend opens
+  // the drawer and routes user messages through the normal /api/chat
+  // endpoint targeted at this session. The system-prompt seeding +
+  // restricted tool registry happen on the chat-route side, gated on
+  // sessions.transient = TRUE.
+
+  router.post(
+    '/:workspaceId/:primitive/:rowId/inspection-session',
+    async (req, res) => {
+      const role = await requireWorkspaceMember(req as any, res)
+      if (!role) return
+
+      const { workspaceId, primitive: primitiveParam, rowId } = req.params as {
+        workspaceId: string
+        primitive: string
+        rowId: string
+      }
+      if (!isValidPrimitive(primitiveParam)) {
+        res.status(400).json({ error: `Unknown primitive '${primitiveParam}'` })
+        return
+      }
+      const userId = (req as any).userId as string
+
+      try {
+        // Validate ownership.
+        const ownership = await query<{ workspace_id: string }>(
+          `SELECT workspace_id FROM ${primitiveToTable(primitiveParam)}
+           WHERE id = $1`,
+          [rowId],
+        )
+        if (
+          ownership.rows.length === 0 ||
+          ownership.rows[0].workspace_id !== workspaceId
+        ) {
+          res.status(404).json({ error: 'Row not found' })
+          return
+        }
+
+        // Resolve the primary assistant for this workspace. Fallback to
+        // the most-recently-created assistant if no kind='primary'
+        // exists. Workspaces with only kind='app' distribution
+        // assistants have no inspectable assistant — return 422.
+        const primary = await query<{ id: string; kind: string; name: string }>(
+          `SELECT id, kind, name FROM assistants
+            WHERE workspace_id = $1
+              AND kind != 'app'
+            ORDER BY (kind = 'primary') DESC, created_at DESC
+            LIMIT 1`,
+          [workspaceId],
+        )
+        if (primary.rows.length === 0) {
+          res.status(422).json({
+            error:
+              'This workspace has no inspectable assistant. Ask features are only available where the workspace has a primary or standard assistant.',
+          })
+          return
+        }
+
+        const session = await createInspectionSession({
+          primaryAssistantId: primary.rows[0].id,
+          userId,
+        })
+
+        res.json({
+          sessionId: session.id,
+          assistantId: session.assistantId,
+          assistantName: primary.rows[0].name,
+          // Inspection context the frontend includes in its first
+          // outbound /api/chat message so the model has the memory in
+          // hand. We pass these here so the frontend doesn't need a
+          // round-trip to load them separately.
+          inspectionContext: {
+            primitive: primitiveParam,
+            rowId,
+          },
+        })
+      } catch (err) {
+        console.error('[brain-inbox] inspection-session failed:', err)
+        res.status(500).json({ error: 'Failed to create inspection session' })
+      }
+    },
+  )
+
+  return router
+}


### PR DESCRIPTION
## Why
On the OSS open build, the brain detail drawer's `GET /api/brain-inbox/:ws/:primitive/:rowId` returned a bare `Cannot GET` 404: the brain-inbox router had drifted into the closed `api-platform` package and `bootOpenApi` never mounted it (the list kept working because it is served by `/api/brain/list`). Files were also un-previewable and un-editable in the drawer.

## What
- **fix:** move the brain-inbox route into the open `@sidanclaw/api` package and mount it once in `bootOpenApi` (open + hosted share it). Deps were all open already.
- **feat (backend):** `GET /:ws/workspace_file/:rowId/content` streams a file's bytes via the optional `filesApi` dep (501 when no blob client); `/adjust` gains a `workspace_file` branch (sensitivity + tags) that stamps verified + audits.
- **feat (frontend):** drawer previews files (image/text/download) and edits sensitivity + tags; SDK + en/ja/zh strings.

## Test
- `pnpm --filter @sidanclaw/api typecheck` and `pnpm --filter app-web typecheck` pass.
- New `packages/api/src/routes/__tests__/brain-inbox.test.ts` (route mount, 404, 400/403, file 501/validation). Could not run vitest in CI sandbox (rollup native dep) — run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)