### PR TITLE
fix(app-web): send signed-out oss users to the local-owner session, not /login

### DIFF
--- a/apps/app-web/src/app/api/auth/local-session/route.ts
+++ b/apps/app-web/src/app/api/auth/local-session/route.ts
@@ -11,12 +11,18 @@
 // neutral owner identity, no email surfaced.
 //
 // Dead outside an oss deploy: 404s when `primaryAuthUrl()` resolves (a sub-app
-// deploy where the primary owns auth) or when the build is not the oss edition.
-// The backend route is itself gated on local + oss, so a token can never be
+// deploy where the primary owns auth) or when this is not the oss edition. The
+// backend route is itself gated on oss + not-cloud, so a token can never be
 // minted in the cloud. We do NOT gate on NODE_ENV: a built self-host runs
 // `next start` (NODE_ENV="production"), so the edition + primary checks are the
-// real gate. Redirects use APP_URL because behind a reverse proxy request.url
+// real gate. `isOssEdition()` resolves the SERVER-side `USEBRIAN_EDITION` at
+// runtime as well as the build-inlined public var, so a prebuilt tree that was
+// compiled without the edition set still opens here when the deploy's env says
+// oss. Redirects use APP_URL because behind a reverse proxy request.url
 // resolves to the bound localhost address.
+//
+// Accepts an optional `?next=<path>` (same-origin absolute paths only) so a
+// signed-out deep link routed here by the proxy resumes where it was headed.
 //
 // Component-map tag: [COMP:app-web/local-session-route].
 
@@ -29,6 +35,7 @@ import {
 } from "@/lib/auth-cookies";
 import { primaryAuthUrl } from "@/lib/primary-auth";
 import { isOssEdition } from "@/lib/edition";
+import { sanitizeNext } from "@/lib/oss-entry";
 
 // Same resolution as the app-web OAuth callback + refresh bridges:
 // server-side `API_URL`, defaulting to the local dev API.
@@ -39,6 +46,7 @@ export async function GET(request: Request) {
   // bound address (localhost:PORT), so absolute redirects must be built from the
   // configured public origin instead.
   const appOrigin = process.env.APP_URL ?? request.url;
+  const nextPath = sanitizeNext(new URL(request.url).searchParams.get("next"));
 
   if (primaryAuthUrl() !== null || !isOssEdition()) {
     return new NextResponse("Not found", { status: 404 });
@@ -65,9 +73,10 @@ export async function GET(request: Request) {
       };
     };
 
-    // Land on the app root, which resolves into the single-workspace redirect
-    // in src/app/page.tsx — the same destination the OAuth callback uses.
-    const response = NextResponse.redirect(new URL("/", appOrigin));
+    // Land on `next` (default `/`), which resolves into the single-workspace
+    // redirect in src/app/page.tsx — the same destination the OAuth callback
+    // uses.
+    const response = NextResponse.redirect(new URL(nextPath, appOrigin));
     response.cookies.set(accessTokenCookie(data.accessToken));
     response.cookies.set(refreshTokenCookie(data.refreshToken));
     response.cookies.set(

--- a/apps/app-web/src/app/page.tsx
+++ b/apps/app-web/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { ossSignedOutRedirect } from "@/lib/oss-entry";
 
 // `||` not `??`: an empty-string NEXT_PUBLIC_API_URL (e.g. inlined as "" by the
 // bundler when unset at build) must also fall back, else this server-side fetch
@@ -20,6 +21,13 @@ type Team = { id: string; name: string };
  * /teams, which re-fetches and renders real workspaces (or bounces to
  * /login). A genuinely empty list is effectively unreachable — every
  * user has a Personal workspace auto-created at signup.
+ *
+ * Signed out, the destination depends on the edition — see
+ * `lib/oss-entry.ts`. The hosted edition goes to /login for Google OAuth;
+ * the open edition has no login, so its root IS the local-owner session.
+ * This path is not proxy-guarded (`/` is absent from GUARDED_PREFIXES), so
+ * this redirect is the only thing standing between a self-hosted visitor
+ * and a Google button that can never complete.
  */
 export default async function HomePage(props: {
   searchParams: Promise<{ capture?: string }>;
@@ -27,7 +35,7 @@ export default async function HomePage(props: {
   const jar = await cookies();
   const accessToken = jar.get("access_token")?.value;
   if (!accessToken) {
-    redirect("/login");
+    redirect(ossSignedOutRedirect() ?? "/login");
   }
 
   // Desktop quick-capture (`?capture=1`): preserve it through the single-

--- a/apps/app-web/src/lib/__tests__/oss-entry.test.ts
+++ b/apps/app-web/src/lib/__tests__/oss-entry.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ossSignedOutRedirect, sanitizeNext } from "@/lib/oss-entry";
+import { isOssEdition } from "@/lib/edition";
+
+vi.mock("@/lib/edition", () => ({ isOssEdition: vi.fn() }));
+
+const mockedIsOss = vi.mocked(isOssEdition);
+
+beforeEach(() => mockedIsOss.mockReset());
+
+describe("[COMP:app-web/oss-entry] sanitizeNext", () => {
+  it("keeps a same-origin absolute path", () => {
+    expect(sanitizeNext("/w/abc/p/123")).toBe("/w/abc/p/123");
+    expect(sanitizeNext("/teams?x=1")).toBe("/teams?x=1");
+  });
+
+  it("collapses a protocol-relative path, which would resolve off-origin", () => {
+    expect(sanitizeNext("//evil.com/steal")).toBe("/");
+  });
+
+  it("collapses an absolute URL and anything not starting with /", () => {
+    expect(sanitizeNext("https://evil.com")).toBe("/");
+    expect(sanitizeNext("w/abc")).toBe("/");
+  });
+
+  it("collapses empty and missing input", () => {
+    expect(sanitizeNext("")).toBe("/");
+    expect(sanitizeNext(null)).toBe("/");
+    expect(sanitizeNext(undefined)).toBe("/");
+  });
+});
+
+describe("[COMP:app-web/oss-entry] ossSignedOutRedirect", () => {
+  /**
+   * The reported bug: a self-hosted (oss) visitor with no cookie was sent to
+   * /login, which in this edition is a Google button with no client ID behind
+   * it. There is no login in single-player — the root IS the owner session.
+   */
+  it("sends a signed-out oss visitor to the local-owner session", () => {
+    mockedIsOss.mockReturnValue(true);
+    expect(ossSignedOutRedirect()).toBe("/api/auth/local-session");
+  });
+
+  it("carries a deep link through as an encoded ?next=", () => {
+    mockedIsOss.mockReturnValue(true);
+    expect(ossSignedOutRedirect("/w/abc/p/123")).toBe(
+      "/api/auth/local-session?next=%2Fw%2Fabc%2Fp%2F123",
+    );
+  });
+
+  it("omits ?next= when the target is already the app root", () => {
+    mockedIsOss.mockReturnValue(true);
+    expect(ossSignedOutRedirect("/")).toBe("/api/auth/local-session");
+  });
+
+  it("never propagates an off-origin next into the redirect", () => {
+    mockedIsOss.mockReturnValue(true);
+    expect(ossSignedOutRedirect("//evil.com")).toBe("/api/auth/local-session");
+    expect(ossSignedOutRedirect("https://evil.com")).toBe(
+      "/api/auth/local-session",
+    );
+  });
+
+  // The hosted edition must be untouched: callers fall back to their own
+  // /login behaviour on null.
+  it("returns null in the hosted edition so /login still owns sign-in", () => {
+    mockedIsOss.mockReturnValue(false);
+    expect(ossSignedOutRedirect()).toBeNull();
+    expect(ossSignedOutRedirect("/w/abc")).toBeNull();
+  });
+});

--- a/apps/app-web/src/lib/auth-fetch.ts
+++ b/apps/app-web/src/lib/auth-fetch.ts
@@ -15,6 +15,7 @@
 
 import { getUserInfo, setUserInfoCache } from "@/lib/user";
 import { primaryAuthUrl } from "@/lib/primary-auth";
+import { ossSignedOutRedirect } from "@/lib/oss-entry";
 import {
   isDesktopAuth,
   desktopAuthSource,
@@ -231,6 +232,17 @@ function redirectToLogin(): void {
   }
   if (window.location.pathname.startsWith("/login")) return;
   authRedirectInFlight = true;
+  // Open edition: there is no login to send anyone to, so an aged-out session
+  // re-mints the local-owner one and resumes where it was. Without this, an
+  // OSS session that outlives its refresh token eventually strands the owner
+  // on a Google button that can never complete.
+  const ossEntry = ossSignedOutRedirect(
+    window.location.pathname + window.location.search,
+  );
+  if (ossEntry) {
+    window.location.href = ossEntry;
+    return;
+  }
   const primary = primaryAuthUrl();
   if (primary) {
     const loginUrl = new URL("/login", primary);

--- a/apps/app-web/src/lib/oss-entry.ts
+++ b/apps/app-web/src/lib/oss-entry.ts
@@ -1,0 +1,52 @@
+/**
+ * Where a signed-out user goes in the open single-player edition.
+ *
+ * The hosted edition sends them to `/login` for Google OAuth. The open edition
+ * has **no login at all** — a local or self-hosted brain is a single-user app
+ * whose identity is the machine's owner — so `/login` there renders a Google
+ * button with nothing behind it: no client ID, no consent screen, no way
+ * forward. Every signed-out surface must instead route to the local-owner
+ * session (`/api/auth/local-session`), which mints the owner's tokens and
+ * bounces back.
+ *
+ * This is the single source of truth for that decision. It was previously
+ * inlined as a bare `redirect("/login")` in each surface, which is how the
+ * self-host root path came to dead-end on an unusable sign-in screen.
+ *
+ * Callers fall back to their own hosted-edition behaviour when this returns
+ * `null`, so the hosted flow is untouched.
+ *
+ * Component-map tag: [COMP:app-web/oss-entry].
+ */
+
+import { isOssEdition } from "@/lib/edition";
+
+/** The web trigger route that mints the local-owner session. */
+export const LOCAL_SESSION_PATH = "/api/auth/local-session";
+
+/**
+ * Keep only same-origin absolute paths. A protocol-relative `//evil.com` would
+ * be resolved by `new URL()` against another origin, and an absolute URL is an
+ * open redirect outright — both collapse to the app root.
+ */
+export function sanitizeNext(raw: string | null | undefined): string {
+  if (!raw) return "/";
+  if (!raw.startsWith("/")) return "/";
+  if (raw.startsWith("//")) return "/";
+  return raw;
+}
+
+/**
+ * The path a signed-out visitor should be sent to, or `null` in the hosted
+ * edition (caller keeps its existing `/login` behaviour).
+ *
+ * `next` is where the user was actually headed; it rides along so the
+ * round-trip resumes there instead of dumping everyone at the app root. A
+ * `next` of `/` is omitted since that's already the route's default.
+ */
+export function ossSignedOutRedirect(next?: string | null): string | null {
+  if (!isOssEdition()) return null;
+  const target = sanitizeNext(next);
+  if (target === "/") return LOCAL_SESSION_PATH;
+  return `${LOCAL_SESSION_PATH}?next=${encodeURIComponent(target)}`;
+}

--- a/apps/app-web/src/proxy.ts
+++ b/apps/app-web/src/proxy.ts
@@ -11,6 +11,7 @@ import {
 import { primaryAuthUrl } from "@/lib/primary-auth";
 import { computeDocRedirect } from "@/lib/doc-redirect";
 import { isAppHost, isGuardedPath, normalizeHostHeader } from "@/lib/site-hosts";
+import { ossSignedOutRedirect } from "@/lib/oss-entry";
 
 const API_URL = process.env.API_URL ?? "http://localhost:4000";
 
@@ -93,6 +94,16 @@ export async function proxy(request: NextRequest) {
   const primary = primaryAuthUrl();
 
   if (!hasAccess && !refreshToken) {
+    // Open edition: no login exists, so a signed-out deep link mints the
+    // local-owner session and comes back to where it was headed, rather than
+    // stranding a self-hosted user on a Google button. Checked before
+    // `primary` for clarity only — `primaryAuthUrl()` is already null in oss.
+    const ossEntry = ossSignedOutRedirect(
+      request.nextUrl.pathname + request.nextUrl.search,
+    );
+    if (ossEntry) {
+      return NextResponse.redirect(new URL(ossEntry, request.url));
+    }
     if (primary) {
       // Cross-origin to the primary's /login. Carries the original URL
       // so post-OAuth lands the user back here.
@@ -118,7 +129,14 @@ export async function proxy(request: NextRequest) {
 
   const refreshed = await tryServerRefresh(refreshToken!);
   if (!refreshed) {
-    const res = NextResponse.redirect(new URL("/login", request.url));
+    // A stale refresh token in the open edition is not a login problem — the
+    // owner is still the owner. Re-mint rather than dead-end on /login.
+    const ossEntry = ossSignedOutRedirect(
+      request.nextUrl.pathname + request.nextUrl.search,
+    );
+    const res = NextResponse.redirect(
+      new URL(ossEntry ?? "/login", request.url),
+    );
     applyClearedCookies(res);
     return res;
   }


### PR DESCRIPTION
## The bug

A self-hosted (oss) user visiting the app origin lands on `/login` — a Google OAuth button with no client ID behind it and no consent screen to reach. There is no way forward from that page in the open edition.

The backend `/auth/local-session` route was mounted and working the whole time. Only the *entry path* was wrong: `/` is not in `GUARDED_PREFIXES`, so the proxy passes it straight through to `app/page.tsx`, which did an unconditional `redirect("/login")` when no `access_token` cookie was present. The launcher hid this by opening `/api/auth/local-session` directly; anyone who just opens the site got the dead end.

## The fix

`lib/oss-entry.ts` becomes the single source of truth for "where does a signed-out user go". `ossSignedOutRedirect(next)` returns the local-session path in the open edition and `null` in the hosted edition, so every caller keeps its existing `/login` behaviour there — the hosted flow is untouched.

Applied at four surfaces:

| Surface | Signed-out behaviour (oss) |
|---|---|
| `app/page.tsx` (root) | → `/api/auth/local-session` |
| `proxy.ts` guard, no cookies | → `…local-session?next=<path>` |
| `proxy.ts`, refresh token stale | Re-mint — a dead refresh token is not a login problem when the owner is still the owner |
| `lib/auth-fetch.ts`, 401 with no usable refresh | Re-mint and resume, instead of stranding an aged-out session on that same unusable button |

The trigger route now honours `?next=` so a deep link resumes where it was headed rather than dumping everyone at the app root.

## Security

`next` is restricted to same-origin absolute paths. A protocol-relative `//host` (which `new URL()` would resolve against another origin) or an absolute URL collapses to `/`, so the round-trip cannot be turned into an open redirect. Covered by tests.

## Deliberately not covered

Explicit sign-out (`lib/account-logout.ts`) and the privacy-section account action still go to `/login`. Auto-re-minting there would make signing out a no-op — what the open edition should do on an explicit logout is a product question, not a bug.

## Testing

- 9 new unit tests — `[COMP:app-web/oss-entry]`, covering the redirect decision, the hosted-edition `null` fallback, and the `next` sanitizer's rejection cases.
- Full app-web suite: 215 files / 1946 tests pass.
- `tsc --noEmit` clean.

Spec + KB entry: use-brian/brian-platform `docs/oss-signed-out-entry` and use-brian/brian-kb#docs/oss-signed-out-entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)