### PR TITLE
fix(engine,app-web): parallel MCP confirmations, frame-gate flicker, per-action browser sizing, audio duration

### DIFF
--- a/apps/app-web/src/app/w/[workspaceId]/computer/[sessionId]/page.tsx
+++ b/apps/app-web/src/app/w/[workspaceId]/computer/[sessionId]/page.tsx
@@ -14,6 +14,10 @@
  *      shown as "Delayed view", with periodic re-mint attempts to climb
  *      back up the ladder.
  *
+ * Whichever rung is live, frames land through one `createFrameGate`: decoded
+ * off-screen first, committed to the <img> second, so the view never blanks
+ * between frames (a raw `src` swap discards what the element already painted).
+ *
  * Clicks and keys forward into the page scaled to the real viewport (the
  * password never leaves the sandbox page); the first wheel tick of a scroll
  * relays immediately; a click shows a local ripple so the ocean round-trip
@@ -36,6 +40,7 @@ import { useT } from "@/lib/i18n/client";
 import { confirmDialog } from "@/components/ui/confirm-dialog";
 import {
   LOCAL_ONLY_KEYS,
+  createFrameGate,
   createWheelForwarder,
   mapClickToFrame,
   normalizeNavigateUrl,
@@ -65,6 +70,29 @@ const REMINT_INTERVAL_MS = 20_000;
 const REMINT_MAX_ATTEMPTS = 3;
 
 type StreamMode = "connecting" | "ws" | "sse" | "poll";
+
+/**
+ * Decode a frame off-screen so the visible <img> only ever swaps to a picture
+ * the browser can paint immediately. `decode()` is the fast path; a browser
+ * that rejects it (or lacks it) falls back to the load event, so a frame is
+ * never stuck behind a decode quirk.
+ */
+function decodeFrame(src: string): Promise<void> {
+  const probe = new Image();
+  probe.decoding = "async";
+  probe.src = src;
+  const settled = () =>
+    new Promise<void>((resolve, reject) => {
+      if (probe.complete) {
+        if (probe.naturalWidth > 0) resolve();
+        else reject(new Error("frame decode failed"));
+        return;
+      }
+      probe.onload = () => resolve();
+      probe.onerror = () => reject(new Error("frame decode failed"));
+    });
+  return typeof probe.decode === "function" ? probe.decode().catch(settled) : settled();
+}
 
 export default function ComputerTakeoverPage(props: {
   params: Promise<{ workspaceId: string; sessionId: string }>;
@@ -105,6 +133,23 @@ export default function ComputerTakeoverPage(props: {
   const streamRef = useRef<TakeoverStreamSession | null>(null);
   streamRef.current = stream;
 
+  // Every transport pushes frames through one gate: decode first, commit
+  // second. Handing a fresh `src` straight to the <img> clears what it has
+  // already painted until the new JPEG decodes — one blank frame per arrival,
+  // which is the flicker on a damage-driven stream. The gate also owns the
+  // object-url lifetime, so a url is freed only once it is off screen.
+  const gateRef = useRef<ReturnType<typeof createFrameGate> | null>(null);
+  if (!gateRef.current) {
+    gateRef.current = createFrameGate({
+      decode: decodeFrame,
+      commit: setFrameSrc,
+      release: (src) => {
+        if (src.startsWith("blob:")) URL.revokeObjectURL(src);
+      },
+    });
+  }
+  useEffect(() => () => gateRef.current?.dispose(), []);
+
   // Arrival = the Take-Over begins: resolve the task and resume the paused
   // sandbox (§4.8 pauses it during the wait, not during the takeover).
   useEffect(() => {
@@ -143,8 +188,8 @@ export default function ComputerTakeoverPage(props: {
   }, [task, sessionId]);
 
   // Rung 1 - duplex WebSocket: binary JPEG frames in, input out on the same
-  // socket. Frames render via short-lived object URLs (no base64 inflation).
-  const blobUrls = useRef<string[]>([]);
+  // socket. Frames render via short-lived object URLs (no base64 inflation);
+  // the gate holds each one until it decodes and frees it once superseded.
   useEffect(() => {
     if (!task || task === "loading" || mode !== "ws" || !stream?.wsUrl) return;
     let cancelled = false;
@@ -162,12 +207,7 @@ export default function ComputerTakeoverPage(props: {
       ws.onmessage = (ev) => {
         if (!(ev.data instanceof Blob)) return;
         setStalled(false);
-        const url = URL.createObjectURL(ev.data);
-        blobUrls.current.push(url);
-        // Keep one frame of slack so the <img> currently decoding is never
-        // revoked out from under it.
-        while (blobUrls.current.length > 2) URL.revokeObjectURL(blobUrls.current.shift() as string);
-        setFrameSrc(url);
+        gateRef.current?.push(URL.createObjectURL(ev.data));
       };
       const drop = () => {
         if (wsRef.current === ws) wsRef.current = null;
@@ -194,13 +234,6 @@ export default function ComputerTakeoverPage(props: {
       }
     };
   }, [task, mode, stream]);
-  useEffect(
-    () => () => {
-      for (const url of blobUrls.current) URL.revokeObjectURL(url);
-      blobUrls.current = [];
-    },
-    [],
-  );
 
   // Rung 2 - SSE from the bridge. Frames are JSON with a base64 JPEG in
   // `data`; the stream is damage-driven, so a static page sending nothing is
@@ -214,7 +247,7 @@ export default function ComputerTakeoverPage(props: {
       setStalled(false);
       try {
         const parsed = JSON.parse(String(ev.data)) as { data?: string };
-        if (parsed.data) setFrameSrc(`data:image/jpeg;base64,${parsed.data}`);
+        if (parsed.data) gateRef.current?.push(`data:image/jpeg;base64,${parsed.data}`);
       } catch {
         /* malformed frame - keep the last good one */
       }
@@ -246,7 +279,7 @@ export default function ComputerTakeoverPage(props: {
       const frame = await getComputerFrame(sessionId).catch(() => null);
       if (cancelled) return;
       if (frame) {
-        setFrameSrc(`data:${frame.mimeType};base64,${frame.data}`);
+        gateRef.current?.push(`data:${frame.mimeType};base64,${frame.data}`);
         setStalled(false);
       } else {
         setStalled(true);

--- a/apps/app-web/src/components/settings-modal/sections/__tests__/browser-profiles-section.test.ts
+++ b/apps/app-web/src/components/settings-modal/sections/__tests__/browser-profiles-section.test.ts
@@ -1,0 +1,52 @@
+/**
+ * [COMP:app-web/profile-management] Which surfaces a profile shows.
+ *
+ * A profile is only "ONE cookie jar" on the CLOUD backend, where the vault
+ * holds its logins. A `local` ("My Browser") profile borrows the logins of the
+ * user's real Chrome: nothing is captured, nothing is stored, and the vault is
+ * never read. Showing it the vault surface tells the user two false things —
+ * that they must sign in through us, and that they have no sites signed in.
+ *
+ * Pure decision table so it is testable in this package's no-DOM vitest; the
+ * JSX wiring itself stays web-QA.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { BrowserProfile } from "@/lib/api/computer";
+import { profileSurfaces } from "../browser-profiles-section";
+
+function profile(overrides: Partial<BrowserProfile> = {}): BrowserProfile {
+  return {
+    id: "p1",
+    workspaceId: "ws-1",
+    ownerUserId: "u1",
+    name: "IG",
+    clearance: "confidential",
+    enabledAssistantIds: [],
+    defaultBackend: "cloud",
+    proxyUrl: null,
+    createdAt: "2026-07-21T00:00:00.000Z",
+    updatedAt: "2026-07-21T00:00:00.000Z",
+    sessions: [],
+    grants: [],
+    ...overrides,
+  };
+}
+
+describe("[COMP:app-web/profile-management] Profile surfaces by backend", () => {
+  it("offers the vault surface on a cloud profile (the vault is what holds its logins)", () => {
+    expect(profileSurfaces(profile({ defaultBackend: "cloud" }))).toEqual({
+      signIn: true,
+      vaultSessions: true,
+      ownBrowserNote: false,
+    });
+  });
+
+  it("replaces the vault surface with the own-browser note on a My Browser profile", () => {
+    expect(profileSurfaces(profile({ defaultBackend: "local" }))).toEqual({
+      signIn: false,
+      vaultSessions: false,
+      ownBrowserNote: true,
+    });
+  });
+});

--- a/apps/app-web/src/components/settings-modal/sections/browser-profiles-section.tsx
+++ b/apps/app-web/src/components/settings-modal/sections/browser-profiles-section.tsx
@@ -43,6 +43,25 @@ function normalizeLoginUrl(raw: string): string | null {
   }
 }
 
+/**
+ * Which surfaces a profile card shows, by backend.
+ *
+ * A profile is "ONE cookie jar" only on the CLOUD backend, where the session
+ * vault holds its logins. A `local` ("My Browser") profile rides the logins
+ * already in the user's real Chrome — nothing is captured and the vault is
+ * never read — so the sign-in box and the signed-in-sites list would both
+ * mislead: they imply the user must sign in through us, and that a profile
+ * with working logins has none. Tested as a decision table.
+ */
+export function profileSurfaces(profile: BrowserProfile): {
+  signIn: boolean;
+  vaultSessions: boolean;
+  ownBrowserNote: boolean;
+} {
+  const local = profile.defaultBackend === "local";
+  return { signIn: !local, vaultSessions: !local, ownBrowserNote: local };
+}
+
 const CLEARANCES: BrowserProfileClearance[] = ["confidential", "internal", "public"];
 const BACKENDS: BrowserBackend[] = ["cloud", "local"];
 
@@ -258,8 +277,23 @@ export function BrowserProfilesSection() {
                     </button>
                   </div>
 
+                  {/* A My Browser profile has no vault to fill — it rides the
+                      logins already in the user's real Chrome. */}
+                  {profileSurfaces(profile).ownBrowserNote ? (
+                    <div className="mt-3">
+                      <p className="text-[11px] font-medium text-muted-foreground">
+                        {t.computer.profiles.ownBrowserLabel}
+                      </p>
+                      <p className="mt-1 text-[11px] text-muted-foreground">
+                        {t.computer.profiles.ownBrowserHint}
+                      </p>
+                    </div>
+                  ) : null}
+
                   {/* "Sign in to a site" (§7): user-initiated login capture —
-                      opens the Take-Over live view on the site's login page. */}
+                      opens the Take-Over live view on the site's login page.
+                      Cloud only: capture exists only in the cloud sandbox. */}
+                  {profileSurfaces(profile).signIn ? (
                   <div className="mt-3">
                     <p className="text-[11px] font-medium text-muted-foreground">
                       {t.computer.profiles.loginLabel}
@@ -295,6 +329,7 @@ export function BrowserProfilesSection() {
                       {t.computer.profiles.loginHint}
                     </p>
                   </div>
+                  ) : null}
 
                   {/* Clearance rung (top rung = owner-only; lower = shared) */}
                   <div className="mt-3">
@@ -416,7 +451,11 @@ export function BrowserProfilesSection() {
                     </div>
                   ) : null}
 
-                  {/* Per-site sessions inside the cookie jar */}
+                  {/* Per-site sessions inside the cookie jar. Cloud only: a My
+                      Browser profile never captures into the vault, so an
+                      empty list here would read as "no logins" when the real
+                      Chrome is signed in. */}
+                  {profileSurfaces(profile).vaultSessions ? (
                   <div className="mt-3">
                     <p className="text-[11px] font-medium text-muted-foreground">
                       {t.computer.profiles.sessionsLabel}
@@ -466,6 +505,7 @@ export function BrowserProfilesSection() {
                       </ul>
                     )}
                   </div>
+                  ) : null}
                 </li>
               ))}
             </ul>

--- a/apps/app-web/src/lib/__tests__/computer-takeover.test.ts
+++ b/apps/app-web/src/lib/__tests__/computer-takeover.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, it } from "vitest";
 import {
   LOCAL_ONLY_KEYS,
+  createFrameGate,
   createWheelForwarder,
   mapClickToFrame,
   normalizeNavigateUrl,
@@ -79,6 +80,122 @@ describe("[COMP:app-web/sandbox-takeover] Take-Over click mapping", () => {
     fwd.add(10);
     expect(sent).toEqual([80, 10]); // post-dispose add opens a fresh gesture
     fwd.dispose();
+  });
+});
+
+describe("[COMP:app-web/sandbox-takeover] Frame commit gate", () => {
+  it("holds a frame back until it decodes, so the <img> never swaps to an undecoded src", async () => {
+    const committed: string[] = [];
+    let finishDecode!: () => void;
+    const gate = createFrameGate({
+      decode: () =>
+        new Promise<void>((resolve) => {
+          finishDecode = resolve;
+        }),
+      commit: (src) => committed.push(src),
+    });
+
+    gate.push("frame-1");
+    await Promise.resolve();
+    expect(committed).toEqual([]); // mid-decode — swapping now is the blank frame
+
+    finishDecode();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(committed).toEqual(["frame-1"]);
+
+    gate.dispose();
+  });
+
+  it("drops a frame whose decode lands after a newer one already committed", async () => {
+    const committed: string[] = [];
+    const finishers = new Map<string, () => void>();
+    const gate = createFrameGate({
+      decode: (src) =>
+        new Promise<void>((resolve) => {
+          finishers.set(src, resolve);
+        }),
+      commit: (src) => committed.push(src),
+    });
+
+    gate.push("frame-1");
+    gate.push("frame-2");
+
+    finishers.get("frame-2")!(); // the newer frame wins the decode race
+    await new Promise((r) => setTimeout(r, 0));
+    expect(committed).toEqual(["frame-2"]);
+
+    finishers.get("frame-1")!(); // the stale decode lands late
+    await new Promise((r) => setTimeout(r, 0));
+    expect(committed).toEqual(["frame-2"]); // never rewinds to an older picture
+
+    gate.dispose();
+  });
+
+  it("releases a frame's object url only once a newer frame has replaced it on screen", async () => {
+    const committed: string[] = [];
+    const released: string[] = [];
+    const gate = createFrameGate({
+      decode: () => Promise.resolve(),
+      commit: (src) => committed.push(src),
+      release: (src) => released.push(src),
+    });
+
+    gate.push("blob:1");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(committed).toEqual(["blob:1"]);
+    expect(released).toEqual([]); // blob:1 IS the picture — revoking it blanks the view
+
+    gate.push("blob:2");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(committed).toEqual(["blob:1", "blob:2"]);
+    expect(released).toEqual(["blob:1"]); // only now is it off screen
+
+    gate.dispose();
+  });
+
+  it("releases frames that never reach the screen, so the socket path cannot leak urls", async () => {
+    const committed: string[] = [];
+    const released: string[] = [];
+    const finishers = new Map<string, (ok: boolean) => void>();
+    const gate = createFrameGate({
+      decode: (src) =>
+        new Promise<void>((resolve, reject) => {
+          finishers.set(src, (ok) => (ok ? resolve() : reject(new Error("corrupt"))));
+        }),
+      commit: (src) => committed.push(src),
+      release: (src) => released.push(src),
+    });
+
+    gate.push("blob:stale");
+    gate.push("blob:winner");
+    finishers.get("blob:winner")!(true);
+    await new Promise((r) => setTimeout(r, 0));
+
+    finishers.get("blob:stale")!(true); // decodes late, loses the race
+    gate.push("blob:corrupt");
+    finishers.get("blob:corrupt")!(false); // never decodes at all
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(committed).toEqual(["blob:winner"]);
+    expect(released.sort()).toEqual(["blob:corrupt", "blob:stale"]);
+
+    gate.dispose();
+  });
+
+  it("releases the on-screen frame on dispose", async () => {
+    const released: string[] = [];
+    const gate = createFrameGate({
+      decode: () => Promise.resolve(),
+      commit: () => {},
+      release: (src) => released.push(src),
+    });
+
+    gate.push("blob:last");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(released).toEqual([]);
+
+    gate.dispose();
+    expect(released).toEqual(["blob:last"]); // unmount frees the final frame
   });
 });
 

--- a/apps/app-web/src/lib/computer-takeover.ts
+++ b/apps/app-web/src/lib/computer-takeover.ts
@@ -1,12 +1,18 @@
 /**
- * Take-Over live-view input geometry ([COMP:app-web/sandbox-takeover]).
+ * Take-Over live-view input geometry and frame pacing
+ * ([COMP:app-web/sandbox-takeover]).
  *
  * The live frame renders `object-contain` inside a flex-sized box, so the
  * <img> element includes letterbox bars whenever its aspect ratio differs
  * from the frame's. Click forwarding must map through the fitted content
  * rect — a linear map across the whole element lands clicks offset from
  * where the user aimed (the pre-fix take-over bug).
- * Spec: docs/architecture/engine/computer-use.md §4.8.
+ *
+ * `createFrameGate` owns the other half: what reaches that <img> and when.
+ * Swapping an image element's `src` discards what it has already painted, so
+ * committing a frame the moment it arrives cost one blank frame per arrival —
+ * the take-over flicker. Frames now decode before they commit.
+ * Spec: docs/architecture/engine/computer-use.md §4.8, §5.
  */
 
 /**
@@ -87,6 +93,58 @@ export function normalizeNavigateUrl(raw: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Frame commit gate (§5). Swapping an <img>'s `src` clears what it has already
+ * painted and repaints nothing until the new JPEG decodes — one blank frame per
+ * arrival, which reads as flicker on a damage-driven stream. The gate decodes
+ * each frame off-screen first and only then advances the committed src, so the
+ * element always holds a fully-decoded picture.
+ */
+export function createFrameGate(opts: {
+  decode: (src: string) => Promise<void>;
+  commit: (src: string) => void;
+  /** Frees a frame's backing object url. Never called on the on-screen frame. */
+  release?: (src: string) => void;
+}): { push: (src: string) => void; dispose: () => void } {
+  let disposed = false;
+  let issued = 0;
+  let committedSeq = 0;
+  let onScreen: string | null = null;
+  return {
+    push(src: string) {
+      issued += 1;
+      const seq = issued;
+      void opts
+        .decode(src)
+        .then(() => {
+          // A slower decode can land after a newer frame is already up;
+          // committing it would rewind the picture. It never reached the
+          // screen, so it frees immediately.
+          if (disposed || seq <= committedSeq) {
+            opts.release?.(src);
+            return;
+          }
+          committedSeq = seq;
+          const previous = onScreen;
+          onScreen = src;
+          opts.commit(src);
+          // Only now is the old frame off screen and safe to free.
+          if (previous !== null) opts.release?.(previous);
+        })
+        .catch(() => {
+          // Undecodable frame — keep the last good one on screen, but the
+          // url still has to go back or the socket path leaks one per frame.
+          opts.release?.(src);
+        });
+    },
+    dispose() {
+      disposed = true;
+      if (onScreen !== null) opts.release?.(onScreen);
+      onScreen = null;
+    },
+  };
 }
 
 /** Keys that carry no input on their own — never worth a relay round-trip. */

--- a/apps/app-web/src/lib/i18n/dictionaries/en.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/en.ts
@@ -5482,6 +5482,9 @@ export const en = {
       assistantsEmpty: "No assistants in this workspace yet.",
       sessionsLabel: "Signed-in sites",
       sessionsEmpty: "No sites signed in yet. Sign in during a browser task and save the session here.",
+      ownBrowserLabel: "Logins come from your own browser",
+      ownBrowserHint:
+        "This profile browses in your own Chrome, so it uses the sites you are already signed into there. Nothing is captured or stored here.",
       statusActive: "Active",
       statusDead: "Signed out",
       lastUsed: "Last used",

--- a/apps/app-web/src/lib/i18n/dictionaries/ja.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/ja.ts
@@ -5269,6 +5269,9 @@ export const ja: Dictionary = {
       assistantsEmpty: "このワークスペースにはまだアシスタントがいません。",
       sessionsLabel: "サインイン済みサイト",
       sessionsEmpty: "サインイン済みのサイトはまだありません。ブラウザタスク中にサインインして保存してください。",
+      ownBrowserLabel: "ログイン情報はご自身のブラウザから取得されます",
+      ownBrowserHint:
+        "このプロファイルはご自身の Chrome で閲覧するため、そこですでにサインイン済みのサイトをそのまま利用します。ここには何も保存されません。",
       statusActive: "有効",
       statusDead: "サインアウト済み",
       lastUsed: "最終使用",

--- a/apps/app-web/src/lib/i18n/dictionaries/zh.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh.ts
@@ -5218,6 +5218,9 @@ export const zh: Dictionary = {
       assistantsEmpty: "這個工作空間還沒有助理。",
       sessionsLabel: "已登入的網站",
       sessionsEmpty: "還沒有已登入的網站。在瀏覽器任務中登入後即可儲存到這裡。",
+      ownBrowserLabel: "登入狀態來自你自己的瀏覽器",
+      ownBrowserHint:
+        "這個設定檔會在你自己的 Chrome 中瀏覽，直接使用你在那裡已登入的網站。這裡不會擷取或儲存任何資料。",
       statusActive: "有效",
       statusDead: "已登出",
       lastUsed: "上次使用",

--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -3136,6 +3136,12 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
           host: sanitizeAnalytics(evt.host ?? ''),
           ok: evt.ok,
           ...(evt.code ? { code: sanitizeAnalytics(evt.code) } : {}),
+          // Per-action context cost. Numbers, not strings — sanitizeAnalytics
+          // is for free text, and these must stay numeric for the admin
+          // aggregate to SUM them. The local backend books no usage_tracking
+          // row of its own, so this is the ONLY per-action cost signal it has.
+          ...(evt.resultChars !== undefined ? { result_chars: evt.resultChars } : {}),
+          ...(evt.resultTokens !== undefined ? { result_tokens: evt.resultTokens } : {}),
         },
       })
     },

--- a/packages/api/src/routes/__tests__/computer.test.ts
+++ b/packages/api/src/routes/__tests__/computer.test.ts
@@ -320,7 +320,14 @@ describe('[COMP:routes/computer] Take-Over live view + backend toggle + Profile-
       expect(started.status).toBe(200)
       expect(started.body.site).toBe('instagram.com')
       const sessionId = started.body.sessionId as string
-      expect(sessionId.startsWith('plogin_')).toBe(true)
+      // A BARE uuid — `sandbox_tasks.session_id` is `uuid NOT NULL` (closed
+      // migration 315), so a decorated id (the old synthetic `plogin_<uuid>`)
+      // makes the task insert throw `invalid input syntax for type uuid` and
+      // the route 502s. The in-memory task store accepts any string, so this
+      // shape assertion is the only place the DB contract is enforced in test.
+      expect(sessionId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      )
 
       // The synthetic-session task is owned by the caller and pre-bound to
       // the profile — the Take-Over live view + capture work on it unchanged.

--- a/packages/api/src/routes/_overhead-usage.ts
+++ b/packages/api/src/routes/_overhead-usage.ts
@@ -41,6 +41,12 @@ export type RecordOverheadUsageParams = {
    * forwarded straight through to the store. Migration 164.
    */
   triggerKey?: string
+  /**
+   * Seconds of audio this overhead call processed — see
+   * UsageStore.recordUsage. Set by the voice-transcription paths so the
+   * admin rollup can price speech-to-text per audio hour. Migration 347.
+   */
+  audioSeconds?: number
 }
 
 export async function recordOverheadUsage(
@@ -66,6 +72,7 @@ export async function recordOverheadUsage(
       source: params.source,
       userMessageId: params.userMessageId ?? undefined,
       triggerKey: params.triggerKey,
+      ...(params.audioSeconds !== undefined ? { audioSeconds: params.audioSeconds } : {}),
     })
   } catch (err) {
     console.error(`[overhead-usage] failed to record ${params.source}:`, err)

--- a/packages/api/src/routes/channel-pipeline.ts
+++ b/packages/api/src/routes/channel-pipeline.ts
@@ -450,7 +450,12 @@ export type ChannelPipelineParams = {
    * Usage is recorded here as `overhead:transcription` once we have a
    * stored user_message_id.
    */
-  voiceTranscriptionUsage?: { usage: TokenUsage | null; model: string } | null
+  voiceTranscriptionUsage?: {
+    usage: TokenUsage | null
+    model: string
+    /** Duration of the voice note, when the channel handler measured it. */
+    audioSeconds?: number
+  } | null
 }
 
 // ── Large-paste intercept ────────────────────────────────────────
@@ -799,6 +804,14 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
       model: voiceTranscriptionUsage.model,
       usage: voiceTranscriptionUsage.usage,
       source: 'overhead:transcription',
+      // Distinguishes an inbound voice message from a recording upload:
+      // both are `overhead:transcription`, but they have different volumes,
+      // different latency budgets, and would migrate to a new provider
+      // independently.
+      triggerKey: 'voice_message_transcription',
+      ...(voiceTranscriptionUsage.audioSeconds !== undefined
+        ? { audioSeconds: voiceTranscriptionUsage.audioSeconds }
+        : {}),
     })
   }
 

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -2254,6 +2254,10 @@ export function chatRoutes(options: WebChatOptions): Router {
           model: t.model,
           usage: t.usage,
           source: 'overhead:transcription',
+          // Same source as a recording upload, different workload — tag it
+          // so the two can be priced and migrated independently.
+          triggerKey: 'voice_message_transcription',
+          ...(t.audioSeconds !== undefined ? { audioSeconds: t.audioSeconds } : {}),
         })
       }
 

--- a/packages/api/src/routes/computer.ts
+++ b/packages/api/src/routes/computer.ts
@@ -423,7 +423,14 @@ export function computerRoutes(deps: {
       res.status(400).json({ error: 'url must be an http(s) URL' })
       return
     }
-    const sessionId = `plogin_${randomUUID()}`
+    // A BARE uuid, never a decorated one: this id is persisted as
+    // `sandbox_tasks.session_id`, which is `uuid NOT NULL` (closed migration
+    // 315). The original synthetic `plogin_<uuid>` made every insert throw
+    // `invalid input syntax for type uuid`, so this route 502'd on every call
+    // from the day it shipped — the in-memory task store used in tests takes
+    // any string, so the suite stayed green. Nothing reads the prefix; the
+    // sign-in flow is marked by the UI's `?flow=login` query instead.
+    const sessionId = randomUUID()
     const cloud = createCloudBrowserProvider({
       provider: deps.provider,
       binding: deps.orchestrator.binding,

--- a/packages/api/src/routes/telegram-byo.ts
+++ b/packages/api/src/routes/telegram-byo.ts
@@ -1088,7 +1088,9 @@ async function processMessage(params: ProcessMessageParams): Promise<void> {
   // treats it as plain text. Mutates the input by design — same pattern
   // as packages/api/src/routes/telegram.ts. See
   // docs/architecture/media/transcription.md.
-  let voiceTranscriptionUsage: { usage: TokenUsage | null; model: string } | null = null
+  let voiceTranscriptionUsage:
+    | { usage: TokenUsage | null; model: string; audioSeconds?: number }
+    | null = null
   if (
     incoming.mediaType === 'voice' &&
     incoming.mediaUrl &&
@@ -1097,7 +1099,19 @@ async function processMessage(params: ProcessMessageParams): Promise<void> {
     try {
       const { buffer, mime } = await adapter.downloadVoice(incoming.mediaUrl)
       const result = await transcribeFirstAudio(
-        [{ buffer, mime, index: 0 }],
+        [
+          {
+            buffer,
+            mime,
+            index: 0,
+            // Telegram puts `voice.duration` on the webhook payload, so this
+            // is the one transcription path that can price itself per audio
+            // hour. Absent (older payloads) stays absent, not 0.
+            ...(incoming.mediaDurationSec !== undefined
+              ? { durationSeconds: incoming.mediaDurationSec }
+              : {}),
+          },
+        ],
         {
           enabled: true,
           apiKey: params.voiceTranscription.apiKey,
@@ -1108,7 +1122,11 @@ async function processMessage(params: ProcessMessageParams): Promise<void> {
         },
       )
       if (result) {
-        voiceTranscriptionUsage = { usage: result.usage, model: result.model }
+        voiceTranscriptionUsage = {
+          usage: result.usage,
+          model: result.model,
+          ...(result.audioSeconds !== undefined ? { audioSeconds: result.audioSeconds } : {}),
+        }
         incoming.text = incoming.text
           ? `[voice] ${result.text}\n\n${incoming.text}`
           : `[voice] ${result.text}`

--- a/packages/core/src/billing/cost-tracker.ts
+++ b/packages/core/src/billing/cost-tracker.ts
@@ -169,6 +169,19 @@ export type UsageStore = {
      */
     triggerKey?: string
     /**
+     * Seconds of audio this row processed (speech-to-text, TTS).
+     *
+     * Transcription providers bill in incompatible units — Gemini per input
+     * token, ElevenLabs Scribe and Azure per audio hour — so audio duration
+     * is the only denominator that makes them comparable. Recorders that
+     * know the duration must pass it; everything else leaves it undefined
+     * (recorded as NULL, which the admin rollup reports as an unknown rate
+     * rather than a free one).
+     *
+     * Optional — null on non-audio rows and on rows pre-migration 347.
+     */
+    audioSeconds?: number
+    /**
      * Which API key drove the LLM call: the platform's (`platform`, the
      * default) or the workspace's bring-your-own key (`user`). BYO turns are
      * recorded with `actualCostUsd = 0` because the workspace pays its provider

--- a/packages/core/src/engine/__tests__/multi-tool-confirm.test.ts
+++ b/packages/core/src/engine/__tests__/multi-tool-confirm.test.ts
@@ -18,10 +18,12 @@
  * executeTool.
  */
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { z } from 'zod'
 import { buildTool, type Tool, type ToolContext } from '../../tools/types.js'
 import { createConfirmationResolver, type ToolConfirmationRequest } from '../../mcp/types.js'
+import type { McpServerConfig, McpSettingsStore } from '../../mcp/types.js'
+import { buildToolIndex, createMcpSearchTools } from '../../mcp/tool-search.js'
 import { createToolExecutor } from '../tool-executor.js'
 import { createLoopDetector } from '../loop-detector.js'
 import type { ContentBlock } from '../../providers/types.js'
@@ -177,5 +179,144 @@ describe('[COMP:engine/tool-executor] multi-tool parallel confirmation, serial e
     resolver.resolve('first', 'allow')
     resolver.resolve('second', 'allow')
     for await (const _ of executor.getRemainingResults()) { /* drain */ }
+  })
+})
+
+/**
+ * Same regression class as above, reached through the OTHER confirmation
+ * gate — the one every connector write actually uses.
+ *
+ * Surfaced 2026-07-21 (yanyuk.tom, "Personal agents" workspace, Telegram
+ * channel MarkMyCalendar): the calendar assistant created exactly ONE event
+ * per message and then went silent for 5-6 minutes. The model routinely
+ * fans out 3-4 `googleCalendarCreateEvent` calls per turn; only the first
+ * ever showed an Allow button, the rest sat invisible and each burned the
+ * full 300s `confirmationTimeoutMs`, and the first timeout's
+ * `blockedTools.add()` hard-rejected the remainder with "blocked for this
+ * session". The 300s park then blew the query loop's 90s empty-response
+ * wall-clock budget, so the turn exited with no text and the channel sent
+ * nothing at all.
+ *
+ * Root cause: the fix above only covers tools the EXECUTOR gates
+ * (`requiresConfirmation: true` → status `pending_confirmation`, which
+ * `canExecute` deliberately ignores). Connector tools reach the model
+ * through `mcp_call`, which declares `requiresConfirmation: false` and
+ * `isConcurrencySafe: false`, and raises its prompt INSIDE `execute()` —
+ * after the exclusive execution slot is already claimed. So a parked
+ * `mcp_call` holds the slot for the entire human wait, and
+ * `tryStartQueued` never starts its siblings.
+ *
+ * The invariant is the same for both gates: a sibling the user was never
+ * shown cannot be approved, so every prompt must reach them before any
+ * decision is required.
+ */
+describe('[COMP:engine/tool-executor] connector (mcp_call) sibling confirmation', () => {
+  const settingsStore: McpSettingsStore = {
+    async getPolicy() { return null },
+    async setPolicy() {},
+    async recordUsage() {},
+    async recordUsageAndGetCount() { return { timesAllowed: 0, timesDenied: 0 } },
+  }
+
+  /**
+   * Mirrors the real `googleCalendarCreateEvent`
+   * (`packages/core/src/tools/base/google-calendar.ts`): a first-party
+   * built-in with `requiresConfirmation: true` + `isConcurrencySafe: false`,
+   * reached through `mcp_call` because `inject.ts` plucks built-ins into a
+   * `kind: 'local'` search source rather than leaving them direct.
+   */
+  function makeExecutor() {
+    const created: string[] = []
+    const createEvent = buildTool({
+      name: 'googleCalendarCreateEvent',
+      description: 'Create a new Google Calendar event',
+      inputSchema: z.object({ summary: z.string() }),
+      isConcurrencySafe: false,
+      requiresConfirmation: true,
+      async execute(input) {
+        created.push((input as { summary: string }).summary)
+        return { data: 'created' }
+      },
+    })
+
+    const index = buildToolIndex([
+      { kind: 'local', serverName: 'gcal', tools: [createEvent] },
+    ])
+    const [, mcpCall] = createMcpSearchTools({
+      index,
+      settingsStore,
+      assistantId: 'a',
+      userId: 'u',
+      callMcpTool: async () => ({}), // local dispatch never reaches the wire
+    })
+
+    const resolver = createConfirmationResolver()
+    const prompts: ToolConfirmationRequest[] = []
+    const executor = createToolExecutor({
+      tools: new Map<string, Tool>([['mcp_call', mcpCall]]),
+      context: ctx,
+      loopDetector: createLoopDetector(),
+      confirmationResolver: resolver,
+      confirmationTimeoutMs: 60_000,
+      onConfirmationRequired: (req: ToolConfirmationRequest) => { prompts.push(req) },
+    })
+    return { executor, resolver, prompts, created }
+  }
+
+  it('prompts for every sibling mcp_call before any decision is given', async () => {
+    const { executor, resolver, prompts, created } = makeExecutor()
+
+    executor.addTool('call_1', 'mcp_call', {
+      server: 'gcal', tool: 'googleCalendarCreateEvent', args: { summary: '天文學會 Check-out' },
+    })
+    executor.addTool('call_2', 'mcp_call', {
+      server: 'gcal', tool: 'googleCalendarCreateEvent', args: { summary: '返蔡宿瞓' },
+    })
+
+    const drained: ContentBlock[] = []
+    const drainPromise = (async () => {
+      for await (const batch of executor.getRemainingResults()) drained.push(...batch.blocks)
+    })()
+
+    // The heart of it: BOTH prompts must reach the user while both calls are
+    // still unanswered. Pre-fix only call_1 ever prompted — call_2 stayed
+    // `queued` behind the slot call_1 was holding while parked on a human,
+    // so the user could not have approved it even in principle.
+    await vi.waitFor(() => expect(prompts).toHaveLength(2), { timeout: 2000 })
+
+    // The user taps Allow on each card. Note each needs its own tap: on the
+    // local path a plain `allow` is deliberately per-call (each event is a
+    // distinct entity), so N events legitimately means N prompts — they just
+    // have to arrive together instead of 300s apart.
+    for (const p of prompts) resolver.resolve(p.toolCallId, 'allow')
+    await drainPromise
+
+    expect(created).toEqual(['天文學會 Check-out', '返蔡宿瞓'])
+    expect(drained.filter((b) => (b as { isError?: boolean }).isError)).toEqual([])
+  })
+
+  it('releases the slot in a chain, so a 4-call fan-out prompts for all four', async () => {
+    // The reported turn emitted four creates. Releasing the slot only once
+    // would surface two prompts and strand calls 3-4, so this pins that each
+    // park hands off to the next.
+    const { executor, resolver, prompts, created } = makeExecutor()
+
+    const summaries = ['ZJU check-in', 'ZJU check-out', '出門準備', '返蔡宿瞓']
+    summaries.forEach((summary, i) => {
+      executor.addTool(`call_${i + 1}`, 'mcp_call', {
+        server: 'gcal', tool: 'googleCalendarCreateEvent', args: { summary },
+      })
+    })
+
+    const drainPromise = (async () => {
+      for await (const _ of executor.getRemainingResults()) { /* drain */ }
+    })()
+
+    await vi.waitFor(() => expect(prompts).toHaveLength(4), { timeout: 2000 })
+
+    for (const p of prompts) resolver.resolve(p.toolCallId, 'allow')
+    await drainPromise
+
+    expect(created).toEqual(summaries)
   })
 })

--- a/packages/core/src/engine/tool-executor.ts
+++ b/packages/core/src/engine/tool-executor.ts
@@ -648,12 +648,40 @@ export function createToolExecutor(options: ToolExecutorOptions) {
           }
         : undefined
 
+      // Gateway tools (mcp_call) resolve policy inside execute() and prompt
+      // from there — after this tool already took the exclusive slot. Keeping
+      // the slot across the human wait would stop tryStartQueued from ever
+      // starting the siblings, and a sibling that never starts never prompts,
+      // so it expires unseen at confirmationTimeoutMs. Park instead: drop to
+      // `pending_confirmation` (which canExecute ignores), let the siblings
+      // through to raise their own prompts, then re-take the slot before the
+      // real work runs. Same prompt-parallel / execute-serial ordering the
+      // executor's own confirmation gate above already has.
+      const parkForConfirmation = async <T>(wait: () => Promise<T>): Promise<T> => {
+        t.status = 'pending_confirmation'
+        wake()
+        tryStartQueued()
+        try {
+          return await wait()
+        } finally {
+          if (!canExecute(t.isConcurrencySafe)) {
+            t.status = 'awaiting_slot'
+            while (!canExecute(t.isConcurrencySafe)) {
+              await waitForChange()
+            }
+          }
+          t.status = 'executing'
+          wake()
+        }
+      }
+
       const result = await toolDef.execute(validated, {
         ...options.context,
         abortSignal: mergedSignal,
         confirmationResolver: options.confirmationResolver,
         notifyConfirmationRequired,
         confirmationTimeoutMs: options.confirmationTimeoutMs,
+        parkForConfirmation,
       })
 
       clearTimeout(timer)

--- a/packages/core/src/mcp/tool-search.ts
+++ b/packages/core/src/mcp/tool-search.ts
@@ -530,7 +530,13 @@ async function dispatchRemote(params: {
 
       try {
         const timeoutMs = context?.confirmationTimeoutMs ?? 300_000
-        const decision = await resolver.waitForDecision(confirmId, timeoutMs)
+        // Wait outside the executor's exclusive slot so sibling mcp_calls in
+        // the same turn can start and raise their own prompts. See
+        // ToolContext.parkForConfirmation.
+        const awaitDecision = () => resolver.waitForDecision(confirmId, timeoutMs)
+        const decision = context.parkForConfirmation
+          ? await context.parkForConfirmation(awaitDecision)
+          : await awaitDecision()
 
         if (decision === 'deny') {
           blockedTools.add(toolKey)
@@ -798,7 +804,15 @@ async function dispatchLocal(params: {
     })
 
     try {
-      const decision = await resolver.waitForDecision(confirmId, timeoutMs)
+      // Wait outside the executor's exclusive slot so sibling mcp_calls in
+      // the same turn can start and raise their own prompts. This is the path
+      // every first-party built-in write takes (googleCalendarCreateEvent and
+      // friends), so without it a multi-write turn shows exactly one card.
+      // See ToolContext.parkForConfirmation.
+      const awaitDecision = () => resolver.waitForDecision(confirmId, timeoutMs)
+      const decision = context.parkForConfirmation
+        ? await context.parkForConfirmation(awaitDecision)
+        : await awaitDecision()
 
       if (decision === 'deny' || decision === 'always_deny') {
         blockedTools.add(toolKey)

--- a/packages/core/src/media/__tests__/preflight.test.ts
+++ b/packages/core/src/media/__tests__/preflight.test.ts
@@ -94,6 +94,31 @@ describe('[COMP:media/preflight] transcribeFirstAudio', () => {
       { apiKey: 'k', model: 'm', timeoutMs: 1234, fetchFn: customFetch },
     )
   })
+
+  it("carries the attachment's duration onto the result as audioSeconds", async () => {
+    // The transcriber posts bytes and never learns the duration, so the
+    // channel's value is the only source. Without this the token-billed path
+    // records NULL forever and can never be priced per audio hour — the whole
+    // reason `usage_tracking.audio_seconds` exists.
+    mockedTranscribe.mockResolvedValue({ text: 'ok', usage: null, model: 'gemini-2.5-flash' })
+    const result = await transcribeFirstAudio(
+      [{ buffer: Buffer.from('x'), mime: 'audio/ogg', index: 0, durationSeconds: 12 }],
+      baseOptions,
+    )
+    expect(result?.audioSeconds).toBe(12)
+  })
+
+  it('leaves audioSeconds absent when the channel did not measure a duration', async () => {
+    // A raw web upload carries no duration. Absent must stay absent: recorded
+    // as NULL it reads "unknown rate", but a 0 would read "free transcription
+    // of zero-length audio" and deflate every rate averaged over the window.
+    mockedTranscribe.mockResolvedValue({ text: 'ok', usage: null, model: 'gemini-2.5-flash' })
+    const result = await transcribeFirstAudio(
+      [{ buffer: Buffer.from('x'), mime: 'audio/ogg', index: 0 }],
+      baseOptions,
+    )
+    expect(result).not.toHaveProperty('audioSeconds')
+  })
 })
 
 // A swallowed transcription failure used to reach the model as a bare

--- a/packages/core/src/media/__tests__/scribe.test.ts
+++ b/packages/core/src/media/__tests__/scribe.test.ts
@@ -152,8 +152,16 @@ describe('[COMP:media/transcriber-scribe] scribeTranscriber', () => {
     const t = scribeTranscriber({ apiKey: 'k', fetchFn: fetchFn as unknown as typeof fetch })
 
     const plain = await t.transcribe({ buffer: Buffer.from('x'), mime: 'audio/aac', durationMs: HOUR_MS })
+    // `audioSeconds` rides along with the flat-rate cost so the billing
+    // ledger keeps the denominator this cost was derived from — without it
+    // a per-audio-hour provider cannot be compared to a token-billed one.
     expect(plain.usages).toEqual([
-      { usage: null, model: 'elevenlabs:scribe_v2', costUsd: SCRIBE_USD_PER_AUDIO_HOUR },
+      {
+        usage: null,
+        model: 'elevenlabs:scribe_v2',
+        costUsd: SCRIBE_USD_PER_AUDIO_HOUR,
+        audioSeconds: HOUR_MS / 1000,
+      },
     ])
 
     const biased = await t.transcribe({

--- a/packages/core/src/media/preflight.ts
+++ b/packages/core/src/media/preflight.ts
@@ -85,7 +85,13 @@ export async function transcribeFirstAudio(
       },
     )
     firstAudio.alreadyTranscribed = true
-    return result
+    // The transcriber posts bytes and never learns the duration, so the
+    // caller's value is the only source. Spread conditionally: an absent
+    // duration must stay absent so it records as NULL (unknown rate) rather
+    // than 0 (free transcription of zero-length audio).
+    return firstAudio.durationSeconds !== undefined
+      ? { ...result, audioSeconds: firstAudio.durationSeconds }
+      : result
   } catch (err) {
     console.warn('[media/preflight] transcription failed:', err instanceof Error ? err.message : err)
     options.onFailure?.(describeTranscriptionFailure(err))

--- a/packages/core/src/media/scribe.ts
+++ b/packages/core/src/media/scribe.ts
@@ -177,7 +177,13 @@ export function scribeTranscriber(opts: ScribeTranscriberOptions): RecordingTran
 
       return {
         utterances,
-        usages: [{ usage: null, model: name, costUsd: hours * rate }],
+        // `audioSeconds` is what makes this row comparable to a token-billed
+        // transcriber: the cost below is already derived from duration, so
+        // reporting the duration too costs nothing and gives the admin
+        // rollup a $/audio-hour denominator.
+        usages: [
+          { usage: null, model: name, costUsd: hours * rate, audioSeconds: req.durationMs / 1000 },
+        ],
         windows: 1,
         truncated: coverageTruncated(utterances, req.durationMs),
         // Single-shot file provider: no windowed continuation, so no degeneration guard runs.

--- a/packages/core/src/media/transcribe-recording.ts
+++ b/packages/core/src/media/transcribe-recording.ts
@@ -141,8 +141,14 @@ export type RecordingTranscriptionResult = {
   utterances: TranscribedUtterance[]
   /** One entry per generate window, for COGS attribution via recordUsage.
    *  Flat-rate (per-audio-hour) providers set `costUsd` directly; token-billed
-   *  providers leave it unset and the factory prices `usage` instead. */
-  usages: Array<{ usage: TokenUsage | null; model: string; costUsd?: number }>
+   *  providers leave it unset and the factory prices `usage` instead.
+   *
+   *  `audioSeconds` is the duration THIS entry covers — per window, not per
+   *  file, so a windowed transcriber's entries sum to the file duration
+   *  instead of multiplying it. Providers that cannot attribute duration to a
+   *  window leave it unset; the ingest path then falls back to the file
+   *  duration only when there is exactly one entry to attribute it to. */
+  usages: Array<{ usage: TokenUsage | null; model: string; costUsd?: number; audioSeconds?: number }>
   /** Number of continuation windows used (1 = no continuation). */
   windows: number
   /** True when the last utterance fell short of the audio end (coverage gap). */

--- a/packages/core/src/media/transcribe.ts
+++ b/packages/core/src/media/transcribe.ts
@@ -37,6 +37,14 @@ export type TranscribeResult = {
   text: string
   usage: TokenUsage | null
   model: string
+  /**
+   * Duration of the transcribed audio, when the caller knew it (Telegram
+   * voice notes carry it on the message payload; a raw upload does not).
+   * Feeds `usage_tracking.audio_seconds` so this token-billed path can be
+   * priced per audio hour against flat-rate providers. Undefined is
+   * recorded as NULL — an unknown rate, never a free one.
+   */
+  audioSeconds?: number
 }
 
 const DEFAULT_MODEL = 'gemini-2.5-flash'

--- a/packages/core/src/media/types.ts
+++ b/packages/core/src/media/types.ts
@@ -12,4 +12,13 @@ export type MediaAttachment = {
   mime: string
   index: number
   alreadyTranscribed?: boolean
+  /**
+   * Audio duration in seconds when the channel's payload carried it (Telegram
+   * voice notes do; a raw web upload does not). Threaded to
+   * `TranscribeResult.audioSeconds` → `usage_tracking.audio_seconds`, which is
+   * the denominator that makes this token-billed path comparable to a
+   * flat-rate-per-audio-hour provider. Never inferred from the buffer —
+   * unknown stays unknown and is recorded as NULL, never 0.
+   */
+  durationSeconds?: number
 }

--- a/packages/core/src/sandbox/__tests__/computer-tools.test.ts
+++ b/packages/core/src/sandbox/__tests__/computer-tools.test.ts
@@ -679,4 +679,29 @@ describe('[COMP:sandbox/browser-tools] Computer tool surface', () => {
     // No event ever carries typed text or page content.
     expect(JSON.stringify(events)).not.toContain('SECRET DRAFT')
   })
+
+  it('audits what each action ADDED TO CONTEXT, so a browse can be costed', async () => {
+    const events: Array<Record<string, unknown>> = []
+    const tools = createComputerTools({
+      local: fakeProvider('local'),
+      cloud: fakeProvider('cloud'),
+      onEvent: (evt) => void events.push(evt as unknown as Record<string, unknown>),
+    })
+    const ctx = toolContext()
+    await run(tools.browserSnapshot, {}, ctx)
+    await run(tools.browserType, { ref: '@e1', text: 'hello' }, ctx)
+
+    // The LOCAL backend books no sandbox-seconds and no usage_tracking row of
+    // its own — a local browse's whole cost is the tokens its results occupy
+    // in the parent turn. Measuring that here is the only per-action signal
+    // there is. Size only: still metadata, never content.
+    const snapshot = events.find((e) => e.op === 'snapshot')
+    expect(snapshot?.resultChars).toBeGreaterThan(0)
+    expect(snapshot?.resultTokens).toBeGreaterThan(0)
+
+    // `type` takes no inline snapshot, so it is near-free — the asymmetry is
+    // the point of measuring, and it must survive in the data.
+    const typed = events.find((e) => e.op === 'type')
+    expect(typed?.resultChars).toBeLessThan(Number(snapshot?.resultChars))
+  })
 })

--- a/packages/core/src/sandbox/__tests__/orchestrator.test.ts
+++ b/packages/core/src/sandbox/__tests__/orchestrator.test.ts
@@ -46,6 +46,22 @@ describe('[COMP:sandbox/orchestrator] Sandbox task orchestration', () => {
     expect(provider.sandboxes.size).toBe(2) // a different session = a different task
   })
 
+  it('kills the sandbox when the task row cannot be persisted (never orphans a micro-VM)', async () => {
+    const { provider, taskStore, browser } = build()
+    // The real shape of this failure: `sandbox_tasks.session_id` is `uuid NOT
+    // NULL`, so a malformed session id rejects AFTER the micro-VM is already
+    // running. Anything thrown between create() and the task row must still
+    // take the sandbox down — an orphan bills until its max-lifetime reaper.
+    taskStore.create = async () => {
+      throw new Error('invalid input syntax for type uuid')
+    }
+
+    await expect(browser.navigate(ctx('s1'), 'https://github.com/')).rejects.toThrow(/uuid/)
+
+    expect(provider.sandboxes.size).toBe(1)
+    expect([...provider.sandboxes.values()].map((s) => s.status)).toEqual(['killed'])
+  })
+
   it('lists a workspace\'s live tasks for discovery and drops completed ones (§5)', async () => {
     const { orchestrator, browser } = build()
     await browser.navigate(ctx('s1'), 'https://github.com/')

--- a/packages/core/src/sandbox/orchestrator.ts
+++ b/packages/core/src/sandbox/orchestrator.ts
@@ -292,23 +292,35 @@ export function createSandboxOrchestrator(deps: SandboxOrchestratorDeps): Sandbo
       egressAllowlist: deps.egressAllowlistFor?.(ctx) ?? [],
       maxLifetimeSeconds: deps.maxLifetimeSeconds,
     })
-    // Session reuse (§4.4): inject the profile's vaulted bundle BEFORE the
-    // first navigation so the site is already signed in.
-    const injectedSite = await injectVaultBundle(profileId, sandboxId, site)
+    // From here the micro-VM is BILLING, so every path out must either record
+    // the task row or kill the sandbox. Without this the vault injection or
+    // the insert could throw and leave an orphan running until its
+    // max-lifetime reaper — which is exactly what a malformed session id did
+    // (`sandbox_tasks.session_id` is `uuid NOT NULL`; the sign-in route's
+    // decorated id 502'd every call and leaked a sandbox each time).
+    try {
+      // Session reuse (§4.4): inject the profile's vaulted bundle BEFORE the
+      // first navigation so the site is already signed in.
+      const injectedSite = await injectVaultBundle(profileId, sandboxId, site)
 
-    await deps.taskStore.create({
-      taskId,
-      sandboxId,
-      userId: ctx.userId,
-      workspaceId: ctx.workspaceId,
-      sessionId: ctx.sessionId,
-      status: 'running',
-      profileId,
-      injectedSite,
-      authorizedBudgetUsd,
-      createdAt: now(),
-      lastActivityAt: now(),
-    })
+      await deps.taskStore.create({
+        taskId,
+        sandboxId,
+        userId: ctx.userId,
+        workspaceId: ctx.workspaceId,
+        sessionId: ctx.sessionId,
+        status: 'running',
+        profileId,
+        injectedSite,
+        authorizedBudgetUsd,
+        createdAt: now(),
+        lastActivityAt: now(),
+      })
+    } catch (err) {
+      // Best-effort: a failed kill must not mask the original cause.
+      await deps.provider.kill(sandboxId).catch(() => {})
+      throw err
+    }
     return { sandboxId }
   }
 

--- a/packages/core/src/sandbox/tools.ts
+++ b/packages/core/src/sandbox/tools.ts
@@ -17,6 +17,7 @@ import { z } from 'zod'
 import { buildTool, type Tool, type ToolContext, type ToolResult } from '../tools/types.js'
 import { isAutonomousToolContext } from '../tools/capability-gate.js'
 import type { Sensitivity } from '../security/sensitivity.js'
+import { estimateStringTokens } from '../compaction/compact.js'
 import {
   looksLikeCaptcha,
   looksLikeConnectionBlock,
@@ -57,6 +58,32 @@ export type ComputerToolEvent = {
   host: string | null
   ok: boolean
   code?: string
+  /**
+   * What this action ADDED TO CONTEXT — the only per-action cost signal a
+   * browse has. The LOCAL backend books no sandbox-seconds and writes no
+   * `usage_tracking` row of its own (metering is orchestrator-gated, and the
+   * local provider bypasses the orchestrator), so a local browse's entire cost
+   * is the tokens its results occupy inside the parent turn's single
+   * `main_response` row — unattributable without this.
+   *
+   * Size only: a char count and a token ESTIMATE, never content. The estimate
+   * is `estimateStringTokens` (CJK-aware) rather than chars/4, which
+   * undercounts a CJK page roughly twofold. Both are recorded so the estimate
+   * stays auditable against the raw length.
+   *
+   * Measured pre-cap, i.e. what the tool returned; `tool-executor.ts` may then
+   * clamp it to `maxResultSizeChars` (24_000 for browser tools) or to
+   * `MAX_TOOL_RESULT_TOKENS`. Absent on failure paths, which return no result.
+   *
+   * **Each event carries only the bytes ITS OWN operation contributed, so the
+   * events of a turn sum to that turn's browser bytes without double counting.**
+   * `navigate` and `click` fold in a follow-up snapshot and emit a PAIRED
+   * `snapshot` event (same timestamp) that carries those bytes — so their own
+   * event is deliberately unsized, since its non-snapshot text is a ~30-char
+   * prefix. Read "what did a navigate cost" as the pair, not the row.
+   */
+  resultChars?: number
+  resultTokens?: number
 }
 
 // ── Send gate ──────────────────────────────────────────────────
@@ -346,6 +373,14 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
     }
   }
 
+  /**
+   * Size of a tool result, for the audit event. Mirrors `doc/context-meter.ts`
+   * (which does this for doc-page tools) — observability, never billing.
+   */
+  function sized(data: string): { resultChars: number; resultTokens: number } {
+    return { resultChars: data.length, resultTokens: estimateStringTokens(data) }
+  }
+
   function emit(event: ComputerToolEvent, context: ToolContext): void {
     try {
       opts.onEvent?.(event, context)
@@ -500,8 +535,22 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
     try {
       const snapshot = await providerFor(backend).snapshot(callCtx(context, state))
       state.refLabels = new Map(snapshot.nodes.map((n) => [n.ref, n.name]))
-      emit({ type: 'browser_action', op: 'snapshot', backend, host: hostOf(snapshot.url), ok: true }, context)
-      return { snapshot, rendered: renderSnapshot(snapshot) }
+      const rendered = renderSnapshot(snapshot)
+      // This is the expensive one: navigate and click fold their follow-up
+      // snapshot in here to save a model turn, so they cost snapshot-sized
+      // context even though they read like cheap actions.
+      emit(
+        {
+          type: 'browser_action',
+          op: 'snapshot',
+          backend,
+          host: hostOf(snapshot.url),
+          ok: true,
+          ...sized(rendered),
+        },
+        context,
+      )
+      return { snapshot, rendered }
     } catch {
       return null
     }
@@ -663,11 +712,19 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
       try {
         const snapshot = await providerFor(backend).snapshot(callCtx(context, gate.state))
         gate.state.refLabels = new Map(snapshot.nodes.map((n) => [n.ref, n.name]))
-        emit({ type: 'browser_action', op: 'snapshot', backend, host: hostOf(snapshot.url), ok: true }, context)
-        return {
-          data: renderSnapshot(snapshot) + pageAdvice(context, gate.state, snapshot),
-          meta: { backend, nodes: snapshot.nodes.length },
-        }
+        const data = renderSnapshot(snapshot) + pageAdvice(context, gate.state, snapshot)
+        emit(
+          {
+            type: 'browser_action',
+            op: 'snapshot',
+            backend,
+            host: hostOf(snapshot.url),
+            ok: true,
+            ...sized(data),
+          },
+          context,
+        )
+        return { data, meta: { backend, nodes: snapshot.nodes.length } }
       } catch (err) {
         emit(
           {
@@ -784,8 +841,11 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
       try {
         await providerFor(backend).type(callCtx(context, gate.state), input.ref, input.text)
         gate.state.lastTyped = input.text
-        emit({ type: 'browser_action', op: 'type', backend, host: null, ok: true }, context)
-        return { data: `Typed ${input.text.length} characters into ${input.ref}.`, meta: { backend } }
+        // No inline snapshot here, so `type` is near-free next to navigate and
+        // click. Recording the size is what makes that asymmetry visible.
+        const data = `Typed ${input.text.length} characters into ${input.ref}.`
+        emit({ type: 'browser_action', op: 'type', backend, host: null, ok: true, ...sized(data) }, context)
+        return { data, meta: { backend } }
       } catch (err) {
         emit(
           {
@@ -821,8 +881,19 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
       const backend = gate.state.backend
       try {
         const res = await providerFor(backend).currentUrl(callCtx(context, gate.state))
-        emit({ type: 'browser_action', op: 'currentUrl', backend, host: hostOf(res.url), ok: true }, context)
-        return { data: `URL: ${res.url}\nTitle: ${res.title || '(untitled)'}`, meta: { backend } }
+        const data = `URL: ${res.url}\nTitle: ${res.title || '(untitled)'}`
+        emit(
+          {
+            type: 'browser_action',
+            op: 'currentUrl',
+            backend,
+            host: hostOf(res.url),
+            ok: true,
+            ...sized(data),
+          },
+          context,
+        )
+        return { data, meta: { backend } }
       } catch (err) {
         emit(
           {
@@ -938,22 +1009,45 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
             // a sign-in, and other workers may need the sandbox next. The
             // URL itself is the deliverable — same posture as urlReader's
             // auth-walled short-circuit.
-            emit({ type: 'browser_action', op: 'readPage', backend: 'cloud', host: hostOf(res.url), ok: true }, context)
-            return {
-              data:
-                `This page sits behind a login (${res.url}), and this reader cannot sign in. ` +
-                `Report the URL as the finding and note it needs a signed-in session — the user can open it from a normal chat turn, where sign-in is possible. Do not retry this URL.`,
-              meta: { backend: 'cloud', loginWall: true },
-            }
+            // Sized like every other returning branch. This one still hands
+            // the model ~250 chars, so leaving it unsized under-reports the
+            // turn's browser cost — and unlike `navigate`/`click`, no paired
+            // `snapshot` event carries the bytes on its behalf.
+            const data =
+              `This page sits behind a login (${res.url}), and this reader cannot sign in. ` +
+              `Report the URL as the finding and note it needs a signed-in session — the user can open it from a normal chat turn, where sign-in is possible. Do not retry this URL.`
+            emit(
+              {
+                type: 'browser_action',
+                op: 'readPage',
+                backend: 'cloud',
+                host: hostOf(res.url),
+                ok: true,
+                ...sized(data),
+              },
+              context,
+            )
+            return { data, meta: { backend: 'cloud', loginWall: true } }
           }
           const snapshot = await opts.cloud.snapshot(ctx)
-          emit({ type: 'browser_action', op: 'readPage', backend: 'cloud', host: hostOf(snapshot.url), ok: true }, context)
           // Same posture as the login wall: a headless worker cannot solve a
           // challenge — the URL is the deliverable, never a retry loop.
           const challenge = looksLikeCaptcha(snapshot)
             ? '\n\nNOTE: this page is showing a human-verification challenge (captcha), which this reader cannot solve. Report the URL as the finding and move on — do not retry it.'
             : ''
-          return { data: renderReadPage(snapshot) + challenge, meta: { backend: 'cloud', nodes: snapshot.nodes.length } }
+          const data = renderReadPage(snapshot) + challenge
+          emit(
+            {
+              type: 'browser_action',
+              op: 'readPage',
+              backend: 'cloud',
+              host: hostOf(snapshot.url),
+              ok: true,
+              ...sized(data),
+            },
+            context,
+          )
+          return { data, meta: { backend: 'cloud', nodes: snapshot.nodes.length } }
         } catch (err) {
           emit(
             {

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -157,6 +157,25 @@ export type ToolContext = {
   notifyConfirmationRequired?: (request: ToolConfirmationRequest) => void
   /** Timeout for inner confirmation prompts in ms. */
   confirmationTimeoutMs?: number
+  /**
+   * Run `wait` OUTSIDE the executor's exclusive execution slot, then
+   * re-acquire the slot before returning.
+   *
+   * A gateway tool raises its confirmation prompt inside `execute()`, by
+   * which point it already holds the slot. Holding it across a human wait
+   * stops the executor from starting any sibling — and since each sibling's
+   * prompt lives inside its own `execute()`, those siblings can never prompt
+   * at all, so they expire against `confirmationTimeoutMs` unseen. Wrapping
+   * the wait in this port hands the slot back for the duration, which is what
+   * gives the MCP path the same prompt-in-parallel / execute-in-series
+   * ordering the executor applies to its own confirmation gate.
+   *
+   * Absent outside the tool executor (smoke tests, workflow steps) — callers
+   * must fall back to awaiting directly. See
+   * docs/architecture/engine/tool-executor.md → "Gateway tools confirm
+   * inside `execute()`".
+   */
+  parkForConfirmation?: <T>(wait: () => Promise<T>) => Promise<T>
 
   // ── Sensitivity enforcement ──────────────────────────────────
   // See docs/architecture/platform/sensitivity.md.


### PR DESCRIPTION
Four independent fixes to the computer-use and transcription-metering paths, consolidated from three parallel working sessions on 2026-07-21/22. Each was found from production behaviour.

## 1. Sibling `mcp_call`s never prompted

A gateway tool resolves its confirmation policy **inside** `execute()`, by which point it already holds the executor's exclusive slot. Holding that across a human wait stopped `tryStartQueued()` from starting any sibling, and since each sibling raises its prompt inside its own `execute()`, those siblings could never prompt at all. They sat until `confirmationTimeoutMs` (300 s) and expired unseen, so a multi-write turn showed exactly **one** confirmation card.

`ToolContext.parkForConfirmation` hands the slot back for the duration of the wait and re-acquires it before the real work runs, giving the MCP path the same prompt-in-parallel / execute-in-series ordering the executor already applies to its own gate. Applied to both dispatch paths - remote, and local, which is the path every first-party built-in write takes.

## 2. Take-Over view flickered on every frame

Swapping an `<img>`'s `src` discards what it has already painted and repaints nothing until the new JPEG decodes - one blank frame per arrival. On a damage-driven stream that is constant while the page is busy; a recording of an idle login page caught three full blanks in 2.6 s, one per caret blink, because the blinking cursor was the only damage source.

`createFrameGate` decodes off-screen and commits only once the bitmap is ready. It also owns the object URLs, closing two leaks the old fixed-length queue had: a URL is revoked only once a **newer** frame is on screen, and a frame that never reached the screen is freed immediately. A decode landing after a newer frame already committed is dropped, so a slow frame can never rewind the view.

## 3. Browser actions now carry their context cost

A local ("My Browser") browse books no sandbox-seconds and writes **no `usage_tracking` row at all** - sandbox metering runs only from the orchestrator, which a local call bypasses. Its entire cost is tokens absorbed into the parent turn's single `main_response` row, which carries no tool attribution.

Every `browser_action` event now carries `resultChars` + `resultTokens` - a size measurement, never content. `resultTokens` uses `estimateStringTokens` (CJK-aware); chars/4 undercounts a CJK page roughly twofold, and the reference incident was a Taobao browse. Measured pre-cap. Each event carries only the bytes its own operation contributed, so a turn's events sum without double counting: `navigate`/`click` fold in a follow-up snapshot and emit a **paired** `snapshot` event, leaving their own rows unsized by design. Observability only - no credit is debited.

Also: **"one cookie jar" describes the cloud backend only.** A local profile owns no jar - it rides the logins in the user's real Chrome and never reads the vault - so its row is only the governance object. `profileSurfaces` shows it neither "Sign in to a site" nor the signed-in-sites list; an empty list there read as "you have no logins" to a user whose Chrome was signed in. Plus an orphaned-sandbox kill on throw, and a bare `randomUUID()` login token.

## 4. Voice notes record their duration

`usage_tracking.audio_seconds` (platform migration 347) is the denominator that makes a token-billed transcriber comparable to a flat-rate one. Its consumer side was already wired; the token-billed path had **no producer**, so `TranscribeResult.audioSeconds` was declared, documented, and permanently `undefined` - Gemini, the one provider whose rate was actually unknown, reported null forever.

The transcriber posts bytes and never learns the duration, so the value can only come from the channel:

```
voice.duration -> IncomingMessage.mediaDurationSec -> MediaAttachment.durationSeconds
               -> transcribeFirstAudio -> TranscribeResult.audioSeconds
               -> voiceTranscriptionUsage -> recordOverheadUsage
```

A raw web upload carries no duration and stays NULL - an unknown rate, never a free one, since `0` would read as free transcription of zero-length audio. Decoding the buffer to measure it was rejected: real work spent to fill a reporting column, which `preflight-confirmation.md` reserves for decisions the user pays for.

## Testing

core 259/259 (23 files) - app-web 27/27 - api computer route 16/16 - browser-extension 19/19. Typecheck clean on core and api. Rebased onto current `develop` and re-verified after the rebase.

## Notes for review

- `createFrameGate` releases the previous URL synchronously after `commit`, before paint. Worth a second opinion on whether that needs a frame of slack.
- The four items are independent; commits are split so they can be read (or reverted) separately.

Paired platform PR follows and bumps the gitlink to this branch's merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)