### PR TITLE
fix(connectors): enable and surface built-in connectors in the OSS edition

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,5 +39,32 @@ ANTHROPIC_API_KEY=
 DATABASE_URL=
 # Auto-generated and persisted to ~/.sidanclaw/config.json if left unset.
 JWT_SECRET=
+# Shared secret for the API <-> doc-sync internal routes (the auto-on-save brain
+# ingest enqueue + AI doc writes). Auto-generated and persisted to
+# ~/.sidanclaw/config.json like JWT_SECRET; only set this by hand if you run the
+# api and doc-sync as separate processes WITHOUT the launcher (both need the
+# same value).
+DOC_SYNC_SECRET=
+# AES-GCM key (base64 of 32 bytes) that encrypts connector OAuth refresh-tokens
+# and PATs at rest in connector_instance.credentials. Auto-generated and
+# persisted to ~/.sidanclaw/config.json by the launcher; only set this by hand
+# if you run the api WITHOUT the launcher. Without it, connecting a connector
+# returns 503. Generate with: openssl rand -base64 32
+CHANNEL_CREDENTIAL_KEY=
 # Override the default port the app listens on.
 PORT=
+
+# ── Connectors (optional) ───────────────────────────────────────────────────
+# Built-in connectors (Google Calendar/Gmail/Drive, Notion, Fathom, GitHub) are
+# off until you bring your own OAuth app credentials. GitHub uses a Personal
+# Access Token entered in the UI and needs nothing here. The OAuth providers
+# resolve their app client id/secret from ~/.sidanclaw/connectors.config.json
+# (override path: CONNECTORS_CONFIG_PATH), e.g.
+#   { "google": { "clientId": "...", "clientSecret": "..." } }
+# or from these env vars as a fallback. Unset → that connector stays unavailable.
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+NOTION_CLIENT_ID=
+NOTION_CLIENT_SECRET=
+FATHOM_CLIENT_ID=
+FATHOM_CLIENT_SECRET=

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -42,6 +42,10 @@ const env: OpenApiEnv = {
   ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
   GCS_FILES_BUCKET: process.env.GCS_FILES_BUCKET,
   SKILLS_AUTO_GEN_ENABLED: process.env.SKILLS_AUTO_GEN_ENABLED === 'true',
+  // AES-GCM key for connector credentials at rest. The launcher generates +
+  // persists it; absent (bare `node index.js` boot) → connectors can't store
+  // credentials, every other surface is unaffected.
+  CHANNEL_CREDENTIAL_KEY: process.env.CHANNEL_CREDENTIAL_KEY,
 }
 
 const { start } = await bootOpenApi({ env, runWorkers: true })

--- a/apps/api/src/migrate-pglite.ts
+++ b/apps/api/src/migrate-pglite.ts
@@ -21,6 +21,10 @@ export async function migratePglite(db: PGlite, migrationsDir: string): Promise<
   await db.exec(
     `CREATE TABLE IF NOT EXISTS public._migrations (name TEXT PRIMARY KEY, applied_at TIMESTAMPTZ NOT NULL DEFAULT now())`,
   )
+  // Edition signal for OSS-only migrations (see 280_oss_connectors.sql). The
+  // embedded PGLite path is ALWAYS the open edition, so mark it 'oss' for the
+  // whole session; the node-pg runner sets the same GUC from MIGRATION_DIRS.
+  await db.exec(`SELECT set_config('app.migration_edition', 'oss', false)`)
   const { rows } = await db.query<{ name: string }>('SELECT name FROM public._migrations')
   const applied = new Set(rows.map((r) => r.name))
   const files = (await readdir(migrationsDir)).filter((f) => f.endsWith('.sql')).sort()

