### PR TITLE
fix(workflow): resolve team-native/team-grant connectors in authoring preflight

### DIFF
--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -1757,6 +1757,12 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     waConnectorUrl: env.WA_CONNECTOR_URL,
     waConnectorSecret: env.WA_CONNECTOR_SECRET,
     connectorStore,
+    // Team credential sources — the connector preflight resolves creds with the
+    // same precedence as the runtime (team-native instance → member grant →
+    // per-user), so a workflow whose connector lives in a team-owned/granted
+    // instance is not falsely rejected as "not connected".
+    connectorInstanceStore,
+    connectorGrantStore,
     // Policy-aware preflight: lets authoring reject an `ask`-policy tool
     // pinned on an `assistant_call` step (never executable there — the callee
     // surface drops ask-policy tools; see dependencyIssues) instead of

--- a/packages/api/src/routes/workflows.ts
+++ b/packages/api/src/routes/workflows.ts
@@ -294,7 +294,7 @@ async function dependencyIssues(
         if (probed.has(tn)) continue
         probed.add(tn)
         try {
-          const res = await opts.preflightConnectorTool({ userId: ctx.userId, toolName: tn })
+          const res = await opts.preflightConnectorTool({ userId: ctx.userId, toolName: tn, workspaceId: ctx.workspaceId })
           if (res && !res.ok) {
             issues.push({
               path: ['definition', 'steps', i],

--- a/packages/api/src/workflow/__tests__/dependency-preflight.test.ts
+++ b/packages/api/src/workflow/__tests__/dependency-preflight.test.ts
@@ -2,9 +2,12 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { createWorkflowDependencyPreflight } from '../dependency-preflight.js'
 import type { ChannelIntegrationStore } from '../../db/channel-integrations.js'
 import type { ConnectorStore } from '../../db/connector-store.js'
+import type { ConnectorInstanceStore } from '../../db/connector-instance-store.js'
+import type { ConnectorGrantStore } from '../../db/connector-grant-store.js'
 
 const ASSISTANT_ID = 'a1'
 const USER_ID = 'u1'
+const WORKSPACE_ID = 'w1'
 
 function integrationStoreWith(
   creds: Record<string, { credentials: Record<string, unknown>; botUserId?: string | null } | null>,
@@ -19,6 +22,32 @@ function connectorStoreWith(creds: Record<string, { client_secret?: string } | n
   return {
     getCredentials: async (_userId: string, connectorId: string) => creds[connectorId] ?? null,
   } as unknown as ConnectorStore
+}
+
+/**
+ * Team-native + team-grant credential sources — the runtime overlays the
+ * preflight must now mirror. `instances` are `scope='workspace'` rows keyed by
+ * instance id; `credsById` are what `getCredentialsSystem(id)` returns. Both
+ * team stores share the same instance-credential reader (grants read the
+ * granted instance's credentials through the instance store), matching
+ * `mcp/inject.ts`.
+ */
+function connectorInstanceStoreWith(
+  instances: Array<{ id: string; provider: string; connected: boolean }>,
+  credsById: Record<string, { client_secret?: string } | null>,
+): ConnectorInstanceStore {
+  return {
+    listByWorkspaceSystem: async (_workspaceId: string) => instances,
+    getCredentialsSystem: async (id: string) => credsById[id] ?? null,
+  } as unknown as ConnectorInstanceStore
+}
+
+function connectorGrantStoreWith(
+  grants: Array<{ instance: { id: string; provider: string; connected: boolean }; grantedByUserId: string }>,
+): ConnectorGrantStore {
+  return {
+    listForTargetSystem: async (_targetType: string, _targetId: string) => grants,
+  } as unknown as ConnectorGrantStore
 }
 
 afterEach(() => {
@@ -197,6 +226,137 @@ describe('[COMP:workflow/dependency-preflight] preflightConnectorTool', () => {
       assistantId: ASSISTANT_ID,
     })
     expect(loosened?.policy).toBe('allow')
+  })
+
+  // Team credential resolution (prod 2026-07-13): the preflight must resolve
+  // credentials with the SAME precedence the runtime uses (team-native
+  // instance → member grant → per-user), or it rejects a workflow the executor
+  // would run. The per-user store below is EMPTY in these cases — the only
+  // credential lives in a team-owned / team-granted instance.
+  it('accepts GitHub when the credential is a team-native (scope=workspace) instance', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ login: 'octocat' }), { status: 200 })))
+    const { preflightConnectorTool } = createWorkflowDependencyPreflight({
+      connectorStore: connectorStoreWith({}), // no per-user GitHub
+      connectorInstanceStore: connectorInstanceStoreWith(
+        [{ id: 'inst-team', provider: 'github', connected: true }],
+        { 'inst-team': { client_secret: 'ghp_team' } },
+      ),
+    })
+    const r = await preflightConnectorTool({
+      userId: USER_ID,
+      toolName: 'githubListPullRequests',
+      workspaceId: WORKSPACE_ID,
+    })
+    expect(r).toEqual({ ok: true, provider: 'GitHub', policy: 'allow' })
+  })
+
+  it('probes the team-native token — a revoked team PAT is blocked (not silently accepted)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('Bad credentials', { status: 401 })))
+    const { preflightConnectorTool } = createWorkflowDependencyPreflight({
+      connectorStore: connectorStoreWith({}),
+      connectorInstanceStore: connectorInstanceStoreWith(
+        [{ id: 'inst-team', provider: 'github', connected: true }],
+        { 'inst-team': { client_secret: 'ghp_team_revoked' } },
+      ),
+    })
+    const r = await preflightConnectorTool({
+      userId: USER_ID,
+      toolName: 'githubGetRepository',
+      workspaceId: WORKSPACE_ID,
+    })
+    expect(r?.ok).toBe(false)
+    expect(r?.reason).toMatch(/invalid or revoked/i)
+  })
+
+  it('accepts GitHub when the credential is a member-exposure grant (team-grant)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ login: 'octocat' }), { status: 200 })))
+    const { preflightConnectorTool } = createWorkflowDependencyPreflight({
+      connectorStore: connectorStoreWith({}), // no per-user GitHub
+      // No team-native instance for github; only a grant of a user instance.
+      connectorInstanceStore: connectorInstanceStoreWith([], { 'inst-granted': { client_secret: 'ghp_granted' } }),
+      connectorGrantStore: connectorGrantStoreWith([
+        { instance: { id: 'inst-granted', provider: 'github', connected: true }, grantedByUserId: 'u2' },
+      ]),
+    })
+    const r = await preflightConnectorTool({
+      userId: USER_ID,
+      toolName: 'githubListPullRequests',
+      workspaceId: WORKSPACE_ID,
+    })
+    expect(r).toEqual({ ok: true, provider: 'GitHub', policy: 'allow' })
+  })
+
+  it('accepts a non-GitHub connector on presence of a team-grant credential', async () => {
+    const { preflightConnectorTool } = createWorkflowDependencyPreflight({
+      connectorStore: connectorStoreWith({}),
+      connectorInstanceStore: connectorInstanceStoreWith([], { 'inst-notion': { client_secret: 'tok' } }),
+      connectorGrantStore: connectorGrantStoreWith([
+        { instance: { id: 'inst-notion', provider: 'notion', connected: true }, grantedByUserId: 'u2' },
+      ]),
+    })
+    const r = await preflightConnectorTool({
+      userId: USER_ID,
+      toolName: 'notionSearch',
+      workspaceId: WORKSPACE_ID,
+    })
+    expect(r).toEqual({ ok: true, provider: 'Notion', policy: 'allow' })
+  })
+
+  it('team-native precedence: a disconnected team instance falls through to the per-user credential', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ login: 'octocat' }), { status: 200 })))
+    const { preflightConnectorTool } = createWorkflowDependencyPreflight({
+      connectorStore: connectorStoreWith({ github: { client_secret: 'ghp_personal' } }),
+      // Team instance exists but is NOT connected → skipped; per-user wins.
+      connectorInstanceStore: connectorInstanceStoreWith(
+        [{ id: 'inst-team', provider: 'github', connected: false }],
+        { 'inst-team': { client_secret: 'ghp_team' } },
+      ),
+    })
+    const r = await preflightConnectorTool({
+      userId: USER_ID,
+      toolName: 'githubGetRepository',
+      workspaceId: WORKSPACE_ID,
+    })
+    expect(r?.ok).toBe(true)
+  })
+
+  it('reports not-connected only when NO source (team-native, team-grant, per-user) has a credential', async () => {
+    const { preflightConnectorTool } = createWorkflowDependencyPreflight({
+      connectorStore: connectorStoreWith({}),
+      connectorInstanceStore: connectorInstanceStoreWith([], {}),
+      connectorGrantStore: connectorGrantStoreWith([]),
+    })
+    const r = await preflightConnectorTool({
+      userId: USER_ID,
+      toolName: 'githubListPullRequests',
+      workspaceId: WORKSPACE_ID,
+    })
+    expect(r).toEqual({
+      ok: false,
+      provider: 'GitHub',
+      reason: expect.stringMatching(/not connected/i),
+      policy: 'allow',
+    })
+  })
+
+  it('a team store that throws is fail-open — falls through to the per-user credential', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ login: 'octocat' }), { status: 200 })))
+    const throwingInstanceStore = {
+      listByWorkspaceSystem: async () => {
+        throw new Error('db down')
+      },
+      getCredentialsSystem: async () => null,
+    } as unknown as ConnectorInstanceStore
+    const { preflightConnectorTool } = createWorkflowDependencyPreflight({
+      connectorStore: connectorStoreWith({ github: { client_secret: 'ghp_personal' } }),
+      connectorInstanceStore: throwingInstanceStore,
+    })
+    const r = await preflightConnectorTool({
+      userId: USER_ID,
+      toolName: 'githubGetRepository',
+      workspaceId: WORKSPACE_ID,
+    })
+    expect(r?.ok).toBe(true)
   })
 })
 

--- a/packages/api/src/workflow/dependency-preflight.ts
+++ b/packages/api/src/workflow/dependency-preflight.ts
@@ -27,6 +27,8 @@ import { createSlackApi } from '@sidanclaw/channels'
 import { APP_LEVEL_ASSISTANT_ID, OFFICIAL_CONNECTOR_TOOLS } from '@sidanclaw/shared'
 import type { ChannelIntegrationStore } from '../db/channel-integrations.js'
 import type { ConnectorStore } from '../db/connector-store.js'
+import type { ConnectorInstanceStore } from '../db/connector-instance-store.js'
+import type { ConnectorGrantStore } from '../db/connector-grant-store.js'
 import { getAuthenticatedUser } from '../github/client.js'
 
 /**
@@ -51,8 +53,28 @@ export type WorkflowDependencyPreflightOptions = {
   /** WhatsApp delivery via the wa-connector — presence makes a WhatsApp target reachable. */
   waConnectorUrl?: string
   waConnectorSecret?: string
-  /** Built-in connector credentials, for the connector preflight. */
+  /**
+   * Legacy per-user built-in connector credentials, for the connector
+   * preflight. Lowest-precedence credential source (see
+   * `preflightConnectorTool`).
+   */
   connectorStore?: ConnectorStore
+  /**
+   * Team-owned (`scope='workspace'`) connector instances — the HIGHEST-
+   * precedence credential source in the runtime's team overlay
+   * (`mcp/inject.ts` → team-native overlay). Wired so the preflight resolves
+   * credentials the same way the executor does; absent → the team-native arm
+   * is skipped (legacy call sites / tests unaffected).
+   */
+  connectorInstanceStore?: ConnectorInstanceStore
+  /**
+   * Member-exposure grants of a user-scoped instance to the workspace — the
+   * middle-precedence credential source in the runtime's team overlay
+   * (`mcp/inject.ts` → team-grant overlay). Reads the granted instance's
+   * credentials via `connectorInstanceStore.getCredentialsSystem`, so both
+   * stores must be wired for the grant arm to resolve.
+   */
+  connectorGrantStore?: ConnectorGrantStore
   /**
    * L1/L2 tool-policy rows (`mcp_tool_settings`) — powers the preflight's
    * `policy` answer so authoring can reject an `ask`-policy tool pinned on an
@@ -95,6 +117,73 @@ const CONNECTOR_LABEL: Record<string, string> = {
   files: 'Workspace Files',
 }
 
+/** The one field the preflight reads off resolved credentials (GitHub PAT). */
+type ProbeableCredential = { client_secret?: string }
+
+/**
+ * Resolve a connector's credential with the SAME source precedence the
+ * runtime uses in `mcp/inject.ts`'s team overlays:
+ *
+ *   1. Team-native — a `scope='workspace'` `connector_instance` for this
+ *      provider (highest precedence; the team admin's shared credential).
+ *   2. Team-grant — a member-exposure grant of a user-scoped instance to this
+ *      workspace, read via the granted instance's system credentials.
+ *   3. Per-user — the legacy `getCredentials(userId, connectorId)` lookup.
+ *
+ * Returns the first source that yields a credential, or null when none do.
+ * Team sources require `workspaceId`; the grant arm also needs
+ * `connectorInstanceStore` (grants read the instance's credentials through
+ * it). Every arm is fail-open — a store throw is logged and skipped so a flaky
+ * lookup degrades to the next source (and ultimately to "not connected"),
+ * never blocking authoring with an exception.
+ */
+async function resolveConnectorCredential(
+  options: WorkflowDependencyPreflightOptions,
+  args: { userId: string; connectorId: string; workspaceId?: string | null },
+): Promise<ProbeableCredential | null> {
+  const { userId, connectorId, workspaceId } = args
+
+  // 1. Team-native instance (scope='workspace').
+  if (workspaceId && options.connectorInstanceStore) {
+    try {
+      const instances = await options.connectorInstanceStore.listByWorkspaceSystem(workspaceId)
+      const inst = instances.find((i) => i.connected && i.provider === connectorId)
+      if (inst) {
+        const creds = await options.connectorInstanceStore.getCredentialsSystem(inst.id)
+        if (creds) return creds as ProbeableCredential
+      }
+    } catch (err) {
+      console.warn('[workflow/dependencyIssues] team-native credential lookup threw (skipping source):', err)
+    }
+  }
+
+  // 2. Member-exposure grant of a user-scoped instance to the workspace.
+  if (workspaceId && options.connectorGrantStore && options.connectorInstanceStore) {
+    try {
+      const grants = await options.connectorGrantStore.listForTargetSystem('workspace', workspaceId)
+      const grant = grants.find((g) => g.instance.connected && g.instance.provider === connectorId)
+      if (grant) {
+        const creds = await options.connectorInstanceStore.getCredentialsSystem(grant.instance.id)
+        if (creds) return creds as ProbeableCredential
+      }
+    } catch (err) {
+      console.warn('[workflow/dependencyIssues] team-grant credential lookup threw (skipping source):', err)
+    }
+  }
+
+  // 3. Legacy per-user store.
+  if (options.connectorStore) {
+    try {
+      const creds = await options.connectorStore.getCredentials(userId, connectorId)
+      if (creds) return creds as ProbeableCredential
+    } catch (err) {
+      console.warn('[workflow/dependencyIssues] per-user credential lookup threw (skipping source):', err)
+    }
+  }
+
+  return null
+}
+
 export type ValidateDeliveryTarget = (args: {
   assistantId: string
   channelType: 'telegram' | 'slack' | 'whatsapp'
@@ -110,6 +199,13 @@ export type PreflightConnectorTool = (args: {
    * default only.
    */
   assistantId?: string
+  /**
+   * The workspace/team id the workflow is authored in. Enables the runtime-
+   * identical team credential resolution (team-native instance, then member-
+   * exposure grant) before the legacy per-user lookup. Absent → per-user only
+   * (a workflow authored outside any team, or a legacy caller).
+   */
+  workspaceId?: string | null
 }) => Promise<{
   ok: boolean
   provider: string
@@ -200,7 +296,7 @@ export function createWorkflowDependencyPreflight(options: WorkflowDependencyPre
     return { ok: true }
   }
 
-  const preflightConnectorTool: PreflightConnectorTool = async ({ userId, toolName, assistantId }) => {
+  const preflightConnectorTool: PreflightConnectorTool = async ({ userId, toolName, assistantId, workspaceId }) => {
     const connectorId = TOOL_TO_CONNECTOR[toolName]
     if (!connectorId || connectorId === 'files') return null // not a (probeable) connector tool
     const provider = CONNECTOR_LABEL[connectorId] ?? connectorId
@@ -233,18 +329,33 @@ export function createWorkflowDependencyPreflight(options: WorkflowDependencyPre
       }
     }
 
-    if (!options.connectorStore) return { ok: true, provider, policy } // can't check → don't block
+    // No credential source wired at all → can't check → don't block.
+    if (!options.connectorStore && !options.connectorInstanceStore && !options.connectorGrantStore) {
+      return { ok: true, provider, policy }
+    }
 
-    const creds = await options.connectorStore.getCredentials(userId, connectorId)
+    // Resolve credentials with the SAME precedence the runtime uses
+    // (mcp/inject.ts team overlays): a team-owned (`scope='workspace'`)
+    // instance wins, then a member-exposure grant of a user instance, then
+    // the legacy per-user store. The preflight previously read ONLY the
+    // per-user store, so a workflow whose connector lived in a team-native /
+    // team-grant instance was rejected as "not connected" even though the
+    // executor would run it — the invariant "authoring must never reject a
+    // workflow the runtime would run" was violated (prod, 2026-07-13). Every
+    // arm is fail-open: a store throw skips that source, never blocks
+    // authoring. Only when NO source yields a credential is it "not connected".
+    const creds = await resolveConnectorCredential(options, { userId, connectorId, workspaceId })
     if (!creds) {
       return { ok: false, provider, reason: `${provider} is not connected in this workspace`, policy }
     }
 
-    // GitHub gets a real token probe (the incident). Other connectors are
-    // recognized but not yet probed here — a live token-refresh probe per
-    // provider is a tracked follow-up; presence of credentials is the check.
+    // GitHub gets a real token probe (the incident) against whichever source
+    // resolved — team credentials carry `client_secret` (the PAT) the same way
+    // the per-user row does. Other connectors are recognized but not yet
+    // probed here — a live token-refresh probe per provider is a tracked
+    // follow-up; presence of credentials is the check.
     if (connectorId === 'github') {
-      const pat = (creds as { client_secret?: string }).client_secret
+      const pat = creds.client_secret
       if (!pat) return { ok: false, provider, reason: 'GitHub credentials are incomplete', policy }
       try {
         await getAuthenticatedUser(pat)

--- a/packages/core/src/workflow/__tests__/tools.test.ts
+++ b/packages/core/src/workflow/__tests__/tools.test.ts
@@ -267,6 +267,7 @@ function makeAllTools(opts?: {
     userId: string
     toolName: string
     assistantId?: string
+    workspaceId?: string | null
   }) => Promise<{
     ok: boolean
     provider: string
@@ -1456,7 +1457,7 @@ describe('[COMP:workflow/tools] external-dependency authoring checks', () => {
     const r = await tools.createWorkflow.execute({ name: 'X', definition: def }, makeContext())
     expect(r.isError).toBe(true)
     expect((r.data as { errors: string[] }).errors.join(' ')).toContain('GitHub')
-    expect(preflightConnectorTool).toHaveBeenCalledWith({ userId: USER_ID, toolName: 'githubListPullRequests' })
+    expect(preflightConnectorTool).toHaveBeenCalledWith({ userId: USER_ID, toolName: 'githubListPullRequests', workspaceId: WORKSPACE_ID })
   })
 
   it('skips preflight for a tool that is not a connector tool (returns null)', async () => {
@@ -1494,11 +1495,13 @@ describe('[COMP:workflow/tools] external-dependency authoring checks', () => {
     expect(errors).toContain('ask-policy')
     expect(errors).toContain('tool_call')
     expect(errors).toContain('Approvals')
-    // The step's target assistant threads through for the L2 policy lookup.
+    // The step's target assistant threads through for the L2 policy lookup;
+    // the workspace id threads through for team credential resolution.
     expect(preflightConnectorTool).toHaveBeenCalledWith({
       userId: USER_ID,
       toolName: 'gmailSendMessage',
       assistantId: 'primary',
+      workspaceId: WORKSPACE_ID,
     })
   })
 

--- a/packages/core/src/workflow/tools.ts
+++ b/packages/core/src/workflow/tools.ts
@@ -192,6 +192,12 @@ export type WorkflowToolDeps = {
     userId: string
     toolName: string
     assistantId?: string
+    /**
+     * The workspace/team id the workflow is authored in, so the credential
+     * probe resolves team-native + team-grant sources the same way the runtime
+     * does (not just the per-user store). Absent → per-user only.
+     */
+    workspaceId?: string | null
   }) => Promise<{
     ok: boolean
     provider: string
@@ -731,6 +737,7 @@ async function dependencyIssues(
           userId: context.userId,
           toolName: ref.toolName,
           assistantId: ref.assistantId,
+          workspaceId: context.workspaceId,
         })
         if (!res) continue
         if (!res.ok) {


### PR DESCRIPTION
## Summary
The workflow authoring preflight (`preflightConnectorTool`) resolved connector credentials only via the per-user `connectorStore.getCredentials` lookup (`connector_instance WHERE scope='user'`), so a workflow whose step used a built-in connector tool was rejected with "not connected" whenever the workspace's credential lived in a **team-native** or **team-grant** `connector_instance` row — even though the runtime executes those tools fine via the team overlays in `mcp/inject.ts`. This violated the preflight's own invariant: *authoring must never reject a workflow the runtime would run*. Hit in prod 2026-07-13: `proposeWorkflow` reported "GitHub is not connected in this workspace" for a workspace whose GitHub connector was team-owned.

## Fix
- `resolveConnectorCredential` resolves with runtime-identical precedence: team-native instance (`listByWorkspaceSystem` + `getCredentialsSystem`) → member-exposure grant (`listForTargetSystem` + instance system creds) → legacy per-user store. First hit wins; every arm is fail-open (a store throw skips the source, never blocks authoring).
- The GitHub live `GET /user` token probe runs against whichever credential resolved.
- `workspaceId` threaded from both authoring paths: chat tools (`context.workspaceId` in `packages/core/src/workflow/tools.ts`) and REST (`ctx.workspaceId` in `routes/workflows.ts`); `boot.ts` wires `connectorInstanceStore` + `connectorGrantStore` into the preflight options.
- Runtime behavior unchanged — authoring preflight only.

## Tests
- `dependency-preflight.test.ts`: +160 lines — team-native resolves, team-grant resolves, precedence order, no-credential still errors, per-user path unchanged, fail-open on store throw. 24/24 pass.
- `packages/core` workflow tools tests: 78/78 pass. Both packages typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)