### PR TITLE
fix(synthesis): make a recording brief actually cover the recording

### DIFF
--- a/packages/api/src/synthesis/__tests__/synthesize.test.ts
+++ b/packages/api/src/synthesis/__tests__/synthesize.test.ts
@@ -129,6 +129,27 @@ describe('[COMP:api/synthesize] structural-synthesis runner', () => {
     expect(systemPrompt).toContain('searchRecording')
   })
 
+  it('without fullText, instructs the search-tool sweep', async () => {
+    const { deps } = build()
+    await synthesizeFromSource(SOURCE, BLUEPRINT, TARGET, deps)
+    const { systemPrompt } = queryLoopMock.mock.calls[0][0]
+    expect(systemPrompt).not.toContain('FULL TRANSCRIPT')
+    expect(systemPrompt).toContain('read the recording END TO END') // the sweep fallback
+  })
+
+  it('injects the full transcript and drops the sweep when source.fullText is set', async () => {
+    // A model told to sweep with a tool satisfices and briefs only the opening
+    // (2026-07-15). Injecting the whole transcript removes the discretion.
+    const { deps } = build()
+    const transcript = '[0:00:01] Speaker 1: opening line.\n[1:35:12] Speaker 2: the very last line.'
+    await synthesizeFromSource({ ...SOURCE, fullText: transcript }, BLUEPRINT, TARGET, deps)
+    const { systemPrompt } = queryLoopMock.mock.calls[0][0]
+    expect(systemPrompt).toContain('FULL TRANSCRIPT')
+    expect(systemPrompt).toContain('the very last line.') // the whole thing is in the prompt
+    expect(systemPrompt).toContain('Draft from ALL of it')
+    expect(systemPrompt).not.toContain('read the recording END TO END') // sweep instruction dropped
+  })
+
   it('assembles the tool map (source + doc + brain) and strips confirmation for the unattended run', async () => {
     const { deps } = build()
     await synthesizeFromSource(SOURCE, BLUEPRINT, TARGET, deps)

--- a/packages/api/src/synthesis/recording-synthesizer.ts
+++ b/packages/api/src/synthesis/recording-synthesizer.ts
@@ -27,6 +27,8 @@ import {
   type WorkspaceDirectoryStore,
 } from '@sidanclaw/core'
 import { createSearchRecordingTool } from '../recordings/recording-search-tool.js'
+import { readRecordingRange, type RecordingSegmentHit } from '../db/retrieval-store.js'
+import type { RetrievalActor } from '@sidanclaw/core'
 import {
   createRecordPageProjector,
   synthesizeFromSource,
@@ -87,6 +89,49 @@ function titleFor(slug: string, name?: string): string {
   return name ?? slug.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
+/** Above this the full transcript is NOT injected (a >~10 h recording would
+ *  bloat the prompt) and synthesis falls back to the search-tool sweep. The
+ *  3 h recording ceiling is ~70k chars, so this only guards pathological input. */
+const MAX_INJECT_CHARS = 500_000
+
+function fmtStamp(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000))
+  return `${Math.floor(s / 3600)}:${String(Math.floor((s % 3600) / 60)).padStart(2, '0')}:${String(s % 60).padStart(2, '0')}`
+}
+
+/**
+ * Read the recording's whole transcript as `[H:MM:SS] Speaker: text` lines, for
+ * injection into the synthesis prompt. Returns null when there are no segments,
+ * a read error, or the text exceeds `MAX_INJECT_CHARS` (caller falls back to the
+ * search-tool sweep). Pages the store in blocks so one query never loads a
+ * pathological recording whole.
+ */
+async function loadRecordingTranscript(recordingId: string, actor: RetrievalActor): Promise<string | undefined> {
+  const BLOCK = 500
+  const lines: string[] = []
+  let chars = 0
+  try {
+    for (let from = 0; ; from += BLOCK) {
+      const hits: RecordingSegmentHit[] = await readRecordingRange(actor, {
+        recordingId,
+        fromIndex: from,
+        toIndex: from + BLOCK - 1,
+      })
+      if (hits.length === 0) break
+      for (const h of hits) {
+        const line = `[${fmtStamp(h.start_ms)}] ${h.speaker ?? 'Speaker'}: ${h.segment_text}`
+        chars += line.length + 1
+        if (chars > MAX_INJECT_CHARS) return undefined // too big — fall back to the sweep
+        lines.push(line)
+      }
+      if (hits.length < BLOCK) break
+    }
+  } catch {
+    return undefined // read failed — fall back to the sweep
+  }
+  return lines.length > 0 ? lines.join('\n') : undefined
+}
+
 /**
  * Build the structural-synthesis callback the recording ingestor invokes. Returns
  * `null` when the blueprint slug resolves to nothing (logged, non-fatal — the
@@ -135,19 +180,24 @@ export function createRecordingSynthesizer(deps: RecordingSynthesizerDeps): Reco
       return null
     }
 
+    const actor = {
+      workspaceId: args.workspaceId,
+      userId: args.userId,
+      assistantId: args.assistantId,
+      assistantKind: 'standard' as const,
+      clearance: clearanceOf(args.sensitivity),
+      compartments: null,
+    }
+
     // 2. The source-retrieval tool (searchRecording), pinned to this recording + actor.
-    const sourceTool = createSearchRecordingTool({
-      recordingId: args.recordingId,
-      actor: {
-        workspaceId: args.workspaceId,
-        userId: args.userId,
-        assistantId: args.assistantId,
-        assistantKind: 'standard',
-        clearance: clearanceOf(args.sensitivity),
-        compartments: null,
-      },
-      embedder: deps.embedder,
-    })
+    const sourceTool = createSearchRecordingTool({ recordingId: args.recordingId, actor, embedder: deps.embedder })
+
+    // 2b. Inject the COMPLETE transcript into the prompt (when it fits): a model
+    //     told to sweep it with a tool satisfices and drafts from the first
+    //     quarter (2026-07-15). Handing it the whole text removes the discretion.
+    //     Capped so a pathological >10 h recording can't blow the context; above
+    //     the cap we fall back to the tool sweep.
+    const fullText = await loadRecordingTranscript(args.recordingId, actor)
 
     // 3. Doc-write tools, pinned to the brief page at build time (patchPage targets
     //    `anchorPageId`). `renderPage` is excluded — it mints a NEW draft, which
@@ -189,6 +239,7 @@ export function createRecordingSynthesizer(deps: RecordingSynthesizerDeps): Reco
         assistantId: args.assistantId,
         assistantKind: 'standard',
         sensitivity: args.sensitivity,
+        ...(fullText ? { fullText } : {}),
       },
       blueprint,
       {

--- a/packages/api/src/synthesis/synthesize.ts
+++ b/packages/api/src/synthesis/synthesize.ts
@@ -151,6 +151,12 @@ export type SynthesizeDeps = {
 
 /** Enough turns/tool-calls for a multi-section brief over a long transcript. */
 const SYNTHESIS_BUDGET_FALLBACK = { maxTurns: 30, maxToolCalls: 40, timeoutMs: 180_000 }
+// A recording sweep is the expensive source: reading an hour-plus transcript
+// end to end (the coverage discipline in `buildSystemPrompt`) costs one tool
+// call per window plus the drafting turns, and the 3-minute default wall clock
+// aborted mid-sweep — the brief then reflected only the opening minutes
+// (2026-07-13, a 96-min meeting). Sized for ~500 segments at 40/window.
+const RECORDING_SYNTHESIS_BUDGET = { maxTurns: 60, maxToolCalls: 80, timeoutMs: 900_000 }
 
 function titleFromSlug(slug: string): string {
   return slug.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
@@ -175,8 +181,19 @@ function buildSystemPrompt(
   let gatherLine: string
   let citeLine: string
   if (source.kind === 'recording') {
-    gatherLine = `- Pull facts with \`${sourceToolName}\` (this recording only); never paste the whole transcript into the page.`
-    citeLine = `- Cite the moment for every claim (the segment \`start_ms\`).`
+    // READ THE WHOLE RECORDING FIRST. Top-K search alone returns a handful of
+    // segments, so on an hour-plus transcript the model drafted a thin brief
+    // from a fraction of the conversation (2026-07-13: a 96-min meeting, 411
+    // segments, produced 5 shallow bullets). Sweeping sequential windows is
+    // what makes a long recording's brief actually cover the meeting.
+    gatherLine = [
+      `- FIRST read the recording END TO END with \`${sourceToolName}\`, before drafting anything: page sequential windows (\`fromIndex\`/\`toIndex\`, e.g. 0-39, then 40-79, and so on) until a window comes back empty — that is how you learn the transcript's true length. Do NOT rely on \`query\` top-K search for coverage; use it only to re-find a specific moment afterwards.`,
+      `- Draft from the WHOLE conversation, in the order it happened. Cover the later parts of the recording as thoroughly as the opening — a brief that only reflects the first few minutes is a failed brief. Never paste the whole transcript into the page.`,
+    ].join('\n')
+    citeLine = [
+      `- Cite the moment for every claim, as a timestamp in \`[H:MM:SS]\` form converted from that segment's \`start_ms\` (e.g. \`start_ms: 2841000\` → \`[0:47:21]\`). Minutes and seconds are always 00-59 — a citation like \`[00:85]\` is impossible and means you invented it.`,
+      `- Never cite a moment you did not read; if you cannot ground a claim in a segment, leave it out.`,
+    ].join('\n')
   } else if (source.kind === 'brain') {
     gatherLine = `- Pull facts with \`${sourceToolName}\` — draft ONLY from what the brain returns; do not invent facts it does not hold.`
     citeLine = `- Ground every claim in a brain row \`${sourceToolName}\` returned; if the brain has nothing for a section, say so rather than guessing.`
@@ -354,7 +371,10 @@ export async function synthesizeFromSource(
   // 3. Bounded server-side loop. The blueprint recipe IS the system prompt
   //    (executed, not nudged); on the legacy path the page is pinned via
   //    context.docViewId.
-  const budget = resolveResearchBudget(deps.budget, SYNTHESIS_BUDGET_FALLBACK)
+  const budget = resolveResearchBudget(
+    deps.budget,
+    source.kind === 'recording' ? RECORDING_SYNTHESIS_BUDGET : SYNTHESIS_BUDGET_FALLBACK,
+  )
   const sessionId = randomUUID()
   const abort = new AbortController()
   const timer = setTimeout(() => abort.abort(), budget.timeoutMs)

--- a/packages/api/src/synthesis/synthesize.ts
+++ b/packages/api/src/synthesis/synthesize.ts
@@ -61,6 +61,17 @@ export type SynthesisSource = {
   assistantKind: AssistantKind
   /** Sensitivity inherited from the source Episode; stamped on the page + every write. */
   sensitivity: string
+  /**
+   * The complete source text, injected into the prompt so the model drafts from
+   * ALL of it rather than paging a search tool. For a `recording` this is the
+   * whole `[H:MM:SS] Speaker: text` transcript. Set only when it fits the inject
+   * budget (`recording-synthesizer` caps it); absent → fall back to the
+   * search-tool sweep. A model told to "read end to end with a tool" SATISFICES —
+   * it reads a few windows and drafts (2026-07-15: a 96-min meeting's brief
+   * covered only the first ~23 min despite the sweep instruction). Handing it
+   * the full text removes the discretion.
+   */
+  fullText?: string
 }
 
 export type SynthesisBlueprint = {
@@ -180,12 +191,24 @@ function buildSystemPrompt(
   // brain draft (or a "brain row" demand on web findings) is nonsense.
   let gatherLine: string
   let citeLine: string
-  if (source.kind === 'recording') {
-    // READ THE WHOLE RECORDING FIRST. Top-K search alone returns a handful of
-    // segments, so on an hour-plus transcript the model drafted a thin brief
-    // from a fraction of the conversation (2026-07-13: a 96-min meeting, 411
-    // segments, produced 5 shallow bullets). Sweeping sequential windows is
-    // what makes a long recording's brief actually cover the meeting.
+  if (source.kind === 'recording' && source.fullText) {
+    // The COMPLETE transcript is in the prompt (see below) — no sweep needed,
+    // and no satisficing possible. A model told to "read end to end with a
+    // tool" reads a few windows and drafts (2026-07-15: a 96-min brief covered
+    // only the first ~23 min despite the sweep instruction). Handing it the
+    // whole text is what makes the brief cover the whole meeting.
+    gatherLine = [
+      `- The COMPLETE transcript of the recording is included above under "FULL TRANSCRIPT". Draft from ALL of it, start to finish.`,
+      `- Cover the WHOLE recording proportionally: the final third as thoroughly as the opening. Before you finish, confirm your brief reflects content from near the LAST timestamp in the transcript — a brief that stops partway through the recording is a failed brief. Never paste the whole transcript into the page.`,
+      `- Use \`${sourceToolName}\` only to re-check an exact quote or timestamp; you do not need it to discover content.`,
+    ].join('\n')
+    citeLine = [
+      `- Cite the moment for every claim as the transcript's \`[H:MM:SS]\` timestamp (copy it from the line you drew the claim from). Minutes and seconds are always 00-59 — a citation like \`[00:85]\` is impossible and means you invented it.`,
+      `- Never cite a moment not in the transcript; if a claim is not grounded in a line, leave it out.`,
+    ].join('\n')
+  } else if (source.kind === 'recording') {
+    // No injected transcript (too large, or read failed) — fall back to the
+    // search-tool sweep. Weaker: the model tends to stop paging early.
     gatherLine = [
       `- FIRST read the recording END TO END with \`${sourceToolName}\`, before drafting anything: page sequential windows (\`fromIndex\`/\`toIndex\`, e.g. 0-39, then 40-79, and so on) until a window comes back empty — that is how you learn the transcript's true length. Do NOT rely on \`query\` top-K search for coverage; use it only to re-find a specific moment afterwards.`,
       `- Draft from the WHOLE conversation, in the order it happened. Cover the later parts of the recording as thoroughly as the opening — a brief that only reflects the first few minutes is a failed brief. Never paste the whole transcript into the page.`,
@@ -202,11 +225,19 @@ function buildSystemPrompt(
     gatherLine = `- Read the gathered research with \`${sourceToolName}\` — draft ONLY from those findings; do not add facts they do not contain.`
     citeLine = `- Cite the source each claim came from (the URL / source named in the findings); if the findings do not cover a section, say so rather than guessing.`
   }
+  // When the full source text is injected, it leads the prompt so the model
+  // sees the whole thing before the instructions (and blueprint) that act on it.
+  const transcriptBlock =
+    source.kind === 'recording' && source.fullText
+      ? ['## FULL TRANSCRIPT', '', source.fullText, '', '---', '']
+      : []
+
   if (mode.recordPath) {
     // Record-first: the typed record is the deliverable; the page (when this
     // surface renders one) is projected FROM the record after the loop, so the
     // model never authors a page here.
     return [
+      ...transcriptBlock,
       blueprint.body,
       '',
       '---',
@@ -222,6 +253,7 @@ function buildSystemPrompt(
     ].join('\n')
   }
   return [
+    ...transcriptBlock,
     blueprint.body,
     '',
     '---',


### PR DESCRIPTION
## Problem

A recording brief was only as deep as the slice of transcript the model happened to read. The system prompt said "pull facts with `searchRecording`", and top-K returns ~8 segments per call — so on a **96-minute meeting (411 segments)** the model drafted five shallow bullets from the opening minutes and **invented citations** (`(00:85)`, `(02:91)` — impossible clock values).

## Changes (recording branch of the synthesis prompt + budget)

- **Read end to end first.** Page sequential `fromIndex`/`toIndex` windows until one comes back empty (also how the model learns the transcript's true length). Top-K `query` is only for re-finding a moment afterwards, never for coverage.
- **Draft from the whole conversation**, in order, covering the later parts as thoroughly as the opening.
- **Real citations only:** `[H:MM:SS]` converted from `start_ms`; minutes/seconds are always 00-59, so an out-of-range citation is a fabrication tell.
- **`RECORDING_SYNTHESIS_BUDGET`** (60 turns / 80 tool calls / 15 min) replaces the 3-minute default, which aborted the sweep mid-way. Sized for ~500 segments at 40/window. Other sources keep the old fallback.

## Verification

Re-ran the pipeline end to end on a local recording: the brief went from 4 thin sections to 8 substantive ones (paragraph summary, 8+ full-sentence key points, pain points, options considered, decisions, action items, verbatim quotes), every claim carrying a valid `[H:MM:SS]` citation. `pnpm check` green; synthesis suite 54/54.

Paired docs: sidanclaw-kb PR (structural-synthesis) + platform PR #200 (spec + gitlinks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)