### PR TITLE
feat: custom-domains home-page in Settings only + launcher Vertex/Alicloud credentials

### DIFF
--- a/apps/app-web/src/components/doc/share-dialog.tsx
+++ b/apps/app-web/src/components/doc/share-dialog.tsx
@@ -41,7 +41,6 @@ import {
   listWorkspaceGroups,
   publishPage,
   revokeGrant,
-  setDomainDefaultPage,
   setPageSlug,
   unpublishPage,
   updateGrantRole,
@@ -133,43 +132,27 @@ function Avatar({ name, url }: { name: string; url?: string | null }) {
 }
 
 /** One connected workspace domain from this page's perspective (workspace-
- *  first lifecycle): home-page state, the alias editor, and a "set as home
- *  page" action when the domain has no default yet. Connecting/claiming
- *  lives in Settings → Domains. */
+ *  first lifecycle): a read-only home-page chip when this page is the domain's
+ *  default, plus the alias editor. The home/default page is set and cleared
+ *  only in Settings → Domains (and cleared automatically on unpublish) — it is
+ *  workspace infrastructure, not per-page state. Connecting/claiming also lives
+ *  in Settings → Domains. */
 function PageDomainCard({
   pageId,
-  workspaceId,
   row,
   t,
   onChanged,
 }: {
   pageId: string;
-  workspaceId: string;
   row: SiteDomainRow;
   t: ShareT;
   onChanged: () => Promise<void>;
 }) {
-  const [busy, setBusy] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
-
   const href = row.isDefault
     ? `https://${row.hostname}`
     : row.slug
       ? `https://${row.hostname}/${row.slug}`
       : `https://${row.hostname}/p/${pageId}`;
-
-  const setHome = async () => {
-    setBusy(true);
-    setErr(null);
-    try {
-      await setDomainDefaultPage(workspaceId, row.domainId, pageId);
-      await onChanged();
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : String(e));
-    } finally {
-      setBusy(false);
-    }
-  };
 
   return (
     <div className="rounded-md border border-border p-3 space-y-2">
@@ -195,25 +178,8 @@ function PageDomainCard({
         ) : null}
       </div>
       {row.isDefault ? null : (
-        <>
-          <SlugRow pageId={pageId} ctx={row} t={t} onChanged={onChanged} />
-          {!row.hasDefault ? (
-            <button
-              type="button"
-              onClick={() => void setHome()}
-              disabled={busy}
-              className="rounded-md border border-border px-3 py-1.5 text-xs font-medium transition-colors hover:bg-muted disabled:opacity-50"
-            >
-              {busy ? t.site.settingHome : t.site.setAsHome}
-            </button>
-          ) : null}
-        </>
+        <SlugRow pageId={pageId} ctx={row} t={t} onChanged={onChanged} />
       )}
-      {err ? (
-        <p role="alert" className="break-all text-xs text-destructive">
-          {err}
-        </p>
-      ) : null}
     </div>
   );
 }
@@ -222,13 +188,11 @@ function PageDomainCard({
  *  page's address on it, or a pointer to Settings when none are connected. */
 function PageDomainsSection({
   pageId,
-  workspaceId,
   site,
   t,
   onChanged,
 }: {
   pageId: string;
-  workspaceId: string;
   site: SiteState | null;
   t: ShareT;
   onChanged: () => Promise<void>;
@@ -254,7 +218,6 @@ function PageDomainsSection({
             <PageDomainCard
               key={row.domainId}
               pageId={pageId}
-              workspaceId={workspaceId}
               row={row}
               t={t}
               onChanged={onChanged}
@@ -349,8 +312,8 @@ function SlugRow({
     <div className="space-y-1.5 border-t border-border pt-3">
       <p className="text-xs font-medium text-muted-foreground">{t.site.pageLinkLabel}</p>
       <div className="flex items-center gap-2">
-        <div className="flex min-w-0 flex-1 items-center rounded-md border border-border bg-background px-3 py-1.5 text-sm focus-within:border-primary">
-          <span className="shrink-0 text-muted-foreground">{ctx.hostname}/</span>
+        <div className="flex min-w-0 flex-1 items-center rounded-md border border-border bg-background text-sm transition-[border-color,box-shadow] focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/30">
+          <span className="shrink-0 pl-3 text-muted-foreground">{ctx.hostname}/</span>
           <input
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
@@ -360,7 +323,7 @@ function SlugRow({
                 void save();
               }
             }}
-            className="min-w-0 flex-1 bg-transparent outline-none"
+            className="min-w-0 flex-1 bg-transparent py-1.5 pr-3 outline-none focus-visible:shadow-none"
             aria-label={t.site.pageLinkLabel}
           />
         </div>
@@ -797,7 +760,6 @@ export function ShareDialog({
             {!publish.published && site?.domains.some((d) => d.servable || d.slug) ? (
               <PageDomainsSection
                 pageId={pageId}
-                workspaceId={workspaceId}
                 site={site}
                 t={t}
                 onChanged={refreshSite}
@@ -840,7 +802,6 @@ export function ShareDialog({
                     (workspace-first: connect/claim lives in Settings). */}
                 <PageDomainsSection
                   pageId={pageId}
-                  workspaceId={workspaceId}
                   site={site}
                   t={t}
                   onChanged={refreshSite}

--- a/apps/app-web/src/components/settings-modal/sections/domains-section.tsx
+++ b/apps/app-web/src/components/settings-modal/sections/domains-section.tsx
@@ -238,7 +238,7 @@ export function SubdomainRow({
       <div className="flex items-center gap-2">
         <Globe className="size-4 shrink-0 text-muted-foreground" aria-hidden />
         {editing ? (
-          <div className="flex min-w-0 flex-1 items-center rounded-md border border-border bg-background focus-within:border-primary">
+          <div className="flex min-w-0 flex-1 items-center rounded-md border border-border bg-background transition-[border-color,box-shadow] focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/30">
             <input
               value={label}
               onChange={(e) => setLabel(e.target.value)}
@@ -249,7 +249,7 @@ export function SubdomainRow({
                 }
               }}
               aria-label={t.subdomainHeading}
-              className="min-w-0 flex-1 bg-transparent px-2 py-1 text-sm outline-none"
+              className="min-w-0 flex-1 bg-transparent px-2 py-1 text-sm outline-none focus-visible:shadow-none"
             />
             <span className="shrink-0 pr-2 text-sm text-muted-foreground">{apexSuffix}</span>
           </div>
@@ -415,7 +415,7 @@ export function SubdomainClaim({
   return (
     <div className="space-y-1.5">
       <div className="flex items-center gap-2">
-        <div className="flex min-w-0 flex-1 items-center rounded-md border border-border bg-background focus-within:border-primary">
+        <div className="flex min-w-0 flex-1 items-center rounded-md border border-border bg-background transition-[border-color,box-shadow] focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/30">
           <input
             value={label}
             onChange={(e) => setLabel(e.target.value)}
@@ -426,7 +426,7 @@ export function SubdomainClaim({
               }
             }}
             aria-label={t.subdomainHeading}
-            className="min-w-0 flex-1 bg-transparent px-3 py-1.5 text-sm outline-none"
+            className="min-w-0 flex-1 bg-transparent px-3 py-1.5 text-sm outline-none focus-visible:shadow-none"
           />
           <span className="shrink-0 pr-2 text-sm text-muted-foreground">.{apex}</span>
           <button

--- a/apps/app-web/src/lib/i18n/dictionaries/en.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/en.ts
@@ -823,8 +823,6 @@ export const en = {
         errBlockedHostname: "That hostname is reserved. Use your own domain, like docs.yourcompany.com.",
         errDomainLimit: "This workspace reached its domain limit.",
         homeChip: "Home page",
-        setAsHome: "Set as home page",
-        settingHome: "Setting...",
         noDomainsHint: "No domains connected yet. Claim your workspace subdomain or connect a custom domain in Settings.",
         openSettingsCta: "Open domain settings",
       },

--- a/apps/app-web/src/lib/i18n/dictionaries/ja.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/ja.ts
@@ -731,8 +731,6 @@ export const ja: Dictionary = {
         errBlockedHostname: "そのホスト名は予約されています。docs.yourcompany.com のように、ご自身のドメインを使用してください。",
         errDomainLimit: "このワークスペースのドメイン数が上限に達しました。",
         homeChip: "ホームページ",
-        setAsHome: "ホームページに設定",
-        settingHome: "設定中...",
         noDomainsHint: "接続済みのドメインはまだありません。設定でワークスペースのサブドメインを取得するか、カスタムドメインを接続してください。",
         openSettingsCta: "ドメイン設定を開く",
       },

--- a/apps/app-web/src/lib/i18n/dictionaries/zh.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh.ts
@@ -719,8 +719,6 @@ export const zh: Dictionary = {
         errBlockedHostname: "該主機名稱為保留名稱。請使用您自己的網域，例如 docs.yourcompany.com。",
         errDomainLimit: "此工作空間已達網域數量上限。",
         homeChip: "首頁",
-        setAsHome: "設為首頁",
-        settingHome: "設定中...",
         noDomainsHint: "尚未連接任何網域。請在設定中取得工作空間子網域，或連接自訂網域。",
         openSettingsCta: "開啟網域設定",
       },

--- a/packages/api/src/db/__tests__/page-domain-store.test.ts
+++ b/packages/api/src/db/__tests__/page-domain-store.test.ts
@@ -313,6 +313,23 @@ describe('[COMP:doc/page-domains] Page domain + slug store', () => {
     })
   })
 
+  describe('clearDefaultPageForPage', () => {
+    it('unbinds the page as home on every domain pointing at it (unpublish cascade)', async () => {
+      mockQueryWithRLS.mockResolvedValueOnce(rows([{ id: 'd_1' }, { id: 'd_2' }]))
+      const count = await store.clearDefaultPageForPage('u_1', ROOT_ID)
+      expect(count).toBe(2)
+      const [, sql, params] = mockQueryWithRLS.mock.calls[0]
+      expect(sql).toContain('UPDATE page_domains SET page_id = NULL')
+      expect(sql).toContain('WHERE page_id = $1')
+      expect(params).toEqual([ROOT_ID])
+    })
+
+    it('reports zero when the page is nobody’s home page', async () => {
+      mockQueryWithRLS.mockResolvedValueOnce(rows([]))
+      expect(await store.clearDefaultPageForPage('u_1', ROOT_ID)).toBe(0)
+    })
+  })
+
   describe('listCurrentSlugs', () => {
     it('short-circuits on an empty id list', async () => {
       const out = await store.listCurrentSlugs('d_1', [])

--- a/packages/api/src/db/page-domain-store.ts
+++ b/packages/api/src/db/page-domain-store.ts
@@ -132,6 +132,11 @@ export type PageDomainStore = {
     domainId: string,
     pageId: string | null,
   ): Promise<PageDomain | { error: 'page_not_in_workspace' } | null>
+  /** Unbind this page as the default (`/`) page on every domain pointing at
+   *  it. Called on unpublish — the domain stays connected but returns to
+   *  unbound (404 at `/`), so a stale home-page pointer can never survive a
+   *  page that no longer serves. Returns how many domains were unbound. */
+  clearDefaultPageForPage(userId: string, pageId: string): Promise<number>
   /** Every workspace domain as seen from this page (Share-dialog select). */
   listDomainContextForPage(userId: string, pageId: string): Promise<PageDomainContext[]>
   /** Every slug on the domain (current + historical) — suggestion dedupe input. */
@@ -420,6 +425,17 @@ export function createDbPageDomainStore(): PageDomainStore {
         [domainId],
       )
       return domain.rows[0] ? { error: 'page_not_in_workspace' } : null
+    },
+
+    async clearDefaultPageForPage(userId, pageId) {
+      // RLS (page_domains_workspace_member) scopes this to the caller's
+      // workspaces, so any member who can unpublish the page can unbind it.
+      const r = await queryWithRLS<{ id: string }>(
+        userId,
+        `UPDATE page_domains SET page_id = NULL WHERE page_id = $1 RETURNING id`,
+        [pageId],
+      )
+      return r.rows.length
     },
 
     async listDomainContextForPage(userId, pageId) {

--- a/packages/api/src/routes/views.ts
+++ b/packages/api/src/routes/views.ts
@@ -941,6 +941,12 @@ export function viewsRoutes(opts: ViewsRouteOptions): Router {
       return res.status(403).json({ error: 'Only the page owner or a workspace admin can unpublish this page' })
     }
     await opts.pageGrantStore.unpublishPage(userId, view.id)
+    // Unpublishing kills the page's ability to serve at `/`, so also unbind it
+    // as any domain's home page. Otherwise the stale `page_domains.page_id`
+    // pointer survives (Settings still shows it as the home page and
+    // re-publishing silently restores it) with no per-page way to clear it.
+    // custom-domains.md → "Serving gate". Home page is set only in Settings.
+    await opts.pageDomainStore?.clearDefaultPageForPage(userId, view.id)
     publishPageShareChange(view.id)
     res.json({ published: false })
   })

--- a/scripts/launch.mjs
+++ b/scripts/launch.mjs
@@ -82,18 +82,34 @@ loadDotEnv(join(ROOT, '.env'))
 // developer's local Postgres on the default 5432 (verified failure mode).
 const PORTS = { pglite: 54329, api: 4000, docSync: 8080, appWeb: 3003, discordConnector: 8090, waConnector: 8091 }
 
-// ── config (the only required input is GEMINI_API_KEY) ─────────────
+// ── config (needs ONE LLM credential — AI Studio, Vertex, or Alicloud) ─────────────
 mkdirSync(CONFIG_DIR, { recursive: true })
 const config = existsSync(CONFIG_FILE) ? JSON.parse(readFileSync(CONFIG_FILE, 'utf8')) : {}
+
+// `.env` was already merged into process.env by loadDotEnv() above, and
+// process.env is spread into the child's `env` below — so a Vertex/Alicloud
+// credential set in .env reaches the api without any extra plumbing here.
 let geminiKey = process.env.GEMINI_API_KEY || config.geminiApiKey
+// Vertex / Alicloud are alternative LLM backends — a deployment in a region
+// where Google blocks AI Studio (e.g. Hong Kong) has no Gemini key and uses
+// one of these instead. Their presence skips the Gemini prompt entirely.
+const hasLlmCredential = Boolean(
+  geminiKey || process.env.VERTEX_PROJECT_ID || process.env.DASHSCOPE_API_KEY,
+)
 // The single-player owner identity — shown in the app, no login. Local config
 // is the source of truth; prompt once (default the OS username) and persist.
 let ownerName = process.env.USEBRIAN_OWNER_NAME || config.ownerName
-if (!geminiKey || !ownerName) {
+if (!hasLlmCredential || !ownerName) {
   const rl = createInterface({ input: process.stdin, output: process.stdout })
-  if (!geminiKey) {
-    geminiKey = (await rl.question('Enter your GEMINI_API_KEY (https://aistudio.google.com/apikey): ')).trim()
-    if (!geminiKey) { rl.close(); console.error('A GEMINI_API_KEY is required to boot. Exiting.'); process.exit(1) }
+  if (!hasLlmCredential) {
+    console.log('No LLM credential found. Enter a Gemini (AI Studio) key, or Ctrl-C and set')
+    console.log('VERTEX_PROJECT_ID (Vertex AI) or DASHSCOPE_API_KEY (Alicloud/Qwen) in .env instead.')
+    geminiKey = (await rl.question('GEMINI_API_KEY (https://aistudio.google.com/apikey): ')).trim()
+    if (!geminiKey) {
+      rl.close()
+      console.error('An LLM credential is required: GEMINI_API_KEY, VERTEX_PROJECT_ID, or DASHSCOPE_API_KEY. Exiting.')
+      process.exit(1)
+    }
   }
   if (!ownerName) {
     const fallback = (userInfo().username || 'You').trim()
@@ -126,7 +142,7 @@ const waConnectorSecret = process.env.WA_CONNECTOR_SECRET || config.waConnectorS
 const channelCredentialKey = config.channelCredentialKey || randomBytes(32).toString('base64')
 writeFileSync(
   CONFIG_FILE,
-  JSON.stringify({ ...config, geminiApiKey: geminiKey, jwtSecret, docSyncSecret, discordConnectorSecret, waConnectorSecret, channelCredentialKey, ownerName }, null, 2),
+  JSON.stringify({ ...config, ...(geminiKey ? { geminiApiKey: geminiKey } : {}), jwtSecret, docSyncSecret, discordConnectorSecret, waConnectorSecret, channelCredentialKey, ownerName }, null, 2),
 )
 
 // External-store escape hatch: a real Postgres URL skips the embedded brain.
@@ -138,6 +154,11 @@ const useLocalWaConnector = !process.env.WA_CONNECTOR_URL
 const env = {
   ...process.env,
   NODE_ENV: 'development',
+  // `...process.env` already carries every LLM credential from .env
+  // (VERTEX_PROJECT_ID, VERTEX_LOCATION, VERTEX_SERVICE_ACCOUNT_JSON,
+  // DASHSCOPE_API_KEY, DASHSCOPE_BASE_URL) — the child (apps/api) accepts any
+  // one and Gemini may be absent. Only GEMINI_API_KEY is overridden here, to
+  // carry the config-persisted / just-prompted value when it isn't in .env.
   GEMINI_API_KEY: geminiKey,
   JWT_SECRET: jwtSecret,
   DATABASE_URL: databaseUrl,


### PR DESCRIPTION
346f726 feat(custom-domains): set/clear home page only in Settings; unbind on unpublish
6065541 Merge pull request #64 from use-brian/fix/launcher-llm-credentials
7297861 fix(launch): accept Vertex/Alicloud credentials, don't force a Gemini key