### PR TITLE
feat: let a self-hosted deployment declare its own API endpoint

### DIFF
--- a/apps/app-desktop/src/__tests__/target-store.test.ts
+++ b/apps/app-desktop/src/__tests__/target-store.test.ts
@@ -4,13 +4,16 @@ import {
   CLOUD_API_URL,
   CLOUD_APP_URL,
   DEFAULT_LOCAL_APP_URL,
+  acceptDeclaredApiUrl,
   cloudTarget,
   deriveApiUrl,
+  desktopConfigUrl,
   deriveLocalApiUrl,
   healthUrl,
   localMintUrl,
   localTarget,
   normalizeTargetUrl,
+  parseDesktopConfig,
   parsePersistedTarget,
   resolveTargetFromPersisted,
   serializePersistedTarget,
@@ -163,5 +166,101 @@ describe("[COMP:app-desktop/target-store] indicator + URL helpers", () => {
       "http://localhost:3003/api/auth/local-session",
     );
     expect(healthUrl("http://localhost:4000")).toBe("http://localhost:4000/health");
+  });
+});
+
+describe("[COMP:app-desktop/target-store] declared API (GET /api/desktop-config)", () => {
+  // A reverse-proxied self-host is the case hostname derivation cannot serve:
+  // its API is on 443 under a name that is neither an `api.` sibling nor the
+  // same host on :4000, so without a declaration the shell probes a dead port.
+  const PROXIED_APP = "https://brain.example.com";
+  const PROXIED_API = "https://backend.example.com";
+
+  it("builds the config URL off the normalized app base", () => {
+    expect(desktopConfigUrl("http://localhost:3003")).toBe(
+      "http://localhost:3003/api/desktop-config",
+    );
+  });
+
+  it("derivation alone strands a reverse-proxied self-host on an unreachable :4000", () => {
+    expect(deriveLocalApiUrl(PROXIED_APP)).toBe(`${PROXIED_APP}:4000`);
+  });
+
+  it("a declared API outranks the hostname guess", () => {
+    expect(localTarget(PROXIED_APP, PROXIED_API)?.apiUrl).toBe(PROXIED_API);
+  });
+
+  it("falls back to derivation with no declaration, or a rejected one", () => {
+    expect(localTarget(PROXIED_APP)?.apiUrl).toBe(`${PROXIED_APP}:4000`);
+    expect(localTarget(PROXIED_APP, null)?.apiUrl).toBe(`${PROXIED_APP}:4000`);
+    expect(localTarget(PROXIED_APP, "not a url")?.apiUrl).toBe(`${PROXIED_APP}:4000`);
+  });
+
+  it("accepts a normalized http(s) declaration and strips trailing slashes", () => {
+    expect(acceptDeclaredApiUrl(`${PROXIED_API}/`)).toBe(PROXIED_API);
+    expect(acceptDeclaredApiUrl("http://localhost:4000")).toBe("http://localhost:4000");
+  });
+
+  it("REFUSES a declaration pointing at the cloud API (paired-API-only rule)", () => {
+    // A typo'd or hostile self-host must not aim the shell's sign-in exchange
+    // and refresh traffic at the origin where a real cloud session lives.
+    expect(acceptDeclaredApiUrl(CLOUD_API_URL)).toBeNull();
+    expect(acceptDeclaredApiUrl(`${CLOUD_API_URL}/v1`)).toBeNull();
+    expect(localTarget(PROXIED_APP, CLOUD_API_URL)?.apiUrl).toBe(`${PROXIED_APP}:4000`);
+  });
+
+  it("rejects a non-http(s) declaration", () => {
+    expect(acceptDeclaredApiUrl("file:///etc/passwd")).toBeNull();
+    expect(acceptDeclaredApiUrl("")).toBeNull();
+  });
+
+  it("parses the declared apiUrl out of a config body, tolerating junk", () => {
+    expect(parseDesktopConfig({ apiUrl: PROXIED_API, edition: "oss" })).toBe(PROXIED_API);
+    expect(parseDesktopConfig({})).toBeNull();
+    expect(parseDesktopConfig({ apiUrl: "" })).toBeNull();
+    expect(parseDesktopConfig({ apiUrl: 42 })).toBeNull();
+    expect(parseDesktopConfig(null)).toBeNull();
+    expect(parseDesktopConfig([{ apiUrl: PROXIED_API }])).toBeNull();
+    expect(parseDesktopConfig("nope")).toBeNull();
+    // The cloud guard holds through the parse seam too.
+    expect(parseDesktopConfig({ apiUrl: CLOUD_API_URL })).toBeNull();
+  });
+
+  it("round-trips the declaration through the persisted record", () => {
+    const raw = serializePersistedTarget("local", PROXIED_APP, PROXIED_API);
+    expect(parsePersistedTarget(raw)).toEqual({
+      v: 1,
+      kind: "local",
+      appUrl: PROXIED_APP,
+      apiUrl: PROXIED_API,
+    });
+    expect(resolveTargetFromPersisted(raw).apiUrl).toBe(PROXIED_API);
+  });
+
+  it("keeps the declaration while parked on cloud, so the way back still works", () => {
+    const raw = serializePersistedTarget("cloud", PROXIED_APP, PROXIED_API);
+    const rec = parsePersistedTarget(raw);
+    expect(rec?.kind).toBe("cloud");
+    expect(rec?.apiUrl).toBe(PROXIED_API);
+    // Parked on cloud, the resolved target is still the cloud one.
+    expect(resolveTargetFromPersisted(raw).apiUrl).toBe(CLOUD_API_URL);
+  });
+
+  it("omits an absent or rejected declaration from the record", () => {
+    expect(parsePersistedTarget(serializePersistedTarget("local", PROXIED_APP))).toEqual({
+      v: 1,
+      kind: "local",
+      appUrl: PROXIED_APP,
+    });
+    expect(
+      parsePersistedTarget(serializePersistedTarget("local", PROXIED_APP, CLOUD_API_URL)),
+    ).toEqual({ v: 1, kind: "local", appUrl: PROXIED_APP });
+  });
+
+  it("re-validates a hand-edited record rather than trusting it", () => {
+    const handEdited = JSON.stringify({ v: 1, kind: "local", appUrl: PROXIED_APP, apiUrl: CLOUD_API_URL });
+    expect(parsePersistedTarget(handEdited)?.apiUrl).toBeUndefined();
+    // ...and the resolved target derives instead of reaching the cloud API.
+    expect(resolveTargetFromPersisted(handEdited).apiUrl).toBe(`${PROXIED_APP}:4000`);
   });
 });

--- a/apps/app-desktop/src/main.ts
+++ b/apps/app-desktop/src/main.ts
@@ -48,9 +48,11 @@ import { resolveConfig } from "./config.js";
 import {
   DEFAULT_LOCAL_APP_URL,
   TARGET_FILE_NAME,
+  desktopConfigUrl,
   healthUrl,
   localMintUrl,
   localTarget,
+  parseDesktopConfig,
   parsePersistedTarget,
   serializePersistedTarget,
   targetWindowTitle,
@@ -441,13 +443,36 @@ async function probeLocalBrain(apiUrl: string): Promise<boolean> {
 }
 
 /**
+ * Ask the deployment where its own API lives (`GET /api/desktop-config`).
+ * Returns the declared base, or `null` for the caller to derive instead.
+ *
+ * This is what lets a reverse-proxied self-host be reached at all: hostname
+ * derivation only covers `localhost`, an `api.` sibling, and same-host `:4000`,
+ * so a brain served at e.g. `https://brian.example.com` with its API on 443
+ * under a different name was previously unreachable. Never throws — an older
+ * self-host 404s here and falls back.
+ */
+async function fetchDeclaredApiUrl(appUrl: string): Promise<string | null> {
+  try {
+    const res = await net.fetch(desktopConfigUrl(appUrl), {
+      signal: AbortSignal.timeout(3500),
+      cache: "no-store",
+    });
+    if (!res.ok) return null; // 404 — a self-host predating the endpoint
+    return parseDesktopConfig(await res.json());
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Persist the target record and relaunch — the §2.1 switch. The config is a
  * process-lifetime constant (keep-alive timers, menu labels, and the policy
  * closures all hang off it), so a switch never re-resolves in place.
  */
-function persistTargetAndRelaunch(kind: TargetKind, appUrl?: string): void {
+function persistTargetAndRelaunch(kind: TargetKind, appUrl?: string, apiUrl?: string | null): void {
   try {
-    writeFileSync(targetFile(), serializePersistedTarget(kind, appUrl));
+    writeFileSync(targetFile(), serializePersistedTarget(kind, appUrl, apiUrl));
   } catch (err) {
     dialog.showErrorBox("Switch failed", `Could not save the target: ${String(err)}`);
     return;
@@ -459,6 +484,15 @@ function persistTargetAndRelaunch(kind: TargetKind, appUrl?: string): void {
 /** The last local address ever used (remembered across a switch to cloud). */
 function rememberedLocalAppUrl(): string {
   return parsePersistedTarget(readPersistedTargetRaw())?.appUrl ?? DEFAULT_LOCAL_APP_URL;
+}
+
+/**
+ * The last API base that local address DECLARED, kept alongside it across a
+ * switch to cloud — otherwise the trip back would silently fall to hostname
+ * derivation and strand a reverse-proxied self-host on an unreachable `:4000`.
+ */
+function rememberedLocalApiUrl(): string | null {
+  return parsePersistedTarget(readPersistedTargetRaw())?.apiUrl ?? null;
 }
 
 let lastLocalMintAt: number | null = null;
@@ -515,7 +549,7 @@ function showLocalDown(win: BrowserWindow, reason: "unreachable" | "auth" = "unr
  */
 function switchTargetFromMenu(): void {
   if (cfg.target === "local") {
-    persistTargetAndRelaunch("cloud", rememberedLocalAppUrl());
+    persistTargetAndRelaunch("cloud", rememberedLocalAppUrl(), rememberedLocalApiUrl());
     return;
   }
   const win = ensureWindow();
@@ -1435,18 +1469,24 @@ if (!gotLock) {
     // so a switch would persist but never survive the relaunch — refuse with
     // an explanation instead of silently reopening in the same place.
     if (cfg.envTargetOverride) return { ok: false, error: "env-override", url: input };
-    const target = localTarget(input);
-    if (!target) return { ok: false, error: "invalid-url", url: input };
+    // Normalize first (cheap reject on a bad URL), then ask the deployment
+    // where its own API lives before probing — a reverse-proxied self-host is
+    // only reachable via its declaration, since derivation would guess `:4000`.
+    const normalized = localTarget(input);
+    if (!normalized) return { ok: false, error: "invalid-url", url: input };
+    const declaredApiUrl = await fetchDeclaredApiUrl(normalized.appUrl);
+    const target = localTarget(normalized.appUrl, declaredApiUrl) ?? normalized;
     if (!(await probeLocalBrain(target.apiUrl))) {
       return { ok: false, error: "unreachable", url: target.appUrl };
     }
     // A short delay (not setImmediate) so the ok-reply actually flushes to the
     // renderer and the landing paints "Restarting..." before the process dies.
-    setTimeout(() => persistTargetAndRelaunch("local", target.appUrl), 150);
+    // The declaration rides along into the record so startup stays sync.
+    setTimeout(() => persistTargetAndRelaunch("local", target.appUrl, declaredApiUrl), 150);
     return { ok: true, url: target.appUrl };
   });
   ipcMain.on("Use Brian:use-cloud", () =>
-    persistTargetAndRelaunch("cloud", rememberedLocalAppUrl()),
+    persistTargetAndRelaunch("cloud", rememberedLocalAppUrl(), rememberedLocalApiUrl()),
   );
 
   // Bundled-mode token bridge: the preload reads/writes the Bearer token here.

--- a/apps/app-desktop/src/target-store.ts
+++ b/apps/app-desktop/src/target-store.ts
@@ -11,9 +11,16 @@
  * The persisted record keeps the last local `appUrl` even while `kind` is
  * `cloud`, so "switch back to Local Brain" reuses the remembered address.
  *
+ * A self-hosted target's API base is DECLARED by the deployment itself (`GET
+ * /api/desktop-config`, fetched in `main.ts`) and only guessed from the
+ * hostname (`deriveLocalApiUrl`) when no declaration is available. Derivation
+ * covers just `localhost`, an `api.` sibling, and same-host `:4000`, so a
+ * reverse-proxied self-host serving its API on 443 under an unrelated name was
+ * previously unreachable.
+ *
  * Pure: serde + URL derivation only. The userData file I/O, the `/health`
- * probe, and the relaunch live in `main.ts`; `resolveConfig` (config.ts)
- * consumes `resolveTargetFromPersisted`'s output.
+ * probe, the config fetch, and the relaunch live in `main.ts`; `resolveConfig`
+ * (config.ts) consumes `resolveTargetFromPersisted`'s output.
  *
  * Spec: docs/architecture/features/app-desktop.md → "Dual target"
  * [COMP:app-desktop/target-store]
@@ -70,12 +77,14 @@ export function deriveApiUrl(appUrl: string): string {
 }
 
 /**
- * Pair the API base URL to a LOCAL/self-hosted app URL. Unlike `deriveApiUrl`
- * this NEVER falls back to the cloud API — a self-hosted target's traffic must
- * only ever reach its own paired backend (§2.3 "paired API only"): `localhost`
- * → `localhost:4000`, an `app.`/`canvas.`-prefixed host → its `api.` sibling
- * (a reverse-proxied self-host), anything else → the same host on `:4000`
- * (the launcher convention).
+ * Pair the API base URL to a LOCAL/self-hosted app URL — the FALLBACK used
+ * only when the deployment did not declare its own API (see
+ * `acceptDeclaredApiUrl`). Unlike `deriveApiUrl` this NEVER falls back to the
+ * cloud API — a self-hosted target's traffic must only ever reach its own
+ * paired backend (§2.3 "paired API only"): `localhost` → `localhost:4000`, an
+ * `app.`/`canvas.`-prefixed host → its `api.` sibling (a reverse-proxied
+ * self-host), anything else → the same host on `:4000` (the launcher
+ * convention).
  */
 export function deriveLocalApiUrl(appUrl: string): string {
   try {
@@ -92,6 +101,44 @@ export function deriveLocalApiUrl(appUrl: string): string {
   } catch {
     return "http://localhost:4000";
   }
+}
+
+/**
+ * Validate an API base a self-hosted deployment declared about itself
+ * (`GET /api/desktop-config`). Returns the normalized URL, or `null` to make
+ * the caller fall back to `deriveLocalApiUrl`.
+ *
+ * The one hard rule is §2.3 "paired API only": a local target must never be
+ * pointed at the CLOUD API. Letting an origin name its own backend is fine —
+ * the user consented to that origin and those are its own tokens — but a
+ * typo'd or hostile self-host must not be able to aim the shell's sign-in
+ * exchange and refresh traffic at `api.usebrian.ai`, where a real cloud
+ * session lives.
+ */
+export function acceptDeclaredApiUrl(rawUrl: string): string | null {
+  const apiUrl = normalizeTargetUrl(rawUrl);
+  if (!apiUrl) return null;
+  if (new URL(apiUrl).hostname === new URL(CLOUD_API_URL).hostname) return null;
+  return apiUrl;
+}
+
+/**
+ * Pull the declared API base out of a `/api/desktop-config` response body.
+ * Tolerant by design: an unparseable body, a missing field, or a rejected URL
+ * all yield `null`, and the caller derives instead — a deployment serving
+ * something unexpected at that path degrades to today's behavior rather than
+ * failing the connect.
+ */
+export function parseDesktopConfig(body: unknown): string | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+  const apiUrl = (body as Record<string, unknown>).apiUrl;
+  if (typeof apiUrl !== "string" || !apiUrl.trim()) return null;
+  return acceptDeclaredApiUrl(apiUrl);
+}
+
+/** The deployment self-description endpoint (an app-web route handler). */
+export function desktopConfigUrl(appUrl: string): string {
+  return `${appUrl}/api/desktop-config`;
 }
 
 /** A fully resolved target — what `resolveConfig` folds into the config. */
@@ -112,6 +159,15 @@ export interface PersistedTarget {
   readonly kind: TargetKind;
   /** The last local brain address; kept across a switch to cloud. */
   readonly appUrl?: string;
+  /**
+   * The API base the target DECLARED via `GET /api/desktop-config`, when it
+   * did. Persisted so startup stays synchronous and offline-safe:
+   * `resolveConfig` runs at module load, before any window exists, so it can
+   * never await a fetch. The declaration is re-resolved only on a switch.
+   * Absent for a target that predates the endpoint (or 404'd it) — those fall
+   * back to `deriveLocalApiUrl`.
+   */
+  readonly apiUrl?: string;
 }
 
 /**
@@ -148,14 +204,22 @@ export function cloudTarget(): ResolvedTarget {
 /**
  * Resolve a local/self-hosted target from a (possibly user-entered) URL.
  * Returns `null` when the URL doesn't normalize — never a half-built target.
+ *
+ * `declaredApiUrl` is the deployment's own answer from `/api/desktop-config`;
+ * it outranks the hostname guess because the deployment is authoritative about
+ * its own backend. It is re-validated here rather than trusted.
  */
-export function localTarget(rawUrl: string = DEFAULT_LOCAL_APP_URL): ResolvedTarget | null {
+export function localTarget(
+  rawUrl: string = DEFAULT_LOCAL_APP_URL,
+  declaredApiUrl?: string | null,
+): ResolvedTarget | null {
   const appUrl = normalizeTargetUrl(rawUrl);
   if (!appUrl) return null;
+  const declared = declaredApiUrl ? acceptDeclaredApiUrl(declaredApiUrl) : null;
   return Object.freeze({
     kind: "local" as const,
     appUrl,
-    apiUrl: deriveLocalApiUrl(appUrl),
+    apiUrl: declared ?? deriveLocalApiUrl(appUrl),
     auth: "local-session" as const,
     label: `Local Brain (${new URL(appUrl).host})`,
   });
@@ -165,7 +229,8 @@ export function localTarget(rawUrl: string = DEFAULT_LOCAL_APP_URL): ResolvedTar
  * Tolerantly parse the persisted record. Anything malformed — unreadable JSON,
  * a non-object, an unknown `kind` — is `null` (the caller falls back to
  * cloud). An `appUrl` that doesn't normalize is dropped rather than poisoning
- * the record, so a hand-edited file degrades to the default local address.
+ * the record, so a hand-edited file degrades to the default local address; a
+ * rejected `apiUrl` likewise degrades to derivation.
  */
 export function parsePersistedTarget(raw: string | null | undefined): PersistedTarget | null {
   if (!raw) return null;
@@ -179,24 +244,43 @@ export function parsePersistedTarget(raw: string | null | undefined): PersistedT
   const rec = parsed as Record<string, unknown>;
   if (rec.kind !== "cloud" && rec.kind !== "local") return null;
   const appUrl = typeof rec.appUrl === "string" ? normalizeTargetUrl(rec.appUrl) : null;
-  return Object.freeze({ v: 1 as const, kind: rec.kind, ...(appUrl ? { appUrl } : {}) });
+  // Re-validated on read, not trusted: the cloud-API guard must hold for a
+  // hand-edited file and for a record written by any other build too.
+  const apiUrl = typeof rec.apiUrl === "string" ? acceptDeclaredApiUrl(rec.apiUrl) : null;
+  return Object.freeze({
+    v: 1 as const,
+    kind: rec.kind,
+    ...(appUrl ? { appUrl } : {}),
+    ...(apiUrl ? { apiUrl } : {}),
+  });
 }
 
 /** Serialize the record `main.ts` writes to `target.json`. */
-export function serializePersistedTarget(kind: TargetKind, appUrl?: string): string {
+export function serializePersistedTarget(
+  kind: TargetKind,
+  appUrl?: string,
+  apiUrl?: string | null,
+): string {
   const normalized = appUrl ? normalizeTargetUrl(appUrl) : null;
-  return JSON.stringify({ v: 1, kind, ...(normalized ? { appUrl: normalized } : {}) });
+  const normalizedApi = apiUrl ? acceptDeclaredApiUrl(apiUrl) : null;
+  return JSON.stringify({
+    v: 1,
+    kind,
+    ...(normalized ? { appUrl: normalized } : {}),
+    ...(normalizedApi ? { apiUrl: normalizedApi } : {}),
+  });
 }
 
 /**
  * The resolution `resolveConfig` consumes: no/invalid record → cloud; a local
- * record → its remembered address (or the launcher default). A local record
- * whose address can't resolve falls back to cloud rather than a broken target.
+ * record → its remembered address (or the launcher default), paired with its
+ * remembered declaration when it has one. A local record whose address can't
+ * resolve falls back to cloud rather than a broken target.
  */
 export function resolveTargetFromPersisted(raw: string | null | undefined): ResolvedTarget {
   const rec = parsePersistedTarget(raw);
   if (!rec || rec.kind === "cloud") return cloudTarget();
-  return localTarget(rec.appUrl ?? DEFAULT_LOCAL_APP_URL) ?? cloudTarget();
+  return localTarget(rec.appUrl ?? DEFAULT_LOCAL_APP_URL, rec.apiUrl) ?? cloudTarget();
 }
 
 /**

--- a/apps/app-web/src/app/api/desktop-config/__tests__/route.test.ts
+++ b/apps/app-web/src/app/api/desktop-config/__tests__/route.test.ts
@@ -1,0 +1,105 @@
+/**
+ * [COMP:app-web/desktop-config-route] Deployment self-description for the
+ * desktop shell.
+ *
+ * `GET /api/desktop-config` is how a self-hosted brain tells the Electron
+ * shell where its own backend lives, so the user types ONE address and the
+ * shell stops guessing from the hostname (`deriveLocalApiUrl` covers only
+ * `localhost`, an `api.` sibling, and same-host `:4000` — a reverse-proxied
+ * self-host serving its API on 443 under an unrelated name was unreachable).
+ *
+ * The module reads its env at import time (module-scope consts, mirroring how
+ * Next inlines `NEXT_PUBLIC_*` at build), so every case re-imports under
+ * `vi.resetModules()` with the env set first.
+ *
+ * Spec: docs/architecture/features/app-desktop.md → "The declared API".
+ */
+
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+
+const ENV_KEYS = [
+  "NEXT_PUBLIC_API_URL",
+  "API_URL",
+  "NEXT_PUBLIC_DOC_SYNC_URL",
+  "NEXT_PUBLIC_USEBRIAN_EDITION",
+  // Scrubbed too: server-side `isOssEdition()` also honours this runtime var,
+  // so leaving an ambient value set would decide the edition cases for us.
+  "USEBRIAN_EDITION",
+] as const;
+
+let saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const k of ENV_KEYS) delete process.env[k];
+  vi.resetModules();
+});
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+/** Import the route fresh so its module-scope env reads re-evaluate. */
+async function getConfig(): Promise<{ status: number; body: Record<string, unknown> }> {
+  const { GET } = await import("../route");
+  const res = await GET();
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+describe("[COMP:app-web/desktop-config-route] GET /api/desktop-config", () => {
+  it("reports the BROWSER-facing API origin, not the server-side hop", async () => {
+    // The case that motivates the whole endpoint: on a reverse-proxied
+    // self-host these differ — the browser dials the public hostname while
+    // API_URL is an internal localhost hop. The shell must dial what the
+    // browser dials, or its token exchange lands on the wrong backend.
+    process.env.NEXT_PUBLIC_API_URL = "https://backend.example.com";
+    process.env.API_URL = "http://localhost:4000";
+
+    const { status, body } = await getConfig();
+    expect(status).toBe(200);
+    expect(body.apiUrl).toBe("https://backend.example.com");
+  });
+
+  it("falls back to the server-side API_URL when only that is set", async () => {
+    process.env.API_URL = "https://api.example.com";
+    expect((await getConfig()).body.apiUrl).toBe("https://api.example.com");
+  });
+
+  it("falls back to the local dev API when neither is set", async () => {
+    expect((await getConfig()).body.apiUrl).toBe("http://localhost:4000");
+  });
+
+  it("reports the doc-sync origin when pinned, else null", async () => {
+    process.env.NEXT_PUBLIC_DOC_SYNC_URL = "wss://docsync.example.com";
+    expect((await getConfig()).body.docSyncUrl).toBe("wss://docsync.example.com");
+
+    vi.resetModules();
+    delete process.env.NEXT_PUBLIC_DOC_SYNC_URL;
+    expect((await getConfig()).body.docSyncUrl).toBeNull();
+  });
+
+  it("reports the edition, so the shell can explain a hosted-edition self-host", async () => {
+    // A hosted-edition brain is reachable but cannot mint a local-owner
+    // session; the shell surfaces that instead of stranding the user on a 404.
+    process.env.NEXT_PUBLIC_USEBRIAN_EDITION = "oss";
+    expect((await getConfig()).body.edition).toBe("oss");
+
+    vi.resetModules();
+    delete process.env.NEXT_PUBLIC_USEBRIAN_EDITION;
+    expect((await getConfig()).body.edition).toBe("hosted");
+  });
+
+  it("is uncached — a moved backend must not be served from a stale copy", async () => {
+    const { GET } = await import("../route");
+    expect((await GET()).headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("discloses only the public origins the client bundle already carries", async () => {
+    process.env.NEXT_PUBLIC_API_URL = "https://api.example.com";
+    const { body } = await getConfig();
+    expect(Object.keys(body).sort()).toEqual(["apiUrl", "docSyncUrl", "edition"]);
+  });
+});

--- a/apps/app-web/src/app/api/desktop-config/route.ts
+++ b/apps/app-web/src/app/api/desktop-config/route.ts
@@ -1,0 +1,60 @@
+// Next.js Route Handler — GET /api/desktop-config
+//
+// Deployment self-description for the desktop shell. The Electron app lets a
+// user point it at a self-hosted brain by typing ONE address (the app URL);
+// this endpoint is how that deployment then declares where its own backend
+// lives, instead of the shell guessing from the hostname.
+//
+// Why an endpoint and not "read it from the page": `NEXT_PUBLIC_*` is inlined
+// by Next as a bare string literal inside webpack module closures at build
+// time. It is not on `window` and `process.env.NEXT_PUBLIC_API_URL` does not
+// survive into the client bundle, so nothing outside the bundle can read it.
+// The shell also needs the value BEFORE it commits to a target — the
+// pre-switch `/health` probe in main.ts `run-local` validates the brain before
+// persisting and relaunching — which rules out anything only readable after
+// the page has loaded in the window.
+//
+// We report the BROWSER-facing origins (`NEXT_PUBLIC_*`), not the server-side
+// `API_URL`: on a reverse-proxied self-host those differ (`API_URL` is often an
+// internal `localhost:4000` hop, while the browser dials the public hostname),
+// and the shell dials the API the same way the browser does. Being read inside
+// a route handler, the `NEXT_PUBLIC_*` reads are inlined at BUILD time, so they
+// report what the client actually calls even when those vars are absent from
+// the runtime environment (the built self-host case).
+//
+// Public and unauthenticated by necessity — the shell calls it before any
+// session exists. It discloses nothing secret: every value here is already
+// shipped inside the public client bundle.
+//
+// Older self-hosts predate this route and 404; the shell falls back to
+// `deriveLocalApiUrl` there, so this is additive.
+//
+// Spec: docs/architecture/features/app-desktop.md → "Dual target"
+// Component-map tag: [COMP:app-web/desktop-config-route].
+
+import { NextResponse } from "next/server";
+import { isOssEdition } from "@/lib/edition";
+
+// The browser-facing API origin. `NEXT_PUBLIC_API_URL` is the one the client
+// bundle uses; `API_URL` is the server-side hop and is only a last resort (it
+// may be an internal address, but it beats defaulting to a dev port on a
+// deployment that set only the server var).
+const API_URL =
+  process.env.NEXT_PUBLIC_API_URL || process.env.API_URL || "http://localhost:4000";
+
+/** The doc-sync WebSocket origin, when this deployment pins one explicitly. */
+const DOC_SYNC_URL = process.env.NEXT_PUBLIC_DOC_SYNC_URL || null;
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      // The shell reads `apiUrl` to pair its target; the rest is discovery
+      // context (the shell surfaces `edition` to explain a brain that is
+      // reachable but cannot mint a local-owner session).
+      apiUrl: API_URL,
+      docSyncUrl: DOC_SYNC_URL,
+      edition: isOssEdition() ? "oss" : "hosted",
+    },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}


### PR DESCRIPTION
## Summary

- The desktop shell pairs a self-hosted target's API by guessing from the app hostname (`deriveLocalApiUrl`), which only covers `localhost`, an `api.` sibling, and same-host `:4000`. A reverse-proxied self-host serving its API on 443 under an unrelated name was therefore **unreachable** — the shell probed a dead port and reported the brain down.
- Adds `GET /api/desktop-config` to app-web, so the deployment declares `{ apiUrl, docSyncUrl, edition }` about itself. It reports the browser-facing `NEXT_PUBLIC_*` origins rather than the server-side `API_URL` (on a proxied self-host those differ), and being read in a route handler those are inlined at build time — so it reports what the client actually calls even when absent from the runtime env, which is the built self-host case.
- The shell fetches it in the `run-local` IPC before the health probe; the declaration outranks derivation, which stays as the fallback so self-hosts predating the route and the launcher's `:3003`/`:4000` convention keep working. The result is persisted into `target.json` because startup must stay synchronous — `resolveConfig` runs at module load and can never await a fetch.
- A declaration pointing at the cloud API is refused and re-validated on every read, keeping the "paired API only" rule intact: a typo'd or hostile self-host must not aim the shell's sign-in exchange at `api.usebrian.ai`.

An endpoint is required rather than reading the value off the page: Next inlines `NEXT_PUBLIC_*` as a bare literal inside module closures, so it is not on `window` and does not survive as `process.env` in the bundle. The shell also needs the value *before* it commits to a target, which rules out anything readable only after the page loads.

Paired docs: brian-platform#227. KB entry: brian-kb#26.

## Test plan

- [ ] `pnpm --filter @use-brian/app-desktop test` — 207 pass (12 new in `target-store.test.ts`)
- [ ] `pnpm --filter app-web test` — 7 new in `desktop-config/__tests__/route.test.ts`
- [ ] `pnpm typecheck` on both apps
- [ ] Manual: point the desktop app at a reverse-proxied self-host (API on 443 under a non-`api.` name) and confirm Connect now succeeds where it previously reported unreachable
- [ ] Manual: confirm a `localhost:3003` launcher brain still connects (derivation fallback)
- [ ] Manual: confirm a self-host predating the route (404s `/api/desktop-config`) still connects via derivation