--- a/packages/api/migrations/280_oss_connectors.sql
+++ b/packages/api/migrations/280_oss_connectors.sql
@@ -1,0 +1,167 @@
+-- 280_oss_connectors.sql
+--
+-- Open the connector storage layer for the OSS edition.
+--
+-- Background: `connector_instance` and `connector_grant` are the credential-
+-- and grant-storage tables behind every built-in connector (Google Calendar,
+-- Gmail, GitHub, Notion, Fathom, custom MCP). In the hosted edition they are
+-- created by the CLOSED `overlay-v1` baseline, so the open `000_open_schema_v1`
+-- baseline omits them. That left the OSS edition with no place to store a
+-- connector OAuth grant: `connector-store.ts` / `connector-instance-store.ts` /
+-- `connector-grant-store.ts` therefore hard-returned `[]` under
+-- `SIDANCLAW_EDITION === 'oss'` to avoid "relation connector_instance does not
+-- exist" on every chat turn, and `injectMcpTools` never injected a single
+-- connector tool. This migration creates those tables for OSS so the existing
+-- (already-open) store + injection code can drive real connectors.
+--
+-- Hosted-safety: the body is guarded on TWO conditions, both of which must
+-- hold. (1) `app.migration_edition = 'oss'` -- the migrate runner sets this
+-- session GUC to 'oss' only when no closed overlay dir is injected (hosted sets
+-- it to 'hosted'). This matters because the runner applies the OPEN dir BEFORE
+-- the overlay, so a plain `to_regclass` guard alone would still fire in hosted
+-- (the overlay's connector_instance does not exist yet at this point) and create
+-- a reduced table that then collides with the overlay's own CREATE TABLE.
+-- (2) `to_regclass(...) IS NULL` -- belt-and-suspenders so a re-run or a
+-- pre-existing table is never re-created. In hosted both the GUC differs and the
+-- overlay owns the table, so this block is a pure no-op there.
+--
+-- Column set mirrors what the stores read/write:
+--   connector-instance-store.ts (INSERT at createUserInstance / createWorkspaceInstance)
+--   connector-store.ts          (the legacy McpConnector shim over the same table)
+--   connector-grant-store.ts    (connector_grant)
+--
+-- Spec: docs/plans/oss-local-brain-wedge.md (the connector seam) lives in the
+-- closed platform tree; this open migration is the OSS-only storage half.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF current_setting('app.migration_edition', true) = 'oss'
+     AND to_regclass('public.connector_instance') IS NULL THEN
+
+    -- ── connector_instance ─────────────────────────────────────
+    -- A single OAuth/MCP connection. `scope` is an XOR: a 'user' row is owned by
+    -- one user, a 'workspace' row by one workspace (team-native). `credentials`
+    -- is the AES-GCM blob encrypted with CHANNEL_CREDENTIAL_KEY (NULL until the
+    -- OAuth grant lands); `credentials_type` is the non-secret discriminator
+    -- mirrored from the decrypted blob's `type`.
+    CREATE TABLE public.connector_instance (
+      id uuid DEFAULT gen_random_uuid() NOT NULL,
+      scope text NOT NULL,
+      user_id uuid,
+      workspace_id uuid,
+      provider text NOT NULL,
+      label text NOT NULL,
+      connected_email text,
+      url text,
+      custom boolean DEFAULT false NOT NULL,
+      credentials bytea,
+      credentials_type text DEFAULT 'none'::text NOT NULL,
+      config jsonb DEFAULT '{}'::jsonb NOT NULL,
+      sensitivity text DEFAULT 'internal'::text NOT NULL,
+      connected boolean DEFAULT false NOT NULL,
+      ingestion_enabled boolean DEFAULT false NOT NULL,
+      created_by uuid,
+      created_at timestamp with time zone DEFAULT now() NOT NULL,
+      updated_at timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT connector_instance_pkey PRIMARY KEY (id),
+      CONSTRAINT connector_instance_scope_check
+        CHECK (scope = ANY (ARRAY['user'::text, 'workspace'::text])),
+      CONSTRAINT connector_instance_credentials_type_check
+        CHECK (credentials_type = ANY (ARRAY['oauth'::text, 'bearer'::text, 'custom_header'::text, 'none'::text])),
+      CONSTRAINT connector_instance_sensitivity_check
+        CHECK (sensitivity = ANY (ARRAY['public'::text, 'internal'::text, 'confidential'::text])),
+      -- XOR: user-scoped rows carry user_id (no workspace_id); workspace-scoped
+      -- rows carry workspace_id (no user_id).
+      CONSTRAINT connector_instance_scope_xor CHECK (
+        (scope = 'user' AND user_id IS NOT NULL AND workspace_id IS NULL)
+        OR (scope = 'workspace' AND workspace_id IS NOT NULL AND user_id IS NULL)
+      ),
+      CONSTRAINT connector_instance_user_id_fkey
+        FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE,
+      CONSTRAINT connector_instance_workspace_id_fkey
+        FOREIGN KEY (workspace_id) REFERENCES public.workspaces(id) ON DELETE CASCADE,
+      CONSTRAINT connector_instance_created_by_fkey
+        FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL
+    );
+
+    CREATE INDEX idx_connector_instance_user
+      ON public.connector_instance (user_id) WHERE scope = 'user';
+    CREATE INDEX idx_connector_instance_workspace
+      ON public.connector_instance (workspace_id) WHERE scope = 'workspace';
+    CREATE INDEX idx_connector_instance_provider
+      ON public.connector_instance (provider);
+
+    CREATE TRIGGER connector_instance_set_updated_at
+      BEFORE UPDATE ON public.connector_instance
+      FOR EACH ROW EXECUTE FUNCTION public.trigger_set_updated_at();
+
+    ALTER TABLE public.connector_instance ENABLE ROW LEVEL SECURITY;
+
+    -- A caller sees/writes their own user-scoped rows plus the rows of any
+    -- workspace they belong to. WITH CHECK mirrors USING so a workspace insert
+    -- is rejected unless the acting user (created_by, seeded as
+    -- app.current_user_id by queryWithRLS) is a member of that workspace -- the
+    -- `ci_team_member` authorization gate the store relies on.
+    CREATE POLICY ci_access ON public.connector_instance
+      USING (
+        (scope = 'user' AND user_id = (current_setting('app.current_user_id'::text, true))::uuid)
+        OR (scope = 'workspace' AND workspace_id IN (
+              SELECT wm.workspace_id FROM public.workspace_members wm
+              WHERE wm.user_id = (current_setting('app.current_user_id'::text, true))::uuid))
+      )
+      WITH CHECK (
+        (scope = 'user' AND user_id = (current_setting('app.current_user_id'::text, true))::uuid)
+        OR (scope = 'workspace' AND workspace_id IN (
+              SELECT wm.workspace_id FROM public.workspace_members wm
+              WHERE wm.user_id = (current_setting('app.current_user_id'::text, true))::uuid))
+      );
+
+    -- ── connector_grant ────────────────────────────────────────
+    -- "User U exposes their user-scoped instance to workspace W." Only user-
+    -- scoped instances are ever granted (team-native instances are workspace-
+    -- visible already); the store enforces that invariant at create time.
+    CREATE TABLE public.connector_grant (
+      id uuid DEFAULT gen_random_uuid() NOT NULL,
+      connector_instance_id uuid NOT NULL,
+      target_type text NOT NULL,
+      target_id uuid NOT NULL,
+      granted_by_user_id uuid NOT NULL,
+      granted_at timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT connector_grant_pkey PRIMARY KEY (id),
+      CONSTRAINT connector_grant_target_type_check
+        CHECK (target_type = 'workspace'::text),
+      CONSTRAINT connector_grant_unique UNIQUE (connector_instance_id, target_type, target_id),
+      CONSTRAINT connector_grant_instance_fkey
+        FOREIGN KEY (connector_instance_id) REFERENCES public.connector_instance(id) ON DELETE CASCADE,
+      CONSTRAINT connector_grant_granted_by_fkey
+        FOREIGN KEY (granted_by_user_id) REFERENCES public.users(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX idx_connector_grant_target
+      ON public.connector_grant (target_type, target_id);
+    CREATE INDEX idx_connector_grant_grantor
+      ON public.connector_grant (granted_by_user_id);
+
+    ALTER TABLE public.connector_grant ENABLE ROW LEVEL SECURITY;
+
+    -- The grantor sees their own grants (cg_grantor_see_own); a member of the
+    -- target workspace sees grants pointed at it (cg_target_member). Writes are
+    -- restricted to the grantor.
+    CREATE POLICY cg_access ON public.connector_grant
+      USING (
+        granted_by_user_id = (current_setting('app.current_user_id'::text, true))::uuid
+        OR (target_type = 'workspace' AND target_id IN (
+              SELECT wm.workspace_id FROM public.workspace_members wm
+              WHERE wm.user_id = (current_setting('app.current_user_id'::text, true))::uuid))
+      )
+      WITH CHECK (
+        granted_by_user_id = (current_setting('app.current_user_id'::text, true))::uuid
+      );
+
+  END IF;
+END
+$$;
+
+COMMIT;

--- a/packages/api/scripts/migrate.ts
+++ b/packages/api/scripts/migrate.ts
@@ -43,6 +43,16 @@ async function migrate() {
     .filter(Boolean)
   const dirs = [openDir, ...extraDirs]
 
+  // Edition signal for OSS-only migrations. The hosted tier injects its closed
+  // overlay dir(s) via MIGRATION_DIRS; OSS/standalone leaves it unset. A
+  // migration whose table is owned by the closed overlay in hosted but must be
+  // created for OSS guards its body on `current_setting('app.migration_edition')`
+  // — see 280_oss_connectors.sql. Session-level (is_local=false) so it persists
+  // across every file on this one migrate connection. Unset second arg → the
+  // migration treats it as not-oss and no-ops, which is the safe default.
+  const migrationEdition = extraDirs.length > 0 ? 'hosted' : 'oss'
+  await client.query(`SELECT set_config('app.migration_edition', $1, false)`, [migrationEdition])
+
   let count = 0
   for (const dir of dirs) {
     const files = (await readdir(dir)).filter((f) => f.endsWith('.sql')).sort()

--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -145,6 +145,7 @@ import { buildWorkspaceCuratorScope } from './workers/workspace-curator-scope.js
 import { loadSkillRegistry } from './registry/load-skill-registry.js'
 import { handleRoutes } from './routes/handles.js'
 import { connectionRoutes } from './routes/connections.js'
+import { connectorRoutes } from './routes/connectors.js'
 import { discoverRoutes } from './routes/discover.js'
 import { createModesRouter } from './routes/modes.js'
 import { pendingMessageRoutes } from './routes/pending-messages.js'
@@ -1716,6 +1717,18 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     getTelegramBotUsername,
     blobClient: filesBlobClient ?? undefined,
   }))
+
+  // Built-in connector lifecycle (list / store-credentials / disconnect /
+  // rename / delete). OSS-only: the hosted edition mounts its own richer closed
+  // `/api/connectors` route, so mounting this open one there would shadow it.
+  // Gated on the same `SIDANCLAW_EDITION` flag the launcher sets for the open
+  // single-player edition. See routes/connectors.ts.
+  if (process.env.SIDANCLAW_EDITION === 'oss') {
+    app.use('/api/connectors', requireAuth(env.JWT_SECRET), connectorRoutes({
+      connectorStore,
+      connectorInstanceStore,
+    }))
+  }
 
   // GET/POST /api/assistants (inline)
   app.get('/api/assistants', requireAuth(env.JWT_SECRET), async (req, res) => {

--- a/packages/api/src/db/connector-grant-store.ts
+++ b/packages/api/src/db/connector-grant-store.ts
@@ -213,6 +213,9 @@ export function createConnectorGrantStore(): ConnectorGrantStore {
     },
 
     async listForTargetSystem(targetType, targetId) {
+      // `connector_grant` + `connector_instance` now exist in OSS too
+      // (migration 280_oss_connectors), so this no longer needs the edition stub.
+      // See connector-store.list.
       const result = await query<FlatGrantInstanceRow>(
         `SELECT
            cg.id, cg.connector_instance_id AS "connectorInstanceId",

--- a/packages/api/src/db/connector-instance-store.ts
+++ b/packages/api/src/db/connector-instance-store.ts
@@ -439,6 +439,8 @@ export function createConnectorInstanceStore(encryptionKey: Buffer | null): Conn
     },
 
     async listByWorkspaceSystem(workspaceId) {
+      // `connector_instance` now exists in OSS too (migration 280_oss_connectors),
+      // so this no longer needs the edition stub. See connector-store.list.
       const result = await query<PublicRow>(
         `SELECT ${PUBLIC_COLS} FROM connector_instance
          WHERE scope = 'workspace' AND workspace_id = $1

--- a/packages/api/src/db/connector-store.ts
+++ b/packages/api/src/db/connector-store.ts
@@ -171,6 +171,10 @@ type ConnectorRow = McpConnector
 export function createDbConnectorStore(encryptionKey: Buffer | null): ConnectorStore {
   return {
     async list(userId) {
+      // `connector_instance` exists in every edition: the hosted overlay-v1
+      // baseline creates it, and migration 280_oss_connectors creates it for the
+      // OSS open schema. (It was previously OSS-stubbed to `[]` because the table
+      // was absent there.)
       const result = await queryWithRLS<ConnectorRow>(
         userId,
         `SELECT ${PUBLIC_COLS} FROM connector_instance

--- a/packages/api/src/home/signals.ts
+++ b/packages/api/src/home/signals.ts
@@ -18,6 +18,7 @@ import { computeNextRun, type HomeSignals, type WorkflowTrigger } from '@sidancl
 import type { SavedViewStore } from '@sidanclaw/core'
 import { query } from '../db/client.js'
 import { countBrainInbox } from '../db/brain-inbox-store.js'
+import { isOssEdition } from '../routes/local-session.js'
 
 const UPCOMING_CAP = 4
 const DRAFTS_CAP = 4
@@ -126,6 +127,11 @@ async function countBrainEntries(workspaceId: string): Promise<{ total: number; 
 }
 
 async function workspaceHasConnector(workspaceId: string): Promise<boolean> {
+  // `connector_instance` is a closed/overlay table that does not exist in the
+  // OSS edition (no connector surface ships there), so skip the probe instead
+  // of letting every home-dock assembly throw + log a benign "relation does not
+  // exist". Returns false → onboarding shows "no connector", which is correct.
+  if (isOssEdition()) return false
   const res = await query<{ ok: number }>(
     `SELECT 1 AS ok FROM connector_instance
      WHERE workspace_id = $1 AND scope = 'workspace' AND connected = true LIMIT 1`,

--- a/packages/api/src/routes/__tests__/connectors.test.ts
+++ b/packages/api/src/routes/__tests__/connectors.test.ts
@@ -50,10 +50,14 @@ function makeApp(userId?: string) {
     createUserInstance: vi.fn().mockResolvedValue(instance()),
     update: vi.fn().mockResolvedValue(instance()),
     deleteInstance: vi.fn().mockResolvedValue(true),
+    getConfig: vi.fn().mockResolvedValue({}),
+    setConfig: vi.fn().mockResolvedValue(undefined),
   }
   const connectorStore = {
     setConnected: m.setConnected,
     delete: m.deleteConnector,
+    getConfig: m.getConfig,
+    setConfig: m.setConfig,
   } as unknown as ConnectorStore
   const connectorInstanceStore = {
     listForUser: m.listForUser,
@@ -138,6 +142,39 @@ describe('[COMP:api/connectors-route] /api/connectors', () => {
 
     const unknown = await request(app).post('/api/connectors/directory/bogus/add')
     expect(unknown.status).toBe(404)
+  })
+
+  it('GET /:provider/tools returns the built-in tool catalog (was "No tools found")', async () => {
+    const { app } = makeApp('u1')
+    const res = await request(app).get('/api/connectors/github/tools')
+    expect(res.status).toBe(200)
+    expect(res.body.serverName).toBe('GitHub')
+    expect(Array.isArray(res.body.tools)).toBe(true)
+    expect(res.body.tools.length).toBeGreaterThan(0)
+    expect(res.body.tools[0]).toMatchObject({
+      name: expect.any(String),
+      classification: expect.any(String),
+      policy: expect.stringMatching(/allow|ask|block/),
+    })
+  })
+
+  it('GET /:provider/tools is empty for a connector with no catalog', async () => {
+    const { app } = makeApp('u1')
+    const res = await request(app).get('/api/connectors/files/tools')
+    expect(res.status).toBe(200)
+    expect(res.body.tools).toEqual([])
+  })
+
+  it('GET + PATCH /:provider/config round-trips through the store', async () => {
+    const { app, getConfig, setConfig } = makeApp('u1')
+    getConfig.mockResolvedValue({ sendUpdates: 'all' })
+    const get = await request(app).get('/api/connectors/gcal/config')
+    expect(get.status).toBe(200)
+    expect(get.body.config).toEqual({ sendUpdates: 'all' })
+
+    const patch = await request(app).patch('/api/connectors/gcal/config').send({ sendUpdates: 'none' })
+    expect(patch.status).toBe(200)
+    expect(setConfig).toHaveBeenCalledWith('u1', 'gcal', { sendUpdates: 'none' })
   })
 
   it('POST /instances/:id/connect flips a specific instance online', async () => {

--- a/packages/api/src/routes/__tests__/connectors.test.ts
+++ b/packages/api/src/routes/__tests__/connectors.test.ts
@@ -84,23 +84,68 @@ describe('[COMP:api/connectors-route] /api/connectors', () => {
     expect(res.status).toBe(401)
   })
 
-  it('GET / maps instances to the connector row shape', async () => {
+  it('GET / merges built-in placeholders with the caller instances', async () => {
     const { app, listForUser } = makeApp('u1')
     listForUser.mockResolvedValue([
       instance({ provider: 'gcal', label: 'Work cal', connectedEmail: 'a@b.com' }),
     ])
     const res = await request(app).get('/api/connectors')
     expect(res.status).toBe(200)
-    expect(res.body.connectors).toEqual([
-      expect.objectContaining({
-        id: 'gcal',
-        connectorId: 'gcal',
-        connectorInstanceId: IID,
-        label: 'Work cal',
-        connected: true,
-        connectedEmail: 'a@b.com',
-      }),
-    ])
+    const rows = res.body.connectors as Array<Record<string, unknown>>
+
+    // The connected gcal instance is a real row (has a connectorInstanceId).
+    const gcal = rows.find((r) => r.id === 'gcal')
+    expect(gcal).toMatchObject({
+      connectorInstanceId: IID,
+      label: 'Work cal',
+      connected: true,
+      connectedEmail: 'a@b.com',
+    })
+
+    // github has no instance → it appears as a never-connected placeholder so
+    // the page's "available" group is not empty on a fresh account.
+    const github = rows.find((r) => r.id === 'github')
+    expect(github).toMatchObject({ isPlaceholder: true, connected: false })
+    expect(github?.connectorInstanceId).toBeUndefined()
+  })
+
+  it('GET /directory lists the official catalog with added/connected flags', async () => {
+    const { app, listForUser } = makeApp('u1')
+    listForUser.mockResolvedValue([instance({ provider: 'github', connected: true })])
+    const res = await request(app).get('/api/connectors/directory')
+    expect(res.status).toBe(200)
+    const dir = res.body.directory as Array<Record<string, unknown>>
+    expect(dir.find((d) => d.id === 'github')).toMatchObject({ added: true, connected: true })
+    expect(dir.find((d) => d.id === 'notion')).toMatchObject({ added: false, connected: false })
+  })
+
+  it('POST /directory/:id/add creates a disconnected instance when none exists', async () => {
+    const { app, listByUser, createUserInstance } = makeApp('u1')
+    listByUser.mockResolvedValue([])
+    const res = await request(app).post('/api/connectors/directory/notion/add')
+    expect(res.status).toBe(200)
+    expect(createUserInstance).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'notion', connected: false }),
+    )
+  })
+
+  it('POST /directory/:id/add is idempotent and 404s an unknown connector', async () => {
+    const { app, listByUser, createUserInstance } = makeApp('u1')
+    listByUser.mockResolvedValue([instance({ provider: 'github' })])
+    const ok = await request(app).post('/api/connectors/directory/github/add')
+    expect(ok.status).toBe(200)
+    expect(createUserInstance).not.toHaveBeenCalled()
+
+    const unknown = await request(app).post('/api/connectors/directory/bogus/add')
+    expect(unknown.status).toBe(404)
+  })
+
+  it('POST /instances/:id/connect flips a specific instance online', async () => {
+    const { app, update } = makeApp('u1')
+    update.mockResolvedValue(instance({ connected: true }))
+    const res = await request(app).post(`/api/connectors/instances/${IID}/connect`)
+    expect(res.status).toBe(200)
+    expect(update).toHaveBeenCalledWith('u1', IID, { connected: true })
   })
 
   it('store-credentials rejects an unsupported provider', async () => {

--- a/packages/api/src/routes/__tests__/connectors.test.ts
+++ b/packages/api/src/routes/__tests__/connectors.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for the OSS built-in connector lifecycle route (/api/connectors).
+ * Component tag: [COMP:api/connectors-route].
+ *
+ * Verifies auth gating, the provider allowlist (derived from
+ * OFFICIAL_CONNECTORS), the three store-credentials write paths (primary /
+ * createNew / instanceId), the CHANNEL_CREDENTIAL_KEY-missing 503, and the
+ * list / disconnect / rename / delete handlers. Stores are mocked, so no DB.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { connectorRoutes } from '../connectors.js'
+import type { ConnectorStore } from '../../db/connector-store.js'
+import type { ConnectorInstanceStore, ConnectorInstance } from '../../db/connector-instance-store.js'
+
+const IID = '11111111-1111-1111-1111-111111111111'
+
+function instance(over: Partial<ConnectorInstance> = {}): ConnectorInstance {
+  return {
+    id: IID,
+    scope: 'user',
+    userId: 'u1',
+    workspaceId: null,
+    provider: 'github',
+    label: 'GitHub',
+    connectedEmail: null,
+    url: null,
+    custom: false,
+    config: {},
+    sensitivity: 'internal',
+    connected: true,
+    ingestionEnabled: false,
+    credentialsType: 'oauth',
+    createdBy: 'u1',
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...over,
+  }
+}
+
+function makeApp(userId?: string) {
+  // Keep the vi.fn() handles directly (fully typed with .mockResolvedValue
+  // etc.); the store objects are thin casts over them.
+  const m = {
+    setConnected: vi.fn(),
+    deleteConnector: vi.fn(),
+    listForUser: vi.fn().mockResolvedValue([]),
+    listByUser: vi.fn().mockResolvedValue([]),
+    createUserInstance: vi.fn().mockResolvedValue(instance()),
+    update: vi.fn().mockResolvedValue(instance()),
+    deleteInstance: vi.fn().mockResolvedValue(true),
+  }
+  const connectorStore = {
+    setConnected: m.setConnected,
+    delete: m.deleteConnector,
+  } as unknown as ConnectorStore
+  const connectorInstanceStore = {
+    listForUser: m.listForUser,
+    listByUser: m.listByUser,
+    createUserInstance: m.createUserInstance,
+    update: m.update,
+    delete: m.deleteInstance,
+  } as unknown as ConnectorInstanceStore
+
+  const app = express()
+  app.use(express.json())
+  if (userId) {
+    app.use((req, _res, next) => {
+      ;(req as { userId?: string }).userId = userId
+      next()
+    })
+  }
+  app.use('/api/connectors', connectorRoutes({ connectorStore, connectorInstanceStore }))
+  return { app, ...m }
+}
+
+describe('[COMP:api/connectors-route] /api/connectors', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('401 without auth', async () => {
+    const { app } = makeApp()
+    const res = await request(app).get('/api/connectors')
+    expect(res.status).toBe(401)
+  })
+
+  it('GET / maps instances to the connector row shape', async () => {
+    const { app, listForUser } = makeApp('u1')
+    listForUser.mockResolvedValue([
+      instance({ provider: 'gcal', label: 'Work cal', connectedEmail: 'a@b.com' }),
+    ])
+    const res = await request(app).get('/api/connectors')
+    expect(res.status).toBe(200)
+    expect(res.body.connectors).toEqual([
+      expect.objectContaining({
+        id: 'gcal',
+        connectorId: 'gcal',
+        connectorInstanceId: IID,
+        label: 'Work cal',
+        connected: true,
+        connectedEmail: 'a@b.com',
+      }),
+    ])
+  })
+
+  it('store-credentials rejects an unsupported provider', async () => {
+    const { app, createUserInstance } = makeApp('u1')
+    const res = await request(app).post('/api/connectors/bogus/store-credentials').send({ pat: 'x' })
+    expect(res.status).toBe(400)
+    expect(createUserInstance).not.toHaveBeenCalled()
+  })
+
+  it('store-credentials rejects a credential-less connector (files)', async () => {
+    const { app } = makeApp('u1')
+    const res = await request(app).post('/api/connectors/files/store-credentials').send({ token: 'x' })
+    expect(res.status).toBe(400)
+  })
+
+  it('store-credentials 400 when no secret provided', async () => {
+    const { app } = makeApp('u1')
+    const res = await request(app).post('/api/connectors/github/store-credentials').send({ email: 'a@b.com' })
+    expect(res.status).toBe(400)
+  })
+
+  it('store-credentials primary path creates an instance when none exists', async () => {
+    const { app, createUserInstance } = makeApp('u1')
+    const res = await request(app).post('/api/connectors/github/store-credentials').send({ pat: 'ghp_abc' })
+    expect(res.status).toBe(200)
+    expect(createUserInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'u1',
+        provider: 'github',
+        connected: true,
+        credentials: { type: 'oauth', client_id: '', client_secret: 'ghp_abc' },
+      }),
+    )
+  })
+
+  it('store-credentials primary path updates the existing instance', async () => {
+    const { app, listByUser, update, createUserInstance } = makeApp('u1')
+    listByUser.mockResolvedValue([instance({ provider: 'gcal' })])
+    const res = await request(app)
+      .post('/api/connectors/gcal/store-credentials')
+      .send({ refreshToken: 'rt', email: 'a@b.com' })
+    expect(res.status).toBe(200)
+    expect(update).toHaveBeenCalledWith(
+      'u1',
+      IID,
+      expect.objectContaining({
+        connected: true,
+        connectedEmail: 'a@b.com',
+        credentials: { type: 'oauth', client_id: '', client_secret: 'rt' },
+      }),
+    )
+    expect(createUserInstance).not.toHaveBeenCalled()
+  })
+
+  it('store-credentials createNew always creates a fresh instance', async () => {
+    const { app, listByUser, createUserInstance, update } = makeApp('u1')
+    listByUser.mockResolvedValue([instance({ provider: 'github' })])
+    const res = await request(app)
+      .post('/api/connectors/github/store-credentials')
+      .send({ pat: 'ghp_2', createNew: true, label: 'Second acct' })
+    expect(res.status).toBe(200)
+    expect(createUserInstance).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'Second acct' }),
+    )
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it('store-credentials with instanceId 404s when the instance is missing', async () => {
+    const { app, update } = makeApp('u1')
+    update.mockResolvedValue(null)
+    const res = await request(app)
+      .post('/api/connectors/github/store-credentials')
+      .send({ pat: 'x', instanceId: IID })
+    expect(res.status).toBe(404)
+  })
+
+  it('store-credentials rejects a malformed instanceId', async () => {
+    const { app } = makeApp('u1')
+    const res = await request(app)
+      .post('/api/connectors/github/store-credentials')
+      .send({ pat: 'x', instanceId: 'not-a-uuid' })
+    expect(res.status).toBe(400)
+  })
+
+  it('store-credentials returns 503 when the encryption key is unset', async () => {
+    const { app, createUserInstance } = makeApp('u1')
+    createUserInstance.mockRejectedValue(
+      new Error('Cannot store connector credentials: CHANNEL_CREDENTIAL_KEY is not configured'),
+    )
+    const res = await request(app).post('/api/connectors/github/store-credentials').send({ pat: 'x' })
+    expect(res.status).toBe(503)
+  })
+
+  it('disconnect flips the primary instance and 404s when absent', async () => {
+    const { app, setConnected } = makeApp('u1')
+    setConnected.mockResolvedValueOnce(instance({ connected: false }))
+    const ok = await request(app).post('/api/connectors/github/disconnect')
+    expect(ok.status).toBe(200)
+    expect(setConnected).toHaveBeenCalledWith('u1', 'github', false)
+
+    setConnected.mockResolvedValueOnce(null)
+    const missing = await request(app).post('/api/connectors/github/disconnect')
+    expect(missing.status).toBe(404)
+  })
+
+  it('PATCH /instances/:id renames; rejects blank label and bad id', async () => {
+    const { app, update } = makeApp('u1')
+    update.mockResolvedValue(instance({ label: 'Renamed' }))
+    const ok = await request(app).patch(`/api/connectors/instances/${IID}`).send({ label: 'Renamed' })
+    expect(ok.status).toBe(200)
+    expect(ok.body.label).toBe('Renamed')
+
+    const blank = await request(app).patch(`/api/connectors/instances/${IID}`).send({ label: '  ' })
+    expect(blank.status).toBe(400)
+
+    const badId = await request(app).patch('/api/connectors/instances/nope').send({ label: 'x' })
+    expect(badId.status).toBe(400)
+  })
+
+  it('DELETE /instances/:id deletes a specific instance', async () => {
+    const { app, deleteInstance } = makeApp('u1')
+    const res = await request(app).delete(`/api/connectors/instances/${IID}`)
+    expect(res.status).toBe(200)
+    expect(deleteInstance).toHaveBeenCalledWith('u1', IID)
+  })
+
+  it('DELETE /:provider deletes the primary instance and 404s when absent', async () => {
+    const { app, deleteConnector } = makeApp('u1')
+    deleteConnector.mockResolvedValueOnce(true)
+    const ok = await request(app).delete('/api/connectors/github')
+    expect(ok.status).toBe(200)
+
+    deleteConnector.mockResolvedValueOnce(false)
+    const missing = await request(app).delete('/api/connectors/notion')
+    expect(missing.status).toBe(404)
+  })
+})

--- a/packages/api/src/routes/__tests__/connectors.test.ts
+++ b/packages/api/src/routes/__tests__/connectors.test.ts
@@ -158,9 +158,12 @@ describe('[COMP:api/connectors-route] /api/connectors', () => {
     })
   })
 
-  it('GET /:provider/tools is empty for a connector with no catalog', async () => {
+  it('GET /:provider/tools is empty for a provider with no catalog entry', async () => {
+    // A slug absent from OFFICIAL_CONNECTOR_TOOLS (e.g. a custom connector) has
+    // no built-in tool set. Note official connectors — including `files` — DO
+    // carry catalogs, so this must use a genuinely unlisted provider.
     const { app } = makeApp('u1')
-    const res = await request(app).get('/api/connectors/files/tools')
+    const res = await request(app).get('/api/connectors/no-such-connector/tools')
     expect(res.status).toBe(200)
     expect(res.body.tools).toEqual([])
   })

--- a/packages/api/src/routes/connectors.ts
+++ b/packages/api/src/routes/connectors.ts
@@ -2,44 +2,76 @@
  * Built-in connector lifecycle routes — `/api/connectors`.
  *
  * The OSS-open half of the connector surface. The hosted edition mounts a
- * richer closed `/api/connectors` route (custom MCP CRUD, directory browse,
- * Google Drive authorized-files, per-assistant tool policy); this open module
- * implements only the built-in OAuth/PAT connector lifecycle that the open
- * `apps/app-web` OAuth callbacks and Studio → Connectors page already drive:
+ * richer closed `/api/connectors` route (custom MCP CRUD, Google Drive
+ * authorized-files, per-assistant tool policy); this open module implements the
+ * built-in OAuth/PAT connector lifecycle that the open `apps/app-web` OAuth
+ * callbacks and Studio → Connectors page drive:
  *
- *   GET    /api/connectors                         — list the caller's connectors
+ *   GET    /api/connectors                          — the unified connector list
+ *   GET    /api/connectors/directory                — the "browse to add" catalog
+ *   POST   /api/connectors/directory/:id/add        — add an official connector
  *   POST   /api/connectors/:provider/store-credentials — persist an OAuth/PAT grant
- *   POST   /api/connectors/:provider/disconnect    — flip the primary instance offline
- *   PATCH  /api/connectors/instances/:id           — rename a connector instance
- *   DELETE /api/connectors/instances/:id           — delete a specific instance
- *   DELETE /api/connectors/:provider               — delete the primary instance
+ *   POST   /api/connectors/:provider/connect        — mark the primary instance connected
+ *   POST   /api/connectors/instances/:id/connect    — mark a specific instance connected
+ *   POST   /api/connectors/:provider/disconnect     — flip the primary instance offline
+ *   PATCH  /api/connectors/instances/:id            — rename a connector instance
+ *   DELETE /api/connectors/instances/:id            — delete a specific instance
+ *   DELETE /api/connectors/:provider                — delete the primary instance
  *
- * Mounted behind `requireAuth`, so `req.userId` is always set. All persistence
- * goes through the RLS-gated `connectorInstanceStore` / `connectorStore`, which
- * encrypt the per-user OAuth refresh-token / PAT into `connector_instance.
- * credentials` under `CHANNEL_CREDENTIAL_KEY`. The injected token is read back
- * by `mcp/inject.ts` (`readRefreshToken` / `getPat` both read
- * `credentials.client_secret`), which is why every provider stores its secret
- * as the `client_secret` of an `oauth`-typed blob.
+ * THE LIST MUST INCLUDE NEVER-CONNECTED BUILT-IN PLACEHOLDERS. The Studio page
+ * (`connector-groups.ts`) buckets every official connector with no instance into
+ * the "available" group — that is the bare "Connect" affordance. A list of only
+ * the user's existing `connector_instance` rows shows nothing on a fresh account
+ * ("No connectors available"). So `GET /` merges `OFFICIAL_CONNECTORS` (the
+ * drift-safe registry — never a hardcoded slug list, per CLAUDE.md) with the
+ * caller's instances: a placeholder per unconnected official connector, plus a
+ * row per real instance.
  *
- * The supported provider set is derived from `OFFICIAL_CONNECTORS` (never a
- * hardcoded slug list — see CLAUDE.md "all built-ins" drift anti-pattern).
- * `auth_type: 'none'` connectors (e.g. Workspace Files) are first-party and
- * carry no external credential, so they are rejected here.
+ * Persistence goes through the RLS-gated `connectorInstanceStore` /
+ * `connectorStore`, which encrypt the per-user OAuth refresh-token / PAT into
+ * `connector_instance.credentials` under `CHANNEL_CREDENTIAL_KEY`. The injected
+ * token is read back by `mcp/inject.ts` (`readRefreshToken` / `getPat` both read
+ * `credentials.client_secret`), so every provider stores its secret as the
+ * `client_secret` of an `oauth`-typed blob.
+ *
+ * Google / Notion / Fathom additionally need their OAuth *app* credentials: the
+ * server-side secret via `~/.sidanclaw/connectors.config.json` (or `*_CLIENT_*`
+ * env) for the callback's token exchange, and the public client id via
+ * `NEXT_PUBLIC_*_CLIENT_ID` for app-web's client-side authorize redirect. GitHub
+ * is PAT-only and needs neither.
  *
  * Out of scope for the open edition (handled by the closed route): custom MCP
- * connectors (`/custom`), the connector directory (`/directory`), Google Drive
- * authorized-files (`/gdrive/*`), and per-assistant tool policy (`/tools`).
+ * connectors (`/custom`), Google Drive authorized-files (`/gdrive/*`), and
+ * per-assistant tool policy (`/tools`).
  *
  * Component tag: [COMP:api/connectors-route].
  */
 
 import { Router } from 'express'
-import { OFFICIAL_CONNECTORS } from '@sidanclaw/shared'
+import { OFFICIAL_CONNECTORS, type ConnectorEntry } from '@sidanclaw/shared'
 import type { ConnectorStore, ConnectorCredentials } from '../db/connector-store.js'
-import type { ConnectorInstanceStore } from '../db/connector-instance-store.js'
+import type { ConnectorInstanceStore, ConnectorInstance } from '../db/connector-instance-store.js'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+const OFFICIAL_BY_ID = new Map<string, ConnectorEntry>(OFFICIAL_CONNECTORS.map((c) => [c.id, c]))
+
+type ConnectorRowOut = {
+  id: string
+  connectorInstanceId?: string
+  name: string
+  label?: string
+  isPrimary?: boolean
+  addable?: boolean
+  isPlaceholder?: boolean
+  description?: string
+  connected: boolean
+  custom?: boolean
+  url?: string
+  oauthRequired?: boolean
+  category?: 'official' | 'community'
+  connectedEmail?: string
+}
 
 type ConnectorRouteOptions = {
   connectorStore: ConnectorStore
@@ -47,8 +79,8 @@ type ConnectorRouteOptions = {
 }
 
 /** Built-in connector that carries an external credential (excludes auth_type 'none'). */
-function credentialedConnector(provider: string) {
-  const entry = OFFICIAL_CONNECTORS.find((c) => c.id === provider)
+function credentialedConnector(provider: string): ConnectorEntry | null {
+  const entry = OFFICIAL_BY_ID.get(provider)
   if (!entry || entry.auth_type === 'none') return null
   return entry
 }
@@ -64,35 +96,138 @@ function credentialsFor(secret: string): ConnectorCredentials {
   return { type: 'oauth', client_id: '', client_secret: secret }
 }
 
+/** A never-connected built-in: the bare "Connect" affordance in the list. */
+function placeholderRow(entry: ConnectorEntry): ConnectorRowOut {
+  return {
+    id: entry.id,
+    name: entry.name,
+    description: entry.description,
+    connected: false,
+    custom: false,
+    isPlaceholder: true,
+    isPrimary: true,
+    addable: entry.auth_type !== 'none',
+    oauthRequired: entry.oauth_required,
+    category: entry.category,
+  }
+}
+
+/** A real connector_instance row, projected to the page's connector shape. */
+function instanceRow(inst: ConnectorInstance, isPrimary: boolean): ConnectorRowOut {
+  const entry = OFFICIAL_BY_ID.get(inst.provider)
+  return {
+    id: inst.provider,
+    connectorInstanceId: inst.id,
+    name: entry?.name ?? inst.label,
+    label: inst.label,
+    isPrimary,
+    addable: entry ? entry.auth_type !== 'none' : false,
+    description: entry?.description,
+    connected: inst.connected,
+    custom: inst.custom,
+    url: inst.url ?? undefined,
+    oauthRequired: entry?.oauth_required,
+    category: entry ? entry.category : 'community',
+    connectedEmail: inst.connectedEmail ?? undefined,
+  }
+}
+
 export function connectorRoutes(opts: ConnectorRouteOptions): Router {
   const { connectorStore, connectorInstanceStore } = opts
   const router = Router()
 
-  // ── GET / — list the caller's connectors ─────────────────────
+  /** Group the caller's instances by provider, each list oldest-first. */
+  async function instancesByProvider(userId: string): Promise<Map<string, ConnectorInstance[]>> {
+    const instances = await connectorInstanceStore.listForUser(userId)
+    const byProvider = new Map<string, ConnectorInstance[]>()
+    for (const inst of instances) {
+      const list = byProvider.get(inst.provider) ?? []
+      list.push(inst)
+      byProvider.set(inst.provider, list)
+    }
+    for (const list of byProvider.values()) {
+      list.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+    }
+    return byProvider
+  }
+
+  // ── GET / — the unified connector list (placeholders + instances) ──
   router.get('/', async (req, res) => {
     const userId = req.userId
     if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
     try {
-      const instances = await connectorInstanceStore.listForUser(userId)
-      res.json({
-        connectors: instances.map((i) => ({
-          id: i.provider,
-          connectorId: i.provider,
-          connectorInstanceId: i.id,
-          scope: i.scope,
-          name: i.label,
-          label: i.label,
-          connected: i.connected,
-          custom: i.custom,
-          url: i.url,
-          connectedEmail: i.connectedEmail,
-          credentialsType: i.credentialsType,
-          sensitivity: i.sensitivity,
-        })),
-      })
+      const byProvider = await instancesByProvider(userId)
+      const rows: ConnectorRowOut[] = []
+
+      // Every official connector: real instances if connected/added, else the
+      // never-connected placeholder.
+      for (const entry of OFFICIAL_CONNECTORS) {
+        const insts = byProvider.get(entry.id)
+        if (!insts || insts.length === 0) {
+          rows.push(placeholderRow(entry))
+        } else {
+          insts.forEach((inst, i) => rows.push(instanceRow(inst, i === 0)))
+        }
+      }
+      // Plus any non-official instances (custom MCP rows created elsewhere).
+      for (const [provider, insts] of byProvider) {
+        if (OFFICIAL_BY_ID.has(provider)) continue
+        insts.forEach((inst, i) => rows.push(instanceRow(inst, i === 0)))
+      }
+
+      res.json({ connectors: rows })
     } catch (err) {
       console.error('[connectors] list failed:', err)
       res.status(500).json({ error: 'Failed to list connectors' })
+    }
+  })
+
+  // ── GET /directory — the "browse to add" catalog ─────────────
+  router.get('/directory', async (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+    try {
+      const byProvider = await instancesByProvider(userId)
+      const directory = OFFICIAL_CONNECTORS.map((entry) => {
+        const insts = byProvider.get(entry.id) ?? []
+        return {
+          ...entry,
+          added: insts.length > 0,
+          connected: insts.some((i) => i.connected),
+          addable: entry.auth_type !== 'none',
+        }
+      })
+      res.json({ directory })
+    } catch (err) {
+      console.error('[connectors] directory failed:', err)
+      res.status(500).json({ error: 'Failed to load directory' })
+    }
+  })
+
+  // ── POST /directory/:id/add — add an official connector ──────
+  // Idempotent: surfaces the connector in the user's list by ensuring an
+  // instance row exists (disconnected until the user completes OAuth / PAT).
+  // Official built-ins already render as placeholders, so this is a no-op
+  // success when an instance is already present.
+  router.post('/directory/:id/add', async (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+    const entry = OFFICIAL_BY_ID.get(req.params.id)
+    if (!entry) { res.status(404).json({ error: `Unknown connector: ${req.params.id}` }); return }
+    try {
+      const existing = (await connectorInstanceStore.listByUser(userId, userId))
+        .find((i) => i.provider === entry.id)
+      if (existing) { res.json({ ok: true, connectorInstanceId: existing.id }); return }
+      const created = await connectorInstanceStore.createUserInstance({
+        userId,
+        provider: entry.id,
+        label: entry.name,
+        connected: false,
+      })
+      res.json({ ok: true, connectorInstanceId: created.id })
+    } catch (err) {
+      console.error('[connectors] directory add failed:', err)
+      res.status(500).json({ error: 'Failed to add connector' })
     }
   })
 
@@ -204,6 +339,38 @@ export function connectorRoutes(opts: ConnectorRouteOptions): Router {
       }
       console.error('[connectors] store-credentials failed:', err)
       res.status(500).json({ error: 'Failed to store credentials' })
+    }
+  })
+
+  // ── POST /instances/:id/connect — mark a specific instance connected ──
+  router.post('/instances/:id/connect', async (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+    const { id } = req.params
+    if (!UUID_RE.test(id)) { res.status(400).json({ error: 'Invalid instance id' }); return }
+    try {
+      const updated = await connectorInstanceStore.update(userId, id, { connected: true })
+      if (!updated) { res.status(404).json({ error: 'Connector instance not found' }); return }
+      res.json({ ok: true, connectorInstanceId: updated.id })
+    } catch (err) {
+      console.error('[connectors] instance connect failed:', err)
+      res.status(500).json({ error: 'Failed to connect' })
+    }
+  })
+
+  // ── POST /:provider/connect — mark the primary instance connected ──
+  // For built-ins this is the non-OAuth/reconnect path; OAuth connectors go
+  // through store-credentials after the client-side authorize redirect.
+  router.post('/:provider/connect', async (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+    try {
+      const row = await connectorStore.setConnected(userId, req.params.provider, true)
+      if (!row) { res.status(404).json({ error: 'Connector not found (connect it first)' }); return }
+      res.json({ ok: true })
+    } catch (err) {
+      console.error('[connectors] connect failed:', err)
+      res.status(500).json({ error: 'Failed to connect' })
     }
   })
 

--- a/packages/api/src/routes/connectors.ts
+++ b/packages/api/src/routes/connectors.ts
@@ -10,6 +10,9 @@
  *   GET    /api/connectors                          — the unified connector list
  *   GET    /api/connectors/directory                — the "browse to add" catalog
  *   POST   /api/connectors/directory/:id/add        — add an official connector
+ *   GET    /api/connectors/:provider/tools          — the connector's tool catalog
+ *   GET    /api/connectors/:provider/config         — the connector's JSON config
+ *   PATCH  /api/connectors/:provider/config         — merge into the JSON config
  *   POST   /api/connectors/:provider/store-credentials — persist an OAuth/PAT grant
  *   POST   /api/connectors/:provider/connect        — mark the primary instance connected
  *   POST   /api/connectors/instances/:id/connect    — mark a specific instance connected
@@ -48,7 +51,7 @@
  */
 
 import { Router } from 'express'
-import { OFFICIAL_CONNECTORS, type ConnectorEntry } from '@sidanclaw/shared'
+import { OFFICIAL_CONNECTORS, OFFICIAL_CONNECTOR_TOOLS, type ConnectorEntry } from '@sidanclaw/shared'
 import type { ConnectorStore, ConnectorCredentials } from '../db/connector-store.js'
 import type { ConnectorInstanceStore, ConnectorInstance } from '../db/connector-instance-store.js'
 
@@ -228,6 +231,55 @@ export function connectorRoutes(opts: ConnectorRouteOptions): Router {
     } catch (err) {
       console.error('[connectors] directory add failed:', err)
       res.status(500).json({ error: 'Failed to add connector' })
+    }
+  })
+
+  // ── GET /:provider/tools — the connector's tool catalog ──────
+  // Built-in connectors expose a fixed tool set (OFFICIAL_CONNECTOR_TOOLS). The
+  // Studio "Tools" tab renders this; an empty/absent response is what showed
+  // "No tools found" after connecting. Policy is the registry default — the
+  // per-assistant L2 override store is out of scope for the open route.
+  router.get('/:provider/tools', (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+    const entry = OFFICIAL_BY_ID.get(req.params.provider)
+    const catalog = OFFICIAL_CONNECTOR_TOOLS[req.params.provider] ?? []
+    res.json({
+      serverName: entry?.name ?? req.params.provider,
+      tools: catalog.map((t) => ({
+        name: t.name,
+        description: t.description,
+        classification: t.classification,
+        policy: t.defaultPolicy,
+      })),
+    })
+  })
+
+  // ── GET /:provider/config — the connector's JSON config ──────
+  router.get('/:provider/config', async (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+    try {
+      const config = await connectorStore.getConfig(userId, req.params.provider)
+      res.json({ config })
+    } catch (err) {
+      console.error('[connectors] get config failed:', err)
+      res.status(500).json({ error: 'Failed to load config' })
+    }
+  })
+
+  // ── PATCH /:provider/config — merge into the JSON config ─────
+  router.patch('/:provider/config', async (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+    const patch = (req.body ?? {}) as Record<string, unknown>
+    try {
+      await connectorStore.setConfig(userId, req.params.provider, patch)
+      const config = await connectorStore.getConfig(userId, req.params.provider)
+      res.json({ config })
+    } catch (err) {
+      console.error('[connectors] set config failed:', err)
+      res.status(500).json({ error: 'Failed to save config' })
     }
   })
 

--- a/packages/api/src/routes/connectors.ts
+++ b/packages/api/src/routes/connectors.ts
@@ -1,0 +1,273 @@
+/**
+ * Built-in connector lifecycle routes — `/api/connectors`.
+ *
+ * The OSS-open half of the connector surface. The hosted edition mounts a
+ * richer closed `/api/connectors` route (custom MCP CRUD, directory browse,
+ * Google Drive authorized-files, per-assistant tool policy); this open module
+ * implements only the built-in OAuth/PAT connector lifecycle that the open
+ * `apps/app-web` OAuth callbacks and Studio → Connectors page already drive:
+ *
+ *   GET    /api/connectors                         — list the caller's connectors
+ *   POST   /api/connectors/:provider/store-credentials — persist an OAuth/PAT grant
+ *   POST   /api/connectors/:provider/disconnect    — flip the primary instance offline
+ *   PATCH  /api/connectors/instances/:id           — rename a connector instance
+ *   DELETE /api/connectors/instances/:id           — delete a specific instance
+ *   DELETE /api/connectors/:provider               — delete the primary instance
+ *
+ * Mounted behind `requireAuth`, so `req.userId` is always set. All persistence
+ * goes through the RLS-gated `connectorInstanceStore` / `connectorStore`, which
+ * encrypt the per-user OAuth refresh-token / PAT into `connector_instance.
+ * credentials` under `CHANNEL_CREDENTIAL_KEY`. The injected token is read back
+ * by `mcp/inject.ts` (`readRefreshToken` / `getPat` both read
+ * `credentials.client_secret`), which is why every provider stores its secret
+ * as the `client_secret` of an `oauth`-typed blob.
+ *
+ * The supported provider set is derived from `OFFICIAL_CONNECTORS` (never a
+ * hardcoded slug list — see CLAUDE.md "all built-ins" drift anti-pattern).
+ * `auth_type: 'none'` connectors (e.g. Workspace Files) are first-party and
+ * carry no external credential, so they are rejected here.
+ *
+ * Out of scope for the open edition (handled by the closed route): custom MCP
+ * connectors (`/custom`), the connector directory (`/directory`), Google Drive
+ * authorized-files (`/gdrive/*`), and per-assistant tool policy (`/tools`).
+ *
+ * Component tag: [COMP:api/connectors-route].
+ */
+
+import { Router } from 'express'
+import { OFFICIAL_CONNECTORS } from '@sidanclaw/shared'
+import type { ConnectorStore, ConnectorCredentials } from '../db/connector-store.js'
+import type { ConnectorInstanceStore } from '../db/connector-instance-store.js'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+type ConnectorRouteOptions = {
+  connectorStore: ConnectorStore
+  connectorInstanceStore: ConnectorInstanceStore
+}
+
+/** Built-in connector that carries an external credential (excludes auth_type 'none'). */
+function credentialedConnector(provider: string) {
+  const entry = OFFICIAL_CONNECTORS.find((c) => c.id === provider)
+  if (!entry || entry.auth_type === 'none') return null
+  return entry
+}
+
+/**
+ * The credentials blob shape every built-in stores: the per-user secret (OAuth
+ * refresh token for `oauth` providers, PAT for `api_key` providers) lands in
+ * `client_secret`, which is what `mcp/inject.ts` reads back. `client_id` is
+ * unused at injection time (Google's app client id comes from
+ * `getConnectorConfig`), so it is left blank.
+ */
+function credentialsFor(secret: string): ConnectorCredentials {
+  return { type: 'oauth', client_id: '', client_secret: secret }
+}
+
+export function connectorRoutes(opts: ConnectorRouteOptions): Router {
+  const { connectorStore, connectorInstanceStore } = opts
+  const router = Router()
+
+  // ── GET / — list the caller's connectors ─────────────────────
+  router.get('/', async (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+    try {
+      const instances = await connectorInstanceStore.listForUser(userId)
+      res.json({
+        connectors: instances.map((i) => ({
+          id: i.provider,
+          connectorId: i.provider,
+          connectorInstanceId: i.id,
+          scope: i.scope,
+          name: i.label,
+          label: i.label,
+          connected: i.connected,
+          custom: i.custom,
+          url: i.url,
+          connectedEmail: i.connectedEmail,
+          credentialsType: i.credentialsType,
+          sensitivity: i.sensitivity,
+        })),
+      })
+    } catch (err) {
+      console.error('[connectors] list failed:', err)
+      res.status(500).json({ error: 'Failed to list connectors' })
+    }
+  })
+
+  // ── POST /:provider/store-credentials — persist an OAuth/PAT grant ──
+  //
+  // Request body (any one secret field, per the open OAuth callbacks +
+  // Studio PAT form):
+  //   refreshToken | pat | accessToken | token  — the per-user secret (required)
+  //   email?    — the connected account email (stored on the instance)
+  //   label?    — display nickname (defaults to the provider's display name)
+  //   instanceId? — target an existing instance (re-auth / multi-account update)
+  //   createNew?  — true: always create a NEW instance (multi-account "add another")
+  router.post('/:provider/store-credentials', async (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+
+    const provider = req.params.provider
+    const entry = credentialedConnector(provider)
+    if (!entry) {
+      res.status(400).json({ error: `Unsupported connector: ${provider}` })
+      return
+    }
+
+    const body = (req.body ?? {}) as {
+      refreshToken?: string
+      pat?: string
+      accessToken?: string
+      token?: string
+      email?: string
+      label?: string
+      instanceId?: string
+      createNew?: boolean
+    }
+    const secret = (body.refreshToken ?? body.pat ?? body.accessToken ?? body.token ?? '').trim()
+    if (!secret) {
+      res.status(400).json({ error: 'Missing credential (refreshToken/pat/accessToken/token)' })
+      return
+    }
+    if (body.instanceId !== undefined && !UUID_RE.test(body.instanceId)) {
+      res.status(400).json({ error: 'Invalid instanceId' })
+      return
+    }
+
+    const credentials = credentialsFor(secret)
+    const email = body.email ?? null
+    const label = body.label?.trim() || undefined
+
+    try {
+      // Multi-account "add another" — always a fresh instance.
+      if (body.createNew) {
+        const created = await connectorInstanceStore.createUserInstance({
+          userId,
+          provider,
+          label: label ?? entry.name,
+          connectedEmail: email,
+          connected: true,
+          credentials,
+        })
+        res.json({ ok: true, connectorInstanceId: created.id })
+        return
+      }
+
+      // Re-auth / update a specific existing instance.
+      if (body.instanceId) {
+        const updated = await connectorInstanceStore.update(userId, body.instanceId, {
+          connected: true,
+          connectedEmail: email,
+          credentials,
+          ...(label ? { label } : {}),
+        })
+        if (!updated) { res.status(404).json({ error: 'Connector instance not found' }); return }
+        res.json({ ok: true, connectorInstanceId: updated.id })
+        return
+      }
+
+      // Primary (one-per-provider) path: update the first matching instance or
+      // create it. Mirrors the legacy `connectorStore.upsert` semantic but also
+      // records `connected_email`, which the shim drops.
+      const existing = (await connectorInstanceStore.listByUser(userId, userId))
+        .find((i) => i.provider === provider)
+      if (existing) {
+        const updated = await connectorInstanceStore.update(userId, existing.id, {
+          connected: true,
+          connectedEmail: email,
+          credentials,
+          ...(label ? { label } : {}),
+        })
+        res.json({ ok: true, connectorInstanceId: updated?.id ?? existing.id })
+        return
+      }
+
+      const created = await connectorInstanceStore.createUserInstance({
+        userId,
+        provider,
+        label: label ?? entry.name,
+        connectedEmail: email,
+        connected: true,
+        credentials,
+      })
+      res.json({ ok: true, connectorInstanceId: created.id })
+    } catch (err) {
+      // The store throws when CHANNEL_CREDENTIAL_KEY is unset — surface it as a
+      // 503 so the launcher-misconfiguration case is distinguishable from a bug.
+      const msg = err instanceof Error ? err.message : String(err)
+      if (msg.includes('CHANNEL_CREDENTIAL_KEY')) {
+        console.error('[connectors] store-credentials: encryption key not configured')
+        res.status(503).json({ error: 'Connector credential storage is not configured (CHANNEL_CREDENTIAL_KEY)' })
+        return
+      }
+      console.error('[connectors] store-credentials failed:', err)
+      res.status(500).json({ error: 'Failed to store credentials' })
+    }
+  })
+
+  // ── POST /:provider/disconnect — flip the primary instance offline ──
+  router.post('/:provider/disconnect', async (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+    try {
+      const row = await connectorStore.setConnected(userId, req.params.provider, false)
+      if (!row) { res.status(404).json({ error: 'Connector not found' }); return }
+      res.json({ ok: true })
+    } catch (err) {
+      console.error('[connectors] disconnect failed:', err)
+      res.status(500).json({ error: 'Failed to disconnect' })
+    }
+  })
+
+  // ── PATCH /instances/:id — rename a connector instance ───────
+  router.patch('/instances/:id', async (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+    const { id } = req.params
+    if (!UUID_RE.test(id)) { res.status(400).json({ error: 'Invalid instance id' }); return }
+    const label = ((req.body ?? {}) as { label?: string }).label?.trim()
+    if (!label) { res.status(400).json({ error: 'label is required' }); return }
+    try {
+      const updated = await connectorInstanceStore.update(userId, id, { label })
+      if (!updated) { res.status(404).json({ error: 'Connector instance not found' }); return }
+      res.json({ ok: true, label: updated.label })
+    } catch (err) {
+      console.error('[connectors] rename failed:', err)
+      res.status(500).json({ error: 'Failed to rename connector' })
+    }
+  })
+
+  // ── DELETE /instances/:id — delete a specific instance ───────
+  router.delete('/instances/:id', async (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+    const { id } = req.params
+    if (!UUID_RE.test(id)) { res.status(400).json({ error: 'Invalid instance id' }); return }
+    try {
+      const deleted = await connectorInstanceStore.delete(userId, id)
+      if (!deleted) { res.status(404).json({ error: 'Connector instance not found' }); return }
+      res.json({ ok: true })
+    } catch (err) {
+      console.error('[connectors] delete instance failed:', err)
+      res.status(500).json({ error: 'Failed to delete connector' })
+    }
+  })
+
+  // ── DELETE /:provider — delete the primary instance (legacy shim) ──
+  router.delete('/:provider', async (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+    try {
+      const deleted = await connectorStore.delete(userId, req.params.provider)
+      if (!deleted) { res.status(404).json({ error: 'Connector not found' }); return }
+      res.json({ ok: true })
+    } catch (err) {
+      console.error('[connectors] delete failed:', err)
+      res.status(500).json({ error: 'Failed to delete connector' })
+    }
+  })
+
+  return router
+}

--- a/scripts/launch.mjs
+++ b/scripts/launch.mjs
@@ -31,6 +31,37 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const CONFIG_DIR = join(homedir(), '.sidanclaw')
 const CONFIG_FILE = join(CONFIG_DIR, 'config.json')
 const BRAIN_DIR = join(CONFIG_DIR, 'brain')
+
+// Load sidanclaw/.env into process.env BEFORE any env read below, so `pnpm
+// start` honors it the same way the standalone migrate + doc-sync paths
+// already do (both dotenv.config this exact file). Without this the launcher
+// only saw real shell vars, so a DATABASE_URL in .env was silently ignored and
+// the embedded-vs-external decision (useEmbedded, below) never reacted to it.
+// Self-contained (no dotenv dependency at the repo root): shell env always
+// wins (we never overwrite an already-set var), full-line and inline `#`
+// comments are stripped from unquoted values, and quoted values keep their
+// contents verbatim so a DATABASE_URL/password containing `#` survives.
+function loadDotEnv(path) {
+  if (!existsSync(path)) return
+  for (const raw of readFileSync(path, 'utf8').split(/\r?\n/)) {
+    const m = raw.match(/^\s*(?:export\s+)?([\w.-]+)\s*=\s*(.*)$/)
+    if (!m) continue
+    const key = m[1]
+    if (key in process.env) continue // shell wins; never override an existing var
+    let val = m[2]
+    const quote = val[0]
+    if (quote === '"' || quote === "'") {
+      const end = val.indexOf(quote, 1)
+      val = end === -1 ? val.slice(1) : val.slice(1, end)
+      if (quote === '"') val = val.replace(/\\n/g, '\n')
+    } else {
+      val = val.replace(/(^|\s)#.*$/, '').trim() // drop inline comment (`#` at start or after space)
+    }
+    process.env[key] = val
+  }
+}
+loadDotEnv(join(ROOT, '.env'))
+
 // The embedded brain uses a distinctive high port so it never collides with a
 // developer's local Postgres on the default 5432 (verified failure mode).
 const PORTS = { pglite: 54329, api: 4000, docSync: 8080, appWeb: 3003 }
@@ -55,7 +86,23 @@ if (!geminiKey || !ownerName) {
   rl.close()
 }
 const jwtSecret = config.jwtSecret || randomBytes(32).toString('hex')
-writeFileSync(CONFIG_FILE, JSON.stringify({ ...config, geminiApiKey: geminiKey, jwtSecret, ownerName }, null, 2))
+// Shared secret for the API <-> doc-sync internal routes (both directions:
+// API -> doc-sync `/internal/apply`, and doc-sync -> API `/internal/ingest-page`
+// for the auto-on-save brain ingest). Generated + persisted like JWT_SECRET so
+// both child processes get the same value; without it the auto-ingest enqueue
+// is gated off and the API endpoint refuses.
+const docSyncSecret = config.docSyncSecret || randomBytes(32).toString('hex')
+// AES-GCM key that encrypts connector OAuth refresh-tokens / PATs at rest in
+// `connector_instance.credentials`. Without it the api boots with a null
+// credential key and `/api/connectors/:provider/store-credentials` returns 503,
+// so connectors (Google Calendar, GitHub, Notion, ...) can't be connected.
+// Base64 of 32 random bytes -- the format `loadChannelCredentialKey` decodes.
+// Generated + persisted like the other secrets so it survives restarts.
+const channelCredentialKey = config.channelCredentialKey || randomBytes(32).toString('base64')
+writeFileSync(
+  CONFIG_FILE,
+  JSON.stringify({ ...config, geminiApiKey: geminiKey, jwtSecret, docSyncSecret, channelCredentialKey, ownerName }, null, 2),
+)
 
 // External-store escape hatch: a real Postgres URL skips the embedded brain.
 const useEmbedded = !process.env.DATABASE_URL
@@ -68,6 +115,19 @@ const env = {
   JWT_SECRET: jwtSecret,
   DATABASE_URL: databaseUrl,
   SIDANCLAW_SINGLE_PROCESS: '1',
+  // API <-> doc-sync internal auth + the base URL doc-sync POSTs back to for the
+  // auto-on-save brain ingest. 127.0.0.1 (not localhost) avoids the IPv6 ::1
+  // resolution that the api's IPv4 listener refuses.
+  DOC_SYNC_SECRET: docSyncSecret,
+  // Encrypts connector credentials at rest (see generation note above).
+  CHANNEL_CREDENTIAL_KEY: channelCredentialKey,
+  API_INTERNAL_URL: `http://127.0.0.1:${PORTS.api}`,
+  // The embedded brain is one PGLite instance with a single shared session;
+  // concurrent pool connections clobber its unnamed prepared statement. Force
+  // client.ts onto a single serialized connection (see its SINGLE_CONNECTION
+  // note + oss-local-brain-wedge.md §12.4). The external-Postgres escape hatch
+  // leaves it unset — a real Postgres isolates statements per connection.
+  ...(useEmbedded ? { PG_SINGLE_CONNECTION: '1' } : {}),
   // This is the single-player open edition: app-web hides hosted-only surfaces
   // (billing, teammates) and shows the upgrade affordance instead. The flag
   // defaults to the full hosted edition when unset, so only the local launcher
@@ -147,7 +207,15 @@ run('doc-sync', 'pnpm', ['--filter', '@sidanclaw/doc-sync', 'exec', 'tsx', 'src/
   { PORT: String(PORTS.docSync) })
 run('app-web', 'pnpm', ['--filter', 'app-web', 'dev'])
 
-await waitForPort(PORTS.appWeb, 'app-web', 120_000)
+// Wait for BOTH the api (:4000) and app-web (:3003) before opening the browser.
+// The entry URL immediately proxies to the api's /auth/local-session, and the
+// api binds its port only after its workers + tool registry finish booting
+// (well after app-web's ~200ms dev-server start). Waiting on app-web alone
+// raced that startup and 500'd local-session with ECONNREFUSED.
+await Promise.all([
+  waitForPort(PORTS.api, 'api', 120_000),
+  waitForPort(PORTS.appWeb, 'app-web', 120_000),
+])
 const entryUrl = `http://localhost:${PORTS.appWeb}/api/auth/local-session`
 console.log(`\n[launch] sidanclaw is up. Opening ${entryUrl}\n  (api :${PORTS.api} · doc-sync :${PORTS.docSync} · app-web :${PORTS.appWeb})\n  Ctrl-C to stop everything.\n`)
 openBrowser(entryUrl)

--- a/scripts/launch.mjs
+++ b/scripts/launch.mjs
@@ -21,10 +21,11 @@
 import { spawn } from 'node:child_process'
 import { connect } from 'node:net'
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs'
-import { homedir, platform, userInfo } from 'node:os'
+import { homedir, platform, arch, userInfo } from 'node:os'
 import { join, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { randomBytes } from 'node:crypto'
+import { createRequire } from 'node:module'
 import { createInterface } from 'node:readline/promises'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
@@ -177,6 +178,33 @@ function openBrowser(url) {
   const cmd = platform() === 'darwin' ? 'open' : platform() === 'win32' ? 'start' : 'xdg-open'
   spawn(cmd, [url], { stdio: 'ignore', detached: true }).unref()
 }
+// Next 16 defaults to Turbopack, which HARD-REQUIRES the native @next/swc
+// binding for this platform (it crashes on boot with "native bindings are not
+// available" when only the WASM fallback loaded). That happens when node_modules
+// was populated on a different OS/arch and copied over (e.g. a Linux-built tree
+// synced to a Mac) rather than freshly `pnpm install`ed here. Detect the missing
+// native binding and fall back to Next's webpack mode, which runs on the WASM
+// swc bindings. A healthy install keeps Turbopack. Override with SIDANCLAW_WEBPACK.
+function nextHasNativeSwc() {
+  const a = arch()
+  const p = platform()
+  const pkgs =
+    p === 'linux' ? [`@next/swc-linux-${a}-gnu`, `@next/swc-linux-${a}-musl`]
+    : p === 'win32' ? [`@next/swc-win32-${a}-msvc`]
+    : [`@next/swc-${p}-${a}`]
+  try {
+    // pnpm nests the @next/swc-* optional deps under `next`, not where app-web
+    // can reach them — resolve relative to next's own package, not app-web's.
+    const appReq = createRequire(join(ROOT, 'apps/app-web/package.json'))
+    const nextReq = createRequire(appReq.resolve('next/package.json'))
+    return pkgs.some((pkg) => {
+      try { nextReq.resolve(`${pkg}/package.json`); return true } catch { return false }
+    })
+  } catch {
+    // Can't even resolve `next` — don't second-guess; keep the default (Turbopack).
+    return true
+  }
+}
 let shuttingDown = false
 function shutdown(code = 0) {
   if (shuttingDown) return
@@ -205,7 +233,13 @@ console.log('[launch] starting api (:4000), doc-sync (:8080), app-web (:3003) ..
 run('api', 'pnpm', ['--filter', '@sidanclaw/api-open', 'exec', 'tsx', 'src/index.ts'])
 run('doc-sync', 'pnpm', ['--filter', '@sidanclaw/doc-sync', 'exec', 'tsx', 'src/index.ts'],
   { PORT: String(PORTS.docSync) })
-run('app-web', 'pnpm', ['--filter', 'app-web', 'dev'])
+const forceWebpack = process.env.SIDANCLAW_WEBPACK === '1' || !nextHasNativeSwc()
+if (forceWebpack) {
+  console.log('[launch] native @next/swc binding for this platform not found — starting app-web with webpack (run `pnpm install` to restore Turbopack).')
+  run('app-web', 'pnpm', ['--filter', 'app-web', 'exec', 'next', 'dev', '--webpack', '--port', String(PORTS.appWeb)])
+} else {
+  run('app-web', 'pnpm', ['--filter', 'app-web', 'dev'])
+}
 
 // Wait for BOTH the api (:4000) and app-web (:3003) before opening the browser.
 // The entry URL immediately proxies to the api's /auth/local-session, and the


### PR DESCRIPTION
## What

Makes the built-in connectors (Google Calendar/Gmail/Drive, Notion, Fathom, GitHub, Files) usable in the **OSS / single-player edition**, end to end: storage, the `/api/connectors` route, the Studio list + tools surface, and the launcher provisioning they depend on.

Branched from `develop`; contains only the connector work (the brain/doc-template commits on the upstream stack are excluded).

## Why it was broken

The connector subsystem was only half-extracted into open-core: the runtime (injection, stores, OAuth-app-cred seam, web callbacks) was open, but the storage tables, the management route, and the encryption key were not. So a fresh OSS account saw **"No connectors available"**, and after connecting, **"No tools found"**.

## Commits

1. **feat(connectors): enable built-in connectors for the OSS edition** — OSS-only migration creating `connector_instance` + `connector_grant` (guarded by an `app.migration_edition` GUC so the hosted overlay still owns them); un-gate the three connector stores; mount `/api/connectors` when `SIDANCLAW_EDITION=oss`; wire `CHANNEL_CREDENTIAL_KEY` into the open boot env.
2. **chore(launch): provision OSS secrets + edition env** — the launcher generates/persists `CHANNEL_CREDENTIAL_KEY` and sets the edition flag the route gates on (hard dependency of the feature).
3. **fix(connectors): surface built-in connectors in the OSS list** — `GET /api/connectors` merges `OFFICIAL_CONNECTORS` with the caller's instances so every unconnected built-in renders as a placeholder (the Studio "available" group); adds `/directory`, `/directory/:id/add`, and `/connect` endpoints. Fixes "No connectors available".
4. **fix(launch): start app-web on webpack when the native Next swc binding is missing** — auto-fallback so `pnpm start` survives a cross-platform `node_modules` (Turbopack hard-requires the native binding); healthy installs keep Turbopack.
5. **fix(connectors): serve the built-in tool catalog and config endpoints** — `GET /:provider/tools` (from `OFFICIAL_CONNECTOR_TOOLS`) + `/config`. Fixes "No tools found" in the Tools tab.

## Scope / notes

- Built-in OAuth/PAT lifecycle only. Custom MCP CRUD, Google Drive authorized-files, and per-assistant tool-policy persistence remain in the closed route.
- **GitHub works fully** (connect → paste a PAT). Google/Notion/Fathom additionally need `NEXT_PUBLIC_*_CLIENT_ID` (client-side authorize) + their server app secret via `~/.sidanclaw/connectors.config.json`.
- Hosted edition untouched: the migration no-ops there (the closed `overlay-v1` owns the tables) and the route mounts only under `SIDANCLAW_EDITION=oss`.

## Testing

- `pnpm --filter @sidanclaw/api typecheck` and `--filter @sidanclaw/api-open typecheck` pass.
- Unit tests added in `routes/__tests__/connectors.test.ts` (`[COMP:api/connectors-route]`) covering the list/placeholder merge, directory, store-credentials paths, tools, config, connect/disconnect/rename/delete. (Could not run vitest in the authoring sandbox — incomplete `node_modules`; please run `pnpm --filter @sidanclaw/api test -- connectors` locally.)