### PR TITLE
feat(app-web): remap surface shortcuts to plain Ctrl in Firefox

### DIFF
--- a/apps/app-web/src/components/doc/doc-sidebar.tsx
+++ b/apps/app-web/src/components/doc/doc-sidebar.tsx
@@ -90,6 +90,7 @@ import {
 } from "@/components/ui/select";
 import { derivePageIcon, type ViewListRow } from "@/lib/api/views";
 import { buildTree, savedAncestorIds, type TreeNode } from "@/lib/sidebar-tree";
+import { surfaceShortcutLabel } from "@/lib/surface-shortcuts";
 import { fetchInboxBadgeCount } from "@/lib/api/inbox";
 import { INBOX_CHANGED_EVENT } from "@/lib/inbox-events";
 import { DOC_COMMENTS_CHANGED_EVENT } from "@/lib/comment-events";
@@ -405,8 +406,11 @@ export function DocSidebar(props: Props) {
           the right of Search drag the window; the icon links/buttons opt back out
           via the `[data-doc-chrome] :is(a, button, …)` rule in globals.css. */}
       <nav data-doc-chrome className="flex flex-row items-center gap-0.5 px-2 pt-1 pb-1.5">
-        {/* Home — ⌘1, first of the ⌘1/2/3/4 surface shortcuts (wired in WorkspaceChrome). */}
-        <Tooltip label={t.iconHome} shortcut="⌘1">
+        {/* Home — first of the ⌘/Ctrl+1/2/3/4 surface shortcuts (wired in
+            WorkspaceChrome). The chip label is browser-dependent
+            (`surfaceShortcutLabel`): ⌘n on mac, ⌃n on mac Firefox (which
+            reserves ⌘+digit for tab switching), Ctrl+n elsewhere. */}
+        <Tooltip label={t.iconHome} shortcut={surfaceShortcutLabel(1)}>
           <Link
             href={`/w/${workspaceId}/p`}
             aria-label={t.iconHomeAria}
@@ -420,9 +424,9 @@ export function DocSidebar(props: Props) {
         </Tooltip>
 
         {/* Surface destinations (consolidation §4) — Brain / Studio / Workflow,
-            with ⌘2/3/4 shortcuts (wired in WorkspaceChrome). Studio shows the
-            cold-start nudge dot until the workspace connects its first tool. */}
-        <Tooltip label={t.iconBrain} shortcut="⌘2">
+            with ⌘/Ctrl+2/3/4 shortcuts (wired in WorkspaceChrome). Studio shows
+            the cold-start nudge dot until the workspace connects its first tool. */}
+        <Tooltip label={t.iconBrain} shortcut={surfaceShortcutLabel(2)}>
           <Link
             href={`/w/${workspaceId}/brain`}
             aria-label={t.iconBrainAria}
@@ -434,7 +438,7 @@ export function DocSidebar(props: Props) {
             ) : null}
           </Link>
         </Tooltip>
-        <Tooltip label={t.iconStudio} shortcut="⌘3">
+        <Tooltip label={t.iconStudio} shortcut={surfaceShortcutLabel(3)}>
           <Link
             href={`/w/${workspaceId}/studio`}
             aria-label={t.iconStudioAria}
@@ -452,7 +456,7 @@ export function DocSidebar(props: Props) {
             ) : null}
           </Link>
         </Tooltip>
-        <Tooltip label={t.iconWorkflow} shortcut="⌘4">
+        <Tooltip label={t.iconWorkflow} shortcut={surfaceShortcutLabel(4)}>
           <Link
             href={`/w/${workspaceId}/workflow`}
             aria-label={t.iconWorkflowAria}

--- a/apps/app-web/src/components/doc/workspace-chrome.tsx
+++ b/apps/app-web/src/components/doc/workspace-chrome.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/lib/doc-page-url";
 import { useT } from "@/lib/i18n/client";
 import { routeProgress } from "@/lib/route-progress";
+import { surfaceShortcutModifierPressed } from "@/lib/surface-shortcuts";
 import { useChatDockSuppressed } from "@/lib/chat-dock-suppress";
 import { useDocChatOthersRun } from "@/lib/doc-chat-relay";
 import { useOfflineSync } from "@/lib/offline/use-offline-sync";
@@ -230,7 +231,11 @@ export function WorkspaceChrome({
   // right in toolbar order: ⌘1 is Home (the `/p` page surface), then Brain /
   // Studio / Workflow on 2 / 3 / 4. Ignored while typing in an
   // input/textarea/contenteditable so it never hijacks editor or form keystrokes;
-  // Shift/Alt-modified combos are left alone too.
+  // Shift/Alt-modified combos are left alone too. The modifier is
+  // browser-dependent (`surfaceShortcutModifierPressed`): Firefox reserves
+  // Accel+digit for tab switching and ignores preventDefault on it, so there
+  // the binding is plain Ctrl+digit and ⌘+digit is left to the browser's tab
+  // switch (never both at once).
   useEffect(() => {
     if (typeof window === "undefined") return;
     const SURFACE_BY_KEY: Record<string, string> = {
@@ -240,7 +245,7 @@ export function WorkspaceChrome({
       "4": "workflow",
     };
     const onKey = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
+      if (!surfaceShortcutModifierPressed(e)) return;
       const surface = SURFACE_BY_KEY[e.key];
       if (!surface) return;
       const el = document.activeElement as HTMLElement | null;

--- a/apps/app-web/src/lib/__tests__/surface-shortcuts.test.ts
+++ b/apps/app-web/src/lib/__tests__/surface-shortcuts.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  isFirefoxUa,
+  isMacUa,
+  surfaceShortcutLabel,
+  surfaceShortcutModifierPressed,
+} from "../surface-shortcuts";
+
+const MAC_CHROME =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+const MAC_FIREFOX =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:127.0) Gecko/20100101 Firefox/127.0";
+const MAC_SAFARI =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15";
+const WIN_CHROME =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+const WIN_FIREFOX =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:127.0) Gecko/20100101 Firefox/127.0";
+const LINUX_FIREFOX =
+  "Mozilla/5.0 (X11; Linux x86_64; rv:127.0) Gecko/20100101 Firefox/127.0";
+// The app-desktop shell: Chromium UA, never "Firefox" — keeps the ⌘ binding.
+const MAC_ELECTRON =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) sidanclaw/1.0.0 Chrome/124.0.6367.243 Electron/30.0.9 Safari/537.36";
+
+const key = (mods: Partial<Record<"metaKey" | "ctrlKey" | "shiftKey" | "altKey", boolean>>) => ({
+  metaKey: false,
+  ctrlKey: false,
+  shiftKey: false,
+  altKey: false,
+  ...mods,
+});
+
+describe("[COMP:app-web/surface-shortcuts] Surface-shortcut modifier per browser", () => {
+  it("detects Firefox and mac from the UA", () => {
+    expect(isFirefoxUa(MAC_FIREFOX)).toBe(true);
+    expect(isFirefoxUa(MAC_CHROME)).toBe(false);
+    expect(isFirefoxUa(MAC_ELECTRON)).toBe(false);
+    expect(isMacUa(MAC_SAFARI)).toBe(true);
+    expect(isMacUa(WIN_FIREFOX)).toBe(false);
+  });
+
+  it("accepts the native Accel key outside Firefox (⌘ on mac, Ctrl elsewhere)", () => {
+    expect(surfaceShortcutModifierPressed(key({ metaKey: true }), MAC_CHROME)).toBe(true);
+    expect(surfaceShortcutModifierPressed(key({ ctrlKey: true }), WIN_CHROME)).toBe(true);
+    expect(surfaceShortcutModifierPressed(key({ metaKey: true }), MAC_ELECTRON)).toBe(true);
+    expect(surfaceShortcutModifierPressed(key({}), MAC_CHROME)).toBe(false);
+  });
+
+  it("remaps to plain Ctrl in Firefox and leaves ⌘+digit to the browser's tab switch", () => {
+    expect(surfaceShortcutModifierPressed(key({ ctrlKey: true }), MAC_FIREFOX)).toBe(true);
+    // ⌘+digit is Firefox's reserved tab switch — matching it too would make a
+    // surface jump double up with the tab switch, so it must NOT match.
+    expect(surfaceShortcutModifierPressed(key({ metaKey: true }), MAC_FIREFOX)).toBe(false);
+    expect(
+      surfaceShortcutModifierPressed(key({ metaKey: true, ctrlKey: true }), MAC_FIREFOX),
+    ).toBe(false);
+    expect(surfaceShortcutModifierPressed(key({ ctrlKey: true }), WIN_FIREFOX)).toBe(true);
+    expect(surfaceShortcutModifierPressed(key({ ctrlKey: true }), LINUX_FIREFOX)).toBe(true);
+  });
+
+  it("always leaves Shift/Alt-modified combos alone", () => {
+    for (const ua of [MAC_CHROME, MAC_FIREFOX, WIN_CHROME, WIN_FIREFOX]) {
+      expect(
+        surfaceShortcutModifierPressed(key({ metaKey: true, shiftKey: true }), ua),
+      ).toBe(false);
+      expect(
+        surfaceShortcutModifierPressed(key({ ctrlKey: true, altKey: true }), ua),
+      ).toBe(false);
+    }
+  });
+
+  it("labels the tooltip chip per browser (⌘n / ⌃n / Ctrl+n)", () => {
+    expect(surfaceShortcutLabel(1, MAC_CHROME)).toBe("⌘1");
+    expect(surfaceShortcutLabel(1, MAC_SAFARI)).toBe("⌘1");
+    expect(surfaceShortcutLabel(1, MAC_ELECTRON)).toBe("⌘1");
+    expect(surfaceShortcutLabel(2, MAC_FIREFOX)).toBe("⌃2");
+    expect(surfaceShortcutLabel(3, WIN_CHROME)).toBe("Ctrl+3");
+    expect(surfaceShortcutLabel(4, WIN_FIREFOX)).toBe("Ctrl+4");
+    // SSR fallback (navigator undefined → empty UA): never reaches paint —
+    // the tooltip popup only mounts on hover — but must not throw.
+    expect(surfaceShortcutLabel(1, "")).toBe("Ctrl+1");
+  });
+});

--- a/apps/app-web/src/lib/surface-shortcuts.ts
+++ b/apps/app-web/src/lib/surface-shortcuts.ts
@@ -1,0 +1,60 @@
+/**
+ * Surface-shortcut keybinding — which modifier the ⌘/Ctrl+1–4 surface jumps
+ * (Home / Brain / Studio / Workflow, wired in `workspace-chrome.tsx`) listen
+ * for, per browser. Spec: docs/architecture/features/doc.md → "Surface
+ * shortcuts".
+ *
+ * Chrome/Chromium, Safari, and the Electron desktop shell deliver Accel+digit
+ * to the page and honor `preventDefault()`, so they keep the native Accel
+ * binding (⌘ on macOS, Ctrl elsewhere). Firefox treats Accel+1–9 as a
+ * RESERVED tab-switching shortcut — the keydown still reaches the page but
+ * `preventDefault()` cannot stop the tab switch — so there the binding remaps
+ * to plain Ctrl+digit, and ⌘+digit is deliberately not matched (a surface
+ * jump must never double up with the browser's tab switch). On Windows/Linux
+ * Firefox Ctrl+digit is itself the reserved tab switch, so the browser wins
+ * when several tabs are open — there is no free single modifier left
+ * (Alt+digit also switches tabs on Linux Firefox).
+ *
+ * UA sniffing is deliberate: there is no feature-detect for "is this shortcut
+ * reserved", and the check only picks which binding to listen for. Electron's
+ * UA contains "Chrome", never "Firefox", so the desktop shell keeps ⌘.
+ *
+ * [COMP:app-web/surface-shortcuts]
+ */
+
+const runtimeUa = typeof navigator === "undefined" ? "" : navigator.userAgent;
+
+export function isFirefoxUa(ua: string): boolean {
+  return ua.includes("Firefox");
+}
+
+export function isMacUa(ua: string): boolean {
+  return ua.includes("Mac");
+}
+
+/**
+ * True when a keydown carries this browser's surface-shortcut modifier
+ * (and no Shift/Alt, which are always left alone).
+ */
+export function surfaceShortcutModifierPressed(
+  e: Pick<KeyboardEvent, "metaKey" | "ctrlKey" | "shiftKey" | "altKey">,
+  ua: string = runtimeUa,
+): boolean {
+  if (e.shiftKey || e.altKey) return false;
+  if (isFirefoxUa(ua)) return e.ctrlKey && !e.metaKey;
+  return e.metaKey || e.ctrlKey;
+}
+
+/**
+ * Tooltip chip label for a surface digit — "⌘1" (mac), "⌃1" (mac Firefox),
+ * "Ctrl+1" (everything else, and the SSR fallback: `navigator` is undefined
+ * on the server, but the tooltip popup only mounts on hover so the fallback
+ * never reaches paint).
+ */
+export function surfaceShortcutLabel(
+  digit: number,
+  ua: string = runtimeUa,
+): string {
+  if (!isMacUa(ua)) return `Ctrl+${digit}`;
+  return isFirefoxUa(ua) ? `⌃${digit}` : `⌘${digit}`;
+}


### PR DESCRIPTION
## Why

Firefox treats Accel+1–9 (⌘ on macOS, Ctrl on Windows/Linux) as a **reserved tab-switching shortcut** and ignores `preventDefault()` on it, so the ⌘/Ctrl+1–4 surface jumps (Home / Brain / Studio / Workflow) were unkeepable there — a ⌘+digit press switched the browser tab *and* navigated the app at once. Chrome/Safari/the Electron shell deliver the keydown and honor `preventDefault()`, so they keep the native Accel binding.

## What

- **New `lib/surface-shortcuts.ts`** (`[COMP:app-web/surface-shortcuts]`) — pure browser→binding seam: `surfaceShortcutModifierPressed(e)` (the keydown predicate) and `surfaceShortcutLabel(digit)` (the tooltip `<kbd>` chip). In Firefox the binding is **plain Ctrl+digit**, and ⌘+digit is deliberately unmatched so a surface jump never doubles the browser's tab switch. Detection is UA sniffing by design (no feature-detect exists for reserved shortcuts); Electron's UA contains `Chrome`, so the desktop shell keeps ⌘.
- **`workspace-chrome.tsx`** gates the keydown handler on the predicate instead of the inline `(metaKey || ctrlKey)` check.
- **`doc-sidebar.tsx`** tooltip chips are now browser-aware (`⌘1` mac / `⌃1` mac Firefox / `Ctrl+1` elsewhere) — also fixes the pre-existing mislabel showing `⌘` to Windows/Linux users.

Known limit (documented): on Windows/Linux Firefox, Ctrl+digit is itself the reserved tab switch, so the browser wins with several tabs open — unchanged from before; no free single modifier exists (Alt+digit also switches tabs on Linux Firefox).

Spec lives in the platform repo: `docs/architecture/features/doc.md` → "Surface shortcuts" + a paired `sidanclaw-kb/features/doc.md` entry + an `app-web/surface-shortcuts` component-map row (committed on the platform side).

## Testing

- `src/lib/__tests__/surface-shortcuts.test.ts` (5 tests: mac/win/linux × Chrome/Firefox/Safari/Electron UAs, ⌘-rejection in Firefox, Shift/Alt passthrough, SSR fallback)
- Full app-web suite: 145 files / 1358 tests pass; `tsc --noEmit` clean; `pnpm smoke` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)