### PR TITLE
feat: make the OSS local single-process edition work end to end

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -15,6 +15,7 @@
 
 import dotenv from 'dotenv'
 import { bootOpenApi, type OpenApiEnv } from '@sidanclaw/api/boot.js'
+import { buildEpisodeIngestors } from '@sidanclaw/api/build-episode-ingestors.js'
 
 dotenv.config()
 
@@ -48,5 +49,13 @@ const env: OpenApiEnv = {
   CHANNEL_CREDENTIAL_KEY: process.env.CHANNEL_CREDENTIAL_KEY,
 }
 
-const { start } = await bootOpenApi({ env, runWorkers: true })
+// Wire the OPEN Pipeline B episode ingestors so brain distillation (doc-page
+// "Sync to brain", brain-MCP ingestToBrain, chat compaction) runs locally. This
+// is the one closed seam the open edition fills with an open impl over the same
+// store graph — see packages/api/src/build-episode-ingestors.ts.
+const { start } = await bootOpenApi({
+  env,
+  runWorkers: true,
+  ports: { buildEpisodeIngestors },
+})
 await start()

--- a/apps/app-web/src/app/page.tsx
+++ b/apps/app-web/src/app/page.tsx
@@ -1,7 +1,10 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
+// `||` not `??`: an empty-string NEXT_PUBLIC_API_URL (e.g. inlined as "" by the
+// bundler when unset at build) must also fall back, else this server-side fetch
+// gets the relative "/api/workspaces" and throws ERR_INVALID_URL.
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
 
 type Team = { id: string; name: string };
 

