### PR TITLE
feat(rebrand): legacy-identifier transition wave + app-web workspace-rename live update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 #
 # Only GEMINI_API_KEY is required to get started.
 # `pnpm dev` auto-generates JWT_SECRET and defaults to an embedded PGLite
-# store under ~/.sidanclaw/, so you do not need to set anything else here.
+# store under ~/.usebrian/, so you do not need to set anything else here.
 # Copy this file to .env if you like, or just let the launcher prompt you
 # for the key on first run.
 
@@ -37,11 +37,11 @@ ANTHROPIC_API_KEY=
 # Point at an external Postgres connection string to use it instead of the
 # embedded PGLite brain.
 DATABASE_URL=
-# Auto-generated and persisted to ~/.sidanclaw/config.json if left unset.
+# Auto-generated and persisted to ~/.usebrian/config.json if left unset.
 JWT_SECRET=
 # Shared secret for the API <-> doc-sync internal routes (the auto-on-save brain
 # ingest enqueue + AI doc writes). Auto-generated and persisted to
-# ~/.sidanclaw/config.json like JWT_SECRET; only set this by hand if you run the
+# ~/.usebrian/config.json like JWT_SECRET; only set this by hand if you run the
 # api and doc-sync as separate processes WITHOUT the launcher (both need the
 # same value).
 DOC_SYNC_SECRET=
@@ -49,7 +49,7 @@ DOC_SYNC_SECRET=
 # and PATs at rest in connector_instance.credentials, and BYO channel bot
 # credentials (Telegram/Slack/Discord bot tokens) in
 # channel_integrations.credentials. Auto-generated and persisted to
-# ~/.sidanclaw/config.json by the launcher; only set this by hand if you run
+# ~/.usebrian/config.json by the launcher; only set this by hand if you run
 # the api WITHOUT the launcher. Without it, connecting a connector or a
 # channel returns 503. Generate with: openssl rand -base64 32
 CHANNEL_CREDENTIAL_KEY=
@@ -83,12 +83,12 @@ API_URL=
 #     service needs the same secret as the API and must relay inbound events to
 #     `${API_URL}/internal/discord/inbound`.
 DISCORD_CONNECTOR_URL=
-# Auto-generated under ~/.sidanclaw/ for local boot. Required on both the API
+# Auto-generated under ~/.usebrian/ for local boot. Required on both the API
 # and connector when deploying the connector separately.
 DISCORD_CONNECTOR_SECRET=
 # WhatsApp BYON also uses a persistent bridge. `pnpm dev` starts the open
 # connector locally on port 8091, points it at the same database as the API,
-# sets its local filesystem credential directory to ~/.sidanclaw/wa-creds, and
+# sets its local filesystem credential directory to ~/.usebrian/wa-creds, and
 # generates/persists the shared secret. Set both values only to use an external
 # connector; that service must use the same DATABASE_URL as the API for BYON
 # credential persistence and call back to `${API_URL}`.
@@ -99,7 +99,7 @@ WA_CONNECTOR_SECRET=
 # Built-in connectors (Google Calendar/Gmail/Drive, Notion, Fathom, GitHub) are
 # off until you bring your own OAuth app credentials. GitHub uses a Personal
 # Access Token entered in the UI and needs nothing here. The OAuth providers
-# resolve their app client id/secret from ~/.sidanclaw/connectors.config.json
+# resolve their app client id/secret from ~/.usebrian/connectors.config.json
 # (override path: CONNECTORS_CONFIG_PATH), e.g.
 #   { "google": { "clientId": "...", "clientSecret": "..." } }
 # or from these env vars as a fallback. Unset → that connector stays unavailable.

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ record. You stay on the decisions. It handles the rest.
 ```bash
 git clone https://github.com/use-brian/use-brian.git
 cd use-brian
-export GEMINI_API_KEY=...   # or let the launcher prompt you; persisted under ~/.sidanclaw/
+export GEMINI_API_KEY=...   # or let the launcher prompt you; persisted under ~/.usebrian/
 pnpm install
 pnpm dev                    # api + canvas + web + Discord/WhatsApp bridges; opens your browser
 ```
 
 That is it. There is no step three. The store defaults to an embedded PGLite
-database under `~/.sidanclaw/`; point `DATABASE_URL` at a local Postgres if you
+database under `~/.usebrian/`; point `DATABASE_URL` at a local Postgres if you
 prefer a container. Self-host overrides live in [`.env.example`](./.env.example).
 
 ### Your data stays yours
@@ -105,7 +105,7 @@ event without you. You set the policy per tool in the app.
 
 That one Gemini key is the floor, not the ceiling. Each key below is optional, and
 each is a service you choose to talk to, so nothing turns on by itself. Drop them
-into `.env` or `~/.sidanclaw/`.
+into `.env` or `~/.usebrian/`.
 
 | Capability | Key(s) to set | What you get |
 |---|---|---|
@@ -119,7 +119,7 @@ into `.env` or `~/.sidanclaw/`.
 | Fathom connector | `FATHOM_CLIENT_ID` / `FATHOM_CLIENT_SECRET` | Fathom via your own OAuth app |
 | GitHub connector | Personal Access Token (entered in the UI) | GitHub, no env key needed |
 
-Connector client id / secret can also live in `~/.sidanclaw/connectors.config.json`.
+Connector client id / secret can also live in `~/.usebrian/connectors.config.json`.
 Every key is documented in [`.env.example`](./.env.example).
 
 ## What's in the box

--- a/apps/app-desktop/src/desktop-token-store.ts
+++ b/apps/app-desktop/src/desktop-token-store.ts
@@ -7,7 +7,7 @@
  * app loads from a `file://` / `app://` origin where those cookies don't apply,
  * so it must hold the JWT pair itself — encrypted at rest via the OS keychain
  * (`safeStorage`) and handed to the renderer through the preload token bridge
- * (`window.sidanclawDesktop.getAccessToken` …), which activates the dormant
+ * (`window.usebrianDesktop.getAccessToken` …), which activates the dormant
  * `desktopAuthSource` in app-web (`lib/desktop-auth-source.ts`).
  *
  * Everything here is **pure / IO-injectable** so it unit-tests with no Electron,

