### PR TITLE
fix(slack): suppress link previews on bot outbound

### DIFF
--- a/packages/channels/src/__tests__/slack.test.ts
+++ b/packages/channels/src/__tests__/slack.test.ts
@@ -278,6 +278,24 @@ describe('[COMP:channels/slack] outbound audit hook', () => {
     await adapter.sendMessage('C_PUBLIC', { text: long })
     expect(onOutboundAudit.mock.calls.length).toBeGreaterThanOrEqual(1)
   })
+
+  it('suppresses link previews on bot outbound (unfurl off)', async () => {
+    // A message full of app links (a digest) must not explode into a stack of
+    // identical unfurl cards — every auth-gated app.sidan.ai link unfurls to
+    // the same generic OG card. postMessage always sends unfurl_links:false /
+    // unfurl_media:false.
+    mockSlackOk('1680000000.000400')
+    const adapter = createSlackAdapter({ botToken: 'xoxb-test' })
+    await adapter.sendMessage('C_PUBLIC', {
+      text: 'see <https://app.sidan.ai/w/x/brain?row=1|task one>',
+    })
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+    const post = fetchMock.mock.calls.find((c) => String(c[0]).endsWith('chat.postMessage'))
+    expect(post).toBeDefined()
+    const body = JSON.parse((post![1] as { body: string }).body)
+    expect(body.unfurl_links).toBe(false)
+    expect(body.unfurl_media).toBe(false)
+  })
 })
 
 describe('[COMP:channels/slack] sendMessage documents', () => {

--- a/packages/channels/src/slack/api.ts
+++ b/packages/channels/src/slack/api.ts
@@ -100,6 +100,15 @@ export function createSlackApi(options: SlackApiOptions) {
           text,
           mrkdwn: opts?.mrkdwn ?? true,
           thread_ts: opts?.threadTs,
+          // Suppress link previews on bot outbound. Every link the assistant
+          // posts is either an auth-gated app.sidan.ai page — which all unfurl
+          // to the SAME generic marketing card ("The shared brain for your
+          // small team"), since the crawler can't see past the login — or an
+          // occasional external link where a preview in a notification is
+          // noise. A digest is a LIST of task links, so default unfurling
+          // buried the actual content under a stack of identical cards.
+          unfurl_links: false,
+          unfurl_media: false,
         })
         await safeAudit({
           kind: 'post_message',


### PR DESCRIPTION
## What

`SlackApi.postMessage` now sends `unfurl_links: false` and `unfurl_media: false` on every `chat.postMessage`.

## Why

Every link the assistant posts to Slack is one of two things:
- an **auth-gated `app.sidan.ai` page** — Slack's crawler can't see past the login, so they *all* unfurl to the same generic marketing card ("The shared brain for your small team");
- an occasional external link, where a preview inside a bot notification is just noise.

A morning digest is a **list** of task links, so the default (unfurl on) buried the actual content under a stack of identical cards. This was reported from a live digest: the per-member messages were dominated by 3-4 duplicate preview cards.

Suppression is unconditional on bot outbound. Links stay clickable; only the preview cards are gone.

## Testing

- New unit test under `[COMP:channels/slack]` asserts the `chat.postMessage` payload carries `unfurl_links: false` / `unfurl_media: false` (27 pass).
- Verified live against a real Slack channel: before, a digest message with two `app.sidan.ai` links carried 3 unfurl attachments; after, **0 attachments**.

Docs: `docs/architecture/channels/adapter-pattern.md` → "Link previews suppressed on bot outbound" (+ paired KB entry) land in the platform-repo companion PR that bumps the gitlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)