--- a/apps/doc-sync/src/index.ts
+++ b/apps/doc-sync/src/index.ts
@@ -407,6 +407,13 @@ httpServer.on('upgrade', (request, socket, head) => {
 
 httpServer.listen(PORT, () => {
   console.log(`[doc-sync] listening on :${PORT}`)
+  // One-time signal so a silent auto-ingest is diagnosable: env unset here means
+  // the enqueue never fires (distinct from a per-page toggle being off).
+  console.log(
+    API_INTERNAL_URL && DOC_SYNC_SECRET
+      ? `[doc-sync] auto brain-ingest ENABLED → ${API_INTERNAL_URL}/internal/ingest-page`
+      : '[doc-sync] auto brain-ingest DISABLED (API_INTERNAL_URL / DOC_SYNC_SECRET unset)',
+  )
 })
 
 // Graceful shutdown: flush pending debounced stores so a redeploy on the

--- a/apps/doc-sync/src/persistence.ts
+++ b/apps/doc-sync/src/persistence.ts
@@ -96,8 +96,9 @@ export async function maybeEnqueueBrainIngest(params: {
     }
 
     // Fire-and-forget POST. A non-2xx / network error is swallowed (logged) so
-    // the snapshot write is never affected.
-    await doFetch(`${config.apiBaseUrl.replace(/\/+$/, '')}/internal/ingest-page`, {
+    // the snapshot write is never affected. We DO log the response status so an
+    // auth (403) / routing (404 — route not mounted) failure is visible.
+    const res = await doFetch(`${config.apiBaseUrl.replace(/\/+$/, '')}/internal/ingest-page`, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
@@ -105,6 +106,7 @@ export async function maybeEnqueueBrainIngest(params: {
       },
       body: JSON.stringify({ pageId }),
     })
+    console.log(`[doc-sync] brain-ingest enqueued for ${pageId} → POST /internal/ingest-page ${res.status}`)
     return 'enqueued'
   } catch (err) {
     console.error(

--- a/packages/api/src/build-episode-ingestors.ts
+++ b/packages/api/src/build-episode-ingestors.ts
@@ -1,0 +1,149 @@
+/**
+ * OPEN episode-ingestor factory — the open default for `ports.buildEpisodeIngestors`.
+ *
+ * Pipeline B (the entity/fact/edge extraction coordinator) lives in OPEN core
+ * (`@sidanclaw/core` → `processEpisode`), and every store it needs is built in
+ * the open boot graph. The only thing the hosted tier kept closed was the thin
+ * WIRING that (a) persists an Episode row and (b) calls `processEpisode` over
+ * those stores. This module is the open implementation of exactly that wiring,
+ * so the single-player OSS edition runs the same brain distillation locally:
+ *
+ *   - `brainEpisodeIngestor` — the atomic "ingest one text Episode" primitive
+ *     behind the doc-page "Sync to brain" runner, the brain-MCP `ingestToBrain`
+ *     tool, and direct file ingest.
+ *   - `chatEpisodeIngestor` — materializes a compacted chat window as an Episode
+ *     and runs the same pipeline (proactive-compaction → brain).
+ *
+ * `apps/api/src/index.ts` passes this as `ports.buildEpisodeIngestors`. The
+ * hosted platform supplies its own factory over the same `EpisodeIngestorDeps`,
+ * so boot is unchanged. See oss-local-brain-wedge.md §12.4 and
+ * docs/plans/canvas-brain-distillation.md.
+ */
+
+import {
+  processEpisode,
+  type PipelineBDeps,
+  type PipelineBEpisode,
+  type Sensitivity,
+  type SourceKind,
+} from '@sidanclaw/core'
+import type { EpisodeIngestorDeps } from './boot.js'
+import type { EpisodeSensitivity } from './db/episodes-store.js'
+import type { BrainEpisodeIngestor, ChatEpisodeIngestor } from './ingest-port.js'
+
+// Extraction runs on the Standard tier (model-routing.md Trigger #11); the
+// optional drift/kind classifier on the Background-Standard lite model.
+const EXTRACTION_MODEL = 'gemini-3-flash-standard'
+const CLASSIFIER_MODEL = 'gemini-3.1-flash-lite'
+
+/** Generic text ingest (brain-MCP / file) lands as a manual paste; the doc-page
+ *  runner overrides this with `'doc_page'` via the input's `sourceKind`. */
+const DEFAULT_BRAIN_SOURCE_KIND: SourceKind = 'manual_paste'
+
+/**
+ * Reverse of `toEpisodeSensitivity` (episode-sensitivity.ts). The Episode store
+ * carries a 4-tier `EpisodeSensitivity`; Pipeline B's `PipelineBEpisode` carries
+ * the core 3-tier `Sensitivity`. Both `private` and `secret` collapse to
+ * `confidential` (the strictest core tier) so the classifier never widens a
+ * stored-sensitive episode.
+ */
+function toCoreSensitivity(s: EpisodeSensitivity): Sensitivity {
+  switch (s) {
+    case 'public':
+      return 'public'
+    case 'internal':
+      return 'internal'
+    case 'private':
+    case 'secret':
+      return 'confidential'
+  }
+}
+
+export function buildEpisodeIngestors(deps: EpisodeIngestorDeps): {
+  chatEpisodeIngestor: ChatEpisodeIngestor
+  brainEpisodeIngestor: BrainEpisodeIngestor
+} {
+  // Pipeline B deps are a 1:1 projection of the boot store graph. Built fresh
+  // per call so the closure stays stateless (the stores themselves are shared).
+  const pipelineDeps = (): PipelineBDeps => ({
+    provider: deps.provider,
+    model: EXTRACTION_MODEL,
+    classifierModel: CLASSIFIER_MODEL,
+    crm: deps.crmStore,
+    entities: deps.entitiesStore,
+    entityLinks: deps.entityLinksStore,
+    memories: deps.memoryStore,
+    tasks: deps.taskStore,
+    episodes: deps.episodesStore,
+    analytics: deps.analytics,
+  })
+
+  const brainEpisodeIngestor: BrainEpisodeIngestor = async (input) => {
+    const sourceKind = input.sourceKind ?? DEFAULT_BRAIN_SOURCE_KIND
+    const sensitivity: EpisodeSensitivity = input.sensitivity ?? 'internal'
+
+    // 1. Persist the Episode (status defaults to 'open'); processEpisode drives
+    //    the open → extracting → archived lifecycle through the episodes port.
+    const episode = await deps.episodesStore.createEpisode(input.userId, {
+      sourceKind,
+      sourceRef: input.sourceRef ?? { source_kind: sourceKind },
+      occurredAt: input.occurredAt,
+      workspaceId: input.workspaceId,
+      userId: input.userId,
+      assistantId: input.assistantId,
+      createdByUserId: input.userId,
+      createdByAssistantId: input.assistantId,
+      sensitivity,
+      summaryText: input.sourceLabel ?? null,
+    })
+
+    // 2. Run Pipeline B over the persisted episode + resolved content.
+    const pbEpisode: PipelineBEpisode = {
+      id: episode.id,
+      sourceKind,
+      occurredAt: input.occurredAt,
+      sensitivity: toCoreSensitivity(sensitivity),
+      workspaceId: input.workspaceId,
+      userId: input.userId,
+      assistantId: input.assistantId,
+      createdByUserId: input.userId,
+      createdByAssistantId: input.assistantId,
+    }
+    return processEpisode(pbEpisode, input.content, pipelineDeps())
+  }
+
+  const chatEpisodeIngestor: ChatEpisodeIngestor = async (input) => {
+    // A compacted chat window → one `web_chat` Episode carrying the session +
+    // message range as its back-edge, then the same extraction pipeline.
+    const episode = await deps.episodesStore.createEpisode(input.userId, {
+      sourceKind: 'web_chat',
+      sourceRef: {
+        source_kind: 'web_chat',
+        session_id: input.sessionId,
+        message_id_range: input.messageIdRange,
+      },
+      occurredAt: input.occurredAt,
+      workspaceId: input.workspaceId,
+      userId: input.userId,
+      assistantId: input.assistantId,
+      createdByUserId: input.userId,
+      createdByAssistantId: input.assistantId,
+      sensitivity: 'internal',
+    })
+
+    const pbEpisode: PipelineBEpisode = {
+      id: episode.id,
+      sourceKind: 'web_chat',
+      occurredAt: input.occurredAt,
+      sensitivity: 'internal',
+      workspaceId: input.workspaceId,
+      userId: input.userId,
+      assistantId: input.assistantId,
+      createdByUserId: input.userId,
+      createdByAssistantId: input.assistantId,
+    }
+    await processEpisode(pbEpisode, input.content, pipelineDeps())
+  }
+
+  return { chatEpisodeIngestor, brainEpisodeIngestor }
+}

--- a/packages/api/src/db/client.ts
+++ b/packages/api/src/db/client.ts
@@ -30,6 +30,46 @@ const POOL_MAX = resolvePoolMax(process.env.PG_POOL_MAX)
 const POOL_OPTS = { max: POOL_MAX, idleTimeoutMillis: 30_000, connectionTimeoutMillis: 5_000 }
 
 /**
+ * Single-connection mode for the embedded PGLite brain (the OSS local default).
+ *
+ * PGLite is ONE in-process WASM instance with a single backend session shared
+ * across every wire connection. node-postgres drives each parameterized query
+ * through the session's UNNAMED prepared statement (Parse→Bind→Execute), so two
+ * concurrent connections clobber that one slot — surfacing as 26000 "unnamed
+ * prepared statement does not exist" and 08P01 "bind ... requires N". With the
+ * default two pools at `max:4` the api opens up to 8 connections, and the home
+ * dock / workers fan out enough concurrent reads to hit it constantly.
+ *
+ * When the launcher boots the embedded brain it sets `PG_SINGLE_CONNECTION=1`;
+ * we then route BOTH pool getters at a single `max:1` pool so all DB access
+ * serializes. PGLite already serializes every query on its one connection (see
+ * oss-local-brain-wedge.md §12.4 "collapse client.ts to one connection" + §198
+ * single-writer), so this costs no throughput — it only removes the clobber.
+ *
+ * Hosted (two-role, `DATABASE_URL_APP` set) and the local-Postgres-container
+ * escape hatch leave this unset and keep the full two-pool / multi-connection
+ * behavior — a real Postgres isolates the unnamed statement per connection and
+ * has no such contention.
+ */
+const SINGLE_CONNECTION = process.env.PG_SINGLE_CONNECTION === '1'
+
+/**
+ * Attach a pool-level `error` listener. `pg.Pool` re-emits a connection-level
+ * `error` (a backend that dies, or a protocol desync) on the Pool itself; with
+ * NO listener, Node treats it as an unhandled `'error'` event and crashes the
+ * process. This bit the embedded PGLite single-connection mode: a query against
+ * a missing relation (e.g. the closed `connector_instance` table) makes the
+ * PGLiteSocketServer send an unexpected `commandComplete`, which pg surfaces as
+ * a fatal Client error and took the whole api down. Logging it keeps the pool
+ * alive — the bad client is discarded and the next checkout reconnects.
+ */
+function attachPoolErrorHandler(pool: pg.Pool, label: string): void {
+  pool.on('error', (err) => {
+    console.error(`[db] idle client error on ${label} pool (recovered, not fatal):`, err.message)
+  })
+}
+
+/**
  * The **system pool** — connects as the table OWNER (`DATABASE_URL`). With
  * `FORCE ROW LEVEL SECURITY` dropped (migration 269), the owner **bypasses RLS
  * entirely**, so this pool is the system-access path: bare `query()`, the
@@ -44,7 +84,16 @@ const POOL_OPTS = { max: POOL_MAX, idleTimeoutMillis: 30_000, connectionTimeoutM
  */
 export function getPool(): pg.Pool {
   if (!systemPool) {
-    systemPool = new pg.Pool({ connectionString: process.env.DATABASE_URL, ...POOL_OPTS })
+    const max = SINGLE_CONNECTION ? 1 : POOL_MAX
+    systemPool = new pg.Pool({ connectionString: process.env.DATABASE_URL, ...POOL_OPTS, max })
+    attachPoolErrorHandler(systemPool, 'system')
+    // No app.current_user_id sentinel seed here — this is the table OWNER
+    // connection, and no table sets FORCE ROW LEVEL SECURITY, so the owner
+    // bypasses RLS: the `current_setting('app.current_user_id')::uuid` casts in
+    // the policies are never evaluated, so the `''` revert that the seed guards
+    // against on the app_user pool cannot throw 22P02 here. (Seeding it via a
+    // fire-and-forget connect handler also raced the first query on the single
+    // connection, tripping pg's "already executing a query" deprecation.)
   }
   return systemPool
 }
@@ -64,6 +113,11 @@ export function getPool(): pg.Pool {
  * docs/architecture/platform/database-schema.md → "Two-role rollout".
  */
 export function getAppPool(): pg.Pool {
+  // Single-connection mode (embedded PGLite): collapse onto the one system pool
+  // so every query serializes through a single wire connection. RLS is retained
+  // single-role (owner connection), satisfied by the auto-provisioned
+  // workspace + membership — see oss-local-brain-wedge.md §12.4.
+  if (SINGLE_CONNECTION) return getPool()
   if (!appPool) {
     const appUrl = process.env.DATABASE_URL_APP
     if (!appUrl) {
@@ -74,6 +128,7 @@ export function getAppPool(): pg.Pool {
       )
     }
     appPool = new pg.Pool({ connectionString: appUrl ?? process.env.DATABASE_URL, ...POOL_OPTS })
+    attachPoolErrorHandler(appPool, 'app')
     // Seed the nil-UUID sentinel for app.current_user_id on every app-pool
     // connection. On this Postgres, `SET LOCAL` of a custom `app.*` GUC reverts
     // to '' (empty string), not NULL, when the connection has no session-level

--- a/packages/api/src/doc/ingest-page-runner.ts
+++ b/packages/api/src/doc/ingest-page-runner.ts
@@ -81,18 +81,31 @@ export async function runIngestPage(
   deps: IngestPageDeps,
 ): Promise<IngestPageOutcome> {
   if (!deps.brainEpisodeIngestor) {
+    console.warn(`[ingest-page] ${args.pageId}: skipped — brain episode ingestor not wired (no Pipeline B)`)
     return { ok: false, reason: 'ingestor_unavailable' }
   }
 
   // RLS-scoped read of the page metadata (workspace, owner, clearance, version)
   // + the live merged page blocks (prefers the Yjs snapshot via getVersionedPage).
   const view = await deps.savedViewStore.getById(args.userId, args.pageId)
-  if (!view) return { ok: false, reason: 'page_not_found' }
+  if (!view) {
+    console.warn(`[ingest-page] ${args.pageId}: skipped — page not found for user ${args.userId}`)
+    return { ok: false, reason: 'page_not_found' }
+  }
   const read = await deps.docPageStore.getVersionedPage(args.userId, args.pageId)
-  if (!read) return { ok: false, reason: 'page_not_found' }
+  if (!read) {
+    console.warn(`[ingest-page] ${args.pageId}: skipped — versioned page body not found`)
+    return { ok: false, reason: 'page_not_found' }
+  }
 
   const assistantId = await deps.resolvePrimaryAssistant(view.workspaceId)
-  if (!assistantId) return { ok: false, reason: 'ingestor_unavailable' }
+  if (!assistantId) {
+    console.warn(
+      `[ingest-page] ${args.pageId}: skipped — no primary assistant in workspace ${view.workspaceId}`,
+    )
+    return { ok: false, reason: 'ingestor_unavailable' }
+  }
+  console.log(`[ingest-page] ${args.pageId}: distilling to brain (workspace ${view.workspaceId})`)
 
   const ingestor = deps.brainEpisodeIngestor
   const episodeSensitivity = episodeSensitivityFromClearance(view.clearance)
@@ -152,6 +165,11 @@ export async function runIngestPage(
     if (result.ingested) {
       // Stamp the dedup/cooldown anchors so the next save can short-circuit.
       await deps.savedViewStore.markBrainIngestedSystem(args.pageId, result.contentHash)
+      console.log(
+        `[ingest-page] ${args.pageId}: ingested ${result.sectionsProcessed} section(s), ${result.chunksUpserted} chunk(s) → brain (hash ${result.contentHash.slice(0, 8)})`,
+      )
+    } else {
+      console.log(`[ingest-page] ${args.pageId}: no-op — authored content unchanged since last ingest`)
     }
     return { ok: true, result }
   } catch (err) {

--- a/packages/api/src/doc/internal-ingest-route.ts
+++ b/packages/api/src/doc/internal-ingest-route.ts
@@ -80,9 +80,11 @@ export function internalIngestRoutes(opts: InternalIngestRouteOptions): Router {
     const state = await opts.savedViewStore.getBrainSyncStateSystem(pageId)
     if (!state) {
       // Page gone — ack so doc-sync never retries a dead page.
+      console.warn(`[internal-ingest] ${pageId}: skipped — page not found`)
       return res.status(200).json({ skipped: 'not_found' })
     }
     if (!state.brainSyncEnabled) {
+      console.log(`[internal-ingest] ${pageId}: skipped — "Sync to brain" toggle is off`)
       return res.status(200).json({ skipped: 'disabled' })
     }
     // Cooldown gate — collapse a save burst into at most one ingest.
@@ -90,8 +92,10 @@ export function internalIngestRoutes(opts: InternalIngestRouteOptions): Router {
       state.brainLastIngestAt &&
       now() - state.brainLastIngestAt.getTime() < INGEST_COOLDOWN_MS
     ) {
+      console.log(`[internal-ingest] ${pageId}: skipped — cooldown (last ingest <5min ago)`)
       return res.status(200).json({ skipped: 'cooldown' })
     }
+    console.log(`[internal-ingest] ${pageId}: queued background ingest`)
 
     // Background runner. The runner's own content-hash skip is the third gate
     // (an unchanged authored layer re-ingests nothing). Acked immediately — a


### PR DESCRIPTION
## What

Brings the OSS single-player local edition up end-to-end: connectors, brain distillation, embedded-DB reliability, auto-ingest observability, and launcher provisioning.

## Commits

- **feat(connectors):** enable built-in connectors for the OSS edition — migration 280 creates `connector_instance` / `connector_grant` for the open schema (guarded on the new `app.migration_edition` GUC so it never collides with the hosted overlay), drops the edition store stubs, mounts an open `/api/connectors` route gated on `SIDANCLAW_EDITION=oss`, and skips the home-dock connector probe for OSS.
- **feat(brain):** wire the open Pipeline B episode ingestors via the `bootOpenApi` ports so doc "Sync to brain" / brain-MCP / chat compaction distill locally.
- **fix(db):** serialize the embedded PGLite brain onto one connection under `PG_SINGLE_CONNECTION` and attach a pool-level error handler so a recoverable pool error no longer crashes the api.
- **fix(doc-sync):** log the auto-on-save brain ingest decision/enqueue/runner gates so a silent failure is diagnosable.
- **fix(app-web):** fall back to the default API URL when `NEXT_PUBLIC_API_URL` is the empty string (`||` not `??`) to avoid `ERR_INVALID_URL`.
- **chore(launch):** load `.env`, generate/persist `DOC_SYNC_SECRET` + `CHANNEL_CREDENTIAL_KEY`, export the env the above paths depend on, and wait for the api port before opening the browser.

## Notes

- Open-edition surfaces are gated on `SIDANCLAW_EDITION=oss` so the hosted edition is unaffected.
- The embeddings worker fix is split into its own PR (#8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)