### PR TITLE
feat(mcp): relay MCP tool image content to the model

### DIFF
--- a/packages/api/src/mcp/__tests__/client.test.ts
+++ b/packages/api/src/mcp/__tests__/client.test.ts
@@ -89,16 +89,41 @@ describe('[COMP:api/mcp-client] discoverMcpServer', () => {
 })
 
 describe('[COMP:api/mcp-client] callRemoteMcpTool', () => {
-  it('extracts and joins the text content of a successful call', async () => {
+  it('extracts and joins the text content of a text-only call', async () => {
     fakeClient.callTool.mockResolvedValueOnce({
       content: [
         { type: 'text', text: 'line 1' },
         { type: 'text', text: 'line 2' },
-        { type: 'image', data: '...' },
       ],
     })
     const out = await callRemoteMcpTool('https://mcp.example/sse', 'search', { q: 'x' })
     expect(out).toBe('line 1\nline 2')
+  })
+
+  it('returns structured { text, images } when the result carries image content', async () => {
+    fakeClient.callTool.mockResolvedValueOnce({
+      content: [
+        { type: 'text', text: 'here are the frames' },
+        { type: 'image', mimeType: 'image/jpeg', data: 'b64a' },
+        { type: 'image', data: 'b64b' }, // mimeType defaulted
+      ],
+    })
+    const out = await callRemoteMcpTool('https://mcp.example/sse', 'get_frames', {})
+    expect(out).toEqual({
+      text: 'here are the frames',
+      images: [
+        { mimeType: 'image/jpeg', data: 'b64a' },
+        { mimeType: 'image/jpeg', data: 'b64b' },
+      ],
+    })
+  })
+
+  it('returns image-only results as { text:"", images }', async () => {
+    fakeClient.callTool.mockResolvedValueOnce({
+      content: [{ type: 'image', mimeType: 'image/png', data: 'b64' }],
+    })
+    const out = await callRemoteMcpTool('https://mcp.example/sse', 'render', {})
+    expect(out).toEqual({ text: '', images: [{ mimeType: 'image/png', data: 'b64' }] })
   })
 
   it('throws with the error text when the result is flagged isError', async () => {
@@ -109,8 +134,8 @@ describe('[COMP:api/mcp-client] callRemoteMcpTool', () => {
     await expect(callRemoteMcpTool('https://mcp.example/sse', 'search', {})).rejects.toThrow('rate limited')
   })
 
-  it('returns the raw content when the result has no text parts', async () => {
-    const content = [{ type: 'image', data: 'b64' }]
+  it('returns the raw content when the result has neither text nor image parts', async () => {
+    const content = [{ type: 'resource', resource: { uri: 'x://y' } }]
     fakeClient.callTool.mockResolvedValueOnce({ content })
     const out = await callRemoteMcpTool('https://mcp.example/sse', 'render', {})
     expect(out).toBe(content)

--- a/packages/api/src/mcp/client.ts
+++ b/packages/api/src/mcp/client.ts
@@ -54,8 +54,20 @@ export async function discoverMcpServer(
 }
 
 /**
+ * A remote MCP tool result that carried inline image content (e.g. sampled
+ * video frames). Returned by `callRemoteMcpTool` instead of a bare string so
+ * the images can be lifted onto `ToolResult.images` and shown to the model.
+ * See `@sidanclaw/core` `mcpResultToToolResult`.
+ */
+export type McpImageToolResult = {
+  text: string
+  images: Array<{ mimeType: string; data: string }>
+}
+
+/**
  * Call a tool on a remote MCP server. Opens a fresh connection, calls the tool,
- * and closes. Returns the text content from the result.
+ * and closes. Returns the joined text content, or — when the tool returned
+ * inline image content — an `McpImageToolResult` carrying the text plus images.
  */
 export async function callRemoteMcpTool(
   serverUrl: string,
@@ -82,12 +94,27 @@ export async function callRemoteMcpTool(
       throw new Error(errorText)
     }
 
-    // Extract text content from the result
-    const texts = (result.content as Array<{ type: string; text?: string }>)
-      ?.filter((c) => c.type === 'text')
-      .map((c) => c.text)
+    // Split the result into text + inline images. Text-only results return the
+    // joined string (unchanged behavior). When the tool returned image content
+    // (e.g. sampled video frames), return a structured payload so the images can
+    // reach the model — core's `mcpResultToToolResult` lifts them onto
+    // `ToolResult.images`, which the engine renders as inline image blocks.
+    const content = (result.content ?? []) as Array<{
+      type: string
+      text?: string
+      data?: string
+      mimeType?: string
+    }>
+    const texts = content.filter((c) => c.type === 'text').map((c) => c.text ?? '')
+    const images = content
+      .filter((c) => c.type === 'image' && typeof c.data === 'string')
+      .map((c) => ({ mimeType: c.mimeType ?? 'image/jpeg', data: c.data as string }))
 
-    return texts?.length ? texts.join('\n') : result.content
+    if (images.length > 0) {
+      const out: McpImageToolResult = { text: texts.join('\n'), images }
+      return out
+    }
+    return texts.length ? texts.join('\n') : result.content
   } finally {
     await client.close().catch(() => {})
   }

--- a/packages/core/scripts/verify-mcp-image.ts
+++ b/packages/core/scripts/verify-mcp-image.ts
@@ -1,0 +1,104 @@
+/**
+ * Manual verification for MCP image tool-results (the feat/mcp-image-tool-results change).
+ *
+ * Drives ONE real Gemini query-loop turn where a tool returns an image via
+ * `ToolResult.images`. If the model can name the image's colour, the whole
+ * path works end to end:
+ *   tool returns images -> executor emits image blocks -> query loop puts them
+ *   in the tool-results turn -> Gemini `inlineData` -> model SEES the pixels.
+ *
+ * This is the one link unit tests can't prove: that Gemini accepts an image
+ * part sitting alongside the functionResponse in the tool-results turn.
+ *
+ * Run:  GEMINI_API_KEY=... pnpm --filter @sidanclaw/core tsx scripts/verify-mcp-image.ts
+ *       (optional VERIFY_MODEL=gemini-flash-3 to match the prod chat model)
+ */
+
+import { z } from 'zod'
+import { queryLoop, type QueryEvent } from '../src/engine/query-loop.js'
+import { buildTool } from '../src/tools/types.js'
+import { createGeminiProvider } from '../src/providers/gemini.js'
+
+// A 96x96 solid-red JPEG (generated with ffmpeg color=red). Small on purpose.
+const RED_JPEG_B64 =
+  '/9j/4AAQSkZJRgABAgAAAQABAAD//gAQTGF2YzYyLjI4LjEwMgD/2wBDAAgEBAQEBAUFBQUFBQYGBgYGBgYGBgYGBgYHBwcICAgHBwcGBgcHCAgICAkJCQgICAgJCQoKCgwMCwsODg4RERT/xABNAAEBAAAAAAAAAAAAAAAAAAAABgEBAQEAAAAAAAAAAAAAAAAAAAYHEAEAAAAAAAAAAAAAAAAAAAAAEQEAAAAAAAAAAAAAAAAAAAAA/8AAEQgAYABgAwEiAAIRAAMRAP/aAAwDAQACEQMRAD8AiwEm38AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB/9k='
+
+const apiKey = process.env.GEMINI_API_KEY
+if (!apiKey) {
+  console.error('Set GEMINI_API_KEY to run this verification.')
+  process.exit(2)
+}
+const model = process.env.VERIFY_MODEL ?? 'gemini-2.5-flash'
+
+let toolCalled = false
+
+const showImage = buildTool({
+  name: 'show_image',
+  description: 'Return an image for you to look at. Call this, then describe what you see.',
+  inputSchema: z.object({}),
+  isConcurrencySafe: true,
+  isReadOnly: true,
+  async execute() {
+    toolCalled = true
+    return {
+      data: 'Here is the image. Look at it and answer the user.',
+      images: [{ mimeType: 'image/jpeg', data: RED_JPEG_B64 }],
+    }
+  },
+})
+
+async function main(): Promise<void> {
+  const events: QueryEvent[] = []
+  for await (const event of queryLoop({
+    provider: createGeminiProvider(apiKey!),
+    model,
+    systemPrompt: 'You are a vision test assistant. Use tools when asked.',
+    messages: [
+      {
+        role: 'user',
+        content:
+          'Call the show_image tool, then reply with ONLY the single dominant colour of the image it returns (one word).',
+      },
+    ],
+    tools: new Map([['show_image', showImage]]),
+    context: {
+      userId: 'verify-user',
+      assistantId: 'verify-assistant',
+      sessionId: 'verify-session',
+      appId: 'verify',
+      channelType: 'web',
+      channelId: 'verify-channel',
+      abortSignal: new AbortController().signal,
+    },
+    maxTurns: 4,
+  })) {
+    events.push(event)
+  }
+
+  const text = events
+    .map((e) => (e.type === 'text_delta' ? e.text : ''))
+    .join('')
+    .trim()
+
+  console.log(`\nmodel (${model}) said: ${JSON.stringify(text)}`)
+  console.log(`tool called: ${toolCalled}`)
+
+  if (!toolCalled) {
+    console.error('\nFAILED: the model never called show_image (cannot conclude anything about images).')
+    process.exit(1)
+  }
+  if (/\bred\b/i.test(text)) {
+    console.log('\nOK - the model saw the image (named the colour). MCP image tool-results reach the model.')
+    return
+  }
+  console.error(
+    '\nFAILED: the model called the tool but did not name the colour - the image likely did NOT reach it as vision.',
+  )
+  process.exit(1)
+}
+
+main().catch((err: unknown) => {
+  console.error('\nVERIFY FAILED (error):')
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/core/src/engine/__tests__/tool-executor.test.ts
+++ b/packages/core/src/engine/__tests__/tool-executor.test.ts
@@ -848,3 +848,66 @@ describe('[COMP:engine/tool-executor-approval-refactor] autonomous approvals-row
     expect(port).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('[COMP:engine/tool-executor] image tool results', () => {
+  it('emits ToolResult.images as image blocks right after the tool_result', async () => {
+    const framesTool = buildTool({
+      name: 'getFrames',
+      description: 'returns frames',
+      inputSchema: z.record(z.unknown()),
+      isConcurrencySafe: true,
+      isReadOnly: true,
+      async execute() {
+        return {
+          data: '[returned 2 image(s)]',
+          images: [
+            { mimeType: 'image/jpeg', data: 'AAA' },
+            { mimeType: 'image/png', data: 'BBB' },
+          ],
+        }
+      },
+    })
+    const executor = createToolExecutor({
+      tools: new Map<string, Tool>([['getFrames', framesTool]]),
+      context: ctx,
+      loopDetector: createLoopDetector(),
+    })
+    executor.addTool('call_1', 'getFrames', {})
+    const results = await drainResults(executor)
+
+    // tool_result first, then one image block per returned frame, in order.
+    expect(results).toHaveLength(3)
+    expect(results[0]).toMatchObject({ type: 'tool_result', toolUseId: 'call_1' })
+    expect(results[1]).toEqual({ type: 'image', mimeType: 'image/jpeg', data: 'AAA' })
+    expect(results[2]).toEqual({ type: 'image', mimeType: 'image/png', data: 'BBB' })
+  })
+
+  it('drops images with empty data', async () => {
+    const tool = buildTool({
+      name: 'mixed',
+      description: 'mixed images',
+      inputSchema: z.record(z.unknown()),
+      isConcurrencySafe: true,
+      isReadOnly: true,
+      async execute() {
+        return {
+          data: 'ok',
+          images: [
+            { mimeType: 'image/jpeg', data: 'GOOD' },
+            { mimeType: 'image/png', data: '' }, // empty data -> dropped
+          ],
+        }
+      },
+    })
+    const executor = createToolExecutor({
+      tools: new Map<string, Tool>([['mixed', tool]]),
+      context: ctx,
+      loopDetector: createLoopDetector(),
+    })
+    executor.addTool('call_1', 'mixed', {})
+    const results = await drainResults(executor)
+
+    expect(results).toHaveLength(2)
+    expect(results[1]).toEqual({ type: 'image', mimeType: 'image/jpeg', data: 'GOOD' })
+  })
+})

--- a/packages/core/src/engine/tool-executor.ts
+++ b/packages/core/src/engine/tool-executor.ts
@@ -45,6 +45,12 @@ type TrackedTool = {
   isConcurrencySafe: boolean
   promise?: Promise<void>
   result?: ContentBlock
+  /**
+   * Inline images the tool produced (ToolResult.images) as `image` content
+   * blocks, emitted right after `result` so they join the tool-results user
+   * turn and a multimodal provider can see them.
+   */
+  resultImages?: ContentBlock[]
   /** Internal-only meta from the tool's ToolResult.meta. Surfaced via getCompletedResults. */
   meta?: ToolResultMeta
   error?: string
@@ -622,6 +628,15 @@ export function createToolExecutor(options: ToolExecutorOptions) {
       content = capToolResultTokens(content)
 
       t.result = { type: 'tool_result', toolUseId: t.id, name: t.name, content, isError: result.isError }
+      // Inline images (e.g. an MCP tool returning sampled frames) become `image`
+      // content blocks emitted right after the tool_result, so a multimodal
+      // provider sees them. Capped + validated; a text-only provider drops them.
+      if (Array.isArray(result.images) && result.images.length > 0) {
+        t.resultImages = result.images
+          .filter((im) => im && typeof im.data === 'string' && im.data.length > 0)
+          .slice(0, 8)
+          .map((im) => ({ type: 'image', mimeType: im.mimeType || 'image/jpeg', data: im.data }))
+      }
       t.meta = result.meta
       t.status = 'completed'
       // Feed the consecutive-failure breaker with this real outcome (a tool may
@@ -696,6 +711,9 @@ export function createToolExecutor(options: ToolExecutorOptions) {
         ) break // preserve order
         if (t.result) {
           blocks.push(t.result)
+          // Emit tool-produced images right after their tool_result so they land
+          // in the same tool-results user turn the model reads next.
+          if (t.resultImages?.length) blocks.push(...t.resultImages)
           if (t.meta) metaByToolUseId[t.id] = t.meta
         }
         t.status = 'yielded'

--- a/packages/core/src/mcp/__tests__/tool-result.test.ts
+++ b/packages/core/src/mcp/__tests__/tool-result.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { mcpResultToToolResult } from '../tool-result.js'
+
+describe('[COMP:mcp/tool-result] mcpResultToToolResult', () => {
+  it('wraps a plain string result as { data }', () => {
+    expect(mcpResultToToolResult('hello')).toEqual({ data: 'hello' })
+  })
+
+  it('passes through a non-multimodal object/array as data (fallback)', () => {
+    const arr = [{ type: 'resource', uri: 'x://y' }]
+    expect(mcpResultToToolResult(arr)).toEqual({ data: arr })
+  })
+
+  it('lifts { text, images } onto ToolResult.images', () => {
+    const out = mcpResultToToolResult({
+      text: 'frames attached',
+      images: [
+        { mimeType: 'image/jpeg', data: 'a' },
+        { mimeType: 'image/png', data: 'b' },
+      ],
+    })
+    expect(out).toEqual({
+      data: 'frames attached',
+      images: [
+        { mimeType: 'image/jpeg', data: 'a' },
+        { mimeType: 'image/png', data: 'b' },
+      ],
+    })
+  })
+
+  it('synthesizes placeholder text when images have no accompanying text', () => {
+    const out = mcpResultToToolResult({ text: '', images: [{ mimeType: 'image/jpeg', data: 'a' }] })
+    expect(out.data).toBe('[returned 1 image(s)]')
+    expect(out.images).toHaveLength(1)
+  })
+
+  it('drops malformed image entries', () => {
+    const out = mcpResultToToolResult({
+      text: 't',
+      images: [{ mimeType: 'image/jpeg', data: 'a' }, { mimeType: 'image/jpeg' }, null, 'nope'],
+    })
+    expect(out.images).toEqual([{ mimeType: 'image/jpeg', data: 'a' }])
+  })
+
+  it('caps the number of lifted images at 8', () => {
+    const many = Array.from({ length: 20 }, (_, i) => ({ mimeType: 'image/jpeg', data: String(i) }))
+    const out = mcpResultToToolResult({ text: 't', images: many })
+    expect(out.images).toHaveLength(8)
+  })
+
+  it('keeps the real text and omits images when the images array is all invalid', () => {
+    const out = mcpResultToToolResult({ text: 'just text', images: [null, 'x'] })
+    expect(out).toEqual({ data: 'just text' })
+    expect(out.images).toBeUndefined()
+  })
+})

--- a/packages/core/src/mcp/connector.ts
+++ b/packages/core/src/mcp/connector.ts
@@ -8,6 +8,7 @@
 import { z } from 'zod'
 import { buildTool, type Tool } from '../tools/types.js'
 import { classifyTool, defaultPolicy } from './classifier.js'
+import { mcpResultToToolResult } from './tool-result.js'
 import type { McpSettingsStore, McpServerConfig, McpToolInfo } from './types.js'
 
 /** Sanitize a string for use in LLM tool names (Gemini restriction). */
@@ -82,7 +83,8 @@ export function wrapMcpTools(params: {
             allowed: true,
           }).catch((err) => console.debug('MCP usage tracking failed:', err))
 
-          return { data: result }
+          // Lift any inline image content onto ToolResult.images so the model sees it.
+          return mcpResultToToolResult(result)
         } catch (err) {
           return {
             data: `MCP tool ${mcpTool.name} failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/core/src/mcp/gateway.ts
+++ b/packages/core/src/mcp/gateway.ts
@@ -12,6 +12,7 @@
 import { z } from 'zod'
 import { buildTool, type Tool } from '../tools/types.js'
 import { classifyTool, defaultPolicy } from './classifier.js'
+import { mcpResultToToolResult } from './tool-result.js'
 import type { McpSettingsStore, McpServerConfig, McpToolInfo } from './types.js'
 
 /** Sanitize a string for use in LLM tool names (Gemini restriction). */
@@ -125,7 +126,8 @@ export function createMcpGateway(params: {
           allowed: true,
         }).catch((err) => console.debug('MCP usage tracking failed:', err))
 
-        return { data: result }
+        // Lift any inline image content onto ToolResult.images so the model sees it.
+        return mcpResultToToolResult(result)
       } catch (err) {
         return {
           data: `MCP tool ${mcpTool.name} failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/core/src/mcp/tool-result.ts
+++ b/packages/core/src/mcp/tool-result.ts
@@ -1,0 +1,36 @@
+/**
+ * Normalize a raw MCP tool return into a sidanclaw `ToolResult`.
+ *
+ * A remote MCP tool returns either plain text (a string / content array) or,
+ * when it emits image content, a `{ text, images }` payload (see the API
+ * package's `callRemoteMcpTool`). This lifts those inline images onto
+ * `ToolResult.images` so the engine can render them as image blocks the model
+ * actually sees — a text-only path just carries the text as `data`.
+ *
+ * See docs/architecture/integrations/mcp.md → "Image tool results".
+ */
+
+import type { ToolResult, ToolResultImage } from '../tools/types.js'
+
+/** Cap on images lifted from a single MCP tool result (defense against abuse). */
+const MAX_MCP_RESULT_IMAGES = 8
+
+function isImage(value: unknown): value is ToolResultImage {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    typeof (value as ToolResultImage).data === 'string' &&
+    typeof (value as ToolResultImage).mimeType === 'string'
+  )
+}
+
+export function mcpResultToToolResult(result: unknown): ToolResult {
+  if (result && typeof result === 'object' && Array.isArray((result as { images?: unknown }).images)) {
+    const r = result as { text?: unknown; images: unknown[] }
+    const images = r.images.filter(isImage).slice(0, MAX_MCP_RESULT_IMAGES)
+    const text =
+      typeof r.text === 'string' && r.text.length > 0 ? r.text : `[returned ${images.length} image(s)]`
+    return images.length > 0 ? { data: text, images } : { data: text }
+  }
+  return { data: result }
+}

--- a/packages/core/src/mcp/tool-search.ts
+++ b/packages/core/src/mcp/tool-search.ts
@@ -29,6 +29,7 @@ import { randomBytes } from 'node:crypto'
 import { z } from 'zod'
 import { buildTool, type Tool } from '../tools/types.js'
 import { classifyTool, defaultPolicy } from './classifier.js'
+import { mcpResultToToolResult } from './tool-result.js'
 import { jsonSchemaFromZod } from '../engine/query-loop.js'
 import type { EngineHooks, PreToolUseDirective } from '../engine/hooks.js'
 import type { McpSettingsStore, McpServerConfig, McpToolInfo } from './types.js'
@@ -660,7 +661,8 @@ async function dispatchRemote(params: {
       }
     }
 
-    return { data: result }
+    // Lift any inline image content onto ToolResult.images so the model sees it.
+    return mcpResultToToolResult(result)
   } catch (err) {
     return {
       data: `MCP tool ${tool} failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -252,10 +252,21 @@ export type ToolContext = {
  */
 export type ToolResultMeta = Record<string, string | number | boolean>
 
+/** Inline base64 image a tool produces for the model to SEE (not just read as text). */
+export type ToolResultImage = { mimeType: string; data: string }
+
 export type ToolResult<T = unknown> = {
   data: T
   isError?: boolean
   meta?: ToolResultMeta
+  /**
+   * Optional inline images the tool produced for the model to look at. The
+   * engine emits these as `image` content blocks appended to the tool-results
+   * user turn, so a multimodal provider (Gemini → inlineData) sees them; a
+   * text-only provider drops them. The primary producer is an MCP tool whose
+   * CallToolResult carries `type:'image'` content (see mcp/client.ts).
+   */
+  images?: ToolResultImage[]
 }
 
 // ── Tool definition ────────────────────────────────────────────


### PR DESCRIPTION
MCP tools can now return **images the model sees** (previously all non-text MCP tool results were dropped).

- `callRemoteMcpTool` preserves `type:'image'` content blocks (returns `{ text, images }`).
- `mcpResultToToolResult` lifts them onto `ToolResult.images` at **every** dispatch site: `tool-search.ts` `dispatchRemote` (the `mcp_call` path custom connectors use), `connector.ts`, `gateway.ts`.
- The tool executor emits them as `image` content blocks in the tool-results turn -> Gemini `inlineData`. Text-only providers drop them.

Verified: unit tests (core+api), a live Gemini check (`scripts/verify-mcp-image.ts`, passes on 2.5-flash and gemini-flash-3), and a full local E2E of a remote MCP returning frames -> model correctly judged pickleball vs not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)