### PR TITLE
fix(connectors): stop a per-resource 403 marking a live connector dead

### DIFF
--- a/packages/api/src/mcp/__tests__/connector-health.test.ts
+++ b/packages/api/src/mcp/__tests__/connector-health.test.ts
@@ -21,13 +21,13 @@ function makeTool(execute: Tool['execute']): Tool {
 }
 
 describe('[COMP:integrations/connector-health] classifyConnectorAuthError', () => {
-  it('flags 401 / 403 / invalid-credential messages as auth failures', () => {
+  it('flags 401 / invalid-credential messages as auth failures', () => {
     // The exact strings the provider clients emit.
     expect(classifyConnectorAuthError(new Error('GitHub PAT is invalid or revoked (401): Bad credentials'))).toBe(true)
-    expect(classifyConnectorAuthError('GitHub error: GitHub API error (403): forbidden')).toBe(true)
     expect(classifyConnectorAuthError('Notion token is invalid or expired. Please reconnect.')).toBe(true)
     expect(classifyConnectorAuthError('Fathom token is invalid or expired.')).toBe(true)
     expect(classifyConnectorAuthError('Google token refresh failed: invalid_grant')).toBe(true)
+    expect(classifyConnectorAuthError(new Error('401 Unauthorized'))).toBe(true)
   })
 
   it('does NOT flag transient / non-auth errors (so a blip never marks a live connector dead)', () => {
@@ -35,6 +35,42 @@ describe('[COMP:integrations/connector-health] classifyConnectorAuthError', () =
     expect(classifyConnectorAuthError(new Error('fetch failed: ECONNRESET'))).toBe(false)
     expect(classifyConnectorAuthError(new Error('GitHub API error (500): server error'))).toBe(false)
     expect(classifyConnectorAuthError('rate limit exceeded')).toBe(false)
+  })
+
+  // ── 403 is NOT 401 ──────────────────────────────────────────────
+  // Regression: production incident 2026-07-20. A fine-grained GitHub PAT with
+  // `Pull requests: Read` on one repo but not another returned this verbatim.
+  // The old classifier matched a bare `\b403\b` and flipped the whole connector
+  // to auth_failed, which made the next injection skip the GitHub tools for
+  // EVERY repo. The credential was alive the entire time.
+  it('does NOT flag a per-resource 403 — the credential is alive, it just cannot touch that resource', () => {
+    const real =
+      'GitHub error: GitHub API error (403): {"message":"Resource not accessible by personal access token",' +
+      '"documentation_url":"https://docs.github.com/rest/pulls/pulls#list-pull-requests","status":"403"}'
+    expect(classifyConnectorAuthError(real)).toBe(false)
+    expect(classifyConnectorAuthError('GitHub error: GitHub API error (403): forbidden')).toBe(false)
+    expect(classifyConnectorAuthError('GitHub API error (403): Resource not accessible by integration')).toBe(false)
+  })
+
+  it('does NOT flag a 403 rate limit or IP allow-list refusal', () => {
+    expect(classifyConnectorAuthError('GitHub API error (403): API rate limit exceeded for user ID 4171296')).toBe(false)
+    expect(classifyConnectorAuthError('GitHub API error (403): You have exceeded a secondary rate limit')).toBe(false)
+    expect(classifyConnectorAuthError('GitHub API error (403): Although you appear to have the correct authorization credentials, your IP address is not permitted')).toBe(false)
+  })
+
+  it('DOES flag a 403 that names a re-authorization requirement (SSO/SAML)', () => {
+    expect(
+      classifyConnectorAuthError(
+        'GitHub API error (403): Resource protected by organization SAML enforcement. ' +
+          'You must grant your Personal Access Token access to this organization.',
+      ),
+    ).toBe(true)
+  })
+
+  it('ignores an incidental 401/403 that is not an HTTP status', () => {
+    // A bare \b403\b previously matched any of these.
+    expect(classifyConnectorAuthError('GitHub error: pull request #403 could not be merged')).toBe(false)
+    expect(classifyConnectorAuthError('GitHub error: 401 files changed')).toBe(false)
   })
 })
 

--- a/packages/api/src/mcp/connector-health.ts
+++ b/packages/api/src/mcp/connector-health.ts
@@ -21,24 +21,90 @@ import type { Tool } from '@use-brian/core'
 import type { ConnectorInstanceStore, ConnectorHealthStatus } from '../db/connector-instance-store.js'
 
 /**
- * True when an error/message looks like a credential or authorization failure
- * (the connector needs reconnecting), as opposed to a transient network blip,
- * rate limit, or a not-found. Deliberately conservative: only a clear auth
- * signal flips health, so a flaky network never marks a live connector dead.
- * Matches the messages the provider clients emit (github/notion/fathom/google).
+ * Message fragments that mean the CREDENTIAL ITSELF is dead — reconnecting is
+ * the only recovery. Provider-agnostic (github/notion/fathom/google).
+ */
+const CREDENTIAL_DEAD_SIGNALS = [
+  'invalid_grant',
+  'bad credentials',
+  'invalid or revoked',
+  'invalid or expired',
+  'expired or revoked',
+  'token expired',
+  'token has been revoked',
+  'unauthorized',
+]
+
+/**
+ * 403s that STILL need a human to re-authorize the credential: the token is
+ * structurally valid but was never authorized for this org, so reconnecting
+ * (and completing SSO) is genuinely the fix. GitHub's SAML/SSO wording.
+ */
+const FORBIDDEN_REAUTH_SIGNALS = [
+  'saml enforcement',
+  'saml sso',
+  'single sign-on',
+  'must grant your personal access token',
+]
+
+/**
+ * Refusals that must NEVER flip health even though the provider returns 403.
+ * The credential is alive and works elsewhere — it simply may not touch THIS
+ * resource, or it is being throttled. Reconnecting changes nothing, and marking
+ * the connector dead disables it for every other repo/workflow in the
+ * workspace. (Production incident 2026-07-20: a fine-grained GitHub PAT lacking
+ * `Pull requests: Read` on one of two repos returned `403 Resource not
+ * accessible by personal access token`; that flipped the whole connector to
+ * `auth_failed`, so the next injection skipped the GitHub tools entirely and the
+ * morning digest lost GitHub for every repo.)
+ */
+const NOT_CREDENTIAL_SIGNALS = [
+  'resource not accessible',
+  'rate limit',
+  'abuse detection',
+  'ip allow list',
+  'ip address is not permitted',
+]
+
+/**
+ * True when `code` appears as an HTTP status rather than as an incidental
+ * number. A bare `\b403\b` also matches a PR number, an id, or a count — an
+ * unrelated message mentioning "403" must not mark a live connector dead.
+ */
+function hasHttpStatus(msg: string, code: '401' | '403'): boolean {
+  return new RegExp(
+    `\\(${code}\\)` +                                  // "GitHub API error (403):"
+      `|"?status"?\\s*[:=]\\s*"?${code}\\b` +          // `"status":"403"` / `status: 403`
+      `|\\bhttp[^0-9]{0,3}${code}\\b` +                // "HTTP 403"
+      `|\\b${code}\\s+(?:unauthorized|forbidden)\\b`,  // "401 Unauthorized"
+  ).test(msg)
+}
+
+/**
+ * True when an error/message means the connector's stored credential is dead
+ * and needs reconnecting. Deliberately conservative — a transient blip, a 404,
+ * a rate limit, or a per-resource permission gap must never mark a live
+ * connector dead.
+ *
+ * 401 and 403 are NOT equivalent and must not be conflated:
+ *   401 → "your credential is bad"            → auth_failed
+ *   403 → "you may not touch THIS resource"   → healthy, unless the message
+ *          says the token needs re-authorizing (SSO/SAML).
  */
 export function classifyConnectorAuthError(err: unknown): boolean {
   const msg = (err instanceof Error ? err.message : String(err)).toLowerCase()
-  return (
-    /\b(401|403)\b/.test(msg) ||
-    msg.includes('invalid_grant') ||
-    msg.includes('bad credentials') ||
-    msg.includes('invalid or revoked') ||
-    msg.includes('invalid or expired') ||
-    msg.includes('expired or revoked') ||
-    msg.includes('unauthorized') ||
-    msg.includes('forbidden')
-  )
+
+  // Unambiguous credential death wins outright.
+  if (CREDENTIAL_DEAD_SIGNALS.some((s) => msg.includes(s))) return true
+  if (hasHttpStatus(msg, '401')) return true
+
+  // Explicit per-resource / quota refusals are healthy, whatever status rides along.
+  if (NOT_CREDENTIAL_SIGNALS.some((s) => msg.includes(s))) return false
+
+  // A 403 only counts when it names a re-authorization requirement.
+  if (hasHttpStatus(msg, '403')) return FORBIDDEN_REAUTH_SIGNALS.some((s) => msg.includes(s))
+
+  return false
 }
 
 /** Fire-and-forget health writer — never blocks or fails the tool call. */


### PR DESCRIPTION
## Problem

`classifyConnectorAuthError` treated **401 and 403 identically**. Any 403 flipped `connector_instance.health_status` to `auth_failed`, which makes `injectMcpTools` skip that connector's tools entirely. For a **workspace-scoped** connector nothing can then reset the flag - no tool call can succeed if no tool is injected - so a perfectly healthy credential stays disabled until a human reconnects it.

## Incident (2026-07-20, prod)

A fine-grained GitHub PAT held `Pull requests: Read` on `use-brian/use-brian` but **not** on `use-brian/brian-platform`. Listing PRs on the second repo returned:

```
GitHub API error (403): {"message":"Resource not accessible by personal access token", ... "status":"403"}
```

That disabled GitHub for **every** repo in the workspace, and the owner was notified their "credentials stopped working" - when nothing had expired or been revoked.

## Fix

| Signal | Health |
|---|---|
| `401`, `bad credentials`, `invalid_grant`, `invalid or revoked`, `token expired` | `auth_failed` |
| `403` naming re-authorization (`SAML enforcement`, `single sign-on`, `must grant your Personal Access Token`) | `auth_failed` |
| `403` anything else (`resource not accessible`, `rate limit`, `abuse detection`, `IP allow list`) | **unchanged** |

Also fixes a latent false positive: `\b(401|403)\b` matched those digits *anywhere*, so `pull request #403 could not be merged` marked a connector dead. Status matching now requires an HTTP context - `(403)`, `"status":"403"`, `HTTP 403`, `403 Forbidden`.

## Behaviour change

This **flips an existing assertion** that encoded the bug (`403 forbidden -> true` is now `false`). Deliberate, and documented in the spec + KB.

## Tests

13 pass, 5 new cases including the verbatim production string as a regression test. `pnpm typecheck` clean; `pnpm check` 18/18.

## Paired docs

- spec: use-brian/brian-platform#219
- KB: use-brian/brian-kb#24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
