### PR TITLE
fix: Qwen-only deployment lane gaps (background models, ASR, silent failures)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,25 @@ That is it. There is no step three. The store defaults to an embedded PGLite
 database under `~/.usebrian/`; point `DATABASE_URL` at a local Postgres if you
 prefer a container. Self-host overrides live in [`.env.example`](./.env.example).
 
+### If the web app dies with "JavaScript heap out of memory"
+
+Turbopack's dev cache under `apps/app-web/.next` is keyed by a generation id,
+and a Next.js upgrade starts a fresh one without reclaiming the old. Left alone
+it grows across upgrades until `next-server` is holding gigabytes before it
+compiles anything, and app-web hits its heap cap on the next compile.
+
+`pnpm dev` prunes generations untouched for 7 days on every boot (keeping the
+live one) and warns when the remaining cache passes 4 GB. If app-web still dies,
+clear it outright - it is regenerable build output:
+
+```bash
+rm -rf apps/app-web/.next
+```
+
+Raising the heap cap is the wrong fix here: with a clean cache the dev server
+idles around 320 MB and peaks near 190 MB of JS heap after compiling a dozen
+routes, so a cap in the low gigabytes is already generous.
+
 ### Your data stays yours
 
 **0** external services. **1** model key. The brain, the store, and the canvas

--- a/packages/api/src/__tests__/model-resolution.test.ts
+++ b/packages/api/src/__tests__/model-resolution.test.ts
@@ -12,6 +12,7 @@ import {
   wouldBudgetDowngradeAffectModel,
   chatTierBudget,
   ensureServableModel,
+  backgroundLatencyBudgetMs,
 } from '../model-resolution.js'
 
 // Research became its own billing tier on 2026-06-02 (10 credits, above Max's
@@ -268,5 +269,52 @@ describe('[COMP:api/model-resolution] ensureServableModel — default falls to a
 
   it('leaves an already-Qwen pick untouched on a Qwen deploy', () => {
     expect(ensureServableModel('qwen3.7-plus', QWEN)).toBe('qwen3.7-plus')
+  })
+
+  // Background lanes (auto-title, topic/research classifiers, session-state
+  // diff) are internal routing and never menu-flagged, so the menu-scoped
+  // lookup can't see them. Before this, a Qwen-only deploy fell through to a
+  // metered CHAT model — a 32-token title billed at chat rates — or, at the
+  // call sites that never resolved at all, hard-failed every turn with
+  // "[routing] model 'gemini-3.1-flash-lite' ... is not configured".
+  it('substitutes the Qwen BACKGROUND model, not a metered chat model', () => {
+    expect(ensureServableModel('gemini-3.1-flash-lite', QWEN)).toBe('qwen3.5-flash')
+  })
+
+  it('keeps the Gemini background model when Gemini is configured', () => {
+    expect(ensureServableModel('gemini-3.1-flash-lite', GEMINI)).toBe('gemini-3.1-flash-lite')
+    expect(ensureServableModel('gemini-3.1-flash-lite', BOTH)).toBe('gemini-3.1-flash-lite')
+  })
+
+  it('is a no-op for a background model when nothing is configured', () => {
+    expect(ensureServableModel('gemini-3.1-flash-lite', new Set())).toBe('gemini-3.1-flash-lite')
+  })
+})
+
+// The auto-title budget silently assumed a sub-second Gemini Flash Lite.
+// Measured 2026-07-21 on a title-shaped call: qwen3.5-flash took 4.3s/9.6s/4.3s
+// against the old flat 10s ceiling, so a Qwen-only deploy dropped the in-stream
+// title_update on most turns (the title itself still landed in DB).
+describe('[COMP:api/model-resolution] backgroundLatencyBudgetMs — budget follows the serving provider', () => {
+  it('gives the Gemini background lane the tight budget', () => {
+    expect(backgroundLatencyBudgetMs('gemini-3.1-flash-lite')).toBe(10_000)
+  })
+
+  it('gives an OpenAI-compatible (DashScope) model a wider budget', () => {
+    expect(backgroundLatencyBudgetMs('qwen3.5-flash')).toBeGreaterThan(
+      backgroundLatencyBudgetMs('gemini-3.1-flash-lite'),
+    )
+  })
+
+  it('covers the whole openai-compat family, not one label', () => {
+    // A new `openai-compat:<label>` row must inherit the slower budget rather
+    // than silently regressing to the Gemini assumption.
+    for (const alias of ['qwen3.5-flash', 'qwen3.7-plus', 'deepseek-v4-pro']) {
+      expect(backgroundLatencyBudgetMs(alias)).toBe(25_000)
+    }
+  })
+
+  it('falls back to the tight budget for an unknown id', () => {
+    expect(backgroundLatencyBudgetMs('not-a-real-model')).toBe(10_000)
   })
 })

