### PR TITLE
feat(brain-mcp): read/edit/delete doc pages via MCP tools

### DIFF
--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -1637,6 +1637,11 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     crmTools,
     retrievalTools: brainRetrievalTools,
     fileTools: brainFileTools ?? undefined,
+    // Doc-page tools (readPage / editPage / deletePage) reuse the same RLS-gated
+    // saved-views + doc-page stores the chat doc tools use, so a brain-key page
+    // op runs the identical SQL (CAS + undo for edits, cascade delete) as an
+    // in-app edit. See packages/api/src/brain-mcp/tools.ts → buildDocPageTools.
+    docTools: { savedViewStore, docPageStore: createDbDocPageStore() },
     ingest: brainEpisodeIngestor,
     agentTools: { reads: agentToolset.reads, writes: agentToolset.writes },
   }))

--- a/packages/api/src/brain-mcp/__tests__/brain-mcp.test.ts
+++ b/packages/api/src/brain-mcp/__tests__/brain-mcp.test.ts
@@ -779,7 +779,7 @@ describe('[COMP:api/brain-mcp] primary-assistant authority (agent-facing capabil
   })
 })
 
-describe('[COMP:api/brain-mcp-page-tools] doc-page tools (readPage / editPage / deletePage)', () => {
+describe('[COMP:api/brain-mcp-page-tools] doc-page tools (readPage / editPage / deletePage / createPage)', () => {
   // A minimal page row the doc-page store stub returns. One heading block is
   // enough for the Markdown export + the delete/edit access-confirm read.
   const SAMPLE_PAGE = {
@@ -815,11 +815,13 @@ describe('[COMP:api/brain-mcp-page-tools] doc-page tools (readPage / editPage / 
     list: (...args: unknown[]) => Promise<ReturnType<typeof listRow>[]>
     applyPatch: (...args: unknown[]) => Promise<{ newVersion: number } | null>
     remove: (...args: unknown[]) => Promise<boolean>
+    createDraft: (...args: unknown[]) => Promise<{ id: string }>
   }> = {}): BrainDocTools {
     return {
       savedViewStore: {
         list: vi.fn(overrides.list ?? (async () => [listRow('Worker Maintenance Log', 'p1')])),
         remove: vi.fn(overrides.remove ?? (async () => true)),
+        createDraft: vi.fn(overrides.createDraft ?? (async () => ({ id: 'new-page-1' }))),
       } as unknown as BrainDocTools['savedViewStore'],
       docPageStore: {
         getVersionedPage: vi.fn(overrides.getVersionedPage ?? (async () => SAMPLE_PAGE)),
@@ -835,26 +837,45 @@ describe('[COMP:api/brain-mcp-page-tools] doc-page tools (readPage / editPage / 
     ...ALL_STUBS,
   } as const
 
-  it('readPage is exposed on a read key; editPage/deletePage are NOT', () => {
+  it('readPage is exposed on a read key; editPage/deletePage/createPage are NOT', () => {
     const tools = buildBrainTools({ ...BASE, scope: 'read', docTools: docToolsStub() })
     const names = tools.map((t) => t.name)
     expect(names).toContain('readPage')
     expect(names).not.toContain('editPage')
     expect(names).not.toContain('deletePage')
+    expect(names).not.toContain('createPage')
   })
 
-  it('editPage and deletePage appear only on a read_write key', () => {
+  it('editPage, deletePage and createPage appear only on a read_write key', () => {
     const tools = buildBrainTools({ ...BASE, scope: 'read_write', docTools: docToolsStub() })
     const names = tools.map((t) => t.name)
     expect(names).toContain('readPage')
     expect(names).toContain('editPage')
     expect(names).toContain('deletePage')
+    expect(names).toContain('createPage')
   })
 
   it('omits the whole page surface when no docTools are wired', () => {
     const tools = buildBrainTools({ ...BASE, scope: 'read_write' })
     const names = tools.map((t) => t.name)
-    for (const n of ['readPage', 'editPage', 'deletePage']) expect(names).not.toContain(n)
+    for (const n of ['readPage', 'editPage', 'deletePage', 'createPage']) expect(names).not.toContain(n)
+  })
+
+  it('createPage mints a new page via createDraft and returns its id', async () => {
+    const docTools = docToolsStub()
+    const tools = buildBrainTools({ ...BASE, scope: 'read_write', docTools })
+    const createPage = tools.find((t) => t.name === 'createPage')!
+    const result = await createPage.handler({ title: 'Launch checklist', content: '## Step 1\nShip it.' })
+    expect(result.isError).toBeFalsy()
+    expect(textBody(result)).toContain('new-page-1')
+    expect(docTools.savedViewStore.createDraft).toHaveBeenCalledTimes(1)
+  })
+
+  it('createPage rejects an empty title', async () => {
+    const tools = buildBrainTools({ ...BASE, scope: 'read_write', docTools: docToolsStub() })
+    const createPage = tools.find((t) => t.name === 'createPage')!
+    const result = await createPage.handler({ title: '   ' })
+    expect(result.isError).toBe(true)
   })
 
   it('readPage by id returns the page as Markdown', async () => {

--- a/packages/api/src/brain-mcp/__tests__/brain-mcp.test.ts
+++ b/packages/api/src/brain-mcp/__tests__/brain-mcp.test.ts
@@ -18,6 +18,7 @@ import {
   buildBrainTools,
   effectiveBrainClearance,
   type BrainCrmTools,
+  type BrainDocTools,
   type BrainFileTools,
   type BrainMemoryTools,
   type BrainRetrievalTools,
@@ -775,5 +776,180 @@ describe('[COMP:api/brain-mcp] primary-assistant authority (agent-facing capabil
     expect(capturedCtx!.clearance).toBe('public')
     expect(capturedCtx!.assistantClearance).toBe('public')
     expect(capturedCtx!.sensitivity?.max).toBe('public')
+  })
+})
+
+describe('[COMP:api/brain-mcp-page-tools] doc-page tools (readPage / editPage / deletePage)', () => {
+  // A minimal page row the doc-page store stub returns. One heading block is
+  // enough for the Markdown export + the delete/edit access-confirm read.
+  const SAMPLE_PAGE = {
+    page: { blocks: [{ kind: 'heading', id: 'b1', level: 1, text: 'Hello' }] },
+    version: 3,
+    title: 'Worker Maintenance Log',
+    nameOrigin: 'user' as const,
+    icon: null,
+  }
+
+  function listRow(name: string, id: string) {
+    return {
+      id,
+      workspaceId: 'ws',
+      name,
+      nameOrigin: 'user' as const,
+      description: null,
+      icon: null,
+      entity: 'tasks' as const,
+      viewType: 'table' as const,
+      state: 'saved' as const,
+      nestParentId: null,
+      position: 0,
+      updatedAt: new Date('2026-01-01T00:00:00Z'),
+    }
+  }
+
+  /** A spyable BrainDocTools stub. The spies let each test assert the right
+   *  store path ran (read → getVersionedPage, edit → applyPatch, delete →
+   *  remove) without a real database. */
+  function docToolsStub(overrides: Partial<{
+    getVersionedPage: (userId: string, pageId: string) => Promise<typeof SAMPLE_PAGE | null>
+    list: (...args: unknown[]) => Promise<ReturnType<typeof listRow>[]>
+    applyPatch: (...args: unknown[]) => Promise<{ newVersion: number } | null>
+    remove: (...args: unknown[]) => Promise<boolean>
+  }> = {}): BrainDocTools {
+    return {
+      savedViewStore: {
+        list: vi.fn(overrides.list ?? (async () => [listRow('Worker Maintenance Log', 'p1')])),
+        remove: vi.fn(overrides.remove ?? (async () => true)),
+      } as unknown as BrainDocTools['savedViewStore'],
+      docPageStore: {
+        getVersionedPage: vi.fn(overrides.getVersionedPage ?? (async () => SAMPLE_PAGE)),
+        applyPatch: vi.fn(overrides.applyPatch ?? (async () => ({ newVersion: 4 }))),
+      } as unknown as BrainDocTools['docPageStore'],
+    }
+  }
+
+  const BASE = {
+    workspaceId: '33333333-3333-3333-3333-333333333333',
+    keyId: '982d4a41-c568-4a5d-8614-833c7594bc1a',
+    maxClearance: null,
+    ...ALL_STUBS,
+  } as const
+
+  it('readPage is exposed on a read key; editPage/deletePage are NOT', () => {
+    const tools = buildBrainTools({ ...BASE, scope: 'read', docTools: docToolsStub() })
+    const names = tools.map((t) => t.name)
+    expect(names).toContain('readPage')
+    expect(names).not.toContain('editPage')
+    expect(names).not.toContain('deletePage')
+  })
+
+  it('editPage and deletePage appear only on a read_write key', () => {
+    const tools = buildBrainTools({ ...BASE, scope: 'read_write', docTools: docToolsStub() })
+    const names = tools.map((t) => t.name)
+    expect(names).toContain('readPage')
+    expect(names).toContain('editPage')
+    expect(names).toContain('deletePage')
+  })
+
+  it('omits the whole page surface when no docTools are wired', () => {
+    const tools = buildBrainTools({ ...BASE, scope: 'read_write' })
+    const names = tools.map((t) => t.name)
+    for (const n of ['readPage', 'editPage', 'deletePage']) expect(names).not.toContain(n)
+  })
+
+  it('readPage by id returns the page as Markdown', async () => {
+    const docTools = docToolsStub()
+    const tools = buildBrainTools({ ...BASE, scope: 'read', docTools })
+    const readPage = tools.find((t) => t.name === 'readPage')!
+    const result = await readPage.handler({ pageId: 'p1' })
+    expect(result.isError).toBeFalsy()
+    const body = textBody(result)
+    // pageToMarkdown renders the title as an H1 + the heading block.
+    expect(body).toContain('Worker Maintenance Log')
+    expect(body).toContain('Hello')
+    expect(docTools.docPageStore.getVersionedPage).toHaveBeenCalledWith(
+      '11111111-1111-1111-1111-111111111111', // resolved owner userId (mocked query)
+      'p1',
+    )
+  })
+
+  it('readPage by title returns content for a single match', async () => {
+    const docTools = docToolsStub()
+    const tools = buildBrainTools({ ...BASE, scope: 'read', docTools })
+    const readPage = tools.find((t) => t.name === 'readPage')!
+    const result = await readPage.handler({ title: 'Worker Maintenance' })
+    expect(result.isError).toBeFalsy()
+    expect(textBody(result)).toContain('Hello')
+  })
+
+  it('readPage by title lists matches (no content) when several pages match', async () => {
+    const docTools = docToolsStub({
+      list: async () => [listRow('Report A', 'pa'), listRow('Report B', 'pb')],
+    })
+    const tools = buildBrainTools({ ...BASE, scope: 'read', docTools })
+    const readPage = tools.find((t) => t.name === 'readPage')!
+    const result = await readPage.handler({ title: 'Report' })
+    const body = textBody(result)
+    expect(body).toContain('pa')
+    expect(body).toContain('pb')
+    // No content fetch on an ambiguous search.
+    expect(docTools.docPageStore.getVersionedPage).not.toHaveBeenCalled()
+  })
+
+  it('editPage append confirms access then applies a CAS patch', async () => {
+    const docTools = docToolsStub()
+    const tools = buildBrainTools({ ...BASE, scope: 'read_write', docTools })
+    const editPage = tools.find((t) => t.name === 'editPage')!
+    const result = await editPage.handler({ pageId: 'p1', content: 'New paragraph.' })
+    expect(result.isError).toBeFalsy()
+    expect(docTools.docPageStore.getVersionedPage).toHaveBeenCalled()
+    expect(docTools.docPageStore.applyPatch).toHaveBeenCalledTimes(1)
+    const call = (docTools.docPageStore.applyPatch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    // CAS uses the read version as the expected base; undo entry captured.
+    expect(call.expectedVersion).toBe(3)
+    expect(call.pageId).toBe('p1')
+    expect(call.undo).toBeDefined()
+    expect(textBody(result)).toMatch(/version 4/i)
+  })
+
+  it('editPage surfaces a concurrent-edit conflict when applyPatch returns null', async () => {
+    const docTools = docToolsStub({ applyPatch: async () => null })
+    const tools = buildBrainTools({ ...BASE, scope: 'read_write', docTools })
+    const editPage = tools.find((t) => t.name === 'editPage')!
+    const result = await editPage.handler({ pageId: 'p1', content: 'x' })
+    expect(result.isError).toBe(true)
+    expect(textBody(result)).toMatch(/concurrent/i)
+  })
+
+  it('editPage refuses a page the key cannot access (null read)', async () => {
+    const docTools = docToolsStub({ getVersionedPage: async () => null })
+    const tools = buildBrainTools({ ...BASE, scope: 'read_write', docTools })
+    const editPage = tools.find((t) => t.name === 'editPage')!
+    const result = await editPage.handler({ pageId: 'nope', content: 'x' })
+    expect(result.isError).toBe(true)
+    // Access not confirmed → never reaches applyPatch.
+    expect(docTools.docPageStore.applyPatch).not.toHaveBeenCalled()
+  })
+
+  it('deletePage confirms access then calls the RLS-scoped remove', async () => {
+    const docTools = docToolsStub()
+    const tools = buildBrainTools({ ...BASE, scope: 'read_write', docTools })
+    const deletePage = tools.find((t) => t.name === 'deletePage')!
+    const result = await deletePage.handler({ pageId: 'p1' })
+    expect(result.isError).toBeFalsy()
+    expect(docTools.docPageStore.getVersionedPage).toHaveBeenCalled()
+    expect(docTools.savedViewStore.remove).toHaveBeenCalledWith(
+      '11111111-1111-1111-1111-111111111111',
+      'p1',
+    )
+  })
+
+  it('deletePage refuses (and never removes) a page the key cannot access', async () => {
+    const docTools = docToolsStub({ getVersionedPage: async () => null })
+    const tools = buildBrainTools({ ...BASE, scope: 'read_write', docTools })
+    const deletePage = tools.find((t) => t.name === 'deletePage')!
+    const result = await deletePage.handler({ pageId: 'nope' })
+    expect(result.isError).toBe(true)
+    expect(docTools.savedViewStore.remove).not.toHaveBeenCalled()
   })
 })

--- a/packages/api/src/brain-mcp/server.ts
+++ b/packages/api/src/brain-mcp/server.ts
@@ -28,6 +28,7 @@ import {
   buildBrainTools,
   resolveAgentGate,
   type BrainCrmTools,
+  type BrainDocTools,
   type BrainFileTools,
   type BrainMemoryTools,
   type BrainRetrievalTools,
@@ -59,6 +60,13 @@ type Options = {
    * surface. `saveFileToBrain` (byte upload) is not part of this set.
    */
   fileTools?: BrainFileTools
+  /**
+   * Doc-page tools (`readPage` / `editPage` / `deletePage`). Optional — only
+   * deployments that build the doc stores pass it; a doc-less deploy omits the
+   * page surface. `readPage` rides both key scopes, `editPage` / `deletePage`
+   * require a `read_write` key. See `BrainDocTools`.
+   */
+  docTools?: BrainDocTools
   /**
    * Programmatic ingest entry to Pipeline B. When wired, the `ingestToBrain`
    * tool decomposes content into entities / edges / memories / tasks instead of
@@ -111,6 +119,7 @@ export function brainMcpRoutes(opts: Options): Router {
       crmTools: opts.crmTools,
       retrievalTools: opts.retrievalTools,
       fileTools: opts.fileTools,
+      docTools: opts.docTools,
       ingest: opts.ingest,
       agentTools: opts.agentTools,
       agentWritesEnabled,

--- a/packages/api/src/brain-mcp/tools.ts
+++ b/packages/api/src/brain-mcp/tools.ts
@@ -58,6 +58,8 @@ import {
   rankPagesByTitle,
 } from '@sidanclaw/core'
 import type {
+  BindingConfig,
+  Block,
   DocPageStore,
   Op,
   Page,
@@ -185,7 +187,7 @@ export type BrainFileTools = {
  *     confirm) + `applyPatch` (atomic version CAS + `last_undo` capture).
  */
 export type BrainDocTools = {
-  savedViewStore: Pick<SavedViewStore, 'list' | 'remove'>
+  savedViewStore: Pick<SavedViewStore, 'list' | 'remove' | 'createDraft'>
   docPageStore: Pick<DocPageStore, 'getVersionedPage' | 'applyPatch'>
 }
 
@@ -344,7 +346,7 @@ function buildDocPageTools(
   docTools: BrainDocTools,
   resolveCtx: () => Promise<ToolContext | { error: string }>,
   workspaceId: string,
-): { readPage: BrainTool; editPage: BrainTool; deletePage: BrainTool } {
+): { readPage: BrainTool; editPage: BrainTool; deletePage: BrainTool; createPage: BrainTool } {
   const { savedViewStore, docPageStore } = docTools
 
   const readPage: BrainTool = {
@@ -552,7 +554,77 @@ function buildDocPageTools(
     },
   }
 
-  return { readPage, editPage, deletePage }
+  // ── createPage ────────────────────────────────────────────────
+  //
+  // The only create path on this surface — `editPage` requires an existing
+  // `pageId` and refuses to mint one. Persists through the same
+  // `savedViewStore.createDraft` seam the chat `renderPage` tool uses (RLS
+  // keyed on the resolved principal), so a brain-key page is born identical
+  // to one authored in-app. Markdown body is parsed with the same
+  // `markdownToBlocks` + `normalizeMarkdownBlocks` expansion `editPage` runs.
+  const createPage: BrainTool = {
+    name: 'createPage',
+    description:
+      'Create a NEW workspace doc page from a `title` and optional Markdown ' +
+      '`content`. Returns the new `pageId` — use `editPage` to add more or ' +
+      '`readPage` to read it back. This is the only way to create a page; ' +
+      "`editPage` only edits existing pages. Scoped to the key's workspace.",
+    inputSchema: {
+      title: z
+        .string()
+        .min(1)
+        .max(200)
+        .describe('Title for the new page.'),
+      content: z
+        .string()
+        .max(MAX_EDIT_CHARS)
+        .optional()
+        .describe('Optional Markdown body. Omit to create an empty page.'),
+    },
+    async handler(args) {
+      const ctx = await resolveCtx()
+      if ('error' in ctx) return text(ctx.error, true)
+      const title = typeof args.title === 'string' ? args.title.trim() : ''
+      if (!title) return text('Provide a `title` for the new page.', true)
+      const content = typeof args.content === 'string' ? args.content : ''
+
+      // Build the initial block list from the Markdown body (same expansion
+      // the chat path + `editPage` apply). An empty body still needs one
+      // block so the page is well-formed.
+      const blocks: Block[] = content.trim()
+        ? normalizeMarkdownBlocks(markdownToBlocks(content))
+        : []
+      if (blocks.length === 0) {
+        blocks.push({ kind: 'text', id: randomUUID(), text: '' })
+      }
+
+      // Prose page: the legacy `entity` / `viewType` columns are placeholders
+      // (the block list is the authoritative content), mirroring `renderPage`'s
+      // non-data default binding.
+      const binding = { entity: 'tasks', viewType: 'table' } as BindingConfig
+      try {
+        const draft = await savedViewStore.createDraft({
+          userId: ctx.userId,
+          workspaceId,
+          name: title,
+          nameOrigin: 'user',
+          icon: null,
+          entity: 'tasks',
+          viewType: 'table',
+          binding,
+          page: { blocks },
+        })
+        return text(
+          `Created page "${title}" (pageId: ${draft.id}). Use editPage to add more, or readPage to read it back.`,
+        )
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        return text(`Failed to create the page: ${msg}`, true)
+      }
+    },
+  }
+
+  return { readPage, editPage, deletePage, createPage }
 }
 
 /**
@@ -865,7 +937,7 @@ export function buildBrainTools(opts: BuildOpts): BrainTool[] {
       t.name === 'fileSetMeta' || t.name === 'fileDelete' ||
       t.name === 'saveFileBytes' || t.name === 'saveFileToBrain',
     ),
-    ...(docPageTools ? [docPageTools.editPage, docPageTools.deletePage] : []),
+    ...(docPageTools ? [docPageTools.editPage, docPageTools.deletePage, docPageTools.createPage] : []),
     ...agentWriteBridges,
   ]
   return opts.scope === 'read'

--- a/packages/api/src/brain-mcp/tools.ts
+++ b/packages/api/src/brain-mcp/tools.ts
@@ -46,8 +46,27 @@
 import { randomUUID } from 'node:crypto'
 import { z } from 'zod'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
-import { SensitivityAccumulator, isSensitivity, minSensitivity } from '@sidanclaw/core'
-import type { PipelineBResult, Sensitivity, Tool, ToolContext } from '@sidanclaw/core'
+import {
+  SensitivityAccumulator,
+  isSensitivity,
+  minSensitivity,
+  applyOps,
+  buildUndoEntry,
+  markdownToBlocks,
+  normalizeMarkdownBlocks,
+  pageToMarkdown,
+  rankPagesByTitle,
+} from '@sidanclaw/core'
+import type {
+  DocPageStore,
+  Op,
+  Page,
+  PipelineBResult,
+  SavedViewStore,
+  Sensitivity,
+  Tool,
+  ToolContext,
+} from '@sidanclaw/core'
 import { query } from '../db/client.js'
 import type { BrainKeyScope } from '../db/brain-keys-store.js'
 import { toEpisodeSensitivity } from '../episode-sensitivity.js'
@@ -150,6 +169,34 @@ export type BrainFileTools = {
 }
 
 /**
+ * Doc-page stores for the brain MCP page surface (`readPage` / `editPage` /
+ * `deletePage`). Optional on `BuildOpts` — a deploy that doesn't build the doc
+ * stores omits the whole page surface rather than exposing tools with no
+ * backing store (mirrors `BrainFileTools`). Both stores are the SAME concrete
+ * singletons the chat-side doc tools use (`createDbSavedViewStore` /
+ * `createDbDocPageStore`), so a brain-key page read/edit/delete runs through
+ * the identical RLS-gated SQL — `queryWithRLS(userId, …)` keyed on the
+ * resolved (owner, primary-assistant) principal — and `editPage` reuses the
+ * very CAS + undo-capture path the chat editor's `patchPage` uses.
+ *
+ *   - `savedViewStore` — `list` (title search) + `remove` (RLS delete; the
+ *     `saved_views` FK cascade drops nested child pages, per migration 210).
+ *   - `docPageStore`   — `getVersionedPage` (RLS read → markdown / access
+ *     confirm) + `applyPatch` (atomic version CAS + `last_undo` capture).
+ */
+export type BrainDocTools = {
+  savedViewStore: Pick<SavedViewStore, 'list' | 'remove'>
+  docPageStore: Pick<DocPageStore, 'getVersionedPage' | 'applyPatch'>
+}
+
+/** Cap on `readPage` title-search matches surfaced to the agent. */
+const READ_PAGE_MAX_MATCHES = 10
+/** Cap on a page's Markdown body so one huge page can't blow the MCP reply. */
+const READ_PAGE_MARKDOWN_CAP = 16_000
+/** Cap on `editPage` content so a single edit can't balloon the page row. */
+const MAX_EDIT_CHARS = 32_000
+
+/**
  * The historical fixed clearance ceiling for a programmatic credential.
  * Since migration 262 the brain MCP binds to the workspace's PRIMARY
  * assistant and reads at `effectiveBrainClearance(primary.clearance,
@@ -222,6 +269,13 @@ type BuildOpts = {
    * `apps/api/src/index.ts` via `createBrainEpisodeIngestor`.
    */
   ingest?: BrainEpisodeIngestor
+  /**
+   * Doc-page stores for the `readPage` / `editPage` / `deletePage` surface.
+   * Optional — a deploy that omits it exposes no page tools (mirrors
+   * `fileTools`). `readPage` rides both key scopes; `editPage` / `deletePage`
+   * are write tools (`read_write` keys only). See `BrainDocTools`.
+   */
+  docTools?: BrainDocTools
 }
 
 /**
@@ -248,6 +302,8 @@ const READ_TOOL_NAMES = new Set<string>([
   // Workspace files (read) — present only when fileTools are wired
   'fileRead',
   'fileSearch',
+  // Doc pages (read) — present only when docTools are wired
+  'readPage',
 ])
 
 function text(body: string, isError = false): CallToolResult {
@@ -255,6 +311,248 @@ function text(body: string, isError = false): CallToolResult {
     content: [{ type: 'text', text: body }],
     ...(isError ? { isError: true } : {}),
   }
+}
+
+/** Truncate a page's Markdown export so one large page can't blow the reply. */
+function capPageMarkdown(md: string): string {
+  if (md.length <= READ_PAGE_MARKDOWN_CAP) return md
+  return `${md.slice(0, READ_PAGE_MARKDOWN_CAP)}\n\n…[truncated — read a smaller page or narrow the request]`
+}
+
+/**
+ * Build the doc-page tools (`readPage` / `editPage` / `deletePage`). All three
+ * resolve the per-request principal via `resolveCtx` and pass its `userId`
+ * straight into the RLS-gated stores, so a brain-key page op is confined to the
+ * key's workspace + the bound primary assistant's clearance exactly like every
+ * other bridged tool. `readPage` is a read tool (both scopes); `editPage` /
+ * `deletePage` are writes (filtered to `read_write` keys by `buildBrainTools`).
+ *
+ * Reuse, not reinvention:
+ *   - `readPage`   → `rankPagesByTitle` (the `findPage` matcher) + `pageToMarkdown`
+ *                    (the `exportPage` / `findPage` page-to-Markdown path).
+ *   - `editPage`   → builds an `Op[]` and runs it through `applyOps` +
+ *                    `docPageStore.applyPatch` — the same validated CAS +
+ *                    `last_undo` capture the chat editor's `patchPage` uses.
+ *   - `deletePage` → confirms RLS-scoped access via `getVersionedPage`, then
+ *                    `savedViewStore.remove` (RLS `DELETE`; the `saved_views`
+ *                    FK cascade drops nested child pages per migration 210).
+ *
+ * Spec pointer (file is OSS, not present in this repo):
+ * docs/architecture/integrations/mcp.md → brain MCP page tools.
+ */
+function buildDocPageTools(
+  docTools: BrainDocTools,
+  resolveCtx: () => Promise<ToolContext | { error: string }>,
+  workspaceId: string,
+): { readPage: BrainTool; editPage: BrainTool; deletePage: BrainTool } {
+  const { savedViewStore, docPageStore } = docTools
+
+  const readPage: BrainTool = {
+    name: 'readPage',
+    description:
+      'Read a workspace doc page as Markdown. Pass `pageId` to read a specific ' +
+      'page, or `title` to find one by name (case-insensitive, ranked by ' +
+      'closeness). When several pages match a `title`, the call returns the ' +
+      'ranked list (each `{ pageId, title }`) WITHOUT content — pick one and ' +
+      're-call with its `pageId`. When exactly one matches, its Markdown body ' +
+      "is returned directly. Scoped to the key's workspace and clearance — a " +
+      'page you cannot access reads as not-found.',
+    inputSchema: {
+      pageId: z
+        .string()
+        .min(1)
+        .max(128)
+        .optional()
+        .describe('Read one specific page by id (e.g. a `pageId` from a prior search).'),
+      title: z
+        .string()
+        .min(1)
+        .max(256)
+        .optional()
+        .describe('Find a page by title (or partial title). Omit when reading by `pageId`.'),
+    },
+    async handler(args) {
+      const ctx = await resolveCtx()
+      if ('error' in ctx) return text(ctx.error, true)
+      const pageId = typeof args.pageId === 'string' ? args.pageId.trim() : ''
+      const title = typeof args.title === 'string' ? args.title.trim() : ''
+      if (!pageId && !title) {
+        return text('Pass `pageId` to read a page, or `title` to search by name.', true)
+      }
+
+      // Read-by-id: RLS hides cross-workspace rows, so a null read is both
+      // "not found" and "no access" — never leak which.
+      if (pageId) {
+        const current = await docPageStore.getVersionedPage(ctx.userId, pageId)
+        if (!current) {
+          return text(`Page not found: ${pageId}. It may not exist or you may not have access.`, true)
+        }
+        return text(capPageMarkdown(pageToMarkdown(current.page, current.title)))
+      }
+
+      // Search-by-title: RLS-scoped list, then the shared title ranker.
+      const rows = await savedViewStore.list({ userId: ctx.userId, workspaceId, state: 'all' })
+      const matches = rankPagesByTitle(rows, title, READ_PAGE_MAX_MATCHES)
+      if (matches.length === 0) {
+        return text(`No page matches "${title}". It may not exist or you may not have access.`)
+      }
+      if (matches.length === 1) {
+        const current = await docPageStore.getVersionedPage(ctx.userId, matches[0].id)
+        if (!current) {
+          return text(`Page not found: ${matches[0].id}. It may not exist or you may not have access.`, true)
+        }
+        return text(capPageMarkdown(pageToMarkdown(current.page, current.title)))
+      }
+      const list = matches
+        .map((m) => `- ${m.name} (pageId: ${m.id})`)
+        .join('\n')
+      return text(
+        `${matches.length} pages match "${title}". Re-call readPage with the right pageId:\n${list}`,
+      )
+    },
+  }
+
+  const editPage: BrainTool = {
+    name: 'editPage',
+    description:
+      'Edit an existing workspace doc page. Two modes: `mode: "append"` adds ' +
+      'your Markdown `content` to the END of the page, `mode: "replace"` ' +
+      'replaces the entire page body with `content` (the title is kept). ' +
+      'Content is parsed as Markdown into the page block format. The edit goes ' +
+      'through the same validated, version-checked path the in-app editor uses ' +
+      '(atomic compare-and-swap with single-step undo capture), so a concurrent ' +
+      'edit is detected and reported rather than silently clobbered. Scoped to ' +
+      "the key's workspace and clearance.",
+    inputSchema: {
+      pageId: z.string().min(1).max(128).describe('The id of the page to edit.'),
+      content: z
+        .string()
+        .min(1)
+        .max(MAX_EDIT_CHARS)
+        .describe('Markdown content to append, or to replace the whole body with.'),
+      mode: z
+        .enum(['append', 'replace'])
+        .optional()
+        .describe('`append` (default) adds to the end; `replace` swaps the entire body.'),
+    },
+    async handler(args) {
+      const ctx = await resolveCtx()
+      if ('error' in ctx) return text(ctx.error, true)
+      const pageId = typeof args.pageId === 'string' ? args.pageId.trim() : ''
+      const content = typeof args.content === 'string' ? args.content : ''
+      const mode = args.mode === 'replace' ? 'replace' : 'append'
+      if (!pageId) return text('Provide a `pageId` to edit.', true)
+      if (!content.trim()) return text('Provide non-empty `content`.', true)
+
+      // 1. RLS-scoped read confirms access AND gives the CAS base version.
+      //    Never trust the input id without this — a null read is no-access.
+      const current = await docPageStore.getVersionedPage(ctx.userId, pageId)
+      if (!current) {
+        return text(`Page not found: ${pageId}. It may not exist or you may not have access.`, true)
+      }
+
+      // 2. Build the new block list from the Markdown content. `replace`
+      //    swaps the whole body; `append` keeps existing blocks and adds the
+      //    new ones. `normalizeMarkdownBlocks` runs the same expansion the
+      //    chat path applies so inline Markdown lands as canonical blocks.
+      const newBlocks = normalizeMarkdownBlocks(markdownToBlocks(content))
+      if (newBlocks.length === 0) {
+        return text('The content produced no blocks — provide some Markdown text.', true)
+      }
+
+      // 3. Express the change as the canonical `Op[]`: replace = delete every
+      //    existing block then append the new ones; append = just add. Running
+      //    it through `applyOps` (the same engine `patchPage` uses) gives us a
+      //    validated working copy + the inverse for single-step undo.
+      const ops: Op[] = []
+      if (mode === 'replace') {
+        for (const b of current.page.blocks) ops.push({ op: 'delete', blockId: b.id })
+      }
+      for (const b of newBlocks) ops.push({ op: 'add', block: b })
+
+      let nextPage: Page
+      try {
+        nextPage = applyOps(current.page, ops).page
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        return text(`Could not apply the edit: ${msg}`, true)
+      }
+
+      // 4. Atomic compare-and-swap with undo capture — the legacy `patchPage`
+      //    DB seam. `null` means a concurrent writer bumped the version first.
+      const undo = buildUndoEntry(current.page, ops, {}, current.version + 1)
+      let result: { newVersion: number } | null
+      try {
+        result = await docPageStore.applyPatch({
+          userId: ctx.userId,
+          pageId,
+          expectedVersion: current.version,
+          nextPage,
+          undo,
+        })
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        return text(`Failed to save the edit: ${msg}`, true)
+      }
+      if (!result) {
+        return text('The page was updated concurrently. Re-read it and retry the edit.', true)
+      }
+
+      // Note: doc pages have their own realtime path (the doc-sync service for
+      // live collaborative docs); they're NOT part of the brain-stream NOTIFY
+      // surface (`BrainPrimitive` covers memory/task/CRM/file/entity only), so
+      // no `notifyBrainChange` here. The web reads the page via the saved-views
+      // / doc endpoints, which reflect this committed version on next fetch.
+      return text(
+        `Edited page "${current.title}" (${mode === 'replace' ? 'replaced body' : 'appended content'}). ` +
+          `New version ${result.newVersion}.`,
+      )
+    },
+  }
+
+  const deletePage: BrainTool = {
+    name: 'deletePage',
+    description:
+      'Permanently delete a workspace doc page by id. Any pages nested under ' +
+      'it are deleted too (the page tree cascades). There is no undo over MCP ' +
+      '— the `read_write` scope is the authorization. The key must be able to ' +
+      "access the page (it's scoped to the key's workspace and clearance) or " +
+      'the call reports not-found.',
+    inputSchema: {
+      pageId: z.string().min(1).max(128).describe('The id of the page to delete.'),
+    },
+    async handler(args) {
+      const ctx = await resolveCtx()
+      if ('error' in ctx) return text(ctx.error, true)
+      const pageId = typeof args.pageId === 'string' ? args.pageId.trim() : ''
+      if (!pageId) return text('Provide a `pageId` to delete.', true)
+
+      // Confirm RLS-scoped access BEFORE deleting — never trust the input id.
+      // A page the key can't see reads null here, so we report not-found
+      // rather than issuing a delete that RLS would no-op anyway.
+      const current = await docPageStore.getVersionedPage(ctx.userId, pageId)
+      if (!current) {
+        return text(`Page not found: ${pageId}. It may not exist or you may not have access.`, true)
+      }
+
+      let removed: boolean
+      try {
+        removed = await savedViewStore.remove(ctx.userId, pageId)
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        return text(`Failed to delete the page: ${msg}`, true)
+      }
+      if (!removed) {
+        return text(`Page not deleted: ${pageId}. It may have already been removed.`, true)
+      }
+
+      // No brain-stream NOTIFY — doc pages aren't a `BrainPrimitive` (see the
+      // editPage note above); the sidebar re-reads the saved-views list.
+      return text(`Deleted page "${current.title}" (${pageId}).`)
+    },
+  }
+
+  return { readPage, editPage, deletePage }
 }
 
 /**
@@ -512,6 +810,14 @@ export function buildBrainTools(opts: BuildOpts): BrainTool[] {
       ]
     : []
 
+  // ── Doc-page tools (readPage / editPage / deletePage). Present only when the
+  // doc stores are wired (opts.docTools set) — mirrors the file surface. The
+  // same RLS-gated stores the chat doc tools use: `readPage` rides both scopes,
+  // `editPage` / `deletePage` are filtered to read_write keys by the split below.
+  const docPageTools = opts.docTools
+    ? buildDocPageTools(opts.docTools, resolveCtx, workspaceId)
+    : null
+
   // ── Agent capability toolset (agent-facing capability surface §3/§4).
   // Reads ride both scopes; writes require read_write + the configure gate
   // (pre-resolved by the server into `agentWritesEnabled`). Same bridge as
@@ -538,6 +844,7 @@ export function buildBrainTools(opts: BuildOpts): BrainTool[] {
       t.name === 'getDeal' || t.name === 'listDeals',
     ),
     ...fileBridges.filter((t) => t.name === 'fileRead' || t.name === 'fileSearch'),
+    ...(docPageTools ? [docPageTools.readPage] : []),
     ...agentReadBridges,
     // Writes
     saveMemory,
@@ -558,6 +865,7 @@ export function buildBrainTools(opts: BuildOpts): BrainTool[] {
       t.name === 'fileSetMeta' || t.name === 'fileDelete' ||
       t.name === 'saveFileBytes' || t.name === 'saveFileToBrain',
     ),
+    ...(docPageTools ? [docPageTools.editPage, docPageTools.deletePage] : []),
     ...agentWriteBridges,
   ]
   return opts.scope === 'read'


### PR DESCRIPTION
## Summary
Exposes doc pages over the brain MCP server as full CRUD: `readPage`, `editPage`, `deletePage`, and **`createPage`**.

## What changes
- `brain-mcp/tools.ts` + `server.ts`:
  - `readPage` (read scope) reuses the find-page markdown export.
  - `editPage` / `deletePage` (write scope) reuse the `patchPage` ops/CAS path and the RLS-scoped saved-views delete.
  - **`createPage`** (write scope) mints a new page through the same `savedViewStore.createDraft` seam the chat `renderPage` tool uses, parsing an optional Markdown body with the same `markdownToBlocks` + `normalizeMarkdownBlocks` expansion `editPage` runs, and returns the new `pageId`. This closes the gap where `editPage` could only edit existing pages and there was no MCP path to create one.
  - All scope-gated exactly like `ingestToBrain`: reads on both key scopes, writes only on `read_write` keys, and the whole page surface is omitted when no doc stores are wired.
- `boot.ts` wiring; `brain-mcp.test.ts` covers all four tools (scope gating + handler behaviour, including `createPage` minting via `createDraft` and rejecting an empty title).


---
_Previously merged into local `develop` but never pushed; opening as its own PR so it lands on `origin/develop` cleanly._

🤖 Generated with [Claude Code](https://claude.com/claude-code)