### PR TITLE
fix(workflow): a pinned assistant_call tool-list can name a built-in connector tool (+ brain row deep links, merged_at)

### DIFF
--- a/apps/app-web/src/app/w/[workspaceId]/brain/page.tsx
+++ b/apps/app-web/src/app/w/[workspaceId]/brain/page.tsx
@@ -76,10 +76,13 @@ import {
   getBrainGraph,
   listBrain,
   primitivesToGraphKinds,
+  projectInboxRowToBrainRow,
   type BrainFacets,
   type BrainGraph,
   type BrainRow,
 } from "@/lib/api/brain";
+import { fetchBrainRow } from "@/lib/api/brain-inbox";
+import { parseBrainDeepLink } from "@/lib/brain-deep-link";
 import {
   listWorkspaceSkills,
   type WorkspaceSkillSummary,
@@ -182,6 +185,38 @@ function BrainPageInner() {
 
   const [rows, setRows] = useState<BrainRow[] | null>(null);
   const [selected, setSelected] = useState<BrainRow | null>(null);
+
+  // Row deep link — `?row=<id>[&kind=<primitive>]` opens that row's drawer
+  // (`[COMP:app-web/brain-deep-link]`). The row is fetched by id rather than
+  // looked up in `rows`, because the list is paginated and hides done tasks
+  // behind the "completed" fold — the two cases an inbound link (a Slack
+  // digest pointing at a shipped task) hits most. A miss (deleted row, wrong
+  // workspace, revoked clearance) leaves the plain list standing.
+  const deepLinkedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!activeId) return;
+    const link = parseBrainDeepLink(
+      new URLSearchParams(searchParams.toString()),
+    );
+    if (!link) return;
+    if (deepLinkedRef.current === link.rowId) return;
+    deepLinkedRef.current = link.rowId;
+
+    let cancelled = false;
+    void fetchBrainRow(activeId, link.primitive, link.rowId).then((detail) => {
+      if (cancelled || !detail) return;
+      setSelected({
+        ...projectInboxRowToBrainRow(detail),
+        // The projection hardcodes `hasPending` — it exists for the inbox,
+        // which by definition holds unverified rows. A deep link addresses ANY
+        // live row, so the real verified state decides.
+        hasPending: detail.verifiedAt == null,
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeId, searchParams]);
   // Completed (done / archived) tasks — fetched separately from the main list
   // (which hides them) so the grouped view can tuck them behind a "Show
   // completed" disclosure that leads with live work. Only fetched when tasks

--- a/apps/app-web/src/lib/__tests__/brain-deep-link.test.ts
+++ b/apps/app-web/src/lib/__tests__/brain-deep-link.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import {
+  brainRowUrl,
+  parseBrainDeepLink,
+  DEFAULT_LINKED_PRIMITIVE,
+} from "@/lib/brain-deep-link";
+
+describe("[COMP:app-web/brain-deep-link] Brain row deep links", () => {
+  describe("parseBrainDeepLink", () => {
+    it("defaults a bare ?row= link to a task", () => {
+      const link = parseBrainDeepLink(new URLSearchParams("row=abc-123"));
+      expect(link).toEqual({ rowId: "abc-123", primitive: "task" });
+      expect(DEFAULT_LINKED_PRIMITIVE).toBe("task");
+    });
+
+    it("honours an explicit linkable kind", () => {
+      expect(
+        parseBrainDeepLink(new URLSearchParams("row=abc-123&kind=company")),
+      ).toEqual({ rowId: "abc-123", primitive: "company" });
+    });
+
+    it("returns null when no row is addressed", () => {
+      expect(parseBrainDeepLink(new URLSearchParams(""))).toBeNull();
+      expect(parseBrainDeepLink(new URLSearchParams("row="))).toBeNull();
+      expect(parseBrainDeepLink(new URLSearchParams("view=graph"))).toBeNull();
+    });
+
+    it("drops an unknown kind rather than coercing it to a task", () => {
+      // A typo'd link must land on the plain list, never open a DIFFERENT row
+      // that happens to share the id namespace.
+      expect(
+        parseBrainDeepLink(new URLSearchParams("row=abc-123&kind=tasks")),
+      ).toBeNull();
+      expect(
+        parseBrainDeepLink(new URLSearchParams("row=abc-123&kind=knowledge")),
+      ).toBeNull();
+    });
+
+    it("ignores the other brain params it shares the query with", () => {
+      expect(
+        parseBrainDeepLink(new URLSearchParams("view=graph&row=abc&kind=deal")),
+      ).toEqual({ rowId: "abc", primitive: "deal" });
+    });
+  });
+
+  describe("brainRowUrl", () => {
+    it("omits kind for a task so the common link stays short", () => {
+      expect(brainRowUrl("https://app.sidan.ai", "ws-1", "task-1")).toBe(
+        "https://app.sidan.ai/w/ws-1/brain?row=task-1",
+      );
+    });
+
+    it("carries kind for every other primitive", () => {
+      expect(brainRowUrl("", "ws-1", "row-9", "memory")).toBe(
+        "/w/ws-1/brain?row=row-9&kind=memory",
+      );
+    });
+
+    it("round-trips through the parser", () => {
+      const url = brainRowUrl("https://app.sidan.ai", "ws-1", "row-9", "deal");
+      const query = url.slice(url.indexOf("?") + 1);
+      expect(parseBrainDeepLink(new URLSearchParams(query))).toEqual({
+        rowId: "row-9",
+        primitive: "deal",
+      });
+    });
+  });
+});

--- a/apps/app-web/src/lib/brain-deep-link.ts
+++ b/apps/app-web/src/lib/brain-deep-link.ts
@@ -1,0 +1,92 @@
+/**
+ * Brain row deep links — `/w/<workspaceId>/brain?row=<rowId>&kind=<primitive>`.
+ *
+ * A brain row (a task, a contact, a company, a deal) opens in the
+ * `BrainDetailDrawer` from page state only, so until now there was no URL that
+ * pointed AT one. That made a row unshareable: a Slack digest, a workflow
+ * message, or a teammate could link to the brain LIST and nothing finer. This
+ * module is the URL contract for that link — one place that builds it and one
+ * place that parses it, so the two can't drift.
+ *
+ * `kind` is optional and defaults to `task`, because a task is the row an
+ * outside surface (digest, reminder, workflow) almost always wants to point
+ * at, and a bare `?row=<uuid>` is the link a human is willing to paste.
+ *
+ * Knowledge rows are deliberately NOT reachable here — they own a full reader
+ * route (`/brain/entry/knowledge/<id>`, `[COMP:app-web/entry-reader]`) and
+ * `openRow` routes them there instead of to the drawer. Sending a knowledge id
+ * through `?row=` would open a worse surface than the one that exists.
+ *
+ * Spec: docs/architecture/features/doc.md → "Brain deep links".
+ * [COMP:app-web/brain-deep-link]
+ */
+
+import type { BrainPrimitive } from "@/lib/api/brain-inbox";
+
+/** Query param carrying the row id. */
+const BRAIN_ROW_PARAM = "row";
+/** Query param carrying the row's primitive. Optional; defaults to `task`. */
+const BRAIN_KIND_PARAM = "kind";
+
+/**
+ * Primitives a `?row=` link may address — every drawer-backed primitive the
+ * single-row read (`GET /api/brain-inbox/:workspaceId/:primitive/:rowId`)
+ * serves. `memory` and `entity` are included: both render in the drawer, and a
+ * memory has no reader route of its own.
+ */
+const LINKABLE: readonly BrainPrimitive[] = [
+  "task",
+  "memory",
+  "entity",
+  "contact",
+  "company",
+  "deal",
+  "workspace_file",
+] as const;
+
+/** The primitive a link with no explicit `kind` addresses. */
+export const DEFAULT_LINKED_PRIMITIVE: BrainPrimitive = "task";
+
+export type BrainDeepLink = {
+  rowId: string;
+  primitive: BrainPrimitive;
+};
+
+/**
+ * Read a deep link off the page's query params. Returns null when the link is
+ * absent or malformed — a bad `kind` is dropped rather than coerced to `task`,
+ * so a typo'd link lands on the plain brain list instead of silently opening
+ * the wrong row.
+ */
+export function parseBrainDeepLink(
+  params: URLSearchParams,
+): BrainDeepLink | null {
+  const rowId = params.get(BRAIN_ROW_PARAM)?.trim();
+  if (!rowId) return null;
+
+  const rawKind = params.get(BRAIN_KIND_PARAM)?.trim();
+  if (!rawKind) return { rowId, primitive: DEFAULT_LINKED_PRIMITIVE };
+
+  const primitive = LINKABLE.find((p) => p === rawKind);
+  return primitive ? { rowId, primitive } : null;
+}
+
+/**
+ * Build the canonical link to a brain row. `origin` is the app origin (e.g.
+ * `https://app.sidan.ai`); pass "" for a relative in-app href.
+ *
+ * The `kind` param is omitted for a task so the common case stays short and
+ * pasteable — `parseBrainDeepLink` defaults it back.
+ */
+export function brainRowUrl(
+  origin: string,
+  workspaceId: string,
+  rowId: string,
+  primitive: BrainPrimitive = DEFAULT_LINKED_PRIMITIVE,
+): string {
+  const q = new URLSearchParams({ [BRAIN_ROW_PARAM]: rowId });
+  if (primitive !== DEFAULT_LINKED_PRIMITIVE) {
+    q.set(BRAIN_KIND_PARAM, primitive);
+  }
+  return `${origin}/w/${workspaceId}/brain?${q.toString()}`;
+}

--- a/packages/api/src/inter-assistant/__tests__/executor.test.ts
+++ b/packages/api/src/inter-assistant/__tests__/executor.test.ts
@@ -616,6 +616,32 @@ describe('[COMP:api/inter-assistant-executor] createCalleeExecutor', () => {
     expect(mockQueryLoop).not.toHaveBeenCalled()
   })
 
+  // ── The pinned built-in must survive injection ──
+  // `injectMcpTools` folds every built-in connector tool behind
+  // `mcp_search`/`mcp_call` unless `keepBuiltinsDirect` is set — it DELETES
+  // `githubListPullRequests` from the map. A step pinning that name then
+  // filtered to nothing (`tools_unavailable`), and a step that also pinned a
+  // first-party tool was worse: it ran with silently zero GitHub access.
+  it('keeps built-ins direct when the caller pins an allow-list', async () => {
+    yieldsText()
+    await executorWithTools(new Map())({
+      ...baseParams,
+      callerChannelType: 'workflow',
+      allowedTools: ['githubListPullRequests', 'listTasks'],
+    })
+    expect(mockInjectMcp).toHaveBeenCalledWith(
+      expect.objectContaining({ keepBuiltinsDirect: true }),
+    )
+  })
+
+  it('leaves built-ins behind mcp_search on an unpinned consult (token win preserved)', async () => {
+    yieldsText()
+    await executorWithTools(new Map())(baseParams)
+    expect(mockInjectMcp).toHaveBeenCalledWith(
+      expect.objectContaining({ keepBuiltinsDirect: false }),
+    )
+  })
+
   it('persists the assistant turn on turn_complete', async () => {
     yields([
       { type: 'text_delta', text: 'done' },

--- a/packages/api/src/inter-assistant/__tests__/executor.test.ts
+++ b/packages/api/src/inter-assistant/__tests__/executor.test.ts
@@ -622,24 +622,40 @@ describe('[COMP:api/inter-assistant-executor] createCalleeExecutor', () => {
   // `githubListPullRequests` from the map. A step pinning that name then
   // filtered to nothing (`tools_unavailable`), and a step that also pinned a
   // first-party tool was worse: it ran with silently zero GitHub access.
+  // Injection only runs when the connector stores are wired, so these build
+  // the callee the way the KB-writes test above does.
+  function injectingExecutor(baseTools: Map<string, unknown>) {
+    return createCalleeExecutor({
+      provider: {} as never,
+      tools: baseTools as never,
+      memoryStore: memoryStore() as never,
+      capabilityStore: { listActive: vi.fn().mockResolvedValue([]) } as never,
+      connectorStore: {} as never,
+      mcpSettingsStore: {} as never,
+    })
+  }
+
   it('keeps built-ins direct when the caller pins an allow-list', async () => {
     yieldsText()
-    await executorWithTools(new Map())({
+    const tools = new Map<string, unknown>([
+      ['githubListPullRequests', plainTool('githubListPullRequests')],
+      ['listTasks', plainTool('listTasks')],
+    ])
+    await injectingExecutor(tools)({
       ...baseParams,
       callerChannelType: 'workflow',
       allowedTools: ['githubListPullRequests', 'listTasks'],
     })
-    expect(mockInjectMcp).toHaveBeenCalledWith(
-      expect.objectContaining({ keepBuiltinsDirect: true }),
-    )
+    expect(mockInjectMcp.mock.calls[0][0].keepBuiltinsDirect).toBe(true)
+    // …and the pinned built-in actually survives to the loop.
+    const passed = mockQueryLoop.mock.calls[0][0].tools as Map<string, unknown>
+    expect(passed.has('githubListPullRequests')).toBe(true)
   })
 
   it('leaves built-ins behind mcp_search on an unpinned consult (token win preserved)', async () => {
     yieldsText()
-    await executorWithTools(new Map())(baseParams)
-    expect(mockInjectMcp).toHaveBeenCalledWith(
-      expect.objectContaining({ keepBuiltinsDirect: false }),
-    )
+    await injectingExecutor(new Map([['searchThings', plainTool()]]))(baseParams)
+    expect(mockInjectMcp.mock.calls[0][0].keepBuiltinsDirect).toBe(false)
   })
 
   it('persists the assistant turn on turn_complete', async () => {

--- a/packages/api/src/inter-assistant/executor.ts
+++ b/packages/api/src/inter-assistant/executor.ts
@@ -456,6 +456,16 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
           userId: connectorUserId,
           assistantId: params.calleeAssistantId,
           tools: calleeTools,
+          // A PINNED allow-list must be able to name a built-in connector tool.
+          // By default `injectMcpTools` DELETES every built-in (github*, gmail*,
+          // notion*, …) from the map and folds it behind `mcp_search`/`mcp_call`
+          // for the token win — so a step pinning `githubListPullRequests` filtered
+          // down to nothing and died `tools_unavailable`, and a step that ALSO
+          // pinned a first-party tool (listTasks) was worse: it ran for weeks with
+          // silently zero GitHub access. Keeping built-ins direct only when the
+          // caller pins tools preserves the token saving on every unpinned callee,
+          // which reaches connectors through `mcp_search` exactly as before.
+          keepBuiltinsDirect: (params.allowedTools?.length ?? 0) > 0,
           connectorStore: options.connectorStore,
           settingsStore: options.mcpSettingsStore,
           assistantConnectorStore: options.assistantConnectorStore,

--- a/packages/api/src/mcp/__tests__/inject.test.ts
+++ b/packages/api/src/mcp/__tests__/inject.test.ts
@@ -988,3 +988,45 @@ describe('[COMP:api/mcp-inject] _getMcpDiscoveryCacheSize', () => {
     expect(size).toBeGreaterThanOrEqual(0)
   })
 })
+
+describe('[COMP:api/mcp-inject] built-in fold vs direct (keepBuiltinsDirect)', () => {
+  // The contract a workflow `assistant_call` step's `tools` allow-list depends
+  // on. With the flag OFF, a built-in connector tool is DELETED from the map
+  // and reachable only through `mcp_search` — so pinning it by name resolves to
+  // nothing. The callee sets the flag whenever the caller pins an allow-list;
+  // this suite is what makes that safe to rely on.
+  function githubConnector() {
+    return {
+      list: vi.fn().mockResolvedValue([
+        { id: 'ci-1', connectorId: 'github', name: 'GitHub', connected: true, createdAt: new Date(0) },
+      ]),
+      getCredentials: vi.fn().mockResolvedValue({ client_secret: 'ghp_test' }),
+    }
+  }
+
+  async function injectWith(keepBuiltinsDirect: boolean) {
+    const tools = new Map()
+    await injectMcpTools({
+      userId: 'u-1',
+      assistantId: 'a-1',
+      tools,
+      connectorStore: githubConnector() as never,
+      settingsStore: settingsStoreStub() as never,
+      keepBuiltinsDirect,
+    })
+    return tools
+  }
+
+  it('keeps githubListPullRequests under its own name when direct', async () => {
+    const tools = await injectWith(true)
+    expect(tools.has('githubListPullRequests')).toBe(true)
+    expect(tools.has('githubGetPullRequest')).toBe(true)
+  })
+
+  it('folds it behind mcp_search when NOT direct (why a pinned name resolved to nothing)', async () => {
+    const tools = await injectWith(false)
+    expect(tools.has('githubListPullRequests')).toBe(false)
+    expect(tools.has('mcp_search')).toBe(true)
+    expect(tools.has('mcp_call')).toBe(true)
+  })
+})

--- a/packages/core/src/tools/base/github.ts
+++ b/packages/core/src/tools/base/github.ts
@@ -41,6 +41,11 @@ const issueRow = (i: Json) => ({
   is_pull_request: i.pull_request != null,
 })
 
+// `merged_at` is the only field that distinguishes a MERGED pull request from
+// one that was closed unmerged — GitHub reports both as `state: 'closed'`.
+// Without it a caller asking "what shipped?" has to re-fetch every closed PR
+// through `githubGetPullRequest` just to read its boolean `merged`, an N+1 the
+// list payload already carries the answer to (null unless merged).
 const prRow = (p: Json) => ({
   number: num(p, 'number'),
   title: str(p, 'title'),
@@ -51,6 +56,7 @@ const prRow = (p: Json) => ({
   draft: bool(p, 'draft'),
   url: str(p, 'html_url'),
   updated_at: str(p, 'updated_at'),
+  merged_at: str(p, 'merged_at'),
 })
 
 /** Repo search: `{ total_count, items: [...] }` → concise rows, total preserved. */
@@ -236,7 +242,10 @@ export function createGitHubTools(api: GitHubApi): Tool[] {
 
   const listPullRequests = buildTool({
     name: 'githubListPullRequests',
-    description: 'List pull requests for a GitHub repository. Returns PR title, state, author, head/base branches, and draft status.',
+    description:
+      'List pull requests for a GitHub repository. Returns PR title, state, author, head/base branches, draft status, and `merged_at`. ' +
+      'A closed PR is only MERGED when `merged_at` is present — a closed PR without it was abandoned, not shipped. ' +
+      'To find what shipped since a date, list with state=closed sort=updated direction=desc and keep the rows whose `merged_at` is after that date; no follow-up call per PR is needed.',
     inputSchema: z.object({
       owner: z.string().describe('Repository owner.'),
       repo: z.string().describe('Repository name.'),


### PR DESCRIPTION
Three changes that together make "post a digest that links to the task, and knows what actually shipped" possible. The first is a live bug: it has been silently costing the morning-digest workflow all of its GitHub access.

## 1. A pinned `tools` allow-list could not name a built-in connector tool

`injectMcpTools` **deletes** every built-in connector tool (`github*`, `gmail*`, `notion*`, …) from the callee's map and folds it behind `mcp_search`/`mcp_call` — a deliberate token saving. The workflow `tool_call` bridge opts out with `keepBuiltinsDirect: true`. The `assistant_call` callee never did, so it ran with the default `false`, and by the time `filterToolsByAllowList` ran, `githubListPullRequests` no longer existed.

Two shapes, and the second is the dangerous one:

- `tools: ["githubListPullRequests"]` → the allow-list survives as **nothing** → the step dies `tools_unavailable`. Loud.
- `tools: ["githubListPullRequests", "listTasks"]` → the first-party tool survives, so the step **runs, reports success, and never touches GitHub**. The production morning-digest `gather` step sat in exactly this state for weeks.

The callee now sets `keepBuiltinsDirect` exactly when the caller pins an allow-list. An **unpinned** callee is unchanged and still reaches connectors through `mcp_search`, so the token win survives where it was the point.

The interaction inverts, which is worth knowing when authoring a step: pin the tool **names**, or pin **nothing**. Pinning `['mcp_search']` to reach a connector is the one shape that cannot work — the pin keeps built-ins direct, so they are absent from the very search index the pin allows.

## 2. `merged_at` on the PR projection

GitHub reports a merged PR and an abandoned one identically as `state: closed`; `merged_at` is the only field that separates them, and the list payload already carried it. Without it, "what shipped since X?" needs a `githubGetPullRequest` per closed PR just to read its boolean `merged` — an N+1 whose answer was already in hand.

## 3. Brain row deep links — `?row=<id>`

A brain row opened only from page state, so no URL pointed **at** one: an outside surface could link to the brain list and nothing finer. `/w/<ws>/brain?row=<rowId>[&kind=<primitive>]` now seeds the drawer. The row is fetched **by id** rather than looked up in the loaded list — the list is paginated and hides done tasks behind the "completed" fold, which is exactly what an inbound digest link points at. `projectInboxRowToBrainRow` hardcodes `hasPending: true` (it exists for the inbox, unverified by definition), so the deep-link path overrides it from the row's real `verifiedAt`; otherwise every linked row would render a false "unverified" nudge. An unknown `kind` yields no link rather than being coerced to `task`, so a typo lands on the list instead of opening the wrong row.

## Testing

Unit — `[COMP:api/mcp-inject]` (34) proves the mechanism against the **real** injector: flag on → `githubListPullRequests` stays under its own name; flag off → it is deleted and only `mcp_search`/`mcp_call` remain. `[COMP:api/inter-assistant-executor]` (72) proves the callee passes the flag iff pinned, and that the pinned tool survives into the query loop. `[COMP:app-web/brain-deep-link]` (8) covers the URL contract.

End-to-end — a local API server, a real GitHub connector, live calls against this repo:

| Build | Result |
|---|---|
| Fixed | `completed` — real open PRs returned |
| Fix removed | `tools_unavailable` — byte-identical to the production error |
| Fix restored | `completed` |

`merged_at` verified against live closed PRs: merged ones carry a timestamp, and a PR closed **unmerged** carries `null` — the case that would otherwise have been announced as "shipped".

🤖 Generated with [Claude Code](https://claude.com/claude-code)