### PR TITLE
feat(connectors): serve custom MCP connectors in the open edition

### DIFF
--- a/packages/api/src/routes/__tests__/connectors.test.ts
+++ b/packages/api/src/routes/__tests__/connectors.test.ts
@@ -10,6 +10,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import express from 'express'
 import request from 'supertest'
+
+const mockDiscover = vi.fn()
+vi.mock('../../mcp/client.js', () => ({
+  discoverMcpServer: (...a: unknown[]) => mockDiscover(...a),
+}))
+
 import { connectorRoutes } from '../connectors.js'
 import type { ConnectorStore } from '../../db/connector-store.js'
 import type { ConnectorInstanceStore, ConnectorInstance } from '../../db/connector-instance-store.js'
@@ -45,6 +51,8 @@ function makeApp(userId?: string) {
   const m = {
     setConnected: vi.fn(),
     deleteConnector: vi.fn(),
+    listConnectors: vi.fn().mockResolvedValue([]),
+    getAuthCredentials: vi.fn().mockResolvedValue(null),
     listForUser: vi.fn().mockResolvedValue([]),
     listByUser: vi.fn().mockResolvedValue([]),
     createUserInstance: vi.fn().mockResolvedValue(instance()),
@@ -56,6 +64,8 @@ function makeApp(userId?: string) {
   const connectorStore = {
     setConnected: m.setConnected,
     delete: m.deleteConnector,
+    list: m.listConnectors,
+    getAuthCredentials: m.getAuthCredentials,
     getConfig: m.getConfig,
     setConfig: m.setConfig,
   } as unknown as ConnectorStore
@@ -156,6 +166,46 @@ describe('[COMP:api/connectors-route] /api/connectors', () => {
       classification: expect.any(String),
       policy: expect.stringMatching(/allow|ask|block/),
     })
+  })
+
+  it('GET /:provider/tools live-discovers a custom connector\'s tools', async () => {
+    // A custom connector (provider = UUID, not in OFFICIAL_CONNECTOR_TOOLS) is
+    // discovered live, so the Tools tab matches the settings-tab probe instead
+    // of "No tools found".
+    const { app, listConnectors, getAuthCredentials } = makeApp('u1')
+    const CX = 'cx-uuid-1'
+    listConnectors.mockResolvedValue([
+      { connectorId: CX, name: 'My MCP', custom: true, url: 'https://mcp.example/sse', connected: true, credentialsType: 'bearer' },
+    ])
+    getAuthCredentials.mockResolvedValue({ type: 'bearer', token: 't1' })
+    mockDiscover.mockResolvedValue({
+      name: 'My MCP',
+      url: 'https://mcp.example/sse',
+      tools: [{ name: 'alpha', description: 'A' }, { name: 'beta', description: 'B' }],
+    })
+    const res = await request(app).get(`/api/connectors/${CX}/tools`)
+    expect(res.status).toBe(200)
+    expect(res.body.serverName).toBe('My MCP')
+    expect(res.body.tools).toHaveLength(2)
+    expect(res.body.tools[0]).toMatchObject({
+      name: 'alpha',
+      classification: expect.any(String),
+      policy: expect.stringMatching(/allow|ask|block/),
+    })
+    // Discovery carries the connector's configured auth headers.
+    expect(mockDiscover).toHaveBeenCalledWith('https://mcp.example/sse', 'My MCP', { Authorization: 'Bearer t1' })
+  })
+
+  it('GET /:provider/tools 500s when custom discovery fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { app, listConnectors } = makeApp('u1')
+    const CX = 'cx-uuid-2'
+    listConnectors.mockResolvedValue([
+      { connectorId: CX, name: 'Broken', custom: true, url: 'https://x', connected: false, credentialsType: 'none' },
+    ])
+    mockDiscover.mockRejectedValue(new Error('unreachable'))
+    const res = await request(app).get(`/api/connectors/${CX}/tools`)
+    expect(res.status).toBe(500)
   })
 
   it('GET /:provider/tools is empty for a provider with no catalog entry', async () => {

--- a/packages/api/src/routes/__tests__/custom-connectors.test.ts
+++ b/packages/api/src/routes/__tests__/custom-connectors.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Unit tests for the shared custom MCP connector routes (/api/connectors/custom*).
+ * Component tag: [COMP:api/custom-connectors-route].
+ *
+ * This is the OPEN home of the custom-connector feature, mounted by both the
+ * open and closed connector routers. Verifies add/edit/delete, the per-auth-type
+ * credential blobs (bearer / custom_header / oauth), the PATCH keep-secret rule,
+ * and the /test probe — including its security contract: it never echoes the
+ * upstream response body (a credentialed-read exfil vector) and surfaces only an
+ * HTTP status code or a generic category. The store and the MCP discovery client
+ * are mocked, so no DB and no network.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+
+const mockDiscover = vi.fn()
+vi.mock('../../mcp/client.js', () => ({
+  discoverMcpServer: (...a: unknown[]) => mockDiscover(...a),
+}))
+
+import { customConnectorRoutes } from '../custom-connectors.js'
+import type { ConnectorStore } from '../../db/connector-store.js'
+
+const store = {
+  list: vi.fn(),
+  getConfig: vi.fn(),
+  getAuthCredentials: vi.fn(),
+  setConfig: vi.fn(),
+  setConnected: vi.fn(),
+  upsert: vi.fn(),
+  delete: vi.fn(),
+}
+
+const storedRow = {
+  id: 'ci-1',
+  userId: 'u-1',
+  connectorId: 'cx-1',
+  name: 'My MCP',
+  url: 'https://mcp.example/sse',
+  custom: true,
+  connected: true,
+  credentialsType: 'bearer',
+}
+
+function app(userId?: string) {
+  const a = express()
+  a.use(express.json())
+  if (userId) {
+    a.use((req, _res, next) => {
+      ;(req as { userId?: string }).userId = userId
+      next()
+    })
+  }
+  a.use('/api/connectors', customConnectorRoutes({ connectorStore: store as unknown as ConnectorStore }))
+  return a
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  store.getConfig.mockResolvedValue({})
+  store.getAuthCredentials.mockResolvedValue(null)
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('[COMP:api/custom-connectors-route] add / delete', () => {
+  it('401 without auth', async () => {
+    const res = await request(app()).post('/api/connectors/custom').send({ name: 'x', url: 'https://x' })
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects a custom connector with no name or url', async () => {
+    expect((await request(app('u-1')).post('/api/connectors/custom').send({ name: 'x' })).status).toBe(400)
+  })
+
+  it('adds a custom connector', async () => {
+    store.upsert.mockResolvedValueOnce({ connectorId: 'uuid-1', name: 'My MCP' })
+    const res = await request(app('u-1'))
+      .post('/api/connectors/custom')
+      .send({ name: 'My MCP', url: 'https://mcp.example/sse' })
+    expect(res.status).toBe(200)
+    expect(res.body.id).toBe('uuid-1')
+    // A fresh custom row is written to the shared connector_instance table.
+    expect(store.upsert).toHaveBeenCalledWith(
+      'u-1',
+      expect.objectContaining({ name: 'My MCP', url: 'https://mcp.example/sse', custom: true, connected: false }),
+    )
+  })
+
+  it('deletes a custom connector (204) and 404s an unknown one', async () => {
+    store.delete.mockResolvedValueOnce(true)
+    expect((await request(app('u-1')).delete('/api/connectors/custom/cx-1')).status).toBe(204)
+    store.delete.mockResolvedValueOnce(false)
+    expect((await request(app('u-1')).delete('/api/connectors/custom/ghost')).status).toBe(404)
+  })
+})
+
+describe('[COMP:api/custom-connectors-route] auth types', () => {
+  it('adds a bearer connector with a typed credential blob and never echoes the secret', async () => {
+    store.upsert.mockResolvedValueOnce({ connectorId: 'uuid-1', name: 'My MCP', credentialsType: 'bearer' })
+    const res = await request(app('u-1'))
+      .post('/api/connectors/custom')
+      .send({ name: 'My MCP', url: 'https://mcp.example/sse', authType: 'bearer', bearerToken: 'tok-s3cret' })
+    expect(res.status).toBe(200)
+    expect(store.upsert).toHaveBeenCalledWith(
+      'u-1',
+      expect.objectContaining({ credentials: { type: 'bearer', token: 'tok-s3cret' } }),
+    )
+    expect(JSON.stringify(res.body)).not.toContain('tok-s3cret')
+  })
+
+  it('adds a custom_header connector and mirrors the header name into config', async () => {
+    store.upsert.mockResolvedValueOnce({ connectorId: 'uuid-2', name: 'My MCP' })
+    const res = await request(app('u-1'))
+      .post('/api/connectors/custom')
+      .send({ name: 'My MCP', url: 'https://mcp.example/sse', authType: 'custom_header', headerName: 'X-Api-Key', headerValue: 'k-s3cret' })
+    expect(res.status).toBe(200)
+    expect(store.upsert).toHaveBeenCalledWith(
+      'u-1',
+      expect.objectContaining({ credentials: { type: 'custom_header', header: 'X-Api-Key', value: 'k-s3cret' } }),
+    )
+    const connectorId = store.upsert.mock.calls[0][1].connectorId
+    expect(store.setConfig).toHaveBeenCalledWith('u-1', connectorId, { authHeaderName: 'X-Api-Key' })
+    expect(JSON.stringify(res.body)).not.toContain('k-s3cret')
+  })
+
+  it('rejects an invalid header name with 400', async () => {
+    const res = await request(app('u-1'))
+      .post('/api/connectors/custom')
+      .send({ name: 'X', url: 'https://x', authType: 'custom_header', headerName: 'X Bad Name', headerValue: 'v' })
+    expect(res.status).toBe(400)
+    expect(store.upsert).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-none auth type with no secret in add mode', async () => {
+    const res = await request(app('u-1'))
+      .post('/api/connectors/custom')
+      .send({ name: 'X', url: 'https://x', authType: 'bearer' })
+    expect(res.status).toBe(400)
+    expect(store.upsert).not.toHaveBeenCalled()
+  })
+
+  it('keeps the legacy oauth-pair contract when authType is omitted', async () => {
+    store.upsert.mockResolvedValueOnce({ connectorId: 'uuid-3' })
+    const res = await request(app('u-1'))
+      .post('/api/connectors/custom')
+      .send({ name: 'X', url: 'https://x', oauthClientId: 'id1', oauthClientSecret: 'sec1' })
+    expect(res.status).toBe(200)
+    expect(store.upsert).toHaveBeenCalledWith(
+      'u-1',
+      expect.objectContaining({ credentials: { type: 'oauth', client_id: 'id1', client_secret: 'sec1' } }),
+    )
+  })
+})
+
+describe('[COMP:api/custom-connectors-route] PATCH keep-secret rule', () => {
+  it('keeps stored credentials when the type is unchanged and the secret is blank', async () => {
+    store.list.mockResolvedValueOnce([storedRow])
+    store.upsert.mockResolvedValueOnce({ connectorId: 'cx-1' })
+    const res = await request(app('u-1'))
+      .patch('/api/connectors/custom/cx-1')
+      .send({ name: 'My MCP', url: 'https://mcp.example/sse', authType: 'bearer' })
+    expect(res.status).toBe(200)
+    const args = store.upsert.mock.calls[0][1]
+    expect(args.credentials).toBeUndefined()
+    expect(args.clearCredentials).toBeUndefined()
+  })
+
+  it('rejects an auth-type change without re-entering the secret', async () => {
+    store.list.mockResolvedValueOnce([{ ...storedRow, credentialsType: 'oauth' }])
+    const res = await request(app('u-1'))
+      .patch('/api/connectors/custom/cx-1')
+      .send({ name: 'My MCP', url: 'https://mcp.example/sse', authType: 'bearer' })
+    expect(res.status).toBe(400)
+    expect(store.upsert).not.toHaveBeenCalled()
+  })
+
+  it('rejects a header-name change without re-entering the value', async () => {
+    store.list.mockResolvedValueOnce([{ ...storedRow, credentialsType: 'custom_header' }])
+    store.getConfig.mockResolvedValueOnce({ authHeaderName: 'X-Api-Key' })
+    const res = await request(app('u-1'))
+      .patch('/api/connectors/custom/cx-1')
+      .send({ name: 'My MCP', url: 'https://mcp.example/sse', authType: 'custom_header', headerName: 'X-Other' })
+    expect(res.status).toBe(400)
+    expect(store.upsert).not.toHaveBeenCalled()
+  })
+
+  it('keeps credentials when the header name is unchanged', async () => {
+    store.list.mockResolvedValueOnce([{ ...storedRow, credentialsType: 'custom_header' }])
+    store.getConfig.mockResolvedValueOnce({ authHeaderName: 'X-Api-Key' })
+    store.upsert.mockResolvedValueOnce({ connectorId: 'cx-1' })
+    const res = await request(app('u-1'))
+      .patch('/api/connectors/custom/cx-1')
+      .send({ name: 'My MCP', url: 'https://mcp.example/sse', authType: 'custom_header', headerName: 'X-Api-Key' })
+    expect(res.status).toBe(200)
+    expect(store.upsert.mock.calls[0][1].credentials).toBeUndefined()
+  })
+
+  it('refuses to edit a non-custom (built-in) connector', async () => {
+    store.list.mockResolvedValueOnce([{ ...storedRow, connectorId: 'gmail', custom: false }])
+    const res = await request(app('u-1'))
+      .patch('/api/connectors/custom/gmail')
+      .send({ name: 'Gmail', url: 'https://x', authType: 'none' })
+    expect(res.status).toBe(400)
+    expect(store.upsert).not.toHaveBeenCalled()
+  })
+
+  it('rejects a half-filled OAuth pair instead of silently keeping', async () => {
+    store.list.mockResolvedValueOnce([{ ...storedRow, credentialsType: 'oauth' }])
+    const res = await request(app('u-1'))
+      .patch('/api/connectors/custom/cx-1')
+      .send({ name: 'My MCP', url: 'https://mcp.example/sse', authType: 'oauth', oauthClientId: 'only-id' })
+    expect(res.status).toBe(400)
+    expect(store.upsert).not.toHaveBeenCalled()
+  })
+
+  it('to none clears credentials and the mirrored header name', async () => {
+    store.list.mockResolvedValueOnce([storedRow])
+    store.upsert.mockResolvedValueOnce({ connectorId: 'cx-1' })
+    const res = await request(app('u-1'))
+      .patch('/api/connectors/custom/cx-1')
+      .send({ name: 'My MCP', url: 'https://mcp.example/sse', authType: 'none' })
+    expect(res.status).toBe(200)
+    expect(store.upsert.mock.calls[0][1].clearCredentials).toBe(true)
+    expect(store.setConfig).toHaveBeenCalledWith('u-1', 'cx-1', { authHeaderName: null })
+  })
+
+  it('replaces credentials when the new secret is supplied with the type change', async () => {
+    store.list.mockResolvedValueOnce([{ ...storedRow, credentialsType: 'oauth' }])
+    store.upsert.mockResolvedValueOnce({ connectorId: 'cx-1' })
+    const res = await request(app('u-1'))
+      .patch('/api/connectors/custom/cx-1')
+      .send({ name: 'My MCP', url: 'https://mcp.example/sse', authType: 'bearer', bearerToken: 'newtok' })
+    expect(res.status).toBe(200)
+    expect(store.upsert.mock.calls[0][1].credentials).toEqual({ type: 'bearer', token: 'newtok' })
+  })
+})
+
+describe('[COMP:api/custom-connectors-route] connection probe', () => {
+  it('success sets connected=true, reports the tool count, and threads the auth headers', async () => {
+    store.list.mockResolvedValueOnce([storedRow])
+    store.getAuthCredentials.mockResolvedValueOnce({ type: 'custom_header', header: 'X-Api-Key', value: 'k1' })
+    store.setConnected.mockResolvedValueOnce({ connectorId: 'cx-1', connected: true })
+    mockDiscover.mockResolvedValueOnce({ name: 'My MCP', url: 'https://mcp.example/sse', tools: [{ name: 'a' }, { name: 'b' }] })
+    const res = await request(app('u-1')).post('/api/connectors/custom/cx-1/test')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ ok: true, toolCount: 2, connected: true })
+    expect(store.setConnected).toHaveBeenCalledWith('u-1', 'cx-1', true)
+    expect(mockDiscover).toHaveBeenCalledWith('https://mcp.example/sse', 'My MCP', { 'X-Api-Key': 'k1' })
+  })
+
+  it('failure sets connected=false and never reflects the upstream body', async () => {
+    store.list.mockResolvedValueOnce([storedRow])
+    store.setConnected.mockResolvedValueOnce({ connectorId: 'cx-1', connected: false })
+    const SECRET_BODY = 'SECRET_PROJECT_TOKEN_ya29.leaked'
+    mockDiscover.mockRejectedValueOnce(new Error(`Streamable HTTP error: Error POSTing to endpoint: ${SECRET_BODY}`))
+    const res = await request(app('u-1')).post('/api/connectors/custom/cx-1/test')
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(false)
+    expect(res.body.connected).toBe(false)
+    expect(res.body.error).toBe('Could not reach the MCP server')
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_BODY)
+    expect(store.setConnected).toHaveBeenCalledWith('u-1', 'cx-1', false)
+  })
+
+  it('surfaces only the HTTP status code for an HTTP error', async () => {
+    store.list.mockResolvedValueOnce([storedRow])
+    store.setConnected.mockResolvedValueOnce({ connectorId: 'cx-1', connected: false })
+    const httpErr = Object.assign(new Error('Streamable HTTP error: Error POSTing to endpoint: leaked-body'), { code: 401 })
+    mockDiscover.mockRejectedValueOnce(httpErr)
+    const res = await request(app('u-1')).post('/api/connectors/custom/cx-1/test')
+    expect(res.body.error).toBe('Server returned HTTP 401')
+    expect(JSON.stringify(res.body)).not.toContain('leaked-body')
+  })
+
+  it('404s an unknown connector and 400s a non-custom one', async () => {
+    store.list.mockResolvedValueOnce([])
+    expect((await request(app('u-1')).post('/api/connectors/custom/ghost/test')).status).toBe(404)
+    store.list.mockResolvedValueOnce([{ ...storedRow, custom: false }])
+    expect((await request(app('u-1')).post('/api/connectors/custom/cx-1/test')).status).toBe(400)
+    expect(mockDiscover).not.toHaveBeenCalled()
+  })
+})

