### PR TITLE
fix(embeddings): stop the worker draining the non-vector 'episodes' primitive

### DIFF
--- a/packages/core/src/embeddings/worker.ts
+++ b/packages/core/src/embeddings/worker.ts
@@ -44,7 +44,20 @@ export const EMBEDDED_PRIMITIVES = [
 
 export type EmbeddingPrimitive = typeof EMBEDDED_PRIMITIVES[number]
 
-const DEFAULT_PRIMITIVES: readonly EmbeddingPrimitive[] = EMBEDDED_PRIMITIVES
+/**
+ * The primitives the worker actually DRAINS each tick (claim → embed → commit).
+ * A strict subset of EMBEDDED_PRIMITIVES: `episodes` is in the registry for
+ * enumeration / observability but has no `embedding` column of its own — its
+ * summaries embed indirectly via `kb_chunks` materialized by Pipeline B. The
+ * embedding store throws if asked to claim `episodes` rows (no vector column),
+ * so the worker must skip it or it logs a drain failure every tick. Derived
+ * from EMBEDDED_PRIMITIVES (not a second hardcoded list) so a newly-embedded
+ * primitive flows through automatically; non-drainable kinds are excluded here.
+ */
+export const DRAINABLE_PRIMITIVES: readonly EmbeddingPrimitive[] =
+  EMBEDDED_PRIMITIVES.filter((p) => p !== 'episodes')
+
+const DEFAULT_PRIMITIVES: readonly EmbeddingPrimitive[] = DRAINABLE_PRIMITIVES
 
 /**
  * One row handed back from `withClaimedRows`. The store has already taken


### PR DESCRIPTION
## What

The embeddings worker was draining the non-vector `episodes` primitive, which it should leave alone. This stops that.

## Why

Split out of the OSS-local-edition work as an independent worker bug fix so it can be reviewed and reverted on its own.

## Scope

- `packages/core/src/embeddings/worker.ts` (14 +/- 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)