### PR TITLE
fix(app-web): route chat video attachments to the recordings pipeline

### DIFF
--- a/apps/app-web/src/components/chrome/floating-chat.tsx
+++ b/apps/app-web/src/components/chrome/floating-chat.tsx
@@ -171,6 +171,7 @@ import { useIsOffline } from "@/lib/offline/use-offline-sync";
 import type { AssistantRunState } from "@sidanclaw/doc-model";
 import { cn } from "@/lib/utils";
 import { imageFilesFromClipboard, useFileAttachments } from "@/lib/use-file-attachments";
+import { useRecordingUpload } from "@/lib/recordings/use-recording-upload";
 import { useFileDrop } from "@/lib/use-file-drop";
 import { useAutoGrowTextarea } from "@/lib/use-auto-grow-textarea";
 import { AttachmentChips, FileDropOverlay } from "@/components/doc/attachment-chips";
@@ -417,6 +418,7 @@ export function FloatingChat({
   const offline = useIsOffline();
   const tRun = useT().docPage.assistantRun;
   const tAttach = useT().attachments;
+  const tRec = useT().recordings;
   const router = useRouter();
   const pathname = usePathname();
   const [expanded, setExpanded] = useState(false);
@@ -479,7 +481,27 @@ export function FloatingChat({
   // (its creature icon) instead of a generic chat glyph. Only the floating
   // launcher renders the FAB, so the fetch is skipped in side-panel mode.
   const [assistant, setAssistant] = useState<AssistantIdentity | null>(null);
-  const att = useFileAttachments(() => sessionIdRef.current ?? undefined);
+  // Attached video is too large for the cache upload (Cloud Run's 32 MiB edge
+  // cap / the 20 MB multer limit) and the model can't consume it inline, so
+  // hand it to the recordings pipeline instead: direct-to-GCS upload → server
+  // cost estimate → transcribe + file to the brain. Brain-only ingest (no
+  // blueprint) here — `run` shows its own cost confirm, which is all the
+  // preflight invariant needs when there's no synthesized page.
+  // See docs/architecture/media/transcription.md.
+  const activeAssistantId = selectedAssistantId || assistantId;
+  const rec = useRecordingUpload(workspaceId, activeAssistantId);
+  const att = useFileAttachments(() => sessionIdRef.current ?? undefined, {
+    // Only offer routing when we have a workspace + assistant to bind the
+    // recording to; otherwise video falls to the guard (unsupported-here) chip.
+    onRouteMedia:
+      workspaceId && activeAssistantId
+        ? (videos) => {
+            void (async () => {
+              for (const file of videos) await rec.run(file);
+            })();
+          }
+        : undefined,
+  });
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [error, setError] = useState<string | null>(null);
   // Resolve the assistant's avatar identity for the floating launcher FAB.
@@ -2556,7 +2578,25 @@ export function FloatingChat({
             }
             sendLabel={t.send}
             slotAttachments={
-              <AttachmentChips attachments={att.attachments} onRemove={att.remove} />
+              <>
+                <AttachmentChips attachments={att.attachments} onRemove={att.remove} />
+                {rec.status !== "idle" ? (
+                  <p
+                    className={
+                      rec.status === "error"
+                        ? "px-1 py-0.5 text-xs text-destructive"
+                        : "px-1 py-0.5 text-xs text-muted-foreground"
+                    }
+                    role="status"
+                  >
+                    {rec.status === "uploading"
+                      ? tRec.uploading
+                      : rec.status === "processing"
+                        ? tRec.processing
+                        : rec.message}
+                  </p>
+                ) : null}
+              </>
             }
             slotPreInput={
               <>

--- a/apps/app-web/src/lib/__tests__/use-file-attachments.test.ts
+++ b/apps/app-web/src/lib/__tests__/use-file-attachments.test.ts
@@ -13,6 +13,7 @@ import {
   applyUploadResult,
   imageFilesFromClipboard,
   markStagedError,
+  partitionUpload,
   readyFileIds,
   type Attachment,
 } from "../use-file-attachments";
@@ -136,5 +137,62 @@ describe("[COMP:app-web/file-attachments] paste image extraction", () => {
   it("returns [] when there is no clipboard data", () => {
     expect(imageFilesFromClipboard(null)).toEqual([]);
     expect(imageFilesFromClipboard(undefined)).toEqual([]);
+  });
+});
+
+function sizedFile(type: string, size: number, name = "file"): File {
+  return { type, name, size } as unknown as File;
+}
+
+describe("[COMP:app-web/file-attachments] upload partition guard", () => {
+  const MAX = 20 * 1024 * 1024;
+
+  it("routes video to media when the host can route", () => {
+    const mp4 = sizedFile("video/mp4", 93 * 1024 * 1024, "call.mp4");
+    const r = partitionUpload([mp4], { maxBytes: MAX, canRouteMedia: true });
+    expect(r.media).toEqual([mp4]);
+    expect(r.attach).toEqual([]);
+    expect(r.rejected).toEqual([]);
+  });
+
+  it("rejects video as unsupported when the host cannot route", () => {
+    const mp4 = sizedFile("video/mp4", 5 * 1024 * 1024, "clip.mp4");
+    const r = partitionUpload([mp4], { maxBytes: MAX, canRouteMedia: false });
+    expect(r.media).toEqual([]);
+    expect(r.attach).toEqual([]);
+    expect(r.rejected).toEqual([{ file: mp4, reason: "video_unsupported" }]);
+  });
+
+  it("rejects an oversized non-video as too_large", () => {
+    const pdf = sizedFile("application/pdf", MAX + 1, "big.pdf");
+    const r = partitionUpload([pdf], { maxBytes: MAX, canRouteMedia: true });
+    expect(r.rejected).toEqual([{ file: pdf, reason: "too_large" }]);
+    expect(r.attach).toEqual([]);
+  });
+
+  it("keeps a normal file on the attach path", () => {
+    const png = sizedFile("image/png", 1024, "shot.png");
+    const r = partitionUpload([png], { maxBytes: MAX, canRouteMedia: false });
+    expect(r.attach).toEqual([png]);
+    expect(r.media).toEqual([]);
+    expect(r.rejected).toEqual([]);
+  });
+
+  it("allows a file exactly at the limit, rejects one byte over", () => {
+    const at = sizedFile("application/pdf", MAX, "at.pdf");
+    const over = sizedFile("application/pdf", MAX + 1, "over.pdf");
+    const r = partitionUpload([at, over], { maxBytes: MAX, canRouteMedia: true });
+    expect(r.attach).toEqual([at]);
+    expect(r.rejected).toEqual([{ file: over, reason: "too_large" }]);
+  });
+
+  it("splits a mixed batch into all three lanes", () => {
+    const mp4 = sizedFile("video/mp4", 40 * 1024 * 1024, "v.mp4");
+    const big = sizedFile("application/pdf", MAX + 10, "big.pdf");
+    const ok = sizedFile("text/plain", 200, "note.txt");
+    const r = partitionUpload([mp4, big, ok], { maxBytes: MAX, canRouteMedia: true });
+    expect(r.media).toEqual([mp4]);
+    expect(r.rejected).toEqual([{ file: big, reason: "too_large" }]);
+    expect(r.attach).toEqual([ok]);
   });
 });

--- a/apps/app-web/src/lib/i18n/dictionaries/en.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/en.ts
@@ -1821,6 +1821,8 @@ export const en = {
     uploading: "Uploading…",
     uploadFailed: "Couldn't upload. Try again.",
     dropToAttach: "Drop files to attach",
+    tooLarge: "That file is too large to attach (max 20 MB).",
+    videoUnsupported: "To use a video, upload it as a recording in Studio to transcribe it.",
   },
   kbGaps: {
     title: "Recurring questions",

--- a/apps/app-web/src/lib/i18n/dictionaries/ja.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/ja.ts
@@ -1633,6 +1633,8 @@ export const ja: Dictionary = {
     uploading: "アップロード中…",
     uploadFailed: "アップロードできませんでした。もう一度お試しください。",
     dropToAttach: "ファイルをドロップして添付",
+    tooLarge: "このファイルは大きすぎて添付できません（最大 20 MB）。",
+    videoUnsupported: "動画を使うには、スタジオで録画としてアップロードして文字起こししてください。",
   },
   kbGaps: {
     title: "繰り返される質問",

--- a/apps/app-web/src/lib/i18n/dictionaries/zh.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh.ts
@@ -1623,6 +1623,8 @@ export const zh: Dictionary = {
     uploading: "上傳中…",
     uploadFailed: "無法上傳，請再試一次。",
     dropToAttach: "拖放檔案以附加",
+    tooLarge: "此檔案太大，無法附加（上限 20 MB）。",
+    videoUnsupported: "若要使用影片，請在工作室中以錄音方式上傳以進行轉錄。",
   },
   kbGaps: {
     title: "重複出現的問題",

--- a/apps/app-web/src/lib/use-file-attachments.ts
+++ b/apps/app-web/src/lib/use-file-attachments.ts
@@ -27,8 +27,21 @@
 
 import * as React from "react";
 import { authFetch } from "@/lib/auth-fetch";
+import { useT } from "@/lib/i18n/client";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
+
+/**
+ * Client-side upload ceiling. Mirrors the backend `MAX_FILE_SIZE` in
+ * `packages/api/src/routes/files.ts` (20 MB) so an oversized file is rejected
+ * with a clear chip here instead of dying as an opaque Cloud Run 413 (its
+ * platform 32 MiB request cap) or a generic 500 from the multer limit. Video is
+ * rejected regardless of size (the route's mime allowlist excludes `video/`);
+ * a host that supplies `onRouteMedia` diverts video to the recordings pipeline
+ * (direct-to-GCS + transcription) instead. See docs/architecture/features/files.md
+ * -> "Client-side upload guard" and docs/architecture/media/transcription.md.
+ */
+export const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024;
 
 type AttachmentStatus = "uploading" | "done" | "error";
 
@@ -110,6 +123,50 @@ export function readyFileIds(attachments: ReadonlyArray<Attachment>): string[] {
     .map((a) => a.fileId!);
 }
 
+/** Why a file was kept out of the `/api/files/upload` POST. */
+export type RejectReason = "too_large" | "video_unsupported";
+
+export type PartitionedUpload = {
+  /** Files that go through the normal cache upload. */
+  attach: File[];
+  /** Video handed to the recordings pipeline (only when the host can route). */
+  media: File[];
+  /** Files never POSTed — surfaced as clear error chips instead of a 413. */
+  rejected: Array<{ file: File; reason: RejectReason }>;
+};
+
+/**
+ * Split a picked/dropped/pasted batch into the three upload lanes. Pure so it
+ * unit-tests without a DOM (same stance as the reconciliation helpers above).
+ *
+ * - `video/*` → `media` when `canRouteMedia` (a host wired `onRouteMedia`);
+ *   otherwise `rejected` as `video_unsupported` (the cache route's mime
+ *   allowlist excludes video, so it could never attach here anyway).
+ * - non-video over `maxBytes` → `rejected` as `too_large`.
+ * - everything else → `attach` (the unchanged POST path).
+ */
+export function partitionUpload(
+  files: readonly File[],
+  opts: { maxBytes: number; canRouteMedia: boolean },
+): PartitionedUpload {
+  const attach: File[] = [];
+  const media: File[] = [];
+  const rejected: PartitionedUpload["rejected"] = [];
+  for (const file of files) {
+    const isVideo = file.type.startsWith("video/");
+    if (isVideo && opts.canRouteMedia) {
+      media.push(file);
+    } else if (isVideo) {
+      rejected.push({ file, reason: "video_unsupported" });
+    } else if (file.size > opts.maxBytes) {
+      rejected.push({ file, reason: "too_large" });
+    } else {
+      attach.push(file);
+    }
+  }
+  return { attach, media, rejected };
+}
+
 /**
  * The image files carried by a clipboard paste — but ONLY when the paste has
  * no plain-text payload. This is the standard "paste a screenshot / copied
@@ -138,20 +195,59 @@ export function imageFilesFromClipboard(
  *   cached against (e.g. a comment thread's `sessionId`). Read lazily on each
  *   upload so a session adopted mid-conversation is picked up. The `fileId`
  *   itself is session-agnostic on the read path, so this is best-effort.
+ * @param opts.maxBytes Reject non-video files over this size before POSTing
+ *   (default {@link MAX_ATTACHMENT_BYTES}). Guards against the opaque Cloud Run
+ *   413 / multer 500.
+ * @param opts.onRouteMedia When set, `video/*` files are diverted here (e.g. the
+ *   recordings transcription pipeline) instead of the cache upload, and no chip
+ *   is staged for them. When absent, video is rejected as unsupported-here.
  */
 export function useFileAttachments(
   getSessionId?: () => string | undefined,
+  opts?: { maxBytes?: number; onRouteMedia?: (files: File[]) => void },
 ): FileAttachmentsApi {
+  const t = useT();
   const [attachments, setAttachments] = React.useState<Attachment[]>([]);
 
-  // Keep the accessor in a ref so `upload` stays referentially stable.
+  // Keep accessors/config in refs so `upload` stays referentially stable.
   const sessionIdRef = React.useRef(getSessionId);
   sessionIdRef.current = getSessionId;
+  const optsRef = React.useRef(opts);
+  optsRef.current = opts;
+  const rejectCopyRef = React.useRef(t.attachments);
+  rejectCopyRef.current = t.attachments;
 
   const upload = React.useCallback(async (fileList: FileList | File[]) => {
-    const files = Array.from(fileList);
-    if (files.length === 0) return;
+    const all = Array.from(fileList);
+    if (all.length === 0) return;
 
+    const { attach, media, rejected } = partitionUpload(all, {
+      maxBytes: optsRef.current?.maxBytes ?? MAX_ATTACHMENT_BYTES,
+      canRouteMedia: !!optsRef.current?.onRouteMedia,
+    });
+
+    // Divert video to the host's media pipeline (recordings). No chip staged —
+    // that flow owns its own cost-confirm + status UI.
+    if (media.length > 0) optsRef.current?.onRouteMedia?.(media);
+
+    // Guard: rejected files never POST; they surface as clear error chips so the
+    // user gets a message instead of an opaque 413 / silent failure.
+    if (rejected.length > 0) {
+      const copy = rejectCopyRef.current;
+      const rejectedChips: Attachment[] = rejected.map(({ file, reason }) => ({
+        localId: crypto.randomUUID(),
+        fileName: file.name,
+        mimeType: file.type || "application/octet-stream",
+        sizeBytes: file.size,
+        status: "error" as const,
+        error: reason === "too_large" ? copy.tooLarge : copy.videoUnsupported,
+      }));
+      setAttachments((prev) => [...prev, ...rejectedChips]);
+    }
+
+    if (attach.length === 0) return;
+
+    const files = attach;
     const staged: Attachment[] = files.map((f) => ({
       localId: crypto.randomUUID(),
       fileName: f.name,

--- a/packages/api/src/routes/files.ts
+++ b/packages/api/src/routes/files.ts
@@ -1,5 +1,5 @@
-import { Router } from 'express'
-import multer from 'multer'
+import { Router, type Request, type Response, type NextFunction } from 'express'
+import multer, { MulterError } from 'multer'
 import { z } from 'zod'
 import { getDefaultAssistant, findAssistantById, getWorkspacePrimaryAssistant } from '../db/users.js'
 import { findOrCreateSession, findSessionById } from '../db/sessions.js'
@@ -479,6 +479,34 @@ export function fileRoutes(
       console.error('File preview error:', err)
       res.status(500).json({ error: 'Failed to load file' })
     }
+  })
+
+  // Map multer limit rejections to a clear 413 instead of the generic 500 a
+  // thrown MulterError would otherwise surface. The web client guards before
+  // POST (`use-file-attachments.ts` → `partitionUpload`), so this is
+  // defense-in-depth for direct API callers and any file between the 20 MB
+  // multer cap and Cloud Run's 32 MiB edge cap. See
+  // docs/architecture/features/files.md → "Upload limits".
+  router.use((err: unknown, _req: Request, res: Response, next: NextFunction) => {
+    if (err instanceof MulterError) {
+      if (err.code === 'LIMIT_FILE_SIZE') {
+        res.status(413).json({
+          error: 'file_too_large',
+          detail: `Each file must be ${MAX_FILE_SIZE / (1024 * 1024)} MB or smaller.`,
+        })
+        return
+      }
+      if (err.code === 'LIMIT_FILE_COUNT') {
+        res.status(413).json({
+          error: 'too_many_files',
+          detail: `Attach at most ${MAX_FILES_PER_REQUEST} files per upload.`,
+        })
+        return
+      }
+      res.status(400).json({ error: 'upload_rejected', detail: err.message })
+      return
+    }
+    next(err)
   })
 
   return router


### PR DESCRIPTION
## Problem

A large video attached in chat POSTed blindly to `/api/files/upload` and died at Cloud Run's 32 MiB HTTP/1 edge cap as an opaque **413** (the route buffers in memory via `multer.memoryStorage`, caps each file at 20 MB, and its mime allowlist excludes `video/`). The client hook did no size/type gating, so oversized/unsupported files failed with no user-facing message.

## Fix

`partitionUpload` (`apps/app-web/src/lib/use-file-attachments.ts`) now splits every picked/dropped/pasted batch into three lanes:

- **`video/*` → the recordings pipeline** when the host wires `onRouteMedia` (the FloatingChat composer does): video is handed to `useRecordingUpload` (signed-URL upload direct to GCS, then transcribe), so a large video never streams through the API. Brain-only ingest, so only the cost confirm is required.
- **non-video over 20 MB** (`MAX_ATTACHMENT_BYTES`) → rejected with a clear `tooLarge` chip, never POSTed.
- **video where no assistant is in scope** (comment/skill composers) → rejected as `videoUnsupported`, pointing at the Studio recording upload.

Server-side, `fileRoutes` maps a multer `LIMIT_FILE_SIZE` / `LIMIT_FILE_COUNT` to a clear **413** JSON body instead of a generic 500 (defense-in-depth for direct callers).

New i18n strings (`attachments.tooLarge`, `attachments.videoUnsupported`) added across en/ja/zh.

## Tests

- `use-file-attachments.test.ts`: 6 new `partitionUpload` cases (video→media, non-video>max→too_large, video without router→unsupported, mixed batch, boundary).
- Verified live end-to-end against real GCS: attaching a 95 MB mp4 fired `upload-url` → 95 MB direct-to-GCS PUT → ffprobe estimate → "103-minute, 11 credits" cost dialog → process enqueue, with **0** `/api/files/upload` requests. Oversized non-video showed the `tooLarge` chip with no POST.

Docs updated in the paired KB repo and the platform docs (see linked PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