--- a/apps/app-desktop/src/offline.html
+++ b/apps/app-desktop/src/offline.html
@@ -159,8 +159,8 @@
       btn.addEventListener("click", function () {
         btn.disabled = true;
         btn.textContent = "Reconnecting...";
-        if (window.sidanclawDesktop && window.sidanclawDesktop.retry) {
-          window.sidanclawDesktop.retry();
+        if (window.usebrianDesktop && window.usebrianDesktop.retry) {
+          window.usebrianDesktop.retry();
         }
       });
     </script>

--- a/apps/app-desktop/src/preload.cjs
+++ b/apps/app-desktop/src/preload.cjs
@@ -68,4 +68,10 @@ if (process.argv.includes("--usebrian-bundled")) {
   };
 }
 
+// Dual-expose during the rebrand transition: `usebrianDesktop` is canonical;
+// `sidanclawDesktop` keeps pre-rebrand app-web builds (which read only the
+// legacy name) working against this shell. app-web reads via its
+// `desktopBridge()` accessor (canonical first). Drop the legacy expose only
+// when no deployed app-web still reads it.
+contextBridge.exposeInMainWorld("usebrianDesktop", bridge);
 contextBridge.exposeInMainWorld("sidanclawDesktop", bridge);

--- a/apps/app-desktop/src/signin.html
+++ b/apps/app-desktop/src/signin.html
@@ -295,7 +295,7 @@
     </div>
 
     <script>
-      var desktop = window.sidanclawDesktop || {};
+      var desktop = window.usebrianDesktop || {};
       var DEFAULT_LOCAL_URL = "http://localhost:3003";
       var qs = new URLSearchParams(location.search);
 

--- a/apps/app-web/src/app/globals.css
+++ b/apps/app-web/src/app/globals.css
@@ -1910,7 +1910,7 @@ html[data-vt-back="true"]::view-transition-new(root) {
    The shell loads app-web inside a frameless `titleBarStyle: "hiddenInset"`
    BrowserWindow, so the macOS traffic-light buttons float over the top-left of
    our own content and no part of the window is draggable. `is-canvas-desktop`
-   is added to <html> when `window.sidanclawDesktop` exists (doc-shell.tsx
+   is added to <html> when `window.usebrianDesktop` (or legacy `window.sidanclawDesktop`) exists (doc-shell.tsx
    effect, plus the layout.tsx before-paint script for prod no-flash), so none
    of this touches the browser build. Two things only the shell needs:
 

--- a/apps/app-web/src/app/layout.tsx
+++ b/apps/app-web/src/app/layout.tsx
@@ -69,14 +69,14 @@ export const metadata: Metadata = {
 };
 
 // Tag <html> before first paint when we're running inside the Electron desktop
-// shell (apps/app-desktop), whose preload exposes `window.sidanclawDesktop`
+// shell (apps/app-desktop), whose preload exposes `window.usebrianDesktop` (+ legacy `window.sidanclawDesktop`)
 // BEFORE any page script runs. The `is-canvas-desktop` class gates desktop-only
 // chrome in globals.css (a draggable title-bar strip that clears the macOS
 // traffic lights + non-selectable app chrome) and is a no-op in the browser.
 // On Windows (`platform === "win32"`) the window keeps a standard OS frame with
 // no traffic lights, so `is-canvas-desktop-win` zeroes the title-bar inset.
 // Same run-before-paint, no-flash shape as THEME_PREPAINT_SCRIPT; no user input.
-const DESKTOP_SHELL_PREPAINT_SCRIPT = `(()=>{try{var d=window.sidanclawDesktop;if(!d)return;var c=document.documentElement.classList;c.add("is-canvas-desktop");if(d.platform==="win32")c.add("is-canvas-desktop-win");}catch(e){}})();`;
+const DESKTOP_SHELL_PREPAINT_SCRIPT = `(()=>{try{var d=window.usebrianDesktop||window.sidanclawDesktop;if(!d)return;var c=document.documentElement.classList;c.add("is-canvas-desktop");if(d.platform==="win32")c.add("is-canvas-desktop-win");}catch(e){}})();`;
 
 // iOS Safari zooms the page when a form control with a computed font-size
 // under 16px receives focus, and the zoom persists after blur — the app then

--- a/apps/app-web/src/components/doc/doc-shell.tsx
+++ b/apps/app-web/src/components/doc/doc-shell.tsx
@@ -748,17 +748,20 @@ export function DocShell({ workspaceId, assistantId }: ShellProps) {
   }, []);
 
   // Desktop shell chrome: tag <html> when running inside the Electron desktop
-  // app (apps/app-desktop), whose preload exposes `window.sidanclawDesktop`.
+  // app (apps/app-desktop), whose preload exposes `window.usebrianDesktop` (+ legacy `window.sidanclawDesktop`).
   // The `is-canvas-desktop` class gates the desktop-only chrome in globals.css —
   // a draggable title-bar strip that clears the macOS traffic lights and
   // non-selectable app chrome. layout.tsx also stamps this before paint (for the
   // production no-flash path); doing it here too makes it robust to that script
   // being absent (e.g. a stale dev root layout) and survives hydration. No-op in
-  // a normal browser, where `window.sidanclawDesktop` is undefined.
+  // a normal browser, where neither desktop bridge global is defined.
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const desktop = (window as unknown as { sidanclawDesktop?: { platform?: string } })
-      .sidanclawDesktop;
+    const w = window as unknown as {
+      usebrianDesktop?: { platform?: string };
+      sidanclawDesktop?: { platform?: string };
+    };
+    const desktop = w.usebrianDesktop ?? w.sidanclawDesktop;
     if (!desktop) return;
     document.documentElement.classList.add("is-canvas-desktop");
     // Windows keeps a standard OS frame (no macOS traffic lights), so zero the

--- a/apps/app-web/src/components/settings-modal/workspace-sections.tsx
+++ b/apps/app-web/src/components/settings-modal/workspace-sections.tsx
@@ -15,8 +15,12 @@
  * name, role, me }. All displayed workspace fields (name, role, purpose,
  * iconSeed) come straight from the `GET /api/workspaces/:id` detail fetch
  * here, and the icon-regenerate path updates local state via `refetch()`
- * instead of pushing into a switcher list (the app-web switcher
- * re-fetches its list when it opens).
+ * instead of pushing into a switcher list. Because the route context is a
+ * static snapshot, a successful rename must also broadcast
+ * `emitWorkspaceRenamed` (picked up by `WorkspaceContextProvider` + the
+ * switcher's cached list) and patch the ported-surface adapter cache via
+ * `updateWorkspace` — otherwise the top-left chrome shows the old name
+ * until a full reload.
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -36,7 +40,11 @@ import { listCustomPageTemplates } from "@/lib/api/views";
 import { buildBlueprintPickerItems } from "@/lib/blueprints";
 import type { CustomPageTemplateSummary } from "@use-brian/doc-model";
 import { getUserInfo } from "@/lib/user";
-import { useWorkspaceContext } from "@/lib/workspace-context";
+import {
+  useWorkspaceContext,
+  emitWorkspaceRenamed,
+} from "@/lib/workspace-context";
+import { updateWorkspace } from "@/contexts/workspace-context";
 import { canDeleteWorkspace } from "@/lib/workspace-permissions";
 import { TeamAvatar } from "@/components/team-avatar";
 import {
@@ -201,7 +209,8 @@ export function WorkspaceGeneralSection({ onWorkspaceDeleted }: { onWorkspaceDel
 
   async function rename() {
     if (!data) return;
-    if (!nameInput.trim() || nameInput.trim() === data.name) {
+    const next = nameInput.trim();
+    if (!next || next === data.name) {
       setEditing(false);
       return;
     }
@@ -209,9 +218,17 @@ export function WorkspaceGeneralSection({ onWorkspaceDeleted }: { onWorkspaceDel
       const res = await authFetch(`${API_URL}/api/workspaces/${data.id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: nameInput.trim() }),
+        body: JSON.stringify({ name: next }),
       });
-      if (res.ok) await refetch();
+      if (res.ok) {
+        // Propagate beyond this modal: the route context is a static
+        // snapshot, so the top-left chrome (and any other `ctx.name`
+        // consumer) only updates via this broadcast; the adapter cache
+        // keeps ported `useWorkspaces()` surfaces consistent too.
+        emitWorkspaceRenamed({ workspaceId: data.id, name: next });
+        updateWorkspace(data.id, { name: next });
+        await refetch();
+      }
     } finally {
       setEditing(false);
     }

--- a/apps/app-web/src/components/workspace-switcher.tsx
+++ b/apps/app-web/src/components/workspace-switcher.tsx
@@ -38,6 +38,7 @@ import { useRouter } from "next/navigation";
 import { docPagePath } from "@/lib/doc-page-url";
 import { routeProgress } from "@/lib/route-progress";
 import { useT } from "@/lib/i18n/client";
+import { desktopBridge } from "@/lib/desktop-auth-source";
 import { format } from "@/lib/i18n/format";
 import { authFetch } from "@/lib/auth-fetch";
 import { primaryAuthUrl, webAppUrl } from "@/lib/primary-auth";
@@ -54,7 +55,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { useWorkspaceContext } from "@/lib/workspace-context";
+import {
+  useWorkspaceContext,
+  WORKSPACE_RENAMED_EVENT,
+  type WorkspaceRenamedDetail,
+} from "@/lib/workspace-context";
 import {
   SettingsModal,
   type SettingsSection,
@@ -160,6 +165,26 @@ export function WorkspaceSwitcher() {
     return () => window.removeEventListener(OPEN_SETTINGS_EVENT, onOpenSettings);
   }, []);
 
+  // Keep the lazily-cached workspace list in sync with a settings-modal
+  // rename (the trigger label itself reads `ctx.name`, which the provider
+  // updates from the same event) — without this the popover rows show the
+  // old name until a full reload.
+  useEffect(() => {
+    function onRenamed(e: Event) {
+      const detail = (e as CustomEvent<WorkspaceRenamedDetail>).detail;
+      if (!detail?.workspaceId || !detail.name) return;
+      setWorkspaces((prev) =>
+        prev
+          ? prev.map((w) =>
+              w.id === detail.workspaceId ? { ...w, name: detail.name } : w,
+            )
+          : prev,
+      );
+    }
+    window.addEventListener(WORKSPACE_RENAMED_EVENT, onRenamed);
+    return () => window.removeEventListener(WORKSPACE_RENAMED_EVENT, onRenamed);
+  }, []);
+
   // Re-read the account directory each time the popover opens so it reflects
   // accounts added/switched in another tab (or on the web app) since the last
   // render. Also clears any transient switch state.
@@ -210,7 +235,7 @@ export function WorkspaceSwitcher() {
     // outcome: on success the shell reloads the window; on failure we surface the
     // message inline and clear the spinner. Same shell-takes-precedence pattern
     // as `desktopSignOut()`.
-    const switchViaShell = window.sidanclawDesktop?.switchAccount;
+    const switchViaShell = desktopBridge()?.switchAccount;
     if (typeof switchViaShell === "function") {
       void switchViaShell(accountId).then((res) => {
         if (!res.ok) {
@@ -268,7 +293,7 @@ export function WorkspaceSwitcher() {
   function handleAddAccount() {
     setOpen(false);
     const addViaShell =
-      typeof window !== "undefined" ? window.sidanclawDesktop?.addAccount : undefined;
+      desktopBridge()?.addAccount;
     if (typeof addViaShell === "function") {
       addViaShell();
       return;

--- a/apps/app-web/src/lib/__tests__/workspace-context-rename.test.ts
+++ b/apps/app-web/src/lib/__tests__/workspace-context-rename.test.ts
@@ -1,0 +1,62 @@
+/**
+ * [COMP:app-web/workspace-context] Rename override for the static workspace
+ * snapshot.
+ *
+ * The `/w/[workspaceId]` context value is fetched once (Next server layout /
+ * desktop `WorkspaceShell`) and never refetched, so a settings-modal rename
+ * must flow through the `WORKSPACE_RENAMED_EVENT` broadcast into
+ * `applyWorkspaceRename` for the top-left chrome to update without a reload.
+ * app-web vitest has no DOM, so the pure override core is what's under test;
+ * the event wiring (dispatch in `workspace-sections.tsx` `rename()`, listeners
+ * in the provider + workspace-switcher) is exercised by hand / e2e.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  applyWorkspaceRename,
+  type WorkspaceContextValue,
+} from "@/lib/workspace-context";
+
+const base: WorkspaceContextValue = {
+  workspaceId: "ws1",
+  name: "Acme",
+  role: "owner",
+  clearance: "internal",
+  me: { id: "u1" },
+};
+
+describe("[COMP:app-web/workspace-context] applyWorkspaceRename", () => {
+  it("overrides the name when the rename targets this workspace", () => {
+    const next = applyWorkspaceRename(base, {
+      workspaceId: "ws1",
+      name: "Acme Robotics",
+    });
+    expect(next.name).toBe("Acme Robotics");
+    // Everything else carries through unchanged.
+    expect(next).toMatchObject({
+      workspaceId: "ws1",
+      role: "owner",
+      clearance: "internal",
+      me: { id: "u1" },
+    });
+  });
+
+  it("ignores a rename for a different workspace (reference-stable)", () => {
+    const next = applyWorkspaceRename(base, {
+      workspaceId: "ws2",
+      name: "Other",
+    });
+    expect(next).toBe(base);
+  });
+
+  it("passes the snapshot through when no rename was observed", () => {
+    expect(applyWorkspaceRename(base, null)).toBe(base);
+  });
+
+  it("stays reference-stable when the rename matches the current name", () => {
+    // e.g. after a full reload the server snapshot already carries the new
+    // name; the lingering override must not mint a new object every render.
+    const next = applyWorkspaceRename(base, { workspaceId: "ws1", name: "Acme" });
+    expect(next).toBe(base);
+  });
+});

--- a/apps/app-web/src/lib/desktop-auth-source.ts
+++ b/apps/app-web/src/lib/desktop-auth-source.ts
@@ -65,8 +65,22 @@ interface DesktopBridge {
 
 declare global {
   interface Window {
+    /** Canonical bridge name (desktop shells ≥ the 2026-07 rebrand dual-expose). */
+    usebrianDesktop?: DesktopBridge;
+    /** Legacy bridge name — the only one pre-rebrand shells expose. */
     sidanclawDesktop?: DesktopBridge;
   }
+}
+
+/**
+ * Resolve the desktop preload bridge under either name. Old shells in the
+ * wild expose only `sidanclawDesktop`; rebranded shells expose both. Every
+ * app-web read goes through this accessor; drop the legacy fallback only
+ * once pre-rebrand desktop installs are gone.
+ */
+export function desktopBridge(): DesktopBridge | undefined {
+  if (typeof window === "undefined") return undefined;
+  return window.usebrianDesktop ?? window.sidanclawDesktop;
 }
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
@@ -79,7 +93,7 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
 export function isDesktopAuth(): boolean {
   return (
     typeof window !== "undefined" &&
-    typeof window.sidanclawDesktop?.getAccessToken === "function"
+    typeof desktopBridge()?.getAccessToken === "function"
   );
 }
 
@@ -101,7 +115,7 @@ export function isDesktopAuth(): boolean {
  */
 export function desktopSignOut(): boolean {
   const signOut =
-    typeof window !== "undefined" ? window.sidanclawDesktop?.signOut : undefined;
+    desktopBridge()?.signOut;
   if (typeof signOut !== "function") return false;
   signOut();
   return true;
@@ -156,11 +170,11 @@ export interface AuthSource {
  */
 export const desktopAuthSource: AuthSource = {
   getAccessToken() {
-    return window.sidanclawDesktop?.getAccessToken?.() ?? null;
+    return desktopBridge()?.getAccessToken?.() ?? null;
   },
 
   async refresh(): Promise<RefreshOutcome> {
-    const bridge = window.sidanclawDesktop;
+    const bridge = desktopBridge();
     const refreshToken = bridge?.getRefreshToken?.();
     if (!refreshToken) {
       bridge?.clear?.();
@@ -197,6 +211,6 @@ export const desktopAuthSource: AuthSource = {
   },
 
   redirectToLogin() {
-    window.sidanclawDesktop?.signIn?.();
+    desktopBridge()?.signIn?.();
   },
 };

--- a/apps/app-web/src/lib/edition.ts
+++ b/apps/app-web/src/lib/edition.ts
@@ -12,15 +12,15 @@
  * OSS launcher (`scripts/launch.mjs`) sets `NEXT_PUBLIC_USEBRIAN_EDITION=oss`
  * to switch app-web into single-player mode.
  */
-type SidanclawEdition = "oss" | "hosted";
+type UsebrianEdition = "oss" | "hosted";
 
-function sidanclawEdition(): SidanclawEdition {
+function usebrianEdition(): UsebrianEdition {
   return process.env.NEXT_PUBLIC_USEBRIAN_EDITION === "oss" ? "oss" : "hosted";
 }
 
 /** True in the open single-player edition (no billing, no teammates). */
 export function isOssEdition(): boolean {
-  return sidanclawEdition() === "oss";
+  return usebrianEdition() === "oss";
 }
 
 /** True in the hosted multi-tenant edition (the default). */

--- a/apps/app-web/src/lib/workspace-context.tsx
+++ b/apps/app-web/src/lib/workspace-context.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { createContext, useContext, type ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 
 export type WorkspaceContextValue = {
   workspaceId: string;
@@ -22,12 +29,71 @@ export type WorkspaceContextValue = {
 
 const WorkspaceContext = createContext<WorkspaceContextValue | null>(null);
 
+/**
+ * Rename broadcast — the provider's `value` is a static snapshot (fetched by
+ * the Next server layout, or once by the desktop SPA's `WorkspaceShell`), so a
+ * client-side rename in the settings modal would otherwise stay stale in every
+ * `ctx.name` consumer (the top-left switcher trigger, breadcrumbs, …) until a
+ * full reload — `router.refresh()` is not an option because the desktop shim
+ * makes it a no-op. The settings rename dispatches this event after a
+ * successful PATCH; the provider applies it as an override when the workspace
+ * id matches. Same window-event pattern as the settings modal's
+ * `OPEN_SETTINGS_EVENT`.
+ */
+export const WORKSPACE_RENAMED_EVENT = "brian:workspace-renamed";
+
+export type WorkspaceRenamedDetail = { workspaceId: string; name: string };
+
+export function emitWorkspaceRenamed(detail: WorkspaceRenamedDetail): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent<WorkspaceRenamedDetail>(WORKSPACE_RENAMED_EVENT, { detail }),
+  );
+}
+
+/**
+ * Pure core of the provider's rename override (unit-tested — app-web vitest
+ * has no DOM to dispatch real events into). Applies the last observed rename
+ * to the static snapshot only when it targets the same workspace; a rename of
+ * another workspace (or none) leaves the snapshot untouched, reference
+ * included, so memoized consumers don't re-render.
+ */
+export function applyWorkspaceRename(
+  base: WorkspaceContextValue,
+  renamed: WorkspaceRenamedDetail | null,
+): WorkspaceContextValue {
+  if (!renamed || renamed.workspaceId !== base.workspaceId) return base;
+  if (renamed.name === base.name) return base;
+  return { ...base, name: renamed.name };
+}
+
 export function WorkspaceContextProvider(props: {
   value: WorkspaceContextValue;
   children: ReactNode;
 }) {
+  // Latest rename observed on this mount. Kept as {id, name} so an override
+  // for one workspace never leaks onto another after a route change (the
+  // provider instance survives `/w/[id]` param swaps — parent layouts don't
+  // remount on child navigation).
+  const [renamed, setRenamed] = useState<WorkspaceRenamedDetail | null>(null);
+
+  useEffect(() => {
+    function onRenamed(e: Event) {
+      const detail = (e as CustomEvent<WorkspaceRenamedDetail>).detail;
+      if (!detail?.workspaceId || !detail.name) return;
+      setRenamed(detail);
+    }
+    window.addEventListener(WORKSPACE_RENAMED_EVENT, onRenamed);
+    return () => window.removeEventListener(WORKSPACE_RENAMED_EVENT, onRenamed);
+  }, []);
+
+  const value = useMemo<WorkspaceContextValue>(
+    () => applyWorkspaceRename(props.value, renamed),
+    [props.value, renamed],
+  );
+
   return (
-    <WorkspaceContext.Provider value={props.value}>
+    <WorkspaceContext.Provider value={value}>
       {props.children}
     </WorkspaceContext.Provider>
   );

--- a/packages/api/src/connector-config.ts
+++ b/packages/api/src/connector-config.ts
@@ -10,7 +10,7 @@
  * back to `process.env` so the hosted platform (creds in env) is unchanged.
  *
  * Resolution order per provider:
- *   1. `~/.sidanclaw/connectors.config.json` (override path: `CONNECTORS_CONFIG_PATH`)
+ *   1. `~/.usebrian/connectors.config.json` (legacy `~/.sidanclaw/` fallback; override path: `CONNECTORS_CONFIG_PATH`)
  *   2. `process.env.<PROVIDER>_CLIENT_ID` / `_CLIENT_SECRET`
  *   3. undefined  → the connector injector no-ops (connector-less boot)
  *
@@ -50,13 +50,24 @@ let _fileConfig: FileConfig | null = null
 /** Load + memoize the optional connectors.config.json. Missing/invalid → {}. */
 function loadConnectorConfig(): FileConfig {
   if (_fileConfig) return _fileConfig
-  const path = process.env.CONNECTORS_CONFIG_PATH || join(homedir(), '.sidanclaw', 'connectors.config.json')
-  try {
-    const parsed = fileSchema.safeParse(JSON.parse(readFileSync(path, 'utf8')))
-    _fileConfig = parsed.success ? parsed.data : {}
-  } catch {
-    // Absent (the default for the open product) or unreadable → no connectors.
-    _fileConfig = {}
+  // Canonical dotdir first; legacy `~/.sidanclaw/` fallback covers a
+  // standalone API run against a not-yet-migrated install (the launcher
+  // renames the whole dir on boot — see scripts/launch.mjs).
+  const candidates = process.env.CONNECTORS_CONFIG_PATH
+    ? [process.env.CONNECTORS_CONFIG_PATH]
+    : [
+        join(homedir(), '.usebrian', 'connectors.config.json'),
+        join(homedir(), '.sidanclaw', 'connectors.config.json'),
+      ]
+  _fileConfig = {}
+  for (const path of candidates) {
+    try {
+      const parsed = fileSchema.safeParse(JSON.parse(readFileSync(path, 'utf8')))
+      _fileConfig = parsed.success ? parsed.data : {}
+      break
+    } catch {
+      // Absent (the default for the open product) or unreadable → try next.
+    }
   }
   return _fileConfig
 }

--- a/packages/api/src/db/skill-store.ts
+++ b/packages/api/src/db/skill-store.ts
@@ -704,7 +704,20 @@ export function createDbWorkspaceSkillStore(hooks?: WorkspaceSkillStoreHooks): W
          WHERE assistant_id = $1`,
         [assistantId],
       )
-      return result.rows
+      // Rebrand alias: the `using-sidanclaw` builtin was renamed `using-brian`
+      // (2026-07-19), but pre-rename rows keep the old slug. Normalize on read
+      // so an old disable still applies; a row already stored under the new
+      // slug wins over a normalized legacy row.
+      const hasNew = result.rows.some((r) => r.skillId === 'using-brian')
+      const rows: Array<{ skillId: string; enabled: boolean }> = []
+      for (const r of result.rows) {
+        if (r.skillId === 'using-sidanclaw') {
+          if (!hasNew) rows.push({ ...r, skillId: 'using-brian' })
+        } else {
+          rows.push(r)
+        }
+      }
+      return rows
     },
 
     async setEnabled(assistantId, skillId, enabled) {

--- a/packages/api/src/files/gcs-byo-validate.ts
+++ b/packages/api/src/files/gcs-byo-validate.ts
@@ -6,7 +6,7 @@
  * bad key, a wrong bucket, or a missing IAM role fails HERE — at setup — not
  * at the user's first file upload. See docs/plans/byo-google-storage.md §4.
  *
- * The probe round-trips a small object under the reserved `.sidanclaw/`
+ * The probe round-trips a small object under the reserved `.usebrian/`
  * prefix and deletes it. The credential object is passed straight through to
  * the GCS client and is never referenced by field name or logged.
  */
@@ -14,7 +14,7 @@
 import { createGcsFilesClient, type GcsServiceAccountCredentials, type GcsFilesClient } from './gcs-client.js'
 
 /** Stable key for the connect-time probe object. */
-export const BYO_HEALTHCHECK_KEY = '.sidanclaw/healthcheck'
+export const BYO_HEALTHCHECK_KEY = '.usebrian/healthcheck'
 
 export type GcsByoValidateFailureCode =
   | 'invalid_key' // key won't parse / sign (bad PEM, malformed JSON)

--- a/packages/api/src/files/s3-byo-validate.ts
+++ b/packages/api/src/files/s3-byo-validate.ts
@@ -8,7 +8,7 @@
  * HERE — at setup — not at the user's first file upload. See
  * docs/plans/byo-s3-storage.md §4.
  *
- * The probe round-trips a small object under the reserved `.sidanclaw/`
+ * The probe round-trips a small object under the reserved `.usebrian/`
  * prefix and deletes it. The credential object is passed straight through to
  * the S3 client and is never referenced by field name or logged.
  */
@@ -17,7 +17,7 @@ import { createS3FilesClient, type S3Credentials } from './s3-client.js'
 import type { GcsFilesClient } from './gcs-client.js'
 
 /** Stable key for the connect-time probe object. */
-export const S3_BYO_HEALTHCHECK_KEY = '.sidanclaw/healthcheck'
+export const S3_BYO_HEALTHCHECK_KEY = '.usebrian/healthcheck'
 
 export type S3ByoValidateFailureCode =
   | 'invalid_key' // access key / secret rejected (signature / auth)

--- a/packages/api/src/google/client.ts
+++ b/packages/api/src/google/client.ts
@@ -463,7 +463,7 @@ function buildMultipartMessage(params: {
   body: string
   attachments: GmailOutgoingAttachment[]
 }): Buffer {
-  const boundary = `=_sidanclaw_${randomUUID()}`
+  const boundary = `=_usebrian_${randomUUID()}`
   const lines: string[] = [
     ...(params.from ? [`From: ${sanitizeHeaderValue(params.from)}`] : []),
     `To: ${sanitizeHeaderValue(params.to)}`,
@@ -861,7 +861,7 @@ export async function createDriveFile(
   if (params.mimeType) metadata.mimeType = params.mimeType
   if (params.folderId) metadata.parents = [params.folderId]
 
-  const boundary = '---sidanclaw-multipart'
+  const boundary = '---usebrian-multipart'
   const body = [
     `--${boundary}`,
     'Content-Type: application/json; charset=UTF-8',
@@ -929,7 +929,7 @@ export async function updateDriveFileContent(
   const metadata: Record<string, unknown> = {}
   if (params.name) metadata.name = params.name
 
-  const boundary = '---sidanclaw-multipart'
+  const boundary = '---usebrian-multipart'
   const body = [
     `--${boundary}`,
     'Content-Type: application/json; charset=UTF-8',

--- a/packages/api/src/mcp/__tests__/auth-headers.test.ts
+++ b/packages/api/src/mcp/__tests__/auth-headers.test.ts
@@ -240,21 +240,30 @@ describe('[COMP:api/connector-preflight-headers] preflightHeadersToRecord', () =
 describe('[COMP:api/actor-identity] actorIdentityHeaders', () => {
   it('builds the full reserved-namespace header set', () => {
     expect(actorIdentityHeaders({ channel: 'web', id: 'a@b.com', email: 'a@b.com', userId: 'u-1' })).toEqual({
+      'X-UseBrian-Actor-Channel': 'web',
       'X-Sidanclaw-Actor-Channel': 'web',
+      'X-UseBrian-User-Id': 'u-1',
       'X-Sidanclaw-User-Id': 'u-1',
+      'X-UseBrian-Actor-Id': 'a@b.com',
       'X-Sidanclaw-Actor-Id': 'a@b.com',
+      'X-UseBrian-Actor-Email': 'a@b.com',
       'X-Sidanclaw-Actor-Email': 'a@b.com',
     })
   })
 
   it('always sends channel + user id; omits absent id / email', () => {
     expect(actorIdentityHeaders({ channel: 'telegram', userId: 'u-2' })).toEqual({
+      'X-UseBrian-Actor-Channel': 'telegram',
       'X-Sidanclaw-Actor-Channel': 'telegram',
+      'X-UseBrian-User-Id': 'u-2',
       'X-Sidanclaw-User-Id': 'u-2',
     })
     expect(actorIdentityHeaders({ channel: 'slack', id: 'U0999', email: null, userId: 'u-3' })).toEqual({
+      'X-UseBrian-Actor-Channel': 'slack',
       'X-Sidanclaw-Actor-Channel': 'slack',
+      'X-UseBrian-User-Id': 'u-3',
       'X-Sidanclaw-User-Id': 'u-3',
+      'X-UseBrian-Actor-Id': 'U0999',
       'X-Sidanclaw-Actor-Id': 'U0999',
     })
   })

--- a/packages/api/src/mcp/__tests__/inject.test.ts
+++ b/packages/api/src/mcp/__tests__/inject.test.ts
@@ -442,9 +442,13 @@ describe('[COMP:api/mcp-inject] custom connector auth threading', () => {
     expect(discoverMcpServer).toHaveBeenCalledWith('http://localhost:9200/mcp', 'Actor MCP', {
       Authorization: 'Bearer tok',
       'X-Tenant': 'acme',
+      'X-UseBrian-Actor-Channel': 'web',
       'X-Sidanclaw-Actor-Channel': 'web',
+      'X-UseBrian-User-Id': 'u-actor-1',
       'X-Sidanclaw-User-Id': 'u-actor-1',
+      'X-UseBrian-Actor-Id': 'ceo@corp.com',
       'X-Sidanclaw-Actor-Id': 'ceo@corp.com',
+      'X-UseBrian-Actor-Email': 'ceo@corp.com',
       'X-Sidanclaw-Actor-Email': 'ceo@corp.com',
     })
   })
@@ -492,6 +496,7 @@ describe('[COMP:api/mcp-inject] custom connector auth threading', () => {
     })
     // Media token present; actor headers absent (that connector opted out of identity).
     expect(discoverMcpServer).toHaveBeenCalledWith('http://localhost:9210/mcp', 'Media MCP', {
+      'X-UseBrian-Media-Token': 'tok.media.sig',
       'X-Sidanclaw-Media-Token': 'tok.media.sig',
     })
   })
@@ -516,8 +521,11 @@ describe('[COMP:api/mcp-inject] custom connector auth threading', () => {
     })
     // Actor headers present (identity opt-in), but NO media token.
     expect(discoverMcpServer).toHaveBeenCalledWith('http://localhost:9211/mcp', 'No-Media MCP', {
+      'X-UseBrian-Actor-Channel': 'whatsapp',
       'X-Sidanclaw-Actor-Channel': 'whatsapp',
+      'X-UseBrian-User-Id': 'u-media-2',
       'X-Sidanclaw-User-Id': 'u-media-2',
+      'X-UseBrian-Actor-Id': '+15551234567',
       'X-Sidanclaw-Actor-Id': '+15551234567',
     })
   })

--- a/packages/api/src/mcp/auth-headers.ts
+++ b/packages/api/src/mcp/auth-headers.ts
@@ -25,12 +25,17 @@ const MAX_HEADER_NAME_LENGTH = 128
 const MAX_HEADER_VALUE_LENGTH = 8192
 
 /**
- * Reserved outbound-header namespace for sidanclaw-asserted values (the actor
+ * Reserved outbound-header namespaces for Use Brian-asserted values (the actor
  * identity headers below). User-controllable config — `preflightHeadersToRecord`
- * — drops any header in this namespace so a user can't forge an identity claim
+ * — drops any header in these namespaces so a user can't forge an identity claim
  * that a connector trusts for auth. Lowercase; matched case-insensitively.
+ *
+ * Two namespaces during the rebrand transition: `x-usebrian-` is canonical;
+ * `x-sidanclaw-` is the legacy namespace still dual-emitted for connectors
+ * that consume it. Retire the legacy emit (never the guard) after a
+ * deprecation window.
  */
-export const RESERVED_HEADER_PREFIX = 'x-sidanclaw-'
+export const RESERVED_HEADER_PREFIXES = ['x-usebrian-', 'x-sidanclaw-'] as const
 
 export function isValidHeaderName(name: string): boolean {
   return name.length > 0 && name.length <= MAX_HEADER_NAME_LENGTH && HEADER_NAME_RE.test(name)
@@ -157,10 +162,12 @@ export function preflightHeadersToRecord(
       typeof (row as { value?: unknown }).value === 'string'
     ) {
       const { name, value } = row as { name: string; value: string }
-      // Reserve the Use Brian namespace: a user-config header may never set an
-      // `X-Sidanclaw-*` value, or it could forge the actor identity a connector
-      // trusts for auth. (Validation of the charset still happens at merge.)
-      if (name.length > 0 && !name.toLowerCase().startsWith(RESERVED_HEADER_PREFIX)) {
+      // Reserve the Use Brian namespaces: a user-config header may never set an
+      // `X-UseBrian-*` or legacy `X-Sidanclaw-*` value, or it could forge the
+      // actor identity a connector trusts for auth. (Charset validation still
+      // happens at merge.)
+      const lower = name.toLowerCase()
+      if (name.length > 0 && !RESERVED_HEADER_PREFIXES.some((p) => lower.startsWith(p))) {
         out[name] = value
       }
     }
@@ -185,7 +192,7 @@ export type ActorIdentity = {
   userId: string
   /**
    * Opaque, short-lived media capability token (minted by the closed platform,
-   * HMAC-signed). When set, `injectMcpTools` emits it as `X-Sidanclaw-Media-Token`
+   * HMAC-signed). When set, `injectMcpTools` emits it as `X-UseBrian-Media-Token` (+ legacy `X-Sidanclaw-Media-Token`)
    * to connectors that opted in via `sendMediaToken`, letting them fetch this
    * user's latest recording server-to-server. Open core carries the string only;
    * it never signs or verifies it. Emitted separately from the actor headers.
@@ -203,11 +210,22 @@ export type ActorIdentity = {
  * user). Empty/missing fields are simply omitted.
  */
 export function actorIdentityHeaders(actor: ActorIdentity): Record<string, string> {
+  // Dual-emit during the rebrand transition: canonical `X-UseBrian-*` plus
+  // legacy `X-Sidanclaw-*` (same values) so existing connector servers keep
+  // working. Drop the legacy set after a deprecation window.
   const headers: Record<string, string> = {
+    'X-UseBrian-Actor-Channel': actor.channel,
     'X-Sidanclaw-Actor-Channel': actor.channel,
+    'X-UseBrian-User-Id': actor.userId,
     'X-Sidanclaw-User-Id': actor.userId,
   }
-  if (actor.id) headers['X-Sidanclaw-Actor-Id'] = actor.id
-  if (actor.email) headers['X-Sidanclaw-Actor-Email'] = actor.email
+  if (actor.id) {
+    headers['X-UseBrian-Actor-Id'] = actor.id
+    headers['X-Sidanclaw-Actor-Id'] = actor.id
+  }
+  if (actor.email) {
+    headers['X-UseBrian-Actor-Email'] = actor.email
+    headers['X-Sidanclaw-Actor-Email'] = actor.email
+  }
   return headers
 }

--- a/packages/api/src/mcp/inject.ts
+++ b/packages/api/src/mcp/inject.ts
@@ -323,7 +323,7 @@ export async function injectMcpTools(params: {
   /**
    * The acting user's resolved identity for this turn (server-side, from the
    * authenticated session — never model output). When set, connectors that
-   * opted in (`config.sendActorIdentity`) receive `X-Sidanclaw-Actor-*` headers
+   * opted in (`config.sendActorIdentity`) receive `X-UseBrian-Actor-*` (+ legacy `X-Sidanclaw-Actor-*`) headers
    * at highest precedence. The call site resolves it cheaply (web = email;
    * channels = the webhook's native id + email). See
    * `docs/architecture/engine/tool-hooks.md`.
@@ -427,9 +427,9 @@ export async function injectMcpTools(params: {
     updatedAt: Date | null
     /** Static operational headers from `config.preflightHeaders` (validated at merge). */
     preflightHeaders: Record<string, string>
-    /** Opt-in: send the acting user's `X-Sidanclaw-Actor-*` identity to this connector. */
+    /** Opt-in: send the acting user's `X-UseBrian-Actor-*` identity to this connector. */
     sendActorIdentity: boolean
-    /** Opt-in: send the acting user's `X-Sidanclaw-Media-Token` capability to this connector. */
+    /** Opt-in: send the acting user's `X-UseBrian-Media-Token` capability to this connector. */
     sendMediaToken: boolean
   }> = connectors
     .filter((c) => c.connected && c.url)
@@ -521,7 +521,13 @@ export async function injectMcpTools(params: {
   // capability (possession fetches the user's latest recording), so it only
   // attaches to connectors the user explicitly granted media access.
   const mediaTokenHeader =
-    actorIdentity?.mediaToken ? { 'X-Sidanclaw-Media-Token': actorIdentity.mediaToken } : null
+    actorIdentity?.mediaToken
+      ? {
+          // Dual-emit during the rebrand transition (canonical + legacy).
+          'X-UseBrian-Media-Token': actorIdentity.mediaToken,
+          'X-Sidanclaw-Media-Token': actorIdentity.mediaToken,
+        }
+      : null
   active.forEach((c, i) => {
     // Layer the connector's static preflight headers (config) over its auth
     // headers (credentials) — preflight wins on a name clash, both validated

--- a/packages/api/src/routes/connectors.ts
+++ b/packages/api/src/routes/connectors.ts
@@ -38,7 +38,7 @@
  * `client_secret` of an `oauth`-typed blob.
  *
  * Google / Notion / Fathom additionally need their OAuth *app* credentials: the
- * server-side secret via `~/.sidanclaw/connectors.config.json` (or `*_CLIENT_*`
+ * server-side secret via `~/.usebrian/connectors.config.json` (or `*_CLIENT_*`
  * env) for the callback's token exchange, and the public client id via
  * `NEXT_PUBLIC_*_CLIENT_ID` for app-web's client-side authorize redirect. GitHub
  * is PAT-only and needs neither.

--- a/packages/api/src/routes/local-session.ts
+++ b/packages/api/src/routes/local-session.ts
@@ -24,7 +24,7 @@ import { isLocalDevEnv } from './dev-auth.js'
  *      cloud (`K_SERVICE`/`NODE_ENV=production`) or in the hosted edition.
  *
  * The owner's display name is local config, not user-editable server state: the
- * launcher prompts once, persists it to `~/.sidanclaw/config.json`, and passes
+ * launcher prompts once, persists it to `~/.usebrian/config.json`, and passes
  * it here via `USEBRIAN_OWNER_NAME`. `findOrCreateUser` re-applies it every
  * boot (idempotent against stable config), so the oss account UI shows it
  * read-only. Spec: docs/architecture/platform/auth.md → "Local owner session".
@@ -53,7 +53,7 @@ const OWNER_DEFAULT_NAME = 'You'
 
 export type LocalSessionDeps = {
   jwtSecret: string | undefined
-  /** From `USEBRIAN_OWNER_NAME` (launcher → ~/.sidanclaw/config.json). */
+  /** From `USEBRIAN_OWNER_NAME` (launcher → ~/.usebrian/config.json). */
   ownerName?: string
   /** Injectable for unit tests; defaults to the real DB-backed upsert. */
   createUser?: typeof findOrCreateUser

--- a/packages/core/src/skills/__tests__/using-brian-skill.test.ts
+++ b/packages/core/src/skills/__tests__/using-brian-skill.test.ts
@@ -1,6 +1,6 @@
 /**
- * Fixture test for the using-sidanclaw built-in skill.
- * Component tag: [COMP:engine/using-sidanclaw-skill].
+ * Fixture test for the using-brian built-in skill.
+ * Component tag: [COMP:engine/using-brian-skill].
  *
  * The skill is the consult-first grounding for "can Use Brian do X?"
  * questions (2026-07-07 capability-hallucination fix). This asserts the
@@ -15,9 +15,9 @@
 import { describe, it, expect } from 'vitest'
 import { loadBuiltinSkills } from '../loader.js'
 
-const skill = loadBuiltinSkills().find((s) => s.id === 'using-sidanclaw')
+const skill = loadBuiltinSkills().find((s) => s.id === 'using-brian')
 
-describe('[COMP:engine/using-sidanclaw-skill] using-sidanclaw skill', () => {
+describe('[COMP:engine/using-brian-skill] using-brian skill', () => {
   it('is registered as a built-in productivity skill, surfaced in every app', () => {
     expect(skill).toBeDefined()
     expect(skill?.source).toBe('builtin')

--- a/packages/core/src/skills/builtin/using-brian.md
+++ b/packages/core/src/skills/builtin/using-brian.md
@@ -1,5 +1,5 @@
 ---
-name: using-sidanclaw
+name: using-brian
 description: Ground-truth guide to what Use Brian can and cannot do (workflows, triggers, brain, pages, channels, connectors). ALWAYS activate before answering whether Use Brian supports something.
 license: MIT
 compatibility: Designed for Use Brian

--- a/scripts/launch.mjs
+++ b/scripts/launch.mjs
@@ -4,7 +4,7 @@
  *
  * `pnpm start` — the whole single-player product on ONE GEMINI_API_KEY:
  *   1. load/prompt GEMINI_API_KEY + generate JWT_SECRET, persisted under
- *      ~/.sidanclaw/config.json (nothing else is required).
+ *      ~/.usebrian/config.json (nothing else is required; a legacy ~/.sidanclaw/ dir is auto-migrated).
  *   2. build the workspace packages (turbo-cached; the apps run from source via
  *      tsx / next dev).
  *   3. start the embedded PGLite brain server (pg-wire socket on :54329) and wait
@@ -21,7 +21,7 @@
  */
 import { spawn } from 'node:child_process'
 import { connect } from 'node:net'
-import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { mkdirSync, readFileSync, writeFileSync, existsSync, renameSync } from 'node:fs'
 import { homedir, platform, arch, userInfo } from 'node:os'
 import { join, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -30,7 +30,21 @@ import { createRequire } from 'node:module'
 import { createInterface } from 'node:readline/promises'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
-const CONFIG_DIR = join(homedir(), '.sidanclaw')
+const CONFIG_DIR = join(homedir(), '.usebrian')
+const LEGACY_CONFIG_DIR = join(homedir(), '.sidanclaw')
+// Rebrand auto-migration: pre-rebrand installs keep their config, brain data,
+// and connector files under ~/.sidanclaw/. Move the whole dir to ~/.usebrian/
+// once (atomic same-filesystem rename; nothing else is running this early in
+// boot). If BOTH exist, ~/.usebrian wins and the legacy dir is left untouched
+// for the user to inspect — merging blind could clobber a newer config.
+try {
+  if (!existsSync(CONFIG_DIR) && existsSync(LEGACY_CONFIG_DIR)) {
+    renameSync(LEGACY_CONFIG_DIR, CONFIG_DIR)
+    console.log(`[launch] migrated ${LEGACY_CONFIG_DIR} -> ${CONFIG_DIR}`)
+  }
+} catch (err) {
+  console.warn(`[launch] could not migrate ${LEGACY_CONFIG_DIR} -> ${CONFIG_DIR}:`, err?.message ?? err)
+}
 const CONFIG_FILE = join(CONFIG_DIR, 'config.json')
 const BRAIN_DIR = join(CONFIG_DIR, 'brain')
 


### PR DESCRIPTION
e951d8e fix(app-web): propagate workspace rename to top-left chrome without reload
8a60a50 feat(rebrand): legacy-identifier transition wave — headers, bridge, dotdir, skill id