--- a/packages/api/src/model-resolution.ts
+++ b/packages/api/src/model-resolution.ts
@@ -19,6 +19,7 @@ import {
   tierClassifierExpression,
   registryRow,
   menuForClass,
+  activeForClass,
   type ModelClass,
   type ModelTier,
 } from '@use-brian/shared/model-registry'
@@ -53,6 +54,17 @@ export function ensureServableModel(
   const sameClass = menuForClass(row.class, configuredProviders)
   if (sameClass.length > 0) return sameClass[0].alias
 
+  // Background lanes (auto-title, topic/research classifiers, session-state
+  // diff) are internal routing and never carry `menu: true`, so the
+  // menu-scoped lookup above cannot see them. Without this, a Qwen-only
+  // deployment substitutes a metered CHAT model for a 32-token title —
+  // functional, but paying chat rates for background work. Prefer a same-class
+  // background model from a configured provider first.
+  if (row.class === 'background') {
+    const background = activeForClass('background', configuredProviders)
+    if (background.length > 0) return background[0].alias
+  }
+
   // Fall through the chat classes in descending capability so the substitute
   // is the best a configured provider offers.
   const CLASS_FALLBACK_ORDER: readonly ModelClass[] = ['max', 'research', 'standard-pro', 'metered']
@@ -61,6 +73,30 @@ export function ensureServableModel(
     if (rows.length > 0) return rows[0].alias
   }
   return model
+}
+
+/**
+ * Wall-clock budget for a background-lane call that a user-facing SSE stream
+ * waits on before giving up and closing (currently auto-title). Missing the
+ * budget is not an error — the write is still in flight and lands in DB — but
+ * the client loses the in-stream `title_update` and sees the placeholder until
+ * its next fetch.
+ *
+ * Derived from the SERVING provider, because the budget silently assumed a
+ * sub-second Gemini Flash Lite. Measured 2026-07-21 on a title-shaped call
+ * (32 max tokens): `gemini-3.1-flash-lite` well under a second;
+ * `qwen3.5-flash` 4.3s / 9.6s / 4.3s — brushing the old 10s ceiling before
+ * stream assembly and the fresh-message DB read are added, so a Qwen-only
+ * deployment missed it on most turns.
+ *
+ * Keep this a provider-family question, not a per-model table: a new
+ * OpenAI-compatible label inherits the slower budget automatically rather than
+ * silently regressing to the Gemini assumption.
+ */
+export function backgroundLatencyBudgetMs(model: string): number {
+  const row = registryRow(model)
+  if (row?.provider.startsWith('openai-compat:')) return 25_000
+  return 10_000
 }
 
 /**

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -28,7 +28,7 @@ import { notifyBrainWriteIfMatch } from '../brain-stream/notify.js'
 // no-op/false/null/unset defaults in chatRoutes(). See oss §12.5.
 import type { Message, LLMProvider, Tool, MemoryStore, UsageStore, AnalyticsLogger, FileStore, ContentBlock, CacheStore, McpSettingsStore, ConfirmationDecision, ConfirmationResolver, TopicClassification, ClassifierRecentTurn, EpisodicStore, CapabilityStore, RetrievalStore, TranscribeResult, TokenUsage, WorkerResult, EngineHooks } from '@use-brian/core'
 
-import { resolveModel, ensureServableModel, isStandardTier, chatTierBudget, planNudgeCap } from '../model-resolution.js'
+import { resolveModel, ensureServableModel, backgroundLatencyBudgetMs, isStandardTier, chatTierBudget, planNudgeCap } from '../model-resolution.js'
 import { registryRow } from '@use-brian/shared/model-registry'
 import { buildPendingContext } from '../inter-assistant/pending-context.js'
 import type { ConnectorStore } from '../db/connector-store.js'
@@ -906,7 +906,15 @@ export function resolveStickyChannelId(
  */
 type GenerateTitleResult = { title: string | null; usage: TokenUsage | null; model: string | null }
 
-async function generateTitle(provider: LLMProvider, messages: Message[]): Promise<GenerateTitleResult> {
+/**
+ * The background-lane workhorse: extraction / classification / structured
+ * output, per docs/architecture/platform/cost-and-pricing.md → Model routing.
+ * Always pass this through `ensureServableModel` before use — on a deployment
+ * with no Google credential it is not servable and the routing provider throws.
+ */
+const BACKGROUND_MODEL = 'gemini-3.1-flash-lite'
+
+async function generateTitle(provider: LLMProvider, messages: Message[], model: string): Promise<GenerateTitleResult> {
   const filteredMessages = messages
     .filter((m) => m.role === 'user' || m.role === 'assistant')
     .map((m) => ({ role: m.role, text: extractPlainText(m.content) }))
@@ -927,9 +935,7 @@ async function generateTitle(provider: LLMProvider, messages: Message[]): Promis
   let rawTitle = ''
   let usage: TokenUsage | null = null
   for await (const chunk of provider.stream({
-    // Standard tier per docs/architecture/platform/cost-and-pricing.md
-    // → Model routing (extraction / classification / structured-output bucket).
-    model: 'gemini-3.1-flash-lite',
+    model,
     systemPrompt:
       'Summarize this conversation into a short descriptive title (3-6 words). The title should capture the specific topic being discussed. Output ONLY the title text — no markdown, quotes, or punctuation.\n\nRules:\n- Always 3-6 words\n- Rephrase questions into topic form (e.g. "what do you think about oil prices" → "Oil Price Analysis Today")\n- Include the specific subject, not just the category\n\nExamples:\nuser: what do you think about oil price today? → Oil Price Analysis Today\nuser: help me plan a trip to Japan → Planning a Trip to Japan\nuser: tell me about the latest crypto news → Latest Crypto Market News',
     messages: [{ role: 'user', content: excerpt }],
@@ -1950,6 +1956,9 @@ export function chatRoutes(options: WebChatOptions): Router {
               const match = file.content.match(/^data:[^;]+;base64,(.+)$/)
               const base64Data = match ? match[1] : file.content
               let transcription: TranscribeResult | undefined
+              // Why the transcript is missing, when we know. Without it the
+              // model receives a bare "unavailable" and invents an explanation.
+              let transcribeFailure: string | undefined
               if (options.voiceTranscription) {
                 const buffer = Buffer.from(base64Data, 'base64')
                 transcription = await transcribeFirstAudio(
@@ -1961,15 +1970,21 @@ export function chatRoutes(options: WebChatOptions): Router {
                       ? { backend: options.voiceTranscription.backend }
                       : {}),
                     model: options.voiceTranscription.model,
+                    onFailure: (reason) => { transcribeFailure = reason },
                   },
                 )
                 if (transcription) transcriptions.push(transcription)
+              } else {
+                transcribeFailure = 'voice transcription is disabled on this deployment (VOICE_TRANSCRIPTION_ENABLED)'
               }
               textParts.push(
                 transcription
                   ? `[voice] ${transcription.text}`
-                  : `<attached_file id="${file.id}" name="${file.fileName}" type="${file.mimeType}">[voice note — transcription unavailable]</attached_file>`,
+                  : `<attached_file id="${file.id}" name="${file.fileName}" type="${file.mimeType}">[voice note — transcription unavailable${transcribeFailure ? `: ${transcribeFailure}` : ''}. Tell the user this plainly; do NOT claim it is still processing or that you will retry.]</attached_file>`,
               )
+              if (!transcription && transcribeFailure) {
+                sendEvent('notice', { kind: 'transcription_unavailable', message: transcribeFailure })
+              }
             } else if (file.artifactFileId) {
               // The upload was silently promoted to a durable artifact
               // (large-content-artifacts §Phase 2.3): the turn carries a
@@ -5094,9 +5109,9 @@ export function chatRoutes(options: WebChatOptions): Router {
             .then((open: SessionStateRecord[]) =>
               runSessionStateDiff({
                 provider: options.provider,
-                // Standard tier per docs/architecture/platform/cost-and-pricing.md
-                // → Model routing (extraction / classification / structured-output bucket).
-                model: 'gemini-3.1-flash-lite',
+                model: options.configuredProviders
+                  ? ensureServableModel(BACKGROUND_MODEL, options.configuredProviders)
+                  : BACKGROUND_MODEL,
                 sessionId: session.id,
                 userId: user.id,
                 assistantId: assistant.id,
@@ -5394,7 +5409,12 @@ export function chatRoutes(options: WebChatOptions): Router {
         // fires, the title write is still in flight — it'll land in DB and
         // show on the next sessions fetch, just without an in-stream
         // `title_update` event for this turn.
-        const AUTO_TITLE_TIMEOUT_MS = 10_000
+        // Resolved once: the same model drives the call and its latency budget,
+        // so a slower serving provider can never be given the Gemini deadline.
+        const autoTitleModel = options.configuredProviders
+          ? ensureServableModel(BACKGROUND_MODEL, options.configuredProviders)
+          : BACKGROUND_MODEL
+        const AUTO_TITLE_TIMEOUT_MS = backgroundLatencyBudgetMs(autoTitleModel)
         const autoTitle = (async () => {
           try {
             // Reload messages from DB so we get the assistant response that was
@@ -5404,7 +5424,7 @@ export function chatRoutes(options: WebChatOptions): Router {
               role: m.role as 'user' | 'assistant' | 'system',
               content: m.content as Message['content'],
             }))
-            const titleResult = await generateTitle(options.provider, freshMessages)
+            const titleResult = await generateTitle(options.provider, freshMessages, autoTitleModel)
             // generateTitle returns `title: null` when it can't produce a
             // meaningful title (empty excerpt, model returned blank). Keep the
             // existing title in that case — overwriting with a generic fallback

--- a/packages/core/src/media/__tests__/preflight.test.ts
+++ b/packages/core/src/media/__tests__/preflight.test.ts
@@ -6,7 +6,7 @@ vi.mock('../transcribe.js', () => ({
 }))
 
 // Import after the mock so the preflight binds to the mocked export.
-const { transcribeFirstAudio } = await import('../preflight.js')
+const { transcribeFirstAudio, describeTranscriptionFailure } = await import('../preflight.js')
 const { transcribeAudio } = await import('../transcribe.js')
 const mockedTranscribe = vi.mocked(transcribeAudio)
 
@@ -93,5 +93,61 @@ describe('[COMP:media/preflight] transcribeFirstAudio', () => {
       { buffer: expect.any(Buffer), mime: 'audio/ogg' },
       { apiKey: 'k', model: 'm', timeoutMs: 1234, fetchFn: customFetch },
     )
+  })
+})
+
+// A swallowed transcription failure used to reach the model as a bare
+// "[voice note — transcription unavailable]", and it filled the gap by
+// inventing status ("the transcription isn't available yet, let me check the
+// recording status") and narrating tool calls at the user. The failure stays
+// swallowed — a bad voice note must not fail the turn — but the reason now
+// travels with it.
+describe('[COMP:media/preflight] transcription failure reporting', () => {
+  it('reports a reason through onFailure while still returning undefined', async () => {
+    mockedTranscribe.mockRejectedValueOnce(new Error('DashScope transcription failed (HTTP 400): The audio is too long'))
+    const seen: string[] = []
+    const out = await transcribeFirstAudio(
+      [{ buffer: Buffer.from('a'), mime: 'audio/mpeg', index: 0 } as MediaAttachment],
+      { enabled: true, apiKey: 'k', onFailure: (r) => seen.push(r) },
+    )
+    expect(out).toBeUndefined()
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toMatch(/too long/i)
+    expect(seen[0]).toMatch(/recording/i)
+  })
+
+  it('does not call onFailure on the success path', async () => {
+    mockedTranscribe.mockResolvedValueOnce({ text: 'hello', usage: null, model: 'm' } as never)
+    const seen: string[] = []
+    await transcribeFirstAudio(
+      [{ buffer: Buffer.from('a'), mime: 'audio/mpeg', index: 0 } as MediaAttachment],
+      { enabled: true, apiKey: 'k', onFailure: (r) => seen.push(r) },
+    )
+    expect(seen).toEqual([])
+  })
+})
+
+describe('[COMP:media/preflight] describeTranscriptionFailure', () => {
+  it('turns the duration cap into routing guidance', () => {
+    expect(describeTranscriptionFailure(new Error('<400> InvalidParameter: The audio is too long')))
+      .toMatch(/too long .*recording/i)
+  })
+
+  it('classifies a rejected format', () => {
+    expect(describeTranscriptionFailure(new Error("The dedicated task `asr` does not support this input")))
+      .toMatch(/rejected by the transcription provider/i)
+  })
+
+  it('classifies a timeout', () => {
+    expect(describeTranscriptionFailure(new Error('request aborted'))).toMatch(/timed out/i)
+  })
+
+  it('passes an unrecognised provider message through rather than inventing one', () => {
+    // Never dress up a failure we do not understand as something friendlier.
+    expect(describeTranscriptionFailure(new Error('quota exceeded for project'))).toBe('quota exceeded for project')
+  })
+
+  it('caps a runaway provider message', () => {
+    expect(describeTranscriptionFailure(new Error('x'.repeat(500))).length).toBeLessThanOrEqual(200)
   })
 })

--- a/packages/core/src/media/backend.ts
+++ b/packages/core/src/media/backend.ts
@@ -180,8 +180,14 @@ async function runDashScope(
       throw new Error(`DashScope transcription expects an audio/* mime, got "${req.mime}".`)
     }
     model = DASHSCOPE_ASR_MODEL
+    // `qwen3-asr-flash` is a DEDICATED ASR task model, not a chat model with
+    // ears: any text part in the same message is rejected outright with
+    // `InternalError.Algo.InvalidParameter: The dedicated task 'asr' ... does
+    // not support this input`, whatever the audio is. So `req.prompt` is
+    // deliberately dropped here — there is no prompt channel to honour, and
+    // sending one fails 100% of transcriptions (verified 2026-07-21: audio-only
+    // 200, text+audio 400, at both 8s and 5min, `format` irrelevant).
     content = [
-      { type: 'text', text: req.prompt },
       // OpenAI-compatible audio part. `format` is the bare subtype
       // (`audio/ogg` → `ogg`), which is what the API expects.
       {

--- a/packages/core/src/media/index.ts
+++ b/packages/core/src/media/index.ts
@@ -24,7 +24,7 @@ export {
   type FieldCitation,
 } from '@use-brian/shared'
 export { transcribeAudio, type TranscribeOptions, type TranscribeResult } from './transcribe.js'
-export { transcribeFirstAudio, type PreflightOptions } from './preflight.js'
+export { transcribeFirstAudio, describeTranscriptionFailure, type PreflightOptions } from './preflight.js'
 export {
   transcribeRecording,
   transcribeRecordingChunks,

--- a/packages/core/src/media/preflight.ts
+++ b/packages/core/src/media/preflight.ts
@@ -23,6 +23,36 @@ export type PreflightOptions = {
   model?: string
   timeoutMs?: number
   fetchFn?: typeof fetch
+  /**
+   * Called with a short, user-facing reason when transcription fails.
+   *
+   * The failure is still swallowed (a bad voice note must not fail the turn),
+   * but silence alone is what made the model confabulate: given only
+   * "[voice note — transcription unavailable]" it invented status claims
+   * ("the transcription isn't available yet, let me check the recording
+   * status") and narrated tool calls at the user. Handing the caller a reason
+   * lets the turn state what actually happened.
+   */
+  onFailure?: (reason: string) => void
+}
+
+/**
+ * Map a provider error to a short, actionable reason. Recognised cases get
+ * guidance; anything else passes the provider's own message through rather
+ * than inventing a friendlier lie about a failure we don't understand.
+ */
+export function describeTranscriptionFailure(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err)
+  // The inline ASR lane is duration-capped; long audio belongs to the
+  // recordings pipeline (async file-transcription), not the voice-note path.
+  if (/too long/i.test(raw)) {
+    return 'the audio is too long for an inline voice note. Upload it as a recording for long-form transcription'
+  }
+  if (/unsupported|invalid.*(format|parameter)|does not support/i.test(raw)) {
+    return 'this audio format was rejected by the transcription provider'
+  }
+  if (/timeout|abort/i.test(raw)) return 'transcription timed out'
+  return raw.slice(0, 200)
 }
 
 /**
@@ -58,6 +88,7 @@ export async function transcribeFirstAudio(
     return result
   } catch (err) {
     console.warn('[media/preflight] transcription failed:', err instanceof Error ? err.message : err)
+    options.onFailure?.(describeTranscriptionFailure(err))
     return undefined
   }
 }

--- a/packages/core/src/providers/__tests__/adapters.test.ts
+++ b/packages/core/src/providers/__tests__/adapters.test.ts
@@ -108,8 +108,19 @@ describe('[COMP:media/backend] Multimodal backend per adapter', () => {
     expect((calls[0] as never as { messages: [{ content: [unknown, { image_url: { url: string } }] }] })
       .messages[0].content[1].image_url.url).toMatch(/^data:image\/png;base64,/)
     expect(calls[1].model).toBe(DASHSCOPE_ASR_MODEL)
-    expect((calls[1] as never as { messages: [{ content: [unknown, { type: string; input_audio: { format: string } }] }] })
-      .messages[0].content[1].input_audio.format).toBe('ogg')
+    // Audio is the ONLY part: qwen3-asr-flash is a dedicated ASR task model and
+    // rejects the whole request when a text part rides along
+    // (`InternalError.Algo.InvalidParameter: The dedicated task 'asr' ... does
+    // not support this input`). Sending a prompt failed 100% of voice notes on
+    // a Qwen deployment, silently — the preflight swallows the error and the
+    // user just sees "I can't transcribe audio".
+    const audioContent = (calls[1] as never as {
+      messages: [{ content: Array<{ type: string; input_audio?: { format: string } }> }]
+    }).messages[0].content
+    expect(audioContent).toHaveLength(1)
+    expect(audioContent[0].type).toBe('input_audio')
+    expect(audioContent[0].input_audio?.format).toBe('ogg')
+    expect(audioContent.some((p) => p.type === 'text')).toBe(false)
   })
 
   it('refuses a PDF on DashScope rather than sending something Qwen-VL misreads', async () => {

--- a/packages/shared/src/model-registry.ts
+++ b/packages/shared/src/model-registry.ts
@@ -803,6 +803,26 @@ export function menuForClass(cls: ModelClass, configuredProviders?: ReadonlySet<
   )
 }
 
+/**
+ * Active rows of a class from configured providers, IGNORING the `menu` flag.
+ *
+ * `menuForClass` is the user-facing selection surface, so it requires
+ * `menu === true`. The `background` class is internal routing only and is
+ * deliberately never menu-flagged (see the `qwen3.5-flash` row — "Internal
+ * routing only, NEVER a menu"), which makes every background model invisible
+ * to `menuForClass`. Substitution for background lanes (auto-title, topic and
+ * research classifiers, session-state diff) must therefore go through here,
+ * or a Qwen-only deployment falls through to a metered CHAT model and pays
+ * chat prices for a 32-token title.
+ */
+export function activeForClass(cls: ModelClass, configuredProviders?: ReadonlySet<string>): ModelRegistryRow[] {
+  return MODEL_REGISTRY.filter((row) =>
+    row.class === cls &&
+    row.status === 'active' &&
+    (!configuredProviders || configuredProviders.has(row.provider)),
+  )
+}
+
 const CHAT_TIER_KEYS: ReadonlySet<string> = new Set(['standard', 'pro', 'max', 'research'])
 
 /** Callable ids for a provider's `models` listing: active, non-embedding

--- a/scripts/launch.mjs
+++ b/scripts/launch.mjs
@@ -21,7 +21,7 @@
  */
 import { spawn } from 'node:child_process'
 import { connect } from 'node:net'
-import { mkdirSync, readFileSync, writeFileSync, existsSync, renameSync } from 'node:fs'
+import { mkdirSync, readFileSync, writeFileSync, existsSync, renameSync, readdirSync, statSync, rmSync } from 'node:fs'
 import { homedir, platform, arch, userInfo } from 'node:os'
 import { join, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -266,6 +266,69 @@ function nextHasNativeSwc() {
     return true
   }
 }
+// Turbopack's persistent dev cache is keyed by a generation id (the Next
+// version, or a config hash). When that key changes — a Next bump, a
+// turbopack config edit — it starts a FRESH generation and never reclaims the
+// old one, so the cache grows monotonically across upgrades. Observed
+// 2026-07-21: 7.9 GB across two generations (5.5 GB active + 1.4 GB orphaned
+// five days earlier), which put next-server at 4.0 GB RSS *before compiling a
+// single route* and OOM-killed app-web against its 2048 MB heap cap. With a
+// cold cache the same server idles at 322 MB and peaks at 187 MB of V8 heap
+// after eight routes — so the cap was never the problem, the cache was.
+//
+// Prune conservatively: keep the most recently written generation (the live
+// one) and drop generations untouched for >7 days. Everything here is
+// regenerable build output; the worst case is one slower first compile.
+const CACHE_STALE_DAYS = 7
+const CACHE_WARN_BYTES = 4 * 1024 ** 3
+function dirSizeBytes(dir) {
+  let total = 0
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name)
+    try { total += entry.isDirectory() ? dirSizeBytes(p) : statSync(p).size } catch { /* raced */ }
+  }
+  return total
+}
+function pruneTurbopackCache() {
+  const cacheDir = join(ROOT, 'apps/app-web/.next/dev/cache/turbopack')
+  if (!existsSync(cacheDir)) return
+  try {
+    const gens = readdirSync(cacheDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => {
+        const p = join(cacheDir, e.name)
+        let newest = 0
+        for (const f of readdirSync(p, { withFileTypes: true })) {
+          try { newest = Math.max(newest, statSync(join(p, f.name)).mtimeMs) } catch { /* raced */ }
+        }
+        return { name: e.name, path: p, newest }
+      })
+    if (gens.length === 0) return
+    gens.sort((a, b) => b.newest - a.newest)
+    const cutoff = Date.now() - CACHE_STALE_DAYS * 86_400_000
+    // gens[0] is the live generation — never a prune candidate, however old.
+    const stale = gens.slice(1).filter((g) => g.newest < cutoff)
+    let freed = 0
+    for (const g of stale) {
+      try { freed += dirSizeBytes(g.path); rmSync(g.path, { recursive: true, force: true }) } catch { /* best effort */ }
+    }
+    if (freed > 0) {
+      const human = freed >= 1024 ** 3 ? `${(freed / 1024 ** 3).toFixed(1)} GB` : `${Math.round(freed / 1024 ** 2)} MB`
+      console.log(`[launch] pruned ${stale.length} stale Turbopack cache generation(s), freed ${human}`)
+    }
+    const remaining = dirSizeBytes(cacheDir)
+    if (remaining > CACHE_WARN_BYTES) {
+      console.warn(
+        `[launch] Turbopack dev cache is ${(remaining / 1024 ** 3).toFixed(1)} GB (one live generation). ` +
+        `This inflates next-server RSS and can OOM app-web against its ${HEAP_MB['app-web']} MB heap cap — ` +
+        `run \`rm -rf apps/app-web/.next\` if app-web starts dying.`,
+      )
+    }
+  } catch (err) {
+    console.warn('[launch] could not inspect the Turbopack dev cache:', err?.message ?? err)
+  }
+}
+
 let shuttingDown = false
 function shutdown(code = 0) {
   if (shuttingDown) return
@@ -294,6 +357,7 @@ console.log('[launch] starting api (:4000), doc-sync (:8080), app-web (:3003) ..
 run('api', 'pnpm', ['--filter', '@use-brian/api-open', 'exec', 'tsx', 'src/index.ts'])
 run('doc-sync', 'pnpm', ['--filter', '@use-brian/doc-sync', 'exec', 'tsx', 'src/index.ts'],
   { PORT: String(PORTS.docSync) })
+pruneTurbopackCache()
 const forceWebpack = process.env.USEBRIAN_WEBPACK === '1' || !nextHasNativeSwc()
 if (forceWebpack) {
   console.log('[launch] native @next/swc binding for this platform not found — starting app-web with webpack (run `pnpm install` to restore Turbopack).')


### PR DESCRIPTION
Fixes the lanes that hard-fail on a Qwen-only (DashScope) deployment. All verified against a live Qwen-only stack.

## 1. Background lanes never resolved their provider

Auto-title and session-state diff pinned `gemini-3.1-flash-lite` without passing it through `ensureServableModel`, so every turn failed with `[routing] model ... is not configured`. Session-state diff failing meant **conversations stopped reaching the knowledge graph entirely**.

The naive fix would have been wrong: `menuForClass` requires `menu === true`, and the `background` class is internal-routing-only and deliberately never menu-flagged. Substitution couldn't see `qwen3.5-flash` and fell through to a **metered chat model** - a 32-token title billed at chat rates. Hence `activeForClass`, which ignores the menu flag.

Also `backgroundLatencyBudgetMs`: the SSE-visible deadline now follows the serving provider family. The flat 10s ceiling assumed sub-second Gemini; `qwen3.5-flash` measured 4.3 / 9.6 / 4.3s on a title-shaped call, so the in-stream `title_update` was dropped on most Qwen turns. Keyed on the family (`openai-compat:*`), not a per-model table, so a new label inherits the slower budget instead of regressing.

**Verified:** `session_state_diff_pass` with `upserts: 1`, in-stream `title_update`, title *"Vendor Contract Review Reminder With Priya"*.

## 2. DashScope ASR rejected every voice note

`qwen3-asr-flash` is a dedicated ASR task model, not a chat model with ears. Any text part alongside `input_audio` is rejected outright, so sending `req.prompt` failed **100% of voice notes on any Qwen deployment**, at any duration. Isolated against the live endpoint:

| Request | Result |
|---|---|
| text + audio, `format=mpeg` (shipped) | 400 |
| text + audio, `format=mp3` | 400 |
| **audio only** | **200** |

Format was a red herring. **Verified:** real Cantonese transcription from a meeting recording.

## 3. Transcription failures were swallowed silently

The model got a bare `[voice note - transcription unavailable]` and confabulated - inventing status ("the transcription isn't available yet, let me check the recording status") and narrating tool calls at the user.

The failure is still swallowed (a bad voice note must not fail the turn), but `onFailure` now carries a reason. An **unrecognised** provider message passes through verbatim rather than being dressed up as something friendlier.

**Before:** invented status + `[Tool call: listRecordings]` leaked into the reply.
**After:** "it's too long for inline transcription. To get it transcribed, upload it as a recording instead."

## 4. Turbopack dev cache OOM-killed app-web

`.next` had grown to **7.9 GB** across two generations (5.5 GB live + 1.4 GB orphaned five days earlier), putting `next-server` at 4.0 GB RSS *before compiling a single route*.

Raising the heap cap would have been the wrong fix - with a cold cache the same server idles at **322 MB** and peaks at **187 MB** of JS heap after eight routes.

## Tests

- core: 286 files / 3979 tests
- api: 307 files / 3610 tests
- `pnpm check`: `kb-pairing` and `copy-emdash` clean

Paired KB entry: `sidanclaw-kb#fix/qwen-only-deployment-gaps`.

## Not covered

PDF distillation still fails on DashScope - `openai-compat.ts` has no `document` branch, so a PDF is sent as an `image_url` data URL and the provider 400 kills the turn. Diagnosed, not fixed.
