### PR TITLE
feat(whatsapp): add the Settings → Account WhatsApp linking UI

### DIFF
--- a/apps/app-web/src/components/settings-modal/sections/account-section.tsx
+++ b/apps/app-web/src/components/settings-modal/sections/account-section.tsx
@@ -24,17 +24,20 @@ import {
   listLinkedAccounts,
   unlinkAccount,
   createTelegramLinkCode,
+  createWhatsappLinkCode,
   MAX_AVATAR_BYTES,
   type LinkedAccount,
   type TelegramLinkCode,
+  type WhatsappLinkCode,
 } from "@/lib/api/account";
 import {
   buildTelegramDeepLink,
   linkCodeSecondsLeft,
   formatCountdown,
 } from "@/lib/telegram-link";
+import { buildWhatsappDeepLink } from "@/lib/whatsapp-link";
 import { format } from "@/lib/i18n/format";
-import { isOssEdition } from "@/lib/edition";
+import { isOssEdition, isHostedEdition } from "@/lib/edition";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
 
@@ -439,6 +442,229 @@ function ConnectedAccountsSection() {
                 className="text-sm font-medium px-4 py-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90"
               >
                 {t.settings.account.openTelegram}
+              </a>
+            )}
+            {expired && (
+              <button
+                type="button"
+                onClick={() => void onConnect()}
+                disabled={busy}
+                className="text-sm font-medium px-4 py-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              >
+                {busy ? "…" : t.settings.account.generateNewCode}
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => setState({ kind: "unlinked" })}
+              className="text-sm text-muted-foreground hover:text-foreground"
+            >
+              {t.settings.common.cancel}
+            </button>
+          </div>
+          <p className="text-[11px] text-muted-foreground">
+            {expired
+              ? t.settings.account.codeExpired
+              : format(t.settings.account.codeExpiresIn, {
+                  time: formatCountdown(secondsLeft),
+                })}
+          </p>
+        </div>
+      )}
+
+      {notice && (
+        <p
+          className={
+            notice.kind === "success"
+              ? "text-[12px] text-primary"
+              : "text-[12px] text-red-400"
+          }
+        >
+          {notice.text}
+        </p>
+      )}
+
+      <WhatsappLinkRow />
+    </div>
+  );
+}
+
+/**
+ * WhatsApp link to the official bot — the sibling of the Telegram row above.
+ *
+ * Connect mints a 6-char code (`POST /api/account/whatsapp/link-code`, bound
+ * server-side to the first-owned assistant) and returns the official number to
+ * send it to; the row then polls the linked-accounts list until the bot redeems
+ * it (`whatsapp.ts` → "Step A: Link code detection"). Unlike Telegram there is
+ * no bot @username, so the deep link is `wa.me/<digits>?text=<code>` — which
+ * also prefills the message, making the whole handshake two taps.
+ *
+ * Hosted-only: the official bot is a hosted concept and the API 503s the route
+ * in OSS, so the row is gated behind `isHostedEdition()` the same way the
+ * Studio official-bot card is.
+ *
+ * Linking matters beyond DMs: an unlinked user who adds the official bot to a
+ * group has no resolvable identity, so the bot silently leaves
+ * (`whatsapp-group-event.ts` → `reason: 'no-account'`).
+ *
+ * See docs/architecture/channels/whatsapp.md → "Account linking".
+ * Component tag: [COMP:app-web/whatsapp-link].
+ */
+type WhatsappLinkState =
+  | { kind: "loading" }
+  | { kind: "unlinked" }
+  | { kind: "linked"; account: LinkedAccount }
+  | { kind: "connecting"; code: WhatsappLinkCode };
+
+function WhatsappLinkRow() {
+  const t = useT();
+  const [state, setState] = useState<WhatsappLinkState>({ kind: "loading" });
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<Status>(null);
+  const [secondsLeft, setSecondsLeft] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    void listLinkedAccounts().then((accounts) => {
+      if (cancelled) return;
+      const wa = accounts.find((a) => a.provider === "whatsapp");
+      setState(wa ? { kind: "linked", account: wa } : { kind: "unlinked" });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // While a code is pending: 1s countdown tick + 3s poll for the bot-side
+  // redemption. Both stop when the row leaves the connecting state; the poll
+  // also stops firing once the code expires.
+  useEffect(() => {
+    if (state.kind !== "connecting") return;
+    const expiresAt = state.code.expiresAt;
+    setSecondsLeft(linkCodeSecondsLeft(expiresAt));
+    const tick = setInterval(() => {
+      setSecondsLeft(linkCodeSecondsLeft(expiresAt));
+    }, 1000);
+    const poll = setInterval(() => {
+      if (linkCodeSecondsLeft(expiresAt) <= 0) return;
+      void listLinkedAccounts().then((accounts) => {
+        const wa = accounts.find((a) => a.provider === "whatsapp");
+        if (wa) {
+          setState({ kind: "linked", account: wa });
+          setNotice({ kind: "success", text: t.settings.account.whatsappLinked });
+        }
+      });
+    }, 3000);
+    return () => {
+      clearInterval(tick);
+      clearInterval(poll);
+    };
+  }, [state, t]);
+
+  async function onConnect() {
+    setBusy(true);
+    setNotice(null);
+    try {
+      const code = await createWhatsappLinkCode();
+      if (!code) {
+        // Covers both "not hosted" and "official bot not paired" — from the
+        // user's side these are the same thing: nowhere to send a code.
+        setNotice({ kind: "error", text: t.settings.account.whatsappUnavailable });
+        return;
+      }
+      setState({ kind: "connecting", code });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onDisconnect() {
+    if (state.kind !== "linked") return;
+    const ok = await confirmDialog({
+      title: t.settings.account.disconnectWhatsappTitle,
+      description: t.settings.account.disconnectWhatsappConfirm,
+      confirmLabel: t.settings.account.disconnect,
+      cancelLabel: t.settings.common.cancel,
+      variant: "destructive",
+    });
+    if (!ok) return;
+    setBusy(true);
+    setNotice(null);
+    try {
+      const removed = await unlinkAccount(state.account.id);
+      if (!removed) {
+        setNotice({ kind: "error", text: t.settings.account.connectError });
+        return;
+      }
+      setState({ kind: "unlinked" });
+      setNotice({ kind: "success", text: t.settings.account.whatsappUnlinked });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // The official bot is hosted-only; OSS has no number to link against.
+  if (!isHostedEdition()) return null;
+
+  const expired = state.kind === "connecting" && secondsLeft <= 0;
+  const deepLink =
+    state.kind === "connecting" && !expired
+      ? buildWhatsappDeepLink(state.code.officialNumber, state.code.code)
+      : null;
+
+  return (
+    <div className="space-y-4 pt-2">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-sm font-medium">{t.settings.account.whatsapp}</div>
+          <div className="text-xs text-muted-foreground truncate">
+            {state.kind === "loading" && t.settings.common.loading}
+            {state.kind === "unlinked" && t.settings.account.notConnected}
+            {state.kind === "connecting" && t.settings.account.notConnected}
+            {state.kind === "linked" && t.settings.account.whatsappConnected}
+          </div>
+        </div>
+        {state.kind === "unlinked" && (
+          <button
+            type="button"
+            onClick={() => void onConnect()}
+            disabled={busy}
+            className="text-sm font-medium px-4 py-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {busy ? "…" : t.settings.account.connect}
+          </button>
+        )}
+        {state.kind === "linked" && (
+          <button
+            type="button"
+            onClick={() => void onDisconnect()}
+            disabled={busy}
+            className="text-sm font-medium border border-border px-4 py-2 rounded-lg hover:bg-muted transition-colors disabled:opacity-50"
+          >
+            {busy ? "…" : t.settings.account.disconnect}
+          </button>
+        )}
+      </div>
+
+      {state.kind === "connecting" && (
+        <div className="rounded-lg border border-border bg-muted/30 p-4 space-y-3">
+          <div className="text-2xl font-mono tracking-[0.3em] text-center select-all">
+            {state.code.code}
+          </div>
+          <p className="text-[12px] text-muted-foreground">
+            {format(t.settings.account.connectWhatsappHint, {
+              number: state.code.officialNumber,
+            })}
+          </p>
+          <div className="flex items-center gap-3">
+            {deepLink && (
+              <a
+                href={deepLink}
+                target="_blank"
+                rel="noreferrer"
+                className="text-sm font-medium px-4 py-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90"
+              >
+                {t.settings.account.openWhatsapp}
               </a>
             )}
             {expired && (

--- a/apps/app-web/src/lib/__tests__/whatsapp-link.test.ts
+++ b/apps/app-web/src/lib/__tests__/whatsapp-link.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { buildWhatsappDeepLink } from "../whatsapp-link";
+
+describe("[COMP:app-web/whatsapp-link] WhatsApp link helpers", () => {
+  it("builds a wa.me deep link with the code prefilled", () => {
+    expect(buildWhatsappDeepLink("+85261234567", "WA1234")).toBe(
+      "https://wa.me/85261234567?text=WA1234",
+    );
+  });
+
+  it("strips display formatting from the operator's number", () => {
+    // The env fallback is operator display text and may carry spacing/punctuation;
+    // wa.me accepts digits only.
+    expect(buildWhatsappDeepLink("+1 (555) 010-0200", "ABC123")).toBe(
+      "https://wa.me/15550100200?text=ABC123",
+    );
+  });
+
+  it("returns null when the number has no digits", () => {
+    expect(buildWhatsappDeepLink("not-a-number", "ABC123")).toBeNull();
+    expect(buildWhatsappDeepLink("", "ABC123")).toBeNull();
+    expect(buildWhatsappDeepLink(null, "ABC123")).toBeNull();
+    expect(buildWhatsappDeepLink(undefined, "ABC123")).toBeNull();
+  });
+
+  it("returns null for a malformed code rather than a broken link", () => {
+    expect(buildWhatsappDeepLink("+85261234567", "abc")).toBeNull();
+    expect(buildWhatsappDeepLink("+85261234567", "TOOLONG7")).toBeNull();
+    expect(buildWhatsappDeepLink("+85261234567", "")).toBeNull();
+    // Lowercase is not the minted charset — the bot upper-cases on receipt,
+    // but a link should carry exactly what was minted.
+    expect(buildWhatsappDeepLink("+85261234567", "wa1234")).toBeNull();
+  });
+});

--- a/apps/app-web/src/lib/api/account.ts
+++ b/apps/app-web/src/lib/api/account.ts
@@ -109,3 +109,27 @@ export async function createTelegramLinkCode(): Promise<TelegramLinkCode | null>
     return null;
   }
 }
+
+export type WhatsappLinkCode = {
+  code: string;
+  expiresAt: string;
+  /** The official number to send the code to — always present on success. */
+  officialNumber: string;
+};
+
+/**
+ * Mint a WhatsApp link code. Resolves `null` on failure, including the
+ * hosted-only 503 (OSS) and the 503 raised when the official bot isn't paired
+ * — in both cases there is nowhere to send a code, so there is no code.
+ */
+export async function createWhatsappLinkCode(): Promise<WhatsappLinkCode | null> {
+  try {
+    const res = await authFetch(`${API_URL}/api/account/whatsapp/link-code`, {
+      method: "POST",
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as WhatsappLinkCode;
+  } catch {
+    return null;
+  }
+}

--- a/apps/app-web/src/lib/i18n/dictionaries/en.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/en.ts
@@ -1493,6 +1493,18 @@ export const en = {
       generateNewCode: "Generate new code",
       telegramLinked: "Telegram connected.",
       telegramUnlinked: "Telegram disconnected.",
+      whatsapp: "WhatsApp",
+      whatsappConnected: "Connected",
+      connectWhatsappHint:
+        "Send this code to {number} on WhatsApp to connect your account.",
+      openWhatsapp: "Open WhatsApp",
+      whatsappLinked: "WhatsApp connected.",
+      whatsappUnlinked: "WhatsApp disconnected.",
+      whatsappUnavailable:
+        "WhatsApp linking isn't available right now. Please try again later.",
+      disconnectWhatsappTitle: "Disconnect WhatsApp?",
+      disconnectWhatsappConfirm:
+        "Your assistant will stop replying to this WhatsApp number, and groups you added the bot to will stop being read.",
       connectError: "Something went wrong. Please try again.",
     },
     privacy: {

--- a/apps/app-web/src/lib/i18n/dictionaries/ja.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/ja.ts
@@ -1318,6 +1318,18 @@ export const ja: Dictionary = {
       generateNewCode: "新しいコードを生成",
       telegramLinked: "Telegram を連携しました。",
       telegramUnlinked: "Telegram の連携を解除しました。",
+      whatsapp: "WhatsApp",
+      whatsappConnected: "連携済み",
+      connectWhatsappHint:
+        "このコードを WhatsApp で {number} に送信すると、アカウントが連携されます。",
+      openWhatsapp: "WhatsApp を開く",
+      whatsappLinked: "WhatsApp を連携しました。",
+      whatsappUnlinked: "WhatsApp の連携を解除しました。",
+      whatsappUnavailable:
+        "現在 WhatsApp の連携はご利用いただけません。しばらくしてからお試しください。",
+      disconnectWhatsappTitle: "WhatsApp の連携を解除しますか？",
+      disconnectWhatsappConfirm:
+        "アシスタントはこの WhatsApp 番号への返信を停止し、ボットを追加したグループの読み取りも停止します。",
       connectError: "問題が発生しました。もう一度お試しください。",
     },
     privacy: {

--- a/apps/app-web/src/lib/i18n/dictionaries/zh.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh.ts
@@ -1305,6 +1305,16 @@ export const zh: Dictionary = {
       generateNewCode: "產生新代碼",
       telegramLinked: "已連結 Telegram。",
       telegramUnlinked: "已解除 Telegram 連結。",
+      whatsapp: "WhatsApp",
+      whatsappConnected: "已連結",
+      connectWhatsappHint: "在 WhatsApp 將此代碼傳送至 {number}，即可連結你的帳號。",
+      openWhatsapp: "開啟 WhatsApp",
+      whatsappLinked: "已連結 WhatsApp。",
+      whatsappUnlinked: "已解除 WhatsApp 連結。",
+      whatsappUnavailable: "目前無法使用 WhatsApp 連結，請稍後再試。",
+      disconnectWhatsappTitle: "要解除 WhatsApp 連結嗎？",
+      disconnectWhatsappConfirm:
+        "助理將停止回覆此 WhatsApp 號碼，你加入機器人的群組也會停止被讀取。",
       connectError: "發生問題，請再試一次。",
     },
     privacy: {

--- a/apps/app-web/src/lib/whatsapp-link.ts
+++ b/apps/app-web/src/lib/whatsapp-link.ts
@@ -1,0 +1,38 @@
+/**
+ * WhatsApp link-code helpers — pure logic behind the Settings → Account →
+ * Connected accounts WhatsApp row.
+ *
+ * The Telegram sibling deep-links by bot @username (`t.me/<bot>?start=<code>`).
+ * WhatsApp has no username, only a number, so the equivalent is
+ * `wa.me/<digits>?text=<code>` — which prefills the outgoing message, making
+ * the handshake two taps instead of a copy-paste.
+ *
+ * Countdown/expiry helpers are shared with Telegram (`telegram-link.ts`);
+ * only the deep link differs.
+ *
+ * See docs/architecture/channels/whatsapp.md → "Account Linking Flow".
+ * Component tag: [COMP:app-web/whatsapp-link].
+ */
+
+/** The code charset minted by LinkCodeStore (ambiguous glyphs excluded). */
+const LINK_CODE_PATTERN = /^[A-Z0-9]{6}$/;
+
+/**
+ * Build the `https://wa.me/<digits>?text=<code>` deep link that opens a chat
+ * with the official bot and prefills the 6-char code.
+ *
+ * The number arrives as display text (`+852 6123 4567`), and wa.me accepts
+ * digits only, so punctuation and spacing are stripped. Returns null when the
+ * number has no digits or the code is out of shape — the UI then just shows
+ * the code for manual sending, which still works.
+ */
+export function buildWhatsappDeepLink(
+  officialNumber: string | null | undefined,
+  code: string,
+): string | null {
+  if (!officialNumber) return null;
+  const digits = officialNumber.replace(/\D/g, "");
+  if (!digits) return null;
+  if (!LINK_CODE_PATTERN.test(code)) return null;
+  return `https://wa.me/${digits}?text=${encodeURIComponent(code)}`;
+}

--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -729,6 +729,14 @@ export interface OpenApiPorts {
   whatsappScheduledBatching?: boolean
   /** A later closed router owns the hosted shared-number fallback. */
   whatsappOfficialFallback?: boolean
+  /**
+   * Resolves the official WhatsApp bot's number for Settings → Account →
+   * Connected accounts. Hosted-only (the number lives behind the closed
+   * official-bot plumbing), and its absence is what 503s the WhatsApp
+   * link-code route in OSS. See docs/architecture/channels/whatsapp.md →
+   * "Account linking".
+   */
+  getWhatsappOfficialNumber?: () => Promise<string | null>
 
   // ── Extension hook: the platform mounts its closed routes/workers ──
   mountExtraRoutes?: (app: Express, ctx: BootContext) => void | Promise<void>
@@ -3544,6 +3552,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     linkedAccountStore,
     linkCodeStore,
     getTelegramBotUsername,
+    getWhatsappOfficialNumber: ports.getWhatsappOfficialNumber,
     blobClient: filesBlobClient ?? undefined,
   }))
 

--- a/packages/api/src/routes/__tests__/account.test.ts
+++ b/packages/api/src/routes/__tests__/account.test.ts
@@ -184,6 +184,109 @@ describe('[COMP:api/account-route] Account routes', () => {
     expect(res.status).toBe(503)
   })
 
+  // ── POST /whatsapp/link-code ─────────────────────────────────
+  // Settings -> Account -> Connected accounts, WhatsApp row. Same shape as the
+  // Telegram route, but the official number is resolved BEFORE minting so a
+  // user never holds a code with nowhere to send it.
+
+  function waLinkCodeStore(code = 'WA1234') {
+    return {
+      create: vi.fn().mockResolvedValue({
+        code,
+        expiresAt: new Date('2026-06-10T00:05:00Z'),
+      }),
+      findValidCode: vi.fn(),
+      claim: vi.fn(),
+      getByUserAndAssistant: vi.fn(),
+    }
+  }
+
+  it('mints a whatsapp link code with the official number to message', async () => {
+    const linkCodeStore = waLinkCodeStore()
+    const app = createTestApp(
+      '/api/account',
+      accountRoutes({
+        linkCodeStore: linkCodeStore as never,
+        getWhatsappOfficialNumber: async () => '+85261234567',
+      }),
+      { userId: 'u_1' },
+    )
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'a_first' }], rowCount: 1 } as never)
+
+    const res = await request(app).post('/api/account/whatsapp/link-code')
+    expect(res.status).toBe(200)
+    expect(res.body.code).toBe('WA1234')
+    expect(res.body.officialNumber).toBe('+85261234567')
+    expect(linkCodeStore.create).toHaveBeenCalledWith({ userId: 'u_1', assistantId: 'a_first' })
+  })
+
+  it('returns 503 official_bot_unavailable and mints nothing when unpaired', async () => {
+    const linkCodeStore = waLinkCodeStore()
+    const app = createTestApp(
+      '/api/account',
+      accountRoutes({
+        linkCodeStore: linkCodeStore as never,
+        getWhatsappOfficialNumber: async () => null,
+      }),
+      { userId: 'u_1' },
+    )
+
+    const res = await request(app).post('/api/account/whatsapp/link-code')
+    expect(res.status).toBe(503)
+    expect(res.body.error).toBe('official_bot_unavailable')
+    // The whole point: no dangling code the user cannot deliver.
+    expect(linkCodeStore.create).not.toHaveBeenCalled()
+  })
+
+  it('treats a throwing number resolver as unavailable, not a 500', async () => {
+    const linkCodeStore = waLinkCodeStore()
+    const app = createTestApp(
+      '/api/account',
+      accountRoutes({
+        linkCodeStore: linkCodeStore as never,
+        getWhatsappOfficialNumber: async () => {
+          throw new Error('connector down')
+        },
+      }),
+      { userId: 'u_1' },
+    )
+
+    const res = await request(app).post('/api/account/whatsapp/link-code')
+    expect(res.status).toBe(503)
+    expect(linkCodeStore.create).not.toHaveBeenCalled()
+  })
+
+  it('returns 503 in OSS, where no official-number resolver is injected', async () => {
+    const linkCodeStore = waLinkCodeStore()
+    const app = createTestApp(
+      '/api/account',
+      accountRoutes({ linkCodeStore: linkCodeStore as never }),
+      { userId: 'u_1' },
+    )
+
+    const res = await request(app).post('/api/account/whatsapp/link-code')
+    expect(res.status).toBe(503)
+    expect(linkCodeStore.create).not.toHaveBeenCalled()
+  })
+
+  it('returns 409 no_assistant when the user owns no assistant', async () => {
+    const linkCodeStore = waLinkCodeStore()
+    const app = createTestApp(
+      '/api/account',
+      accountRoutes({
+        linkCodeStore: linkCodeStore as never,
+        getWhatsappOfficialNumber: async () => '+85261234567',
+      }),
+      { userId: 'u_1' },
+    )
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 } as never)
+
+    const res = await request(app).post('/api/account/whatsapp/link-code')
+    expect(res.status).toBe(409)
+    expect(res.body.error).toBe('no_assistant')
+    expect(linkCodeStore.create).not.toHaveBeenCalled()
+  })
+
   // ── PATCH /timezone ─────────────────────────────────────────
 
   it('updates timezone with valid IANA value', async () => {

--- a/packages/api/src/routes/account.ts
+++ b/packages/api/src/routes/account.ts
@@ -29,6 +29,13 @@ type AccountRouteOptions = {
    */
   getTelegramBotUsername?: () => Promise<string | null>
   /**
+   * Resolves the official WhatsApp bot's number so the Settings UI can tell the
+   * user where to send their code (and render a `wa.me` deep link). Hosted-only
+   * — absent in OSS, which is what gates `POST /whatsapp/link-code` off.
+   * See docs/architecture/channels/whatsapp.md → "Account linking".
+   */
+  getWhatsappOfficialNumber?: () => Promise<string | null>
+  /**
    * GCS blob client for avatar upload/remove/proxy. When absent (prod without
    * GCS_FILES_BUCKET), the avatar routes are not registered — same gating as
    * the file tools. See user-profile.md → "Uploading your own photo".
@@ -154,6 +161,60 @@ export function accountRoutes(options: AccountRouteOptions = {}): Router {
       res.json({ code: code.code, expiresAt: code.expiresAt, botUsername })
     } catch (err) {
       console.error('[account] telegram link-code failed:', err)
+      res.status(500).json({ error: 'Failed to generate linking code' })
+    }
+  })
+
+  // ── POST /api/account/whatsapp/link-code ────────────────────────
+  // Settings → Account → Connected accounts "Connect" flow for the official
+  // WhatsApp bot. Same shape as the Telegram route above: mint a 6-char code
+  // bound to the user's FIRST-OWNED assistant; the user sends it to the
+  // official number and the bot redeems it (whatsapp.ts → "Step A: Link code
+  // detection"), upserting the `whatsapp` identity.
+  //
+  // `officialNumber` is returned so the UI can name the number to message and
+  // build a wa.me deep link. It doubles as the hosted gate: the resolver is
+  // injected only by the hosted API, so OSS gets 503 rather than a code the
+  // user has nowhere to send. See docs/architecture/channels/whatsapp.md →
+  // "Account linking".
+
+  router.post('/whatsapp/link-code', async (req, res) => {
+    const userId = req.userId
+    if (!userId) {
+      res.status(401).json({ error: 'Missing or invalid Authorization header' })
+      return
+    }
+    if (!options.linkCodeStore || !options.getWhatsappOfficialNumber) {
+      res.status(503).json({ error: 'WhatsApp linking not configured' })
+      return
+    }
+
+    try {
+      // A code the user can't deliver is worse than an honest failure — resolve
+      // the number first and refuse if the official bot isn't paired.
+      const officialNumber = await options.getWhatsappOfficialNumber().catch(() => null)
+      if (!officialNumber) {
+        res.status(503).json({ error: 'official_bot_unavailable' })
+        return
+      }
+
+      const assistantRow = await query<{ id: string }>(
+        `SELECT id FROM assistants
+         WHERE owner_user_id = $1
+         ORDER BY created_at ASC
+         LIMIT 1`,
+        [userId],
+      )
+      const assistantId = assistantRow.rows[0]?.id
+      if (!assistantId) {
+        res.status(409).json({ error: 'no_assistant' })
+        return
+      }
+
+      const code = await options.linkCodeStore.create({ userId, assistantId })
+      res.json({ code: code.code, expiresAt: code.expiresAt, officialNumber })
+    } catch (err) {
+      console.error('[account] whatsapp link-code failed:', err)
       res.status(500).json({ error: 'Failed to generate linking code' })
     }
   })


### PR DESCRIPTION
## Problem

The official-bot Studio card tells users:

> Link your WhatsApp to your account first (Settings, then Account), or the bot will leave the group.

**Settings → Account only ever offered Telegram.** Both the initial load and the poll hard-filtered to `provider === "telegram"` (`account-section.tsx:295,316`), and there was no `whatsapp` key in that dictionary block. The instruction dead-ended.

This mattered beyond DMs: an unlinked adder has no resolvable identity, so `whatsapp-group-event.ts` makes the bot **leave the group** (`reason: 'no-account'`) - silently, per spec. Every user following step 2 hit that branch.

## What was already there

The backend half was complete and mounted - the closed `whatsapp-linking.ts` routes, plus bot-side redemption in `whatsapp.ts` ("Step A: Link code detection"), with passing tests. Only the web half was missing. (Worth noting: the bot's own unlinked-DM reply pointed at the same nonexistent screen, and at the stale `sidan.ai` domain - fixed in the platform-side PR.)

## What this adds

- **`POST /api/account/whatsapp/link-code`** - sibling of the Telegram route. Binds a 6-char code to the first-owned assistant and returns the official number to send it to. It resolves that number **first** and 503s `official_bot_unavailable` when the bot is unpaired, so a user never holds a code with nowhere to send it.
- **`WhatsappLinkRow`** in `ConnectedAccountsSection`, gated behind `isHostedEdition()` like the Studio card. Code + `wa.me/<digits>?text=<code>` deep link that **prefills the message** (there is no bot @username as on Telegram), 1s countdown, 3s poll for the `whatsapp` identity, `confirmDialog`-gated disconnect.
- **`buildWhatsappDeepLink`** extracted as pure logic and tested, mirroring `telegram-link.ts`.
- **`settings.account.whatsapp*`** copy in `en` / `ja` / `zh`, same commit.

## Open-core seam

The route lives in the open tree but is **inert** without an injected `getWhatsappOfficialNumber` resolver, supplied only by the hosted API. OSS gets a 503 rather than a code it cannot deliver. That resolver is the *same shared instance* the Studio card uses, so the number a user is told to message can never drift from the number the card displays.

## Testing

- `pnpm --filter app-web test` - **1950 passed** (216 files), including 4 new `[COMP:app-web/whatsapp-link]` cases
- `packages/api/src/routes/__tests__/account.test.ts` - **24 passed**, including 5 new cases: mints with the number, 503 + mints nothing when unpaired, throwing resolver treated as unavailable (not a 500), 503 in OSS, 409 no_assistant
- `pnpm --filter app-web typecheck` - **clean**, which is what proves all three locale dictionaries have the keys (the `Dictionary` type is the enforcement)
- `pnpm smoke` - OK

⚠️ **Pre-existing, not from this PR:** `@use-brian/api` has 58 typecheck errors on `develop` and does not build (`createTaskTriageJudge`, `GoalRecord.brief`, `SchedulingToolDeps.backgroundModel`, …). None are in `account.ts` or `boot.ts`'s new lines - verified by grepping the error list for my symbols. Flagging because it blocks the package build independently of this change.

## Pairs with

The platform-side PR (docs, component-map rows, the shared resolver, the `sidan.ai` copy fix) - this submodule branch must land with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)