### PR TITLE
fix(workflow): emit page lifecycle events from interactive-chat doc writes

### DIFF
--- a/packages/api/src/brain-mcp/__tests__/brain-mcp.test.ts
+++ b/packages/api/src/brain-mcp/__tests__/brain-mcp.test.ts
@@ -824,6 +824,7 @@ describe('[COMP:api/brain-mcp-page-tools] doc-page tools (readPage / listPages /
     // existing tests still exercise the built-in-only catalog.
     templateList: (...args: unknown[]) => Promise<unknown[]>
     templateGetById: (...args: unknown[]) => Promise<unknown>
+    templateCreate: (...args: unknown[]) => Promise<unknown>
   }> = {}): BrainDocTools {
     const tools: BrainDocTools = {
       savedViewStore: {
@@ -840,10 +841,25 @@ describe('[COMP:api/brain-mcp-page-tools] doc-page tools (readPage / listPages /
         applyPatch: vi.fn(overrides.applyPatch ?? (async () => ({ newVersion: 4 }))),
       } as unknown as BrainDocTools['docPageStore'],
     }
-    if (overrides.templateList || overrides.templateGetById) {
+    if (overrides.templateList || overrides.templateGetById || overrides.templateCreate) {
       tools.pageTemplateStore = {
         list: vi.fn(overrides.templateList ?? (async () => [])),
         getById: vi.fn(overrides.templateGetById ?? (async () => null)),
+        create: vi.fn(
+          overrides.templateCreate ??
+            (async (_userId: string, input: { name: string; category: string }) => ({
+              id: 'ct-new-uuid',
+              workspaceId: '33333333-3333-3333-3333-333333333333',
+              createdBy: 'u',
+              name: input.name,
+              description: null,
+              icon: null,
+              category: input.category,
+              blocks: [],
+              createdAt: '2026-01-01T00:00:00Z',
+              updatedAt: '2026-01-01T00:00:00Z',
+            })),
+        ),
       } as unknown as NonNullable<BrainDocTools['pageTemplateStore']>
     }
     return tools
@@ -1203,5 +1219,73 @@ describe('[COMP:api/brain-mcp-page-tools] doc-page tools (readPage / listPages /
     // Block ids are re-minted, so the stored 'orig-block' id never reaches the page.
     expect(arg.page.blocks).toHaveLength(1)
     expect(arg.page.blocks[0].id).not.toBe('orig-block')
+  })
+
+  it('createPageTemplate is omitted unless the pageTemplateStore is wired', () => {
+    // Built-in catalog tools need no store; createPageTemplate has no fallback.
+    const noStore = buildBrainTools({ ...BASE, scope: 'read_write', docTools: docToolsStub() }).map(
+      (t) => t.name,
+    )
+    expect(noStore).toContain('createPageFromTemplate')
+    expect(noStore).not.toContain('createPageTemplate')
+
+    const withStore = buildBrainTools({
+      ...BASE,
+      scope: 'read_write',
+      docTools: docToolsStub({ templateCreate: async () => ({}) }),
+    }).map((t) => t.name)
+    expect(withStore).toContain('createPageTemplate')
+  })
+
+  it('createPageTemplate is a write tool (absent on a read key)', () => {
+    const readNames = buildBrainTools({
+      ...BASE,
+      scope: 'read',
+      docTools: docToolsStub({ templateCreate: async () => ({}) }),
+    }).map((t) => t.name)
+    expect(readNames).not.toContain('createPageTemplate')
+  })
+
+  it('createPageTemplate persists a template via the store and returns its id', async () => {
+    // `templateList` flips the store branch on; `create` defaults to the stub.
+    const docTools = docToolsStub({ templateList: async () => [] })
+    const tools = buildBrainTools({ ...BASE, scope: 'read_write', docTools })
+    const tool = tools.find((t) => t.name === 'createPageTemplate')!
+    const result = await tool.handler({
+      name: 'Weekly sync',
+      category: 'meeting',
+      content: '## Agenda\n- [ ] Item one',
+      icon: '🗓️',
+      description: 'Recurring sync layout',
+    })
+    expect(result.isError).toBeFalsy()
+    expect(textBody(result)).toContain('ct-new-uuid')
+    const create = docTools.pageTemplateStore!.create as ReturnType<typeof vi.fn>
+    expect(create).toHaveBeenCalledTimes(1)
+    const arg = create.mock.calls[0][1]
+    expect(arg.name).toBe('Weekly sync')
+    expect(arg.category).toBe('meeting')
+    expect(arg.icon).toBe('🗓️')
+    expect(arg.description).toBe('Recurring sync layout')
+    // Markdown body became a non-empty canonical block list.
+    expect(arg.blocks.length).toBeGreaterThan(0)
+  })
+
+  it('createPageTemplate rejects an empty name without writing', async () => {
+    const docTools = docToolsStub({ templateList: async () => [] })
+    const tools = buildBrainTools({ ...BASE, scope: 'read_write', docTools })
+    const tool = tools.find((t) => t.name === 'createPageTemplate')!
+    const result = await tool.handler({ name: '   ', category: 'meeting', content: '## X' })
+    expect(result.isError).toBe(true)
+    expect(docTools.pageTemplateStore!.create).not.toHaveBeenCalled()
+  })
+
+  it('createPageTemplate rejects content that yields no blocks', async () => {
+    const docTools = docToolsStub({ templateList: async () => [] })
+    const tools = buildBrainTools({ ...BASE, scope: 'read_write', docTools })
+    const tool = tools.find((t) => t.name === 'createPageTemplate')!
+    const result = await tool.handler({ name: 'Empty', category: 'meeting', content: '   ' })
+    expect(result.isError).toBe(true)
+    expect(docTools.pageTemplateStore!.create).not.toHaveBeenCalled()
   })
 })

