### PR TITLE
fix(sandbox): surface detached/consent_denied instead of backend_error

### DIFF
--- a/packages/core/src/sandbox/__tests__/browser-provider.test.ts
+++ b/packages/core/src/sandbox/__tests__/browser-provider.test.ts
@@ -93,6 +93,20 @@ describe('[COMP:sandbox/local-browser] LocalBrowserProvider', () => {
     expect((err as BrowserBackendError).code).toBe('stopped')
   })
 
+  it('passes through the extension refusal codes instead of flattening them', async () => {
+    // `detached` (Chrome ended the CDP session) and `consent_denied` (the user
+    // said no in the Allow window) are both actionable states with distinct
+    // recoveries. Collapsing them into `backend_error` is what let a prod
+    // browse read as a site problem: the model told the user Luma was blocking
+    // automation when Chrome had simply dropped the debugger.
+    for (const code of ['detached', 'consent_denied'] as const) {
+      const { transport } = transportRecording(() => ({ ok: false, error: `nope: ${code}`, code }))
+      const provider = createLocalBrowserProvider({ transport })
+      const err = await provider.snapshot(CTX).catch((e: unknown) => e)
+      expect((err as BrowserBackendError).code).toBe(code)
+    }
+  })
+
   it('rejects a malformed snapshot payload at the zod boundary', async () => {
     const { transport } = transportRecording(() => ({ ok: true, data: { nodes: 'nope' } }))
     const provider = createLocalBrowserProvider({ transport })

--- a/packages/core/src/sandbox/local-browser-provider.ts
+++ b/packages/core/src/sandbox/local-browser-provider.ts
@@ -25,6 +25,8 @@ const KNOWN_ERROR_CODES: ReadonlySet<string> = new Set([
   'timeout',
   'stopped',
   'tab_closed',
+  'detached',
+  'consent_denied',
   'stale_ref',
   'backend_error',
 ])

--- a/packages/core/src/sandbox/types.ts
+++ b/packages/core/src/sandbox/types.ts
@@ -68,6 +68,8 @@ export type BrowserBackendErrorCode =
   | 'timeout'        // the extension/sandbox did not answer in time
   | 'stopped'        // the user hit Stop in the extension
   | 'tab_closed'     // the controlled tab went away
+  | 'detached'       // Chrome ended the CDP session (banner cancelled, DevTools, crash)
+  | 'consent_denied' // the user declined the extension's per-tab Allow prompt
   | 'stale_ref'      // ref is not from the latest snapshot
   | 'backend_error'  // anything else the backend reported
 


### PR DESCRIPTION
## Why

A local ("My Browser") browse whose Chrome debugger session ended reported the generic `backend_error` code, giving the model no way to tell a lost CDP session from a hostile page.

On 2026-07-22 an assistant hit exactly this on `luma.com`. Every op after the detach returned `Debugger is not attached to the tab with id: 38686551`, and the assistant concluded the site was defending itself, telling the user Luma had "安全保護或特殊的 Overlay 彈窗阻擋了自動化工具". The debugger had simply gone away.

## What

`detached` (Chrome ended the CDP session) and `consent_denied` (the user declined the extension's per-tab Allow prompt) are both actionable states with distinct recoveries. Make them first-class `BrowserBackendErrorCode`s and let them through `local-browser-provider`'s known-code set instead of flattening them to `backend_error`.

`consent_denied` was already being thrown by `task-gate.ts` and silently collapsed — this is the first time it survives the trip to the model.

## Verification

`packages/core` sandbox suite: **158/158 passing**, typecheck clean, `pnpm check` passes.

The extension + relay half of this fix ships in the paired brian-platform PR; this repo carries only the error-code seam.

Spec: `docs/architecture/engine/computer-use.md` §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)