--- a/packages/api/src/routes/connectors.ts
+++ b/packages/api/src/routes/connectors.ts
@@ -43,17 +43,24 @@
  * `NEXT_PUBLIC_*_CLIENT_ID` for app-web's client-side authorize redirect. GitHub
  * is PAT-only and needs neither.
  *
- * Out of scope for the open edition (handled by the closed route): custom MCP
- * connectors (`/custom`), Google Drive authorized-files (`/gdrive/*`), and
- * per-assistant tool policy (`/tools`).
+ * Custom MCP connectors (`POST/PATCH/DELETE /custom`, `POST /custom/:id/test`)
+ * are mounted from the shared `customConnectorRoutes` factory in
+ * `./custom-connectors.ts` — the same factory the closed edition mounts, so the
+ * feature has one implementation across both editions.
+ *
+ * Out of scope for the open edition (handled by the closed route): Google Drive
+ * authorized-files (`/gdrive/*`) and per-assistant tool policy (`/tools`).
  *
  * Component tag: [COMP:api/connectors-route].
  */
 
 import { Router } from 'express'
+import { classifyTool, defaultPolicy } from '@sidanclaw/core'
 import { OFFICIAL_CONNECTORS, OFFICIAL_CONNECTOR_TOOLS, type ConnectorEntry } from '@sidanclaw/shared'
 import type { ConnectorStore, ConnectorCredentials } from '../db/connector-store.js'
 import type { ConnectorInstanceStore, ConnectorInstance } from '../db/connector-instance-store.js'
+import { buildConnectorAuthHeaders } from '../mcp/auth-headers.js'
+import { customConnectorRoutes } from './custom-connectors.js'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -138,6 +145,11 @@ function instanceRow(inst: ConnectorInstance, isPrimary: boolean): ConnectorRowO
 export function connectorRoutes(opts: ConnectorRouteOptions): Router {
   const { connectorStore, connectorInstanceStore } = opts
   const router = Router()
+
+  // Custom MCP connector CRUD. Mounted FIRST so the literal `/custom` and
+  // `/custom/:id` paths resolve before the `/:provider` catch-all routes below
+  // (otherwise `/custom/:id` would be captured by `DELETE /:provider`).
+  router.use(customConnectorRoutes({ connectorStore }))
 
   /** Group the caller's instances by provider, each list oldest-first. */
   async function instancesByProvider(userId: string): Promise<Map<string, ConnectorInstance[]>> {
@@ -235,24 +247,59 @@ export function connectorRoutes(opts: ConnectorRouteOptions): Router {
   })
 
   // ── GET /:provider/tools — the connector's tool catalog ──────
-  // Built-in connectors expose a fixed tool set (OFFICIAL_CONNECTOR_TOOLS). The
-  // Studio "Tools" tab renders this; an empty/absent response is what showed
-  // "No tools found" after connecting. Policy is the registry default — the
-  // per-assistant L2 override store is out of scope for the open route.
-  router.get('/:provider/tools', (req, res) => {
+  // Built-in connectors expose a fixed tool set (OFFICIAL_CONNECTOR_TOOLS).
+  // Custom MCP connectors (provider = a generated UUID, not in the registry)
+  // are discovered LIVE — the same MCP handshake the `/custom/:id/test` probe
+  // runs — so the Studio "Tools" tab shows the same tools the probe counted
+  // instead of "No tools found". Policy is the registry/classification default;
+  // the per-assistant L2 override store is out of scope for the open route.
+  router.get('/:provider/tools', async (req, res) => {
     const userId = req.userId
     if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
-    const entry = OFFICIAL_BY_ID.get(req.params.provider)
-    const catalog = OFFICIAL_CONNECTOR_TOOLS[req.params.provider] ?? []
-    res.json({
-      serverName: entry?.name ?? req.params.provider,
-      tools: catalog.map((t) => ({
-        name: t.name,
-        description: t.description,
-        classification: t.classification,
-        policy: t.defaultPolicy,
-      })),
-    })
+    const provider = req.params.provider
+
+    // Built-in: static registry catalog.
+    const catalog = OFFICIAL_CONNECTOR_TOOLS[provider]
+    if (catalog) {
+      const entry = OFFICIAL_BY_ID.get(provider)
+      res.json({
+        serverName: entry?.name ?? provider,
+        tools: catalog.map((t) => ({
+          name: t.name,
+          description: t.description,
+          classification: t.classification,
+          policy: t.defaultPolicy,
+        })),
+      })
+      return
+    }
+
+    // Otherwise it may be a custom MCP connector — discover its tools live.
+    try {
+      const connector = (await connectorStore.list(userId)).find((c) => c.connectorId === provider)
+      if (!connector || !connector.custom || !connector.url) {
+        res.json({ serverName: connector?.name ?? provider, tools: [] })
+        return
+      }
+      const { discoverMcpServer } = await import('../mcp/client.js')
+      const authCreds = await connectorStore.getAuthCredentials(userId, provider)
+      const server = await discoverMcpServer(connector.url, connector.name, buildConnectorAuthHeaders(authCreds))
+      res.json({
+        serverName: server.name,
+        tools: server.tools.map((t) => {
+          const classification = classifyTool(t.name, t.description)
+          return {
+            name: t.name,
+            description: t.description,
+            classification,
+            policy: defaultPolicy(classification),
+          }
+        }),
+      })
+    } catch (err) {
+      console.error('[connectors] custom tool discovery failed:', err)
+      res.status(500).json({ error: 'Failed to discover tools' })
+    }
   })
 
   // ── GET /:provider/config — the connector's JSON config ──────

--- a/packages/api/src/routes/custom-connectors.ts
+++ b/packages/api/src/routes/custom-connectors.ts
@@ -1,0 +1,320 @@
+/**
+ * Custom MCP connector CRUD — the `/custom` slice of `/api/connectors`.
+ *
+ * This is the OPEN home of the custom-connector feature. It used to live only
+ * in the closed `@sidanclaw/api-platform` connectors route; it now lives here so
+ * BOTH editions share one implementation. The open `connectorRoutes` mounts it,
+ * and the closed route imports and mounts the SAME factory instead of carrying a
+ * duplicate (the import boundary allows closed→open, never open→closed).
+ *
+ * It depends only on open primitives — the `ConnectorStore` (custom rows live in
+ * the same `connector_instance` table the rest of the connector surface reads,
+ * so a row written here shows up in `GET /api/connectors` with no extra wiring),
+ * `buildConnectorAuthHeaders` / `isValidHeaderName` from `mcp/auth-headers`, and
+ * `discoverMcpServer` from `mcp/client` for the connection probe.
+ *
+ *   POST   /custom          — add a custom MCP connector
+ *   PATCH  /custom/:id      — update one (keep-secret PATCH contract)
+ *   POST   /custom/:id/test — probe (MCP initialize + tools/list), set `connected`
+ *   DELETE /custom/:id      — remove one
+ *
+ * Mounted behind requireAuth by both editions — no guest access. Secrets are
+ * validated at this boundary (size caps + no CR/LF, the header-injection vector)
+ * and never echoed back in any response.
+ *
+ * See docs/architecture/integrations/mcp.md → "Custom connector auth".
+ * Component tag: [COMP:api/custom-connectors-route].
+ */
+
+import { randomUUID } from 'node:crypto'
+import { Router } from 'express'
+import { z } from 'zod'
+import { CONNECTOR_AUTH_TYPES } from '@sidanclaw/shared'
+import type { ConnectorStore, ConnectorCredentials } from '../db/connector-store.js'
+import { buildConnectorAuthHeaders, isValidHeaderName } from '../mcp/auth-headers.js'
+
+const noCrLf = (v: string) => !/[\r\n]/.test(v)
+
+const customConnectorBody = z.object({
+  name: z.string().optional(),
+  url: z.string().optional(),
+  authType: z.enum(CONNECTOR_AUTH_TYPES).optional(),
+  oauthClientId: z.string().max(2048).refine(noCrLf).optional(),
+  oauthClientSecret: z.string().max(8192).refine(noCrLf).optional(),
+  bearerToken: z.string().max(8192).refine(noCrLf).optional(),
+  headerName: z.string().max(128).optional(),
+  headerValue: z.string().max(8192).refine(noCrLf).optional(),
+})
+
+type CustomConnectorBody = z.infer<typeof customConnectorBody>
+
+type ResolvedCustomAuth =
+  | { ok: true; credentials?: ConnectorCredentials; clearCredentials?: boolean; authHeaderName?: string | null }
+  | { ok: false; error: string }
+
+/**
+ * Map a validated POST/PATCH /custom body to the credentials write.
+ *
+ * `stored` carries the existing row's state for the PATCH keep-secret rule:
+ * same auth type (and, for custom_header, an unchanged header name) with
+ * blank secret fields keeps the stored credentials untouched; changing the
+ * type or the header name requires re-entering the secret. `stored` is null
+ * in add mode, where every non-none type requires its secret.
+ * `authType` omitted entirely preserves the legacy contract: both OAuth
+ * fields set the pair, anything else leaves credentials untouched.
+ */
+function resolveCustomAuth(
+  body: CustomConnectorBody,
+  stored: { credentialsType: string; authHeaderName?: string } | null,
+): ResolvedCustomAuth {
+  const { authType } = body
+  const oauthPair =
+    body.oauthClientId && body.oauthClientSecret
+      ? { type: 'oauth' as const, client_id: body.oauthClientId, client_secret: body.oauthClientSecret }
+      : undefined
+
+  if (authType === undefined) {
+    return { ok: true, credentials: oauthPair }
+  }
+
+  switch (authType) {
+    case 'none':
+      return { ok: true, clearCredentials: true, authHeaderName: null }
+    case 'oauth':
+      if (oauthPair) return { ok: true, credentials: oauthPair }
+      // A half-filled pair is an error, not a silent keep — otherwise a
+      // caller rotating just the client_id would have it silently dropped
+      // while the old secret is retained. Matches the client-side rule in
+      // apps/app-web/src/lib/connector-auth-form.ts.
+      if (body.oauthClientId || body.oauthClientSecret) {
+        return { ok: false, error: 'Both OAuth Client ID and Client Secret are required' }
+      }
+      break
+    case 'bearer':
+      if (body.bearerToken) return { ok: true, credentials: { type: 'bearer', token: body.bearerToken } }
+      break
+    case 'custom_header':
+      if (body.headerName !== undefined && !isValidHeaderName(body.headerName)) {
+        return { ok: false, error: 'Header name must contain only HTTP token characters' }
+      }
+      if (body.headerName && body.headerValue) {
+        return {
+          ok: true,
+          credentials: { type: 'custom_header', header: body.headerName, value: body.headerValue },
+          authHeaderName: body.headerName,
+        }
+      }
+      break
+  }
+
+  // Secret fields absent — keep the stored credentials when nothing
+  // material changed; otherwise the caller must (re-)enter the secret.
+  if (stored && stored.credentialsType === authType) {
+    const headerUnchanged =
+      authType !== 'custom_header' || !body.headerName || body.headerName === stored.authHeaderName
+    if (headerUnchanged) return { ok: true }
+  }
+  return {
+    ok: false,
+    error: stored
+      ? 'Re-enter the secret when changing the auth type or header name'
+      : 'Secret required for the selected auth type',
+  }
+}
+
+/**
+ * A safe, body-free message for a failed connection probe. Surfaces the
+ * HTTP status code when the failure carries one (StreamableHTTPError.code),
+ * the timeout category, or a generic "could not reach" — never the upstream
+ * response body the MCP SDK embeds in its error message.
+ */
+function probeErrorMessage(err: unknown, timeoutMarker: string): string {
+  if (err instanceof Error && err.message === timeoutMarker) return 'Connection timed out'
+  const code = (err as { code?: unknown } | null)?.code
+  if (typeof code === 'number') return `Server returned HTTP ${code}`
+  return 'Could not reach the MCP server'
+}
+
+type CustomConnectorRouteOptions = {
+  connectorStore: ConnectorStore
+}
+
+/**
+ * Build the `/custom` sub-router. Both editions mount it on `/api/connectors`
+ * (`router.use(customConnectorRoutes({ connectorStore }))`), so it must be
+ * mounted BEFORE any `/:param` catch-all route or `/custom/:id` would be
+ * swallowed by `/:id`.
+ */
+export function customConnectorRoutes({ connectorStore }: CustomConnectorRouteOptions): Router {
+  const router = Router()
+
+  // ── POST /custom — add custom connector ──────────────────────
+  router.post('/custom', async (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+
+    const parsed = customConnectorBody.safeParse(req.body ?? {})
+    if (!parsed.success) { res.status(400).json({ error: 'Invalid request body' }); return }
+    const body = parsed.data
+
+    const name = body.name?.trim()
+    const url = body.url?.trim()
+    if (!name || !url) {
+      res.status(400).json({ error: 'Name and URL are required' })
+      return
+    }
+
+    const auth = resolveCustomAuth(body, null)
+    if (!auth.ok) { res.status(400).json({ error: auth.error }); return }
+
+    try {
+      const connectorId = randomUUID()
+      const row = await connectorStore.upsert(userId, {
+        connectorId,
+        name,
+        url,
+        custom: true,
+        connected: false,
+        credentials: auth.credentials,
+      })
+      // Mirror the (non-secret) header name into config so the edit form
+      // can display it without ever decrypting the credentials blob.
+      if (typeof auth.authHeaderName === 'string') {
+        await connectorStore.setConfig(userId, connectorId, { authHeaderName: auth.authHeaderName })
+      }
+      res.json({ id: row.connectorId, connector: row })
+    } catch (err) {
+      console.error('[connectors] add custom failed:', err)
+      res.status(500).json({ error: 'Failed to add connector' })
+    }
+  })
+
+  // ── PATCH /custom/:id — update custom connector ───────────────
+  router.patch('/custom/:id', async (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+
+    const parsed = customConnectorBody.safeParse(req.body ?? {})
+    if (!parsed.success) { res.status(400).json({ error: 'Invalid request body' }); return }
+    const body = parsed.data
+
+    const name = body.name?.trim()
+    const url = body.url?.trim()
+    if (!name || !url) {
+      res.status(400).json({ error: 'Name and URL are required' })
+      return
+    }
+
+    try {
+      // Stored state for the keep-secret rule. A PATCH on a missing id
+      // keeps the legacy upsert-create behavior and is treated as add mode.
+      let stored: { credentialsType: string; authHeaderName?: string } | null = null
+      const rows = await connectorStore.list(userId)
+      const existing = rows.find((r) => r.connectorId === req.params.id)
+      // Only custom connectors are editable here. Without this guard the
+      // `authType: 'none'` → clearCredentials path could null a built-in's
+      // stored OAuth refresh token (upsert matches any (user, provider) row
+      // regardless of `custom`), leaving it connected-but-broken.
+      if (existing && !existing.custom) {
+        res.status(400).json({ error: 'Only custom connectors can be edited here' })
+        return
+      }
+      if (existing) {
+        const config = await connectorStore.getConfig(userId, req.params.id)
+        stored = {
+          credentialsType: existing.credentialsType,
+          authHeaderName: typeof config.authHeaderName === 'string' ? config.authHeaderName : undefined,
+        }
+      }
+
+      const auth = resolveCustomAuth(body, stored)
+      if (!auth.ok) { res.status(400).json({ error: auth.error }); return }
+
+      const row = await connectorStore.upsert(userId, {
+        connectorId: req.params.id,
+        name,
+        url,
+        custom: true,
+        credentials: auth.credentials,
+        clearCredentials: auth.clearCredentials,
+      })
+      if (auth.authHeaderName !== undefined) {
+        await connectorStore.setConfig(userId, row.connectorId, { authHeaderName: auth.authHeaderName })
+      }
+      res.json({ id: row.connectorId, connector: row })
+    } catch (err) {
+      console.error('[connectors] update custom failed:', err)
+      res.status(500).json({ error: 'Failed to update connector' })
+    }
+  })
+
+  // ── POST /custom/:id/test — connection probe ──────────────────
+  //
+  // Runs a real MCP initialize + tools/list against the connector's URL
+  // with its configured auth, and sets `connected` from the outcome —
+  // unlike the blind /:id/connect flip. Always responds 200 when the
+  // probe ran; the result is data ({ ok, toolCount | error }). The
+  // credential read deliberately skips the `connected = true` filter
+  // (getAuthCredentials) so a never-connected connector can be probed.
+  router.post('/custom/:id/test', async (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+
+    const connectorId = req.params.id
+    try {
+      const connectors = await connectorStore.list(userId)
+      const connector = connectors.find((c) => c.connectorId === connectorId)
+      if (!connector) { res.status(404).json({ error: 'Connector not found' }); return }
+      if (!connector.custom || !connector.url) {
+        res.status(400).json({ error: 'Only custom connectors with a URL can be tested' })
+        return
+      }
+
+      const creds = await connectorStore.getAuthCredentials(userId, connectorId)
+      const headers = buildConnectorAuthHeaders(creds)
+      const { discoverMcpServer } = await import('../mcp/client.js')
+
+      const PROBE_TIMEOUT = 10_000
+      const TIMEOUT_MARKER = 'sidanclaw:probe-timeout'
+      try {
+        const server = await Promise.race([
+          discoverMcpServer(connector.url, connector.name, headers),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error(TIMEOUT_MARKER)), PROBE_TIMEOUT),
+          ),
+        ])
+        await connectorStore.setConnected(userId, connectorId, true)
+        res.json({ ok: true, toolCount: server.tools.length, connected: true })
+      } catch (probeErr) {
+        await connectorStore.setConnected(userId, connectorId, false)
+        // Categorize WITHOUT reflecting the upstream response body. The MCP
+        // SDK's StreamableHTTPError embeds `await response.text()` in its
+        // message; echoing that to the caller would turn this probe into a
+        // credentialed read primitive (point url at a metadata/internal
+        // endpoint, set a custom header, read the body back). Surface only
+        // the HTTP status code or a generic category.
+        res.json({ ok: false, error: probeErrorMessage(probeErr, TIMEOUT_MARKER), connected: false })
+      }
+    } catch (err) {
+      console.error('[connectors] connection probe failed:', err)
+      res.status(500).json({ error: 'Failed to test connector' })
+    }
+  })
+
+  // ── DELETE /custom/:id — remove custom connector ─────────────
+  router.delete('/custom/:id', async (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+
+    try {
+      const deleted = await connectorStore.delete(userId, req.params.id)
+      if (!deleted) { res.status(404).json({ error: 'Connector not found' }); return }
+      res.status(204).end()
+    } catch (err) {
+      console.error('[connectors] delete failed:', err)
+      res.status(500).json({ error: 'Failed to delete connector' })
+    }
+  })
+
+  return router
+}


### PR DESCRIPTION
## What

Brings the **custom MCP connector** feature to the open edition.

- Adds a shared `customConnectorRoutes` factory (`packages/api/src/routes/custom-connectors.ts`) implementing the `/custom` CRUD + the `POST /custom/:id/test` connection probe, mounted by the open connectors route. The open edition previously 404'd on `POST /api/connectors/custom`.
- Live-discovers a custom connector's tools in `GET /:provider/tools` (provider is a generated UUID, absent from `OFFICIAL_CONNECTOR_TOOLS`) using the same MCP handshake the probe runs — so the Studio **Tools** tab shows the discovered tools instead of "No tools found".

## Why

The `/custom` CRUD and the Tools-tab discovery only existed in the closed `api-platform` route. The open edition mounted a minimal connectors route, so adding a custom MCP server failed to save and its tools never appeared.

## Notes

- Custom rows persist through `connectorStore` into the shared `connector_instance` table, so they surface in `GET /api/connectors` with no extra wiring.
- The probe / discovery never reflect the upstream response body (credentialed-read guard); failures are categorized by HTTP status or a generic reachability message.
- The closed `api-platform` route is updated (companion PR in `sidanclaw-platform`) to mount this same factory instead of its own copy — one implementation across editions.

## Tests

New `custom-connectors.test.ts` (CRUD, the PATCH keep-secret rule, the probe SSRF guard) + custom tool-discovery cases in `connectors.test.ts`. Open routes/mcp suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)