--- a/packages/api/src/brain-mcp/tools.ts
+++ b/packages/api/src/brain-mcp/tools.ts
@@ -60,6 +60,8 @@ import {
   instantiatePageTemplate,
   pageTemplateIds,
   withFreshBlockIds,
+  PAGE_TEMPLATE_CATEGORIES,
+  pageTemplateCategorySchema,
 } from '@sidanclaw/core'
 import type {
   BindingConfig,
@@ -202,11 +204,13 @@ export type BrainDocTools = {
   docPageStore: Pick<DocPageStore, 'getVersionedPage' | 'applyPatch'>
   /**
    * Custom page templates (migration 281). When wired, `listPageTemplates`
-   * also surfaces the workspace's custom templates and `createPageFromTemplate`
-   * resolves a custom template id (a uuid) to its stored blocks. Optional — a
-   * deploy without the store still serves the built-in catalog.
+   * also surfaces the workspace's custom templates, `createPageFromTemplate`
+   * resolves a custom template id (a uuid) to its stored blocks, and
+   * `createPageTemplate` persists a new workspace template. Optional — a
+   * deploy without the store still serves the built-in catalog (read +
+   * instantiate), but `createPageTemplate` (no built-in fallback) is omitted.
    */
-  pageTemplateStore?: Pick<PageTemplateStore, 'list' | 'getById'>
+  pageTemplateStore?: Pick<PageTemplateStore, 'list' | 'getById' | 'create'>
 }
 
 /** Cap on `readPage` title-search matches surfaced to the agent. */
@@ -378,6 +382,12 @@ function capPageMarkdown(md: string): string {
  *                    create path reuses the same `createDraft` seam as
  *                    `createPage`, seeding the page with the template's blocks
  *                    + icon. See docs/architecture/features/doc-templates.md.
+ *   - `createPageTemplate` (write) → persists a NEW workspace custom template
+ *                    (`pageTemplateStore.create`, migration 281) from a Markdown
+ *                    body parsed with the same `markdownToBlocks` +
+ *                    `normalizeMarkdownBlocks` path. Present only when the
+ *                    optional `pageTemplateStore` is wired (no built-in
+ *                    fallback). See doc-templates.md → "Custom templates".
  *
  * Spec pointer (file is OSS, not present in this repo):
  * docs/architecture/integrations/mcp.md → brain MCP page tools.
@@ -394,6 +404,7 @@ function buildDocPageTools(
   createPage: BrainTool
   listPageTemplates: BrainTool
   createPageFromTemplate: BrainTool
+  createPageTemplate: BrainTool
 } {
   const { savedViewStore, docPageStore, pageTemplateStore } = docTools
 
@@ -895,6 +906,111 @@ function buildDocPageTools(
     },
   }
 
+  // ── createPageTemplate ────────────────────────────────────────
+  //
+  // A write tool that persists a NEW workspace CUSTOM template (migration 281).
+  // The inverse of `createPageFromTemplate`: instead of instantiating a template
+  // into a page, it snapshots a Markdown body into a reusable, workspace-shared
+  // template row. The body is parsed with the SAME `markdownToBlocks` +
+  // `normalizeMarkdownBlocks` path `createPage` runs, so a template authored
+  // over MCP carries the identical canonical block list a hand-authored one
+  // would — and `createPageFromTemplate` (which re-mints block ids via
+  // `withFreshBlockIds`) can instantiate it straight away. Strictly needs the
+  // optional `pageTemplateStore` — there is no built-in catalog to fall back to
+  // (the code catalog is read-only), so the tool is registered only when the
+  // store is wired; the in-handler guard is defensive.
+  const createPageTemplate: BrainTool = {
+    name: 'createPageTemplate',
+    description:
+      'Create a NEW reusable workspace page template from Markdown. The template ' +
+      'is saved to the workspace gallery (shared with every member) and can then ' +
+      'be instantiated into pages with `createPageFromTemplate`; its id also ' +
+      'appears in `listPageTemplates` (labelled custom). Provide a `name`, a ' +
+      `\`category\` (one of: ${PAGE_TEMPLATE_CATEGORIES.join(', ')}), and the ` +
+      'template body as Markdown `content` (headings, lists, checklists, tables, ' +
+      'callouts — the same Markdown `createPage` accepts). Optional `description` ' +
+      "and `icon` (an emoji). Returns the new templateId. Scoped to the key's " +
+      'workspace.',
+    inputSchema: {
+      name: z
+        .string()
+        .min(1)
+        .max(256)
+        .describe('Display name for the template (shown in the gallery).'),
+      category: pageTemplateCategorySchema.describe(
+        `Gallery category: one of ${PAGE_TEMPLATE_CATEGORIES.join(', ')}.`,
+      ),
+      content: z
+        .string()
+        .min(1)
+        .max(MAX_EDIT_CHARS)
+        .describe('Markdown body — the page skeleton this template seeds.'),
+      description: z
+        .string()
+        .max(2000)
+        .optional()
+        .describe('Optional one-line description shown in the gallery.'),
+      icon: z
+        .string()
+        .max(16)
+        .optional()
+        .describe("Optional emoji glyph; seeds the template's (and seeded page's) icon."),
+    },
+    async handler(args) {
+      const ctx = await resolveCtx()
+      if ('error' in ctx) return text(ctx.error, true)
+      // Strictly needs the custom-template store — there is no built-in fallback
+      // (unlike listPageTemplates / createPageFromTemplate, which serve the code
+      // catalog). A deploy without the store never registers this tool; guard
+      // defensively in case it is reached anyway.
+      if (!pageTemplateStore?.create) {
+        return text('Custom page templates are not enabled on this deployment.', true)
+      }
+      const name = typeof args.name === 'string' ? args.name.trim() : ''
+      if (!name) return text('Provide a `name` for the template.', true)
+      const category = pageTemplateCategorySchema.safeParse(args.category)
+      if (!category.success) {
+        return text(
+          `Provide a valid \`category\` (one of: ${PAGE_TEMPLATE_CATEGORIES.join(', ')}).`,
+          true,
+        )
+      }
+      const content = typeof args.content === 'string' ? args.content : ''
+      const description =
+        typeof args.description === 'string' && args.description.trim()
+          ? args.description.trim()
+          : null
+      const icon = typeof args.icon === 'string' && args.icon.trim() ? args.icon.trim() : null
+
+      // Same Markdown → blocks expansion `createPage` / `editPage` run, so a
+      // template body lands as the identical canonical block list a hand-authored
+      // page would. A template must carry at least one block (the store's
+      // `blocks` schema enforces min(1) too).
+      const blocks = normalizeMarkdownBlocks(markdownToBlocks(content))
+      if (blocks.length === 0) {
+        return text('The `content` produced no blocks — provide some Markdown text.', true)
+      }
+
+      try {
+        const created = await pageTemplateStore.create(ctx.userId, {
+          workspaceId,
+          name,
+          description,
+          icon,
+          category: category.data,
+          blocks,
+        })
+        return text(
+          `Created page template "${created.name}" (templateId: ${created.id}, category: ${created.category}). ` +
+            'Pass this id to createPageFromTemplate to mint a page from it.',
+        )
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        return text(`Failed to create the template: ${msg}`, true)
+      }
+    },
+  }
+
   return {
     readPage,
     listPages,
@@ -903,6 +1019,7 @@ function buildDocPageTools(
     createPage,
     listPageTemplates: listPageTemplatesTool,
     createPageFromTemplate,
+    createPageTemplate,
   }
 }
 
@@ -1280,6 +1397,10 @@ export function buildBrainTools(opts: BuildOpts): BrainTool[] {
           docPageTools.deletePage,
           docPageTools.createPage,
           docPageTools.createPageFromTemplate,
+          // Custom-template authoring has no built-in fallback, so it is exposed
+          // only when the `pageTemplateStore` is wired (mirrors the store gate
+          // inside the handler). Built-in catalog tools above need no store.
+          ...(opts.docTools?.pageTemplateStore ? [docPageTools.createPageTemplate] : []),
         ]
       : []),
     ...agentWriteBridges,

--- a/packages/api/src/doc/__tests__/inject-page-lifecycle.test.ts
+++ b/packages/api/src/doc/__tests__/inject-page-lifecycle.test.ts
@@ -1,0 +1,116 @@
+/**
+ * [COMP:api/doc-inject] Doc inject — page-lifecycle fallback wiring.
+ *
+ * Regression guard for the empty PageWorkflowRuns chip (workflow.md → "Page
+ * event source"). The interactive chat route calls `injectDocTools` WITHOUT a
+ * `savedViewStore`, so the assistant's createSubPage / patchPage / renderPage
+ * writes reach the DB through `inject.ts`'s lazily-cached fallback store. That
+ * fallback MUST be constructed with `onPageLifecycle: publishPageLifecycle` or
+ * those `system` page writes emit no lifecycle event and a `page`-source
+ * workflow never fires — most visible in single-player OSS, where the assistant
+ * authors most pages.
+ *
+ * The other inject tests always pass a `savedViewStore` explicitly, so they
+ * never exercise the fallback; this file omits it on purpose.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type {
+  DocEntityStore,
+  DocPageStore,
+  CrmStore,
+  PageLifecycleEvent,
+  TaskStore,
+  Tool,
+  WorkflowRunStore,
+  WorkspaceDirectoryStore,
+} from '@sidanclaw/core'
+
+vi.mock('../../db/client.js', () => ({
+  query: vi.fn(),
+  queryWithRLS: vi.fn(),
+  getPool: vi.fn(),
+}))
+
+// Capture the options the inject fallback hands the store factory. The factory
+// returns a proxy "store" — the inject path never calls its methods (the tool
+// factories are pure constructors), so a no-op stand-in is enough.
+vi.mock('../../db/saved-views-store.js', () => ({
+  createDbSavedViewStore: vi.fn(
+    () =>
+      new Proxy({}, { get: () => vi.fn() }) as unknown,
+  ),
+}))
+
+import { injectDocTools } from '../inject.js'
+import { createDbSavedViewStore } from '../../db/saved-views-store.js'
+import { setPageEventDispatcher } from '../../page-event-fanout.js'
+import type { DispatchEvent, WorkflowEventDispatcher } from '@sidanclaw/core'
+
+function noopStore<T>(): T {
+  return new Proxy({}, { get: () => vi.fn() }) as T
+}
+
+// Note: NO `savedViewStore` — that is the whole point, the fallback resolves it.
+const baseOpts = {
+  userId: 'user-1',
+  assistant: {
+    id: 'primary-1',
+    kind: 'primary' as const,
+    appType: null,
+    workspaceId: 'ws-1',
+  },
+  docSurface: true,
+  docPageStore: noopStore<DocPageStore>(),
+  docEntityStore: noopStore<DocEntityStore>(),
+  taskStore: noopStore<TaskStore>(),
+  crmStore: noopStore<CrmStore>(),
+  workflowRunStore: noopStore<WorkflowRunStore>(),
+  workspaceDirectory: noopStore<WorkspaceDirectoryStore>(),
+}
+
+const EVENT: PageLifecycleEvent = {
+  workspaceId: 'ws-1',
+  pageId: 'p1',
+  parentId: null,
+  title: 'Spec',
+  actorId: 'user-1',
+  action: 'updated',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  setPageEventDispatcher(null)
+})
+
+describe('[COMP:api/doc-inject] injectDocTools page-lifecycle fallback', () => {
+  it('constructs the fallback store with a page-lifecycle hook that reaches the bound dispatcher', async () => {
+    const dispatch = vi.fn(async (_ev: DispatchEvent) => {})
+    setPageEventDispatcher({ dispatch } as unknown as WorkflowEventDispatcher)
+
+    const tools = new Map<string, Tool>()
+    const result = await injectDocTools({ ...baseOpts, tools })
+
+    // Doc tools still inject normally through the fallback store.
+    expect(result.injected).toBe(true)
+
+    // The fallback was built WITH a lifecycle hook (the bug was an unhooked
+    // `createDbSavedViewStore()` here).
+    expect(createDbSavedViewStore).toHaveBeenCalledWith(
+      expect.objectContaining({ onPageLifecycle: expect.any(Function) }),
+    )
+
+    // And that hook is `publishPageLifecycle` — invoking it dispatches the
+    // converted event to the dispatcher bootOpenApi binds.
+    const opts = vi.mocked(createDbSavedViewStore).mock.calls[0]?.[0]
+    opts?.onPageLifecycle?.(EVENT)
+    await Promise.resolve() // let the fire-and-forget settle
+
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    // action='updated' → the watched page is the page itself.
+    expect(dispatch.mock.calls[0][0].source).toEqual({ type: 'page', pageId: 'p1' })
+  })
+})

--- a/packages/api/src/doc/inject.ts
+++ b/packages/api/src/doc/inject.ts
@@ -92,6 +92,7 @@ import { createDbCommentThreadStore } from '../db/comment-thread-store.js'
 import { createRefineActiveThemeTool } from './theme-tools.js'
 import { createDbCrmStore } from '../db/crm-store.js'
 import { createDbSavedViewStore } from '../db/saved-views-store.js'
+import { publishPageLifecycle } from '../page-event-fanout.js'
 import { createDbTaskStore } from '../db/tasks-store.js'
 import { createDbWorkflowRunStore } from '../db/workflow-store.js'
 import { createWorkspaceStore } from '../db/workspace-store.js'
@@ -311,9 +312,20 @@ export async function injectDocTools(
   const docEntityStore =
     options.docEntityStore ??
     (cachedDocEntityStore ??= createDbDocEntityStore())
+  // The cached fallback MUST carry the page-lifecycle hook: the interactive
+  // chat route injects doc tools without supplying a store, so an assistant's
+  // createSubPage / patchPage / renderPage write reaches the DB through this
+  // singleton. Without the hook those `system` writes emit no page event and a
+  // `page`-source workflow never fires (the empty PageWorkflowRuns chip — most
+  // visible in single-player OSS where the assistant authors most pages). The
+  // hook is a no-op until `bootOpenApi` binds the dispatcher and best-effort
+  // thereafter, so it is safe on every fallback consumer. See
+  // docs/architecture/features/workflow.md → "Page event source".
   const savedViewStore =
     options.savedViewStore ??
-    (cachedSavedViewStore ??= createDbSavedViewStore())
+    (cachedSavedViewStore ??= createDbSavedViewStore({
+      onPageLifecycle: publishPageLifecycle,
+    }))
   const taskStore =
     options.taskStore ?? (cachedTaskStore ??= createDbTaskStore())
   const crmStore = options.crmStore ?? (cachedCrmStore ??= createDbCrmStore())


### PR DESCRIPTION
## Summary

The interactive chat route injects doc tools via `injectDocTools` **without** supplying a saved-views store, so an assistant's `createSubPage` / `patchPage` / `renderPage` writes resolve through the lazily-cached fallback singleton in `packages/api/src/doc/inject.ts`. That fallback was built with a bare `createDbSavedViewStore()` — no `onPageLifecycle` hook — so those `system` page writes emitted no lifecycle event, no `page`-source workflow fired, and the `PageWorkflowRuns` chip stayed empty.

Most visible in single-player OSS, where the assistant authors most pages; the routed store used by human doc edits, brain-MCP, and workflow page anchors already carried the hook, masking it in the team product.

## Change

- Build the fallback with `createDbSavedViewStore({ onPageLifecycle: publishPageLifecycle })`. The hook is a no-op until `bootOpenApi` binds the dispatcher and best-effort thereafter, so it is safe on every fallback consumer.
- Add a regression test (`inject-page-lifecycle.test.ts`) that omits `savedViewStore` and asserts the fallback dispatches a lifecycle event — the gap the existing mock-based inject tests miss.

## Verification

- `@sidanclaw/api` full suite: 2306 passed
- `tsc --noEmit` (api): clean
- `pnpm smoke`: OK

> Note: this branch also carries the `createPageTemplate` brain-MCP tool commit that predates this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)