### PR TITLE
fix(providers): serve every background lane without a Google credential

### DIFF
--- a/packages/api/src/__tests__/model-resolution.test.ts
+++ b/packages/api/src/__tests__/model-resolution.test.ts
@@ -12,6 +12,8 @@ import {
   wouldBudgetDowngradeAffectModel,
   chatTierBudget,
   ensureServableModel,
+  backgroundModelFor,
+  BACKGROUND_MODEL,
   backgroundLatencyBudgetMs,
 } from '../model-resolution.js'
 
@@ -316,5 +318,30 @@ describe('[COMP:api/model-resolution] backgroundLatencyBudgetMs — budget follo
 
   it('falls back to the tight budget for an unknown id', () => {
     expect(backgroundLatencyBudgetMs('not-a-real-model')).toBe(10_000)
+  })
+})
+
+describe('[COMP:api/model-resolution] backgroundModelFor — the lane seam boot injects', () => {
+  const GEMINI = new Set(['gemini'])
+  const QWEN = new Set(['openai-compat:dashscope-intl'])
+
+  it('resolves the Gemini workhorse when Gemini is configured', () => {
+    expect(backgroundModelFor(GEMINI)).toBe(BACKGROUND_MODEL)
+  })
+
+  it('resolves the Qwen background model on a Google-free deploy', () => {
+    // The lane is hardcoded at ~17 call sites; this is the single seam that
+    // keeps them alive when the routing provider has no Gemini entry.
+    expect(backgroundModelFor(QWEN)).toBe('qwen3.5-flash')
+  })
+
+  it('falls back to the literal when the caller has no boot context', () => {
+    // Leaf modules and tests call the lanes without a provider table; they
+    // must behave exactly as they did before the injection existed.
+    expect(backgroundModelFor(undefined)).toBe(BACKGROUND_MODEL)
+  })
+
+  it('is a no-op when nothing is configured, so routing still fails loudly', () => {
+    expect(backgroundModelFor(new Set())).toBe(BACKGROUND_MODEL)
   })
 })

--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -142,6 +142,8 @@ import { createDbMagicLinkStore } from './db/magic-link-store.js'
 import { createSmtpClient, createWorkspaceSmtpTransport } from './email/smtp-client.js'
 import { chatRoutes, runSessionResume, tryResolveLiveToolApproval } from './routes/chat.js'
 import { menuForClass } from '@use-brian/shared/model-registry'
+import { BACKGROUND_MODEL, ensureServableModel } from './model-resolution.js'
+import { EXTRACTION_MODEL } from './build-episode-ingestors.js'
 import { createMeteredProfileStore } from './db/metered-profile-store.js'
 import { createWorkspaceModelDefaultsStore } from './db/workspace-model-defaults-store.js'
 import { createSessionResumeReplay } from './routes/session-resume-replay.js'
@@ -210,7 +212,6 @@ import { createGeminiSkillReviewLLM } from './workers/skill-review-llm.js'
 import { createWorkflowLifecycleWorker } from './workers/workflow-lifecycle-worker.js'
 import {
   createGeminiWorkflowDigestLLM,
-  WORKFLOW_DIGEST_MODEL,
 } from './workers/workflow-digest-llm.js'
 import { buildWorkspaceCuratorScope } from './workers/workspace-curator-scope.js'
 import { loadSkillRegistry } from './registry/load-skill-registry.js'
@@ -553,6 +554,14 @@ export interface OpenApiEnv {
  */
 export interface EpisodeIngestorDeps {
   provider: LLMProvider
+  /**
+   * The background lane's servable model id, resolved once at boot against the
+   * configured providers. Absent = the caller had no boot context (tests, the
+   * platform factory pre-dating this) and the ingestor keeps its own default.
+   */
+  backgroundModel?: string
+  /** Same, for the chat-class extraction model Pipeline B runs episodes through. */
+  extractionModel?: string
   crmStore: ReturnType<typeof createDbCrmStore>
   entitiesStore: ReturnType<typeof createDbEntitiesStore>
   entityLinksStore: ReturnType<typeof createDbEntityLinksStore>
@@ -1170,6 +1179,27 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
   const meteredModelsAvailable: ReadonlySet<string> = new Set(
     menuForClass('metered', configuredProviders).map((r) => r.alias),
   )
+  // The background lane is internal routing with no menu, so L12 can't drop a
+  // keyless model out of it the way it does for chat: the id is baked into the
+  // call sites. Resolve it once here and inject the result, or a deployment
+  // without a Google credential loses every background job — auto-title, memory
+  // splitting, classification, digests, themes, skill review. Logged because
+  // this lane spends real money and shapes what the brain extracts, so which
+  // model serves it should never be implicit.
+  const backgroundModel = configuredProviders.size > 0
+    ? ensureServableModel(BACKGROUND_MODEL, configuredProviders)
+    : BACKGROUND_MODEL
+  if (backgroundModel !== BACKGROUND_MODEL) {
+    console.log(`[provider] background lane: ${backgroundModel} (${BACKGROUND_MODEL} not servable)`)
+  }
+  // Pipeline B's extraction model is chat-class, not background-class, but it
+  // is hardcoded the same way and dies the same way without a Google key.
+  const extractionModel = configuredProviders.size > 0
+    ? ensureServableModel(EXTRACTION_MODEL, configuredProviders)
+    : EXTRACTION_MODEL
+  if (extractionModel !== EXTRACTION_MODEL) {
+    console.log(`[provider] extraction: ${extractionModel} (${EXTRACTION_MODEL} not servable)`)
+  }
   const provider: LLMProvider = createRoutingProvider(providerInstances, {
     analytics: {
       onFallback({ primaryModel, fallbackModel, errorKind, errorStatus }) {
@@ -1443,6 +1473,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     tools.set('stopWorker', stopWorker)
 
     const { createScheduledJob, updateScheduledJob, searchScheduledJobs, deleteScheduledJob } = createSchedulingTools({
+      backgroundModel,
       jobStore,
       workflowStore,
       provider,
@@ -1578,6 +1609,8 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
   const builtIngestors = ports.buildEpisodeIngestors?.({
     provider, crmStore, entitiesStore, entityLinksStore, memoryStore, taskStore, episodesStore, analytics,
     usageStore,
+    backgroundModel,
+    extractionModel,
     ingestCharge: ports.ingestCharge,
   })
   const chatEpisodeIngestor: ChatEpisodeIngestor =
@@ -2595,7 +2628,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
   // draft goal with the generated brief; on fail/error, no draft (fail-closed).
   // Wired only when a provider is configured, so keyless OSS never logs judge
   // errors — tasks simply stay goal-free.
-  const TRIAGE_MODEL = 'gemini-3.1-flash-lite'
+  const TRIAGE_MODEL = backgroundModel
   if (configuredProviders.size > 0) {
     const taskTriageJudge = createTaskTriageJudge({
       provider,
@@ -4014,7 +4047,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
 
   app.use('/api', requireAuth(env.JWT_SECRET), docEntitiesRoutes({ docEntityStore, workspaceStore }))
 
-  app.use('/api', requireAuth(env.JWT_SECRET), docThemesRoutes({ docThemesStore, workspaceStore, provider }))
+  app.use('/api', requireAuth(env.JWT_SECRET), docThemesRoutes({ docThemesStore, workspaceStore, provider, backgroundModel }))
 
   const commentThreadStore = createDbCommentThreadStore()
   const docNotificationsStore = createDbDocNotificationsStore()
@@ -4449,7 +4482,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
   }
 
   // ── Skill-review worker ──
-  const SKILL_REVIEW_MODEL = 'gemini-3.1-flash-lite'
+  const SKILL_REVIEW_MODEL = backgroundModel
   const skillReviewLLM = createGeminiSkillReviewLLM(
     async ({ systemPrompt, prompt, maxTokens, attribution }) => {
       const response = await collectStream(provider.stream({
@@ -4503,13 +4536,13 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
   const workflowDigestLLM = createGeminiWorkflowDigestLLM(
     async ({ systemPrompt, prompt, maxTokens, attribution }) => {
       const response = await collectStream(provider.stream({
-        model: WORKFLOW_DIGEST_MODEL,
+        model: backgroundModel,
         messages: [{ role: 'user', content: prompt }],
         systemPrompt,
         maxTokens,
       }))
       if (response.usage && usageStore) {
-        const cost = calculateCost(WORKFLOW_DIGEST_MODEL, response.usage)
+        const cost = calculateCost(backgroundModel, response.usage)
         usageStore.recordUsage({
           userId: attribution.userId,
           // Blank assistant + workspace fallback — the mig-305 attribution
@@ -4517,7 +4550,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
           assistantId: '',
           workspaceId: attribution.workspaceId,
           sessionId: null,
-          model: WORKFLOW_DIGEST_MODEL,
+          model: backgroundModel,
           inputTokens: response.usage.inputTokens,
           outputTokens: response.usage.outputTokens,
           cacheReadTokens: response.usage.cacheReadTokens,
@@ -5029,6 +5062,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
         runPipeline: async ({ ctx: channel, input, hooks, abortController }) => {
           if (!channel.assistantId) return
           await processChannelMessage({
+            backgroundModel,
             userId: channel.ownerUserId,
             ownerId: channel.ownerUserId,
             assistant: {
@@ -5106,6 +5140,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     // JWT guard. All gated on the integration store (CHANNEL_CREDENTIAL_KEY).
     if (integrationStore) {
       app.use('/webhook/telegram', telegramByoRoutes({
+        backgroundModel,
         provider, systemPrompt: LAYER_1_SYSTEM_PROMPT, tools: allTools, capabilityStore,
         memoryStore, usageStore, checkCreditBudget: ports.checkCreditBudget,
         appUrl: env.APP_URL, apiUrl: env.API_URL, integrationStore,
@@ -5119,6 +5154,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
         artifactPromoter, fileStore,
       }))
       app.use('/webhook/slack', slackRoutes({
+        backgroundModel,
         ingestChannelMediaRef: channelHosts.slackIngestChannelMediaRef,
         artifactPromoter,
         provider, systemPrompt: LAYER_1_SYSTEM_PROMPT, tools: allTools, capabilityStore,
@@ -5135,6 +5171,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
       // JWT-verified. No connector app (webhook transport). See
       // docs/architecture/channels/msteams.md.
       app.use('/webhook/msteams', msteamsRoutes({
+        backgroundModel,
         provider, systemPrompt: LAYER_1_SYSTEM_PROMPT, tools: allTools, capabilityStore,
         memoryStore, usageStore, checkCreditBudget: ports.checkCreditBudget,
         integrationStore, channelUserStore,
@@ -5146,6 +5183,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
       }))
       if (env.DISCORD_CONNECTOR_SECRET) {
         app.use('/internal/discord', discordRoutes({
+        backgroundModel,
           ingestChannelMediaRef: channelHosts.discordIngestChannelMediaRef,
           artifactPromoter,
           connectorSecret: env.DISCORD_CONNECTOR_SECRET, provider, systemPrompt: LAYER_1_SYSTEM_PROMPT,

--- a/packages/api/src/build-episode-ingestors.ts
+++ b/packages/api/src/build-episode-ingestors.ts
@@ -77,8 +77,12 @@ export function buildEpisodeIngestors(deps: EpisodeIngestorDeps): {
   // per call so the closure stays stateless (the stores themselves are shared).
   const pipelineDeps = (): PipelineBDeps => ({
     provider: deps.provider,
-    model: EXTRACTION_MODEL,
-    classifierModel: CLASSIFIER_MODEL,
+    // Both fall back to their literals when boot supplied nothing (tests, a
+    // platform factory that predates the injection). Boot passes ids it has
+    // already checked are servable, so a Google-free deploy extracts instead
+    // of throwing on every episode.
+    model: deps.extractionModel ?? EXTRACTION_MODEL,
+    classifierModel: deps.backgroundModel ?? CLASSIFIER_MODEL,
     crm: deps.crmStore,
     entities: deps.entitiesStore,
     entityLinks: deps.entityLinksStore,

--- a/packages/api/src/doc/auto-title.ts
+++ b/packages/api/src/doc/auto-title.ts
@@ -30,6 +30,8 @@ import {
 import { pageToPlaintext } from '@use-brian/doc-model'
 
 export type RunDocAutoTitleParams = {
+  /** Servable background-lane model; omitted = the generator's own default. */
+  backgroundModel?: string
   userId: string
   pageId: string
   provider: LLMProvider
@@ -70,7 +72,7 @@ const SKIPPED: RunDocAutoTitleResult = {
 export async function runDocAutoTitle(
   params: RunDocAutoTitleParams,
 ): Promise<RunDocAutoTitleResult> {
-  const { userId, pageId, provider, docPageStore, savedViewStore, minChars } = params
+  const { userId, pageId, provider, docPageStore, savedViewStore, minChars, backgroundModel } = params
 
   // 1. Read the merged page (prefers the live Yjs snapshot). `nameOrigin`
   //    rides along — only 'placeholder' pages are eligible.
@@ -85,7 +87,7 @@ export async function runDocAutoTitle(
   // 3. Generate. Null when the model can't produce a meaningful title — keep
   //    the placeholder rather than overwrite it (attribution still returned).
   //    `gen.icon` is a suggested emoji (may be null).
-  const gen = await generatePageTitle(provider, text)
+  const gen = await generatePageTitle(provider, text, backgroundModel)
   if (!gen.title) {
     return { applied: false, title: null, icon: null, usage: gen.usage, model: gen.model }
   }

--- a/packages/api/src/doc/inject.ts
+++ b/packages/api/src/doc/inject.ts
@@ -153,6 +153,9 @@ export type InjectDocToolsOptions = {
   activeThemeId?: string | null
   /** Provider for `refineActiveTheme`'s seed-adjustment call. */
   provider?: LLMProvider
+  /** Servable background-lane model, resolved by the caller against the
+   * configured providers. Forwarded to the theme tool's LLM call. */
+  backgroundModel?: string
   /** Themes store for `refineActiveTheme`; falls back to the lazy singleton. */
   docThemesStore?: DocThemeStore
   /** Fired after a chat-driven theme refine so the route can stream the new
@@ -466,6 +469,7 @@ export async function injectDocTools(
     const refineActiveTheme = createRefineActiveThemeTool({
       themeId: options.activeThemeId,
       provider: options.provider,
+      model: options.backgroundModel,
       store:
         options.docThemesStore ?? (cachedDocThemesStore ??= createDbDocThemesStore()),
       onRefined: options.onThemeRefined,

--- a/packages/api/src/doc/theme-tools.ts
+++ b/packages/api/src/doc/theme-tools.ts
@@ -28,6 +28,8 @@ import type { DocThemeStore } from '../db/doc-themes-store.js'
 import { refineCustomTheme, ThemeGenerationError } from './theme-generator.js'
 
 export type RefineActiveThemeDeps = {
+  /** Servable background-lane model; omitted = the generator's own default. */
+  model?: string
   /** The custom theme the user currently has applied (from turn context). */
   themeId: string
   provider: LLMProvider
@@ -73,6 +75,7 @@ export function createRefineActiveThemeTool(deps: RefineActiveThemeDeps): Tool {
       try {
         refined = await refineCustomTheme({
           provider: deps.provider,
+          model: deps.model,
           currentSeed: theme.seed,
           instruction: input.instruction,
         })

--- a/packages/api/src/model-resolution.ts
+++ b/packages/api/src/model-resolution.ts
@@ -25,6 +25,18 @@ import {
 } from '@use-brian/shared/model-registry'
 
 /**
+ * The background-lane workhorse: extraction / classification / structured
+ * output, per docs/architecture/platform/cost-and-pricing.md → Model routing.
+ *
+ * Lives here rather than in each lane so there is ONE literal to change, and
+ * so `ensureServableModel` is the obvious next step at every read. Never send
+ * this to a provider unresolved — on a deployment with no Google credential it
+ * is not servable and the routing provider throws. Boot resolves it once
+ * against the configured providers and injects the result into every lane.
+ */
+export const BACKGROUND_MODEL = 'gemini-3.1-flash-lite'
+
+/**
  * Ensure the resolved model can actually be served by a configured provider,
  * substituting a configured chat model when it can't.
  *
@@ -73,6 +85,15 @@ export function ensureServableModel(
     if (rows.length > 0) return rows[0].alias
   }
   return model
+}
+
+/**
+ * The servable background-lane id for a request, given boot's configured
+ * providers. `undefined` providers (a caller with no boot context) keeps the
+ * literal, which is what the pre-substitution code did.
+ */
+export function backgroundModelFor(configuredProviders?: ReadonlySet<string>): string {
+  return configuredProviders ? ensureServableModel(BACKGROUND_MODEL, configuredProviders) : BACKGROUND_MODEL
 }
 
 /**

--- a/packages/api/src/routes/channel-pipeline.ts
+++ b/packages/api/src/routes/channel-pipeline.ts
@@ -54,7 +54,7 @@ import {
   getGroupChatContext, buildGroupChatContextPrompt, getSessionTopicLabels,
   markDowngradeNoticeSent, clearDowngradeNotice,
 } from '../db/sessions.js'
-import { resolveModel, wouldBudgetDowngradeAffectModel, chatTierBudget } from '../model-resolution.js'
+import { resolveModel, wouldBudgetDowngradeAffectModel, chatTierBudget, BACKGROUND_MODEL } from '../model-resolution.js'
 import type { ConnectorStore } from '../db/connector-store.js'
 import type { AssistantConnectorStore } from '../db/assistant-connector-store.js'
 import type { PendingMessageStore } from '../db/pending-message-store.js'
@@ -262,6 +262,12 @@ export type ChannelHooks = {
 // ── Pipeline params ──────────────────────────────────────────────
 
 export type ChannelPipelineParams = {
+  /**
+   * Background-lane model, resolved once at boot against the configured
+   * providers. Omitted = fall back to the literal, which is only servable
+   * where a Google credential exists.
+   */
+  backgroundModel?: string
   // ── Identity ──
   /** The user whose session this is (channel user or owner). */
   userId: string
@@ -572,6 +578,12 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
     capabilityStore,
   } = params
 
+  // Every background call in this pipeline (session-state diff, memory nudge,
+  // research classifier) runs on this one id. Boot resolves it against the
+  // configured providers; the literal is the fallback for callers without
+  // boot context.
+  const laneModel = params.backgroundModel ?? BACKGROUND_MODEL
+
   // `messageText` + `userContentBlocks` are `let` — the large-paste intercept
   // below may rewrite them to a manifest + head excerpt before anything reads
   // them (classifier, persist, query loop).
@@ -660,7 +672,7 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
   ) {
     try {
       const { classifyResearchIntent } = await import('@use-brian/core')
-      const adaptive = await classifyResearchIntent({ provider, message: messageText })
+      const adaptive = await classifyResearchIntent({ provider, message: messageText, model: laneModel })
       if (adaptive.research) {
         effectiveModelAlias = 'research'
         adaptiveResearchActive = true
@@ -1632,7 +1644,7 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
             provider,
             // Standard tier per docs/architecture/platform/cost-and-pricing.md
             // → Model routing (extraction / classification / structured-output bucket).
-            model: 'gemini-3.1-flash-lite',
+            model: laneModel,
             sessionId: session.id,
             userId,
             assistantId: assistant.id,
@@ -1677,7 +1689,7 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
         turns: pendingAssistantTurns,
         callModel: async (prompt) => {
           const resp = await collectStream(provider.stream({
-            model: 'gemini-3.1-flash-lite',
+            model: laneModel,
             messages: [{ role: 'user', content: prompt }],
             systemPrompt: 'You are a memory utility judge. Follow instructions exactly.',
             maxTokens: 256,
@@ -1688,7 +1700,7 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
               .map((b) => b.text)
               .join(''),
             usage: resp.usage,
-            model: 'gemini-3.1-flash-lite',
+            model: laneModel,
           }
         },
         store: memoryStore,

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -28,7 +28,7 @@ import { notifyBrainWriteIfMatch } from '../brain-stream/notify.js'
 // no-op/false/null/unset defaults in chatRoutes(). See oss §12.5.
 import type { Message, LLMProvider, Tool, MemoryStore, UsageStore, AnalyticsLogger, FileStore, ContentBlock, CacheStore, McpSettingsStore, ConfirmationDecision, ConfirmationResolver, TopicClassification, ClassifierRecentTurn, EpisodicStore, CapabilityStore, RetrievalStore, TranscribeResult, TokenUsage, WorkerResult, EngineHooks } from '@use-brian/core'
 
-import { resolveModel, ensureServableModel, backgroundLatencyBudgetMs, isStandardTier, chatTierBudget, planNudgeCap } from '../model-resolution.js'
+import { resolveModel, ensureServableModel, backgroundLatencyBudgetMs, backgroundModelFor, isStandardTier, chatTierBudget, planNudgeCap } from '../model-resolution.js'
 import { registryRow } from '@use-brian/shared/model-registry'
 import { buildPendingContext } from '../inter-assistant/pending-context.js'
 import type { ConnectorStore } from '../db/connector-store.js'
@@ -906,14 +906,6 @@ export function resolveStickyChannelId(
  */
 type GenerateTitleResult = { title: string | null; usage: TokenUsage | null; model: string | null }
 
-/**
- * The background-lane workhorse: extraction / classification / structured
- * output, per docs/architecture/platform/cost-and-pricing.md → Model routing.
- * Always pass this through `ensureServableModel` before use — on a deployment
- * with no Google credential it is not servable and the routing provider throws.
- */
-const BACKGROUND_MODEL = 'gemini-3.1-flash-lite'
-
 async function generateTitle(provider: LLMProvider, messages: Message[], model: string): Promise<GenerateTitleResult> {
   const filteredMessages = messages
     .filter((m) => m.role === 'user' || m.role === 'assistant')
@@ -954,13 +946,13 @@ async function generateTitle(provider: LLMProvider, messages: Message[], model: 
     const firstUserText = filteredMessages.find((m) => m.role === 'user')?.text ?? ''
     const fallback = sanitizeTitle(firstUserText)
     if (fallback.split(/\s+/).length >= 2) {
-      return { title: fallback.charAt(0).toUpperCase() + fallback.slice(1), usage, model: 'gemini-3.1-flash-lite' }
+      return { title: fallback.charAt(0).toUpperCase() + fallback.slice(1), usage, model }
     }
   }
   return {
     title: cleaned.length > 0 ? cleaned : null,
     usage,
-    model: 'gemini-3.1-flash-lite',
+    model,
   }
 }
 
@@ -1618,6 +1610,7 @@ export function chatRoutes(options: WebChatOptions): Router {
         const adaptive = await classifyResearchIntent({
           provider: options.provider,
           message,
+          model: backgroundModelFor(options.configuredProviders),
         }).catch(() => ({ research: false, operateSite: false, reason: null, usage: null, model: null }))
         adaptiveResearchOverhead = {
           model: adaptive.model,
@@ -3247,6 +3240,7 @@ export function chatRoutes(options: WebChatOptions): Router {
           const { injectDocTools } = await import('../doc/inject.js')
           await injectDocTools({
             tools: allTools,
+            backgroundModel: backgroundModelFor(options.configuredProviders),
             userId: user.id,
             assistant: {
               id: assistant.id,
@@ -3738,7 +3732,7 @@ export function chatRoutes(options: WebChatOptions): Router {
           // being true here means the explicit toggle: splitter is moot.
           if (!researchMode && !operateSiteIntent) {
             const { classifySplit } = await import('@use-brian/core')
-            const splitResult = await classifySplit({ provider: options.provider, message })
+            const splitResult = await classifySplit({ provider: options.provider, message, model: backgroundModelFor(options.configuredProviders) })
               .catch(() => ({ tasks: null, usage: null, model: null }))
             // Attribute splitter tokens as overhead. Recorded regardless of
             // whether the classifier chose to split — the Gemini call happened.
@@ -5113,9 +5107,7 @@ export function chatRoutes(options: WebChatOptions): Router {
             .then((open: SessionStateRecord[]) =>
               runSessionStateDiff({
                 provider: options.provider,
-                model: options.configuredProviders
-                  ? ensureServableModel(BACKGROUND_MODEL, options.configuredProviders)
-                  : BACKGROUND_MODEL,
+                model: backgroundModelFor(options.configuredProviders),
                 sessionId: session.id,
                 userId: user.id,
                 assistantId: assistant.id,
@@ -5154,11 +5146,12 @@ export function chatRoutes(options: WebChatOptions): Router {
         // Records usage as `overhead:nudge` once the judge call returns.
         // Standard tier per docs/architecture/platform/cost-and-pricing.md
         // → Model routing (extraction / classification / structured-output bucket).
+        const nudgeModel = backgroundModelFor(options.configuredProviders)
         runMemoryNudge({
           turns: pendingAssistantTurns,
           callModel: async (prompt) => {
             const resp = await collectStream(options.provider.stream({
-              model: 'gemini-3.1-flash-lite',
+              model: nudgeModel,
               messages: [{ role: 'user', content: prompt }],
               systemPrompt: 'You are a memory utility judge. Follow instructions exactly.',
               maxTokens: 256,
@@ -5166,7 +5159,7 @@ export function chatRoutes(options: WebChatOptions): Router {
             return {
               text: resp.content.filter((b): b is { type: 'text'; text: string } => b.type === 'text').map((b) => b.text).join(''),
               usage: resp.usage,
-              model: 'gemini-3.1-flash-lite',
+              model: nudgeModel,
             }
           },
           store: options.memoryStore,
@@ -5415,9 +5408,7 @@ export function chatRoutes(options: WebChatOptions): Router {
         // `title_update` event for this turn.
         // Resolved once: the same model drives the call and its latency budget,
         // so a slower serving provider can never be given the Gemini deadline.
-        const autoTitleModel = options.configuredProviders
-          ? ensureServableModel(BACKGROUND_MODEL, options.configuredProviders)
-          : BACKGROUND_MODEL
+        const autoTitleModel = backgroundModelFor(options.configuredProviders)
         const AUTO_TITLE_TIMEOUT_MS = backgroundLatencyBudgetMs(autoTitleModel)
         const autoTitle = (async () => {
           try {
@@ -5616,6 +5607,7 @@ export function chatRoutes(options: WebChatOptions): Router {
                 docPageStore,
                 savedViewStore,
                 minChars: AUTO_TITLE_AI_MIN_CHARS,
+                backgroundModel: backgroundModelFor(options.configuredProviders),
               })
               if (result.applied && result.title && !res.writableEnded) {
                 // `icon` is the emoji the generator suggested + the commit

--- a/packages/api/src/routes/discord.ts
+++ b/packages/api/src/routes/discord.ts
@@ -42,6 +42,9 @@ import { billingPartyForAssistant } from '../billing-party.js'
 import { classifyMedia, buildDocumentFiledReply, buildOversizeDocReply } from '../ingest/channel-media-intake.js'
 
 export type DiscordRouteOptions = {
+  /** Servable background-lane model, resolved at boot; forwarded to the
+   * channel pipeline so its background calls work without a Google key. */
+  backgroundModel?: string
   /** Shared secret the connector presents on every call (DISCORD_CONNECTOR_SECRET). */
   connectorSecret: string
   provider: LLMProvider
@@ -504,6 +507,7 @@ export function discordRoutes(options: DiscordRouteOptions): Router {
     const abortController = new AbortController()
 
     await processChannelMessage({
+      backgroundModel: options.backgroundModel,
       userId: channelUserId,
       ownerId,
       assistant: { ...assistant, ownerUserId: ownerId },

--- a/packages/api/src/routes/doc-themes.ts
+++ b/packages/api/src/routes/doc-themes.ts
@@ -41,6 +41,8 @@ export type DocThemesRouteOptions = {
   workspaceStore: WorkspaceStore
   /** Optional — when unset, POST (the only model-using route) returns 503. */
   provider?: LLMProvider
+  /** Servable background-lane model, resolved at boot. */
+  backgroundModel?: string
 }
 
 const createSchema = z.object({ prompt: z.string().trim().min(1).max(600) })
@@ -111,7 +113,7 @@ export function docThemesRoutes(opts: DocThemesRouteOptions): Router {
 
     let generated
     try {
-      generated = await generateCustomTheme({ provider: opts.provider, prompt: parsed.data.prompt })
+      generated = await generateCustomTheme({ provider: opts.provider, prompt: parsed.data.prompt, model: opts.backgroundModel })
     } catch (err) {
       if (err instanceof ThemeGenerationError) {
         return res.status(422).json({ error: err.message })
@@ -180,6 +182,7 @@ export function docThemesRoutes(opts: DocThemesRouteOptions): Router {
     try {
       refined = await refineCustomTheme({
         provider: opts.provider,
+        model: opts.backgroundModel,
         currentSeed: theme.seed,
         instruction: parsed.data.instruction,
       })

--- a/packages/api/src/routes/msteams.ts
+++ b/packages/api/src/routes/msteams.ts
@@ -76,6 +76,9 @@ export type MsTeamsWebhookIngestor = {
 }
 
 export type MsTeamsRouteOptions = {
+  /** Servable background-lane model, resolved at boot; forwarded to the
+   * channel pipeline so its background calls work without a Google key. */
+  backgroundModel?: string
   provider: LLMProvider
   systemPrompt: string
   tools: Map<string, Tool>
@@ -367,6 +370,7 @@ export function msteamsRoutes(options: MsTeamsRouteOptions): Router {
     const abortController = new AbortController()
 
     await processChannelMessage({
+      backgroundModel: options.backgroundModel,
       userId: channelUserId,
       ownerId,
       assistant: { ...assistant, ownerUserId: ownerId },

--- a/packages/api/src/routes/slack.ts
+++ b/packages/api/src/routes/slack.ts
@@ -102,6 +102,9 @@ export type SlackWebhookIngestor = {
 }
 
 type SlackRouteOptions = {
+  /** Servable background-lane model, resolved at boot; forwarded to the
+   * channel pipeline so its background calls work without a Google key. */
+  backgroundModel?: string
   provider: LLMProvider
   systemPrompt: string
   tools: Map<string, Tool>
@@ -628,6 +631,7 @@ export function slackRoutes(options: SlackRouteOptions): Router {
     try {
       await withChatLock(`slack:${incoming.channelId}`, () =>
         processMessage({
+          backgroundModel: options.backgroundModel,
           adapter,
           incoming,
           assistant,
@@ -973,6 +977,8 @@ async function dispatchSlackReactionFeedback(params: {
 // ── Per-message handler (mirrors the Telegram route) ──────────
 
 type ProcessMessageParams = {
+  /** Servable background-lane model, threaded from the route options. */
+  backgroundModel?: string
   adapter: ReturnType<typeof createSlackAdapter>
   incoming: IncomingMessage
   assistant: { id: string; name: string; ownerUserId: string; slackModelAlias: string; workspaceId: string | null; systemPrompt: string | null; clearance: 'public' | 'internal' | 'confidential'; kind: 'primary' | 'standard' | 'app' }
@@ -1191,6 +1197,7 @@ async function processMessage(params: ProcessMessageParams): Promise<void> {
   params.activeAbortControllers.set(incoming.channelId, abortController)
 
   await processChannelMessage({
+    backgroundModel: params.backgroundModel,
     userId: channelUserId,
     ownerId,
     assistant: { ...assistant, ownerUserId: ownerId },

--- a/packages/api/src/routes/telegram-byo.ts
+++ b/packages/api/src/routes/telegram-byo.ts
@@ -76,6 +76,9 @@ export type ChannelRecordingIngest = {
 // getConnectorUserId now used inside channel-pipeline.ts
 
 type TelegramByoRouteOptions = {
+  /** Servable background-lane model, resolved at boot; forwarded to the
+   * channel pipeline so its background calls work without a Google key. */
+  backgroundModel?: string
   provider: LLMProvider
   systemPrompt: string
   tools: Map<string, Tool>
@@ -862,6 +865,7 @@ export function telegramByoRoutes(options: TelegramByoRouteOptions): Router {
       // 6. Sequentialize per chat via Postgres advisory lock
       await withChatLock(`tg-byo:${incoming.channelId}`, () =>
         processMessage({
+          backgroundModel: options.backgroundModel,
           adapter,
           incoming,
           assistant: routedAssistant,
@@ -955,6 +959,8 @@ export function telegramByoRoutes(options: TelegramByoRouteOptions): Router {
 // ── Per-message handler ─────────────────────────────────────────
 
 type ProcessMessageParams = {
+  /** Servable background-lane model, threaded from the route options. */
+  backgroundModel?: string
   adapter: ReturnType<typeof createTelegramAdapter>
   incoming: IncomingMessage
   assistant: { id: string; name: string; ownerUserId: string; telegramModelAlias: string; workspaceId: string | null; systemPrompt: string | null; clearance: 'public' | 'internal' | 'confidential'; kind: 'primary' | 'standard' | 'app' }
@@ -1239,6 +1245,7 @@ async function processMessage(params: ProcessMessageParams): Promise<void> {
   // users with no @username). Same raw access as the allowlist check above.
   const byoUsername = (incoming.raw as { from?: { username?: string } }).from?.username
   await processChannelMessage({
+    backgroundModel: params.backgroundModel,
     userId: channelUserId,
     ownerId,
     assistant: { ...assistant, ownerUserId: ownerId },

--- a/packages/api/src/workers/workflow-digest-llm.ts
+++ b/packages/api/src/workers/workflow-digest-llm.ts
@@ -15,9 +15,6 @@
 
 import { z } from 'zod'
 
-/** Cheap non-thinking background tier — same as the skill-review worker. */
-export const WORKFLOW_DIGEST_MODEL = 'gemini-3.1-flash-lite'
-
 /** Ceiling for one plan call (a candidate carries a full skill body). */
 export const WORKFLOW_DIGEST_MAX_TOKENS = 8192
 

--- a/packages/core/src/doc/auto-title.ts
+++ b/packages/core/src/doc/auto-title.ts
@@ -157,14 +157,17 @@ export function deriveCommentTitle(body: string, max = 90): string | null {
 export async function generatePageTitle(
   provider: LLMProvider,
   plaintext: string,
+  /** Servable background-lane model; defaults to the historical literal. */
+  modelOverride?: string,
 ): Promise<GenerateTitleResult> {
+  const model = modelOverride ?? TITLE_MODEL
   const excerpt = plaintext.replace(/\s+/g, ' ').trim().slice(0, 600)
   if (!excerpt) return { title: null, icon: null, usage: null, model: null }
 
   let rawTitle = ''
   let usage: TokenUsage | null = null
   for await (const chunk of provider.stream({
-    model: TITLE_MODEL,
+    model: model,
     systemPrompt: PAGE_TITLE_SYSTEM_PROMPT,
     messages: [{ role: 'user', content: excerpt }] as Message[],
     maxTokens: 32,
@@ -182,7 +185,7 @@ export async function generatePageTitle(
   const cleaned = sanitizeTitle(rest)
   const cleanedWords = cleaned.split(/\s+/).filter(Boolean).length
   // A solid multi-word title — use it.
-  if (cleanedWords >= 3) return { title: cleaned, icon, usage, model: TITLE_MODEL }
+  if (cleanedWords >= 3) return { title: cleaned, icon, usage, model: model }
 
   // Thin model output (0–2 words) — prefer deriving a fuller title from the
   // document opening; sanitizeTitle caps the length at a word boundary.
@@ -192,7 +195,7 @@ export async function generatePageTitle(
       title: fallback.charAt(0).toUpperCase() + fallback.slice(1),
       icon,
       usage,
-      model: TITLE_MODEL,
+      model: model,
     }
   }
 
@@ -200,6 +203,6 @@ export async function generatePageTitle(
   // empty) isn't worth committing — leave the placeholder. A page title should
   // be descriptive, so we're stricter here than the session-title generator.
   // No title → no icon (don't decorate a page we're leaving untitled).
-  if (cleanedWords >= 2) return { title: cleaned, icon, usage, model: TITLE_MODEL }
-  return { title: null, icon: null, usage, model: TITLE_MODEL }
+  if (cleanedWords >= 2) return { title: cleaned, icon, usage, model: model }
+  return { title: null, icon: null, usage, model: model }
 }

--- a/packages/core/src/scheduling/tools.ts
+++ b/packages/core/src/scheduling/tools.ts
@@ -63,6 +63,8 @@ export type SchedulingToolDeps = {
    * scheduling tools degrade silently to the placeholder.
    */
   provider?: LLMProvider
+  /** Servable background-lane model for the auto-titler; omitted = its default. */
+  backgroundModel?: string
   /**
    * Optional — resolves a job's stored `(channelType, channelId)` into a
    * human-readable delivery target the tools echo back as `deliveryTarget`,
@@ -337,6 +339,7 @@ export function createSchedulingTools(deps: SchedulingToolDeps): {
               timezone,
             },
             ac.signal,
+            deps.backgroundModel,
           )
           if (result.title) {
             const written = await workflowStore.updateAutoName(

--- a/packages/core/src/workers/__tests__/research-classifier.test.ts
+++ b/packages/core/src/workers/__tests__/research-classifier.test.ts
@@ -179,3 +179,32 @@ describe('[COMP:workers/research-classifier] classifyResearchIntent', () => {
     expect(result.operateSite).toBe(false)
   })
 })
+
+describe('[COMP:workers/research-classifier] background-lane model injection', () => {
+  const LONG = 'Please research the current state of solid-state battery manufacturing in detail.'
+
+  it('sends the injected model on the wire, not the Gemini literal', () => {
+    // A Google-free deploy passes a servable id here. If this ever regresses
+    // to the module constant the routing provider throws "not configured" and
+    // the whole lane dies silently in a background job.
+    const provider = makeProvider('{"research":true,"reason":"deep topic"}')
+    return classifyResearchIntent({ provider, message: LONG, model: 'qwen3.5-flash' }).then((r) => {
+      expect(provider.stream).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'qwen3.5-flash' }),
+      )
+      // The result attributes usage to the model that actually served it —
+      // otherwise cost lands on a model that was never called.
+      expect(r.model).toBe('qwen3.5-flash')
+    })
+  })
+
+  it('defaults to the historical literal when nothing is injected', () => {
+    const provider = makeProvider('{"research":true,"reason":"deep topic"}')
+    return classifyResearchIntent({ provider, message: LONG }).then((r) => {
+      expect(provider.stream).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gemini-3.1-flash-lite' }),
+      )
+      expect(r.model).toBe('gemini-3.1-flash-lite')
+    })
+  })
+})

--- a/packages/core/src/workers/research-classifier.ts
+++ b/packages/core/src/workers/research-classifier.ts
@@ -69,6 +69,12 @@ export type ResearchClassifyOptions = {
   message: string
   /** Override the short-message bypass; defaults to 40 chars. */
   minMessageLength?: number
+  /**
+   * Background-lane model. Callers with boot context (the API routes) pass an
+   * id already checked servable against the configured providers; the default
+   * keeps standalone/test use on the historical literal.
+   */
+  model?: string
 }
 
 export type ResearchClassifyResult = {
@@ -143,6 +149,7 @@ export async function classifyResearchIntent(
   options: ResearchClassifyOptions,
 ): Promise<ResearchClassifyResult> {
   const { provider, message, minMessageLength = MIN_MESSAGE_LENGTH } = options
+  const model = options.model ?? CLASSIFIER_MODEL
 
   // Operate-site fast-path — before the length check (site operations are
   // length-independent) and before the LLM call (zero classifier cost).
@@ -159,7 +166,7 @@ export async function classifyResearchIntent(
 
   try {
     const stream = provider.stream({
-      model: CLASSIFIER_MODEL,
+      model: model,
       systemPrompt: CLASSIFIER_SYSTEM_PROMPT,
       messages: [{ role: 'user', content: message }],
       maxTokens: 128,
@@ -174,7 +181,7 @@ export async function classifyResearchIntent(
 
     const jsonMatch = text.match(/\{[\s\S]*\}/)
     if (!jsonMatch) {
-      return { research: false, operateSite: false, reason: null, usage: response.usage, model: CLASSIFIER_MODEL }
+      return { research: false, operateSite: false, reason: null, usage: response.usage, model: model }
     }
 
     const parsed = JSON.parse(jsonMatch[0]) as {
@@ -188,7 +195,7 @@ export async function classifyResearchIntent(
         operateSite: parsed.operate_site === true,
         reason: parsed.operate_site === true ? 'operate_site_classifier' : null,
         usage: response.usage,
-        model: CLASSIFIER_MODEL,
+        model: model,
       }
     }
     return {
@@ -196,7 +203,7 @@ export async function classifyResearchIntent(
       operateSite: false,
       reason: typeof parsed.reason === 'string' ? parsed.reason : null,
       usage: response.usage,
-      model: CLASSIFIER_MODEL,
+      model: model,
     }
   } catch {
     // Any failure → safe default, no research. Usage is lost because the

--- a/packages/core/src/workers/splitter.ts
+++ b/packages/core/src/workers/splitter.ts
@@ -46,6 +46,12 @@ export type SplitOptions = {
   provider: LLMProvider
   message: string
   minMessageLength?: number
+  /**
+   * Background-lane model. Callers with boot context (the API routes) pass an
+   * id already checked servable against the configured providers; the default
+   * keeps standalone/test use on the historical literal.
+   */
+  model?: string
 }
 
 export type SplitResult = {
@@ -65,6 +71,7 @@ export type SplitResult = {
  * the classifier cost as `overhead:splitter`.
  */
 export async function classifySplit(options: SplitOptions): Promise<SplitResult> {
+  const model = options.model ?? CLASSIFIER_MODEL
   const { provider, message, minMessageLength = MIN_MESSAGE_LENGTH } = options
 
   // Short messages never need splitting — short-circuit before the LLM call.
@@ -72,7 +79,7 @@ export async function classifySplit(options: SplitOptions): Promise<SplitResult>
 
   try {
     const stream = provider.stream({
-      model: CLASSIFIER_MODEL,
+      model: model,
       systemPrompt: CLASSIFIER_SYSTEM_PROMPT,
       messages: [{ role: 'user', content: message }],
       maxTokens: 512,
@@ -87,15 +94,15 @@ export async function classifySplit(options: SplitOptions): Promise<SplitResult>
 
     const jsonMatch = text.match(/\{[\s\S]*\}/)
     if (!jsonMatch) {
-      return { tasks: null, usage: response.usage, model: CLASSIFIER_MODEL }
+      return { tasks: null, usage: response.usage, model: model }
     }
 
     const parsed = JSON.parse(jsonMatch[0])
     if (!parsed.split || !Array.isArray(parsed.tasks) || parsed.tasks.length < 2) {
-      return { tasks: null, usage: response.usage, model: CLASSIFIER_MODEL }
+      return { tasks: null, usage: response.usage, model: model }
     }
 
-    return { tasks: parsed.tasks as string[], usage: response.usage, model: CLASSIFIER_MODEL }
+    return { tasks: parsed.tasks as string[], usage: response.usage, model: model }
   } catch {
     // Any failure in classification → safe default, no split. Usage is lost
     // because the stream didn't complete — caller records nothing.

--- a/packages/core/src/workflow/auto-title.ts
+++ b/packages/core/src/workflow/auto-title.ts
@@ -124,7 +124,10 @@ export async function generateWorkflowTitle(
   provider: LLMProvider,
   params: GenerateWorkflowTitleParams,
   signal?: AbortSignal,
+  /** Servable background-lane model; defaults to the historical literal. */
+  modelOverride?: string,
 ): Promise<GenerateWorkflowTitleResult> {
+  const model = modelOverride ?? AUTO_TITLE_MODEL
   const parts: string[] = []
   if (params.instructions && params.instructions.trim().length > 0) {
     parts.push(`Instructions: ${params.instructions.trim()}`)
@@ -142,7 +145,7 @@ export async function generateWorkflowTitle(
   let usage: TokenUsage | null = null
   try {
     for await (const chunk of provider.stream({
-      model: AUTO_TITLE_MODEL,
+      model: model,
       systemPrompt: SYSTEM_PROMPT,
       messages: [{ role: 'user', content: excerpt }],
       maxTokens: 32,
@@ -160,13 +163,13 @@ export async function generateWorkflowTitle(
     // placeholder. The job/workflow record is already persisted; missing
     // a title is purely cosmetic.
     console.warn('[workflow/auto-title] generation failed:', err)
-    return { title: null, usage: null, model: AUTO_TITLE_MODEL }
+    return { title: null, usage: null, model: model }
   }
 
   const cleaned = sanitizeWorkflowTitle(raw)
   if (cleaned.length === 0) {
     // Model produced nothing usable — let the caller keep its placeholder.
-    return { title: null, usage, model: AUTO_TITLE_MODEL }
+    return { title: null, usage, model: model }
   }
-  return { title: cleaned, usage, model: AUTO_TITLE_MODEL }
+  return { title: cleaned, usage, model: model }
 }


### PR DESCRIPTION
## Why

On a DashScope-only self-host, `[routing] model 'gemini-3.1-flash-lite' routes to provider 'gemini', which is not configured` killed background work. Auto-title was the visible symptom — it logs — but the whole lane was down: memory splitting, research and episode classifiers, session-state diff, memory nudge, workflow and doc auto-titles, theme generation, workflow digest, skill review.

`ensureServableModel` (#67) already knew how to substitute a background-class model. The gap was reach: only the chat route called it. Every other lane held its own `gemini-3.1-flash-lite` literal and handed it to the router unresolved.

## What

- `BACKGROUND_MODEL` moves into `model-resolution.ts` beside the resolver — one literal instead of nine, and `ensureServableModel` is the obvious next step at every read.
- `backgroundModelFor(configuredProviders)` replaces the ternary the chat route had open-coded three times.
- **Boot resolves once and injects** into the lanes it constructs (episode ingestors, scheduling tools, doc themes, the four channel routes, workflow digest, skill review, task triage). Request-scoped lanes resolve per turn. Leaf literals are demoted to defaults so standalone and test callers are unchanged — but a leaf never decides.
- Pipeline B's chat-class `EXTRACTION_MODEL` is hardcoded the same way and dies the same death, so boot resolves it too.

## Two bugs found along the way

- **Mis-attributed usage.** `generateTitle` has taken `model` as a parameter since #67 but still returned the hardcoded id, so a substituted lane recorded usage and cost against a model that never ran.
- **Brain ingest was equally dead** on a Google-free deploy via `EXTRACTION_MODEL`, which is easy to miss because it is chat-class, not background-class.

## Behaviour

With Gemini configured, every id resolves to itself — this can only change behaviour on a deploy that would otherwise have thrown. Boot logs any substitution rather than deferring the surprise to first use. No new env var (single-env rule holds).

## Note for review

A Gemini-free self-host now runs `qwen3.5-flash` for brain extraction, which is **un-evalled** — §5.1 gates it pending extraction-quality evals. That gate governs choosing it over an *available* Flash Lite; where no Google key exists the alternative is a dead lane, and registry order means it can never outrank a configured Flash Lite. Worth a conscious ack.

## Verification

`typecheck` clean (shared/core/api) · api 3655 + core 4005 + shared 259 tests pass · `smoke` OK · new tests for `backgroundModelFor` and for leaf model injection. Re-run in isolation to confirm the commits stand alone.

Docs: `docs/plans/model-registry.md` L12a (platform-root PR, pairs with this).