### PR TITLE
feat(media): measure transcription language signal (migration 354)

### DIFF
--- a/packages/api/migrations/354_recordings_language_signal.sql
+++ b/packages/api/migrations/354_recordings_language_signal.sql
@@ -1,0 +1,56 @@
+-- Transcription language observability — measurement columns on `recordings`.
+--
+-- Cantonese and Mandarin share a writing system, so a provider asked to
+-- auto-detect never reports "wrong language": it reports Chinese, returns 200,
+-- and emits fluent Standard Written Chinese where the speaker said 嘅/咗/唔.
+-- These columns are what make that silent normalization measurable, so the
+-- provider decision can be made on production traffic rather than on public
+-- benchmarks run over corpora that do not resemble it.
+--
+-- Every column is NULLABLE and NULL means NOT MEASURED. In particular
+-- `canto_density_per_k` distinguishes NULL from 0 and they must never be
+-- conflated: NULL is "no CJK present, the ratio is undefined" (an English
+-- recording), 0 is "Chinese, carrying no Cantonese markers" — which is exactly
+-- the normalization being hunted. Defaulting any of these to 0 would report
+-- every English recording as Chinese-without-Cantonese and drag the statistics
+-- with it. Recordings processed before this ships stay NULL, so a backfill gap
+-- can never be read as a measurement.
+--
+-- Spec: docs/architecture/media/transcription.md → "Language signal".
+
+BEGIN;
+
+-- What the PROVIDER said it heard. Parsed from the response of providers that
+-- perform language identification; never inferred from the transcript, because
+-- inference is what the density below does and conflating the two would make
+-- it impossible to measure one against the other.
+ALTER TABLE recordings ADD COLUMN IF NOT EXISTS detected_language TEXT;
+ALTER TABLE recordings ADD COLUMN IF NOT EXISTS detected_language_confidence REAL;
+
+-- What the transcript actually READS like. Cantonese markers per 1000 CJK
+-- characters, plus the raw counts it was taken over — a ratio measured across
+-- 14 characters carries nothing like the weight of one measured across 50,000,
+-- and keeping both is what lets an aggregate weight recordings instead of
+-- averaging the averages.
+ALTER TABLE recordings ADD COLUMN IF NOT EXISTS canto_density_per_k INTEGER;
+ALTER TABLE recordings ADD COLUMN IF NOT EXISTS canto_marker_count INTEGER;
+ALTER TABLE recordings ADD COLUMN IF NOT EXISTS cjk_count INTEGER;
+
+-- Latin-script tokens — the code-switch signal. HK speech drops English words
+-- mid-sentence, and those are measured rather than guessed at.
+ALTER TABLE recordings ADD COLUMN IF NOT EXISTS latin_tokens INTEGER;
+
+-- Four-way label from the published CanCLID classifier. Density measures
+-- Cantonese PRESENCE and so cannot separate "Mandarin" from "no markers here";
+-- this can. Unconstrained TEXT on purpose: a CHECK would turn an upstream
+-- classifier revision into a write failure on a column that only instruments.
+ALTER TABLE recordings ADD COLUMN IF NOT EXISTS chinese_variant TEXT;
+
+-- Slicing production traffic by variant and density is the whole point, and it
+-- must not require exporting the table first. Partial, because the rows that
+-- matter are the measured ones and pre-ship rows are all NULL.
+CREATE INDEX IF NOT EXISTS recordings_language_signal_idx
+  ON recordings (chinese_variant, canto_density_per_k)
+  WHERE chinese_variant IS NOT NULL;
+
+COMMIT;

--- a/packages/api/src/db/__tests__/recordings-store.test.ts
+++ b/packages/api/src/db/__tests__/recordings-store.test.ts
@@ -155,6 +155,37 @@ describe('[COMP:recordings/recordings-store] update', () => {
     expect(values).toEqual([null, 'rec-1'])
   })
 
+  // The language signal is instrumentation: it must land in typed columns an
+  // operator can slice in SQL, and a density of 0 must be storable as 0. Zero
+  // is a real reading — "Chinese, carrying no Cantonese", which is exactly the
+  // normalization the metric exists to catch — so it can never be treated as
+  // "nothing to write" and skipped.
+  it('writes the language signal, including a density of zero', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [ROW] } as never)
+    await updateRecording('rec-1', {
+      cantoDensityPerK: 0,
+      cantoMarkerCount: 0,
+      cjkCount: 240,
+      latinTokens: 12,
+      chineseVariant: 'mandarin',
+    })
+    const [sql, values] = mockQuery.mock.calls[0]!
+    const setClause = sql.slice(sql.indexOf('SET'), sql.indexOf('WHERE'))
+    expect(setClause).toMatch(/canto_density_per_k = \$1/)
+    expect(values).toEqual([0, 0, 240, 12, 'mandarin', 'rec-1'])
+  })
+
+  // An unmeasured recording and one measured at zero must stay distinguishable
+  // in every aggregate, so "no CJK present" is written as a real NULL rather
+  // than defaulted to 0 — a 0 there would report every English recording as
+  // Chinese-with-no-Cantonese and drag the statistics with it.
+  it('writes an unmeasurable density as NULL, never as 0', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [ROW] } as never)
+    await updateRecording('rec-1', { cantoDensityPerK: null, cjkCount: 0 })
+    const [, values] = mockQuery.mock.calls[0]!
+    expect(values).toEqual([null, 0, 'rec-1'])
+  })
+
   it('bounds lastError — provider errors can be arbitrarily long', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [ROW] } as never)
     await updateRecording('rec-1', { lastError: 'x'.repeat(5000) })

--- a/packages/api/src/db/recordings-store.ts
+++ b/packages/api/src/db/recordings-store.ts
@@ -259,6 +259,24 @@ export async function updateRecording(
     truncated?: boolean
     lastError?: string | null
     deleteAfter?: Date | null
+    /**
+     * Transcription language observability (migration 354). Every field is
+     * nullable and NULL means NOT MEASURED — in particular a null density is
+     * not a zero one: null is "no CJK present, the ratio is undefined", zero
+     * is "Chinese, carrying no Cantonese markers", which is precisely the
+     * silent Mandarin-normalization the metric exists to surface. Recordings
+     * processed before this shipped stay NULL, so a backfill gap can never be
+     * read as a measurement.
+     *
+     * Spec: docs/architecture/media/transcription.md → "Language signal".
+     */
+    detectedLanguage?: string | null
+    detectedLanguageConfidence?: number | null
+    cantoDensityPerK?: number | null
+    cantoMarkerCount?: number | null
+    cjkCount?: number | null
+    latinTokens?: number | null
+    chineseVariant?: string | null
   },
 ): Promise<Recording | null> {
   const sets: string[] = []
@@ -281,6 +299,16 @@ export async function updateRecording(
   // once bounded.
   if (patch.lastError !== undefined) put('last_error', patch.lastError?.slice(0, 2000) ?? null)
   if (patch.deleteAfter !== undefined) put('delete_after', patch.deleteAfter)
+  // Language signal — `!== undefined` (not a truthiness check) because 0 is a
+  // real reading for every one of these counts.
+  if (patch.detectedLanguage !== undefined) put('detected_language', patch.detectedLanguage)
+  if (patch.detectedLanguageConfidence !== undefined)
+    put('detected_language_confidence', patch.detectedLanguageConfidence)
+  if (patch.cantoDensityPerK !== undefined) put('canto_density_per_k', patch.cantoDensityPerK)
+  if (patch.cantoMarkerCount !== undefined) put('canto_marker_count', patch.cantoMarkerCount)
+  if (patch.cjkCount !== undefined) put('cjk_count', patch.cjkCount)
+  if (patch.latinTokens !== undefined) put('latin_tokens', patch.latinTokens)
+  if (patch.chineseVariant !== undefined) put('chinese_variant', patch.chineseVariant)
 
   if (sets.length === 0) return getRecordingSystem(id)
 

--- a/packages/core/src/media/__tests__/language-signal.test.ts
+++ b/packages/core/src/media/__tests__/language-signal.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Language signal over a finished transcript.
+ *
+ * Spec: docs/plans/transcription-language-observability.md
+ */
+
+import { describe, expect, it } from 'vitest'
+import { CANTO_MARKER_CHARS, languageSignal } from '../language-signal.js'
+
+const utt = (text: string) => ({ startMs: 0, endMs: 1_000, speaker: null, text })
+
+describe('[COMP:media/language-signal] languageSignal density', () => {
+  // The feature in one assertion: the same sentence, spoken in Cantonese and
+  // normalized into Standard Written Chinese, must be tellable apart. If this
+  // does not hold, none of the recorded data means anything.
+  //
+  // Counted by hand against the canonical marker set, not by re-running the
+  // implementation: 我哋今日喺屋企食飯，佢話唔嚟喇 carries 14 CJK characters
+  // (the fullwidth comma is not CJK) of which 喺 佢 唔 嚟 喇 are markers — 哋
+  // is deliberately absent from the set. 5/14 → 357 per 1000.
+  it('separates verbatim Cantonese from the same sentence normalized to Standard Written Chinese', () => {
+    const cantonese = languageSignal([utt('我哋今日喺屋企食飯，佢話唔嚟喇')])
+    const normalized = languageSignal([utt('我们今天在家里吃饭，他说不来了')])
+
+    expect(cantonese.cantoDensityPerK).toBe(357)
+    expect(normalized.cantoDensityPerK).toBe(0)
+  })
+
+  // A ratio of markers to the CJK they are drawn from cannot exceed 1000 per
+  // 1000 — unless the two are counted over different character ranges, which
+  // is exactly the defect this pins. 㗎 (U+35CE) lives in CJK Extension A,
+  // outside the `一-鿿` Unified block, so a numerator that counts it against a
+  // denominator that does not yields a density above its own ceiling.
+  //
+  // Stated over the whole set rather than one character, so that widening the
+  // markers later without widening the CJK range fails here rather than in
+  // production data.
+  it('never reports a density above 1000, whichever markers the set carries', () => {
+    const everyMarker = languageSignal([utt(CANTO_MARKER_CHARS)])
+
+    expect(everyMarker.cantoDensityPerK).toBe(1000)
+  })
+
+  // A density is a ratio, and a ratio taken over 14 characters carries nothing
+  // like the weight of one taken over 50,000. Storing the raw counts next to it
+  // is what lets an aggregate weight the recordings instead of averaging the
+  // averages. Same hand count as the case above: 5 markers, 14 CJK.
+  it('reports the raw marker and CJK counts the density was taken over', () => {
+    const s = languageSignal([utt('我哋今日喺屋企食飯，佢話唔嚟喇')])
+
+    expect(s.markerCount).toBe(5)
+    expect(s.cjkCount).toBe(14)
+  })
+
+  // Counts are over the whole recording, not the first thing said in it. A
+  // chunked transcription arrives as many utterances and must measure the same
+  // as if it had arrived as one.
+  it('aggregates counts across every utterance in the recording', () => {
+    const split = languageSignal([utt('我哋今日喺屋企食飯'), utt('佢話唔嚟喇')])
+    const whole = languageSignal([utt('我哋今日喺屋企食飯佢話唔嚟喇')])
+
+    expect(split.markerCount).toBe(whole.markerCount)
+    expect(split.cjkCount).toBe(whole.cjkCount)
+    expect(split.cantoDensityPerK).toBe(whole.cantoDensityPerK)
+  })
+})
+
+describe('[COMP:media/language-signal] languageSignal code-switching', () => {
+  // HK speech drops English words mid-sentence, and those tokens are the
+  // code-switch signal rather than noise. They must not land in the CJK count:
+  // inflating the denominator would dilute the density of exactly the
+  // recordings this metric cares most about.
+  //
+  // Hand-counted: 佢話唔記得…個…畀我，我睇完再…佢 is 13 CJK characters, and
+  // send / email / reply are the three Latin tokens.
+  it('counts Latin tokens without letting them dilute the CJK denominator', () => {
+    const s = languageSignal([utt('佢話唔記得send個email畀我，我睇完再reply佢')])
+
+    expect(s.latinTokens).toBe(3)
+    expect(s.cjkCount).toBe(13)
+  })
+})
+
+describe('[COMP:media/canto-filter] languageSignal variant label', () => {
+  // Density measures Cantonese PRESENCE, so a Mandarin transcript and an
+  // English one both score 0 markers and are indistinguishable by it. The
+  // four-way label is what separates them, and telling "the provider
+  // normalized to Mandarin" from "there was no Chinese here" is the reason the
+  // metric exists at all.
+  it('separates Mandarin from merely-no-markers, which density cannot', () => {
+    const cantonese = languageSignal([utt('我哋今日喺屋企食飯，佢話唔嚟喇')])
+    const mandarin = languageSignal([utt('我們今天在家裡吃飯，他說不來了')])
+    const english = languageSignal([utt('We should ship the eval harness first.')])
+
+    expect(cantonese.variant).toBe('cantonese')
+    expect(mandarin.variant).toBe('mandarin')
+    expect(english.variant).toBe('neutral')
+
+    // The point: density alone collapses the last two together.
+    expect(mandarin.cantoDensityPerK).toBe(0)
+    expect(english.cantoDensityPerK).toBeNull()
+  })
+
+  // Characterization, not red-first: `canto-filter.ts` is a verbatim port of
+  // the published CanCLID classifier, brought in whole because a partial port
+  // means partial regexes and a wrong answer. These pin the upstream behaviour
+  // a hand-rolled marker count cannot express at all — a Mandarin-feature
+  // character sitting inside a loanword, where it is not evidence of anything.
+  it('treats Mandarin-feature characters inside loanwords as innocent', () => {
+    // 那 is a Mandarin feature; 剎那 is a loanword, so it is not evidence.
+    expect(languageSignal([utt('剎那之間')]).variant).toBe('neutral')
+    // 的 likewise inside 的士, in a sentence that is otherwise Cantonese.
+    expect(languageSignal([utt('我哋搭的士去')]).variant).toBe('cantonese')
+    // Bare 的 outside a loanword IS evidence.
+    expect(languageSignal([utt('我的書')]).variant).toBe('mandarin')
+  })
+})
+
+describe('[COMP:media/language-signal] languageSignal null and zero', () => {
+  // "English recording" and "Chinese recording carrying no Cantonese" are the
+  // two things this metric exists to tell apart. Collapsing both to 0 would
+  // drag every English recording into the Cantonese statistics; collapsing
+  // both to null would hide the normalization this was built to catch. The
+  // pair is asserted together because neither half means anything alone.
+  it('distinguishes no-CJK (null) from CJK-without-markers (zero)', () => {
+    const englishOnly = languageSignal([utt('We should ship the eval harness first.')])
+    const chineseNoMarkers = languageSignal([utt('我们今天在家里吃饭')])
+
+    expect(englishOnly.cantoDensityPerK).toBeNull()
+    expect(englishOnly.cjkCount).toBe(0)
+    expect(chineseNoMarkers.cantoDensityPerK).toBe(0)
+    expect(chineseNoMarkers.cjkCount).toBeGreaterThan(0)
+  })
+
+  // A recording can produce nothing at all — a silent file, or one whose
+  // utterances were all dropped by the degeneracy guard. Measuring it must
+  // report "unmeasurable", never a divide-by-zero or a spurious 0.
+  it('reports an unmeasurable density for empty and whitespace-only transcripts', () => {
+    for (const empty of [languageSignal([]), languageSignal([utt('   \n  ')])]) {
+      expect(empty.cantoDensityPerK).toBeNull()
+      expect(empty.markerCount).toBe(0)
+      expect(empty.cjkCount).toBe(0)
+      expect(empty.latinTokens).toBe(0)
+      expect(empty.variant).toBe('neutral')
+    }
+  })
+
+  // The marker set omits 係 and 都 because both are ordinary in Standard
+  // Written Chinese compounds (關係, 首都). If they were included, the very
+  // Mandarin-normalized output this metric exists to detect would score as
+  // Cantonese — the failure mode would become invisible in its own metric.
+  it('does not score Standard Written Chinese compounds as Cantonese', () => {
+    const swc = languageSignal([utt('這個關係很重要，首都在北京')])
+
+    expect(swc.cantoDensityPerK).toBe(0)
+    expect(swc.markerCount).toBe(0)
+  })
+})

--- a/packages/core/src/media/canto-filter.ts
+++ b/packages/core/src/media/canto-filter.ts
@@ -1,0 +1,97 @@
+/**
+ * Cantonese / Standard-Written-Chinese classifier — a faithful TypeScript port
+ * of CanCLID/canto-filter (`cantofilter/judge.py`).
+ *
+ *   Upstream: https://github.com/CanCLID/canto-filter  (MIT)
+ *   Method:   Lau, Lau & To, "Cantonese Natural Language Processing in the
+ *             Transformers Era" / canto-filter, EURALI @ LREC-COLING 2024
+ *             https://aclanthology.org/2024.eurali-1.4/
+ *
+ * Why a port rather than a dependency: upstream ships Python only (no npm
+ * package exists), and the algorithm is pure regex with no model files — so a
+ * port is ~100 lines and carries no runtime cost. Character classes and the
+ * decision tree are reproduced VERBATIM from upstream; do not "tidy" them.
+ *
+ * Note the `u` flag on every pattern: the Cantonese classes contain
+ * astral-plane characters (𨋢 𥄫 𡃁 𨳍 …) which silently mis-match without it.
+ *
+ * Why this rather than a hand-curated marker list: the naive approach counts
+ * Cantonese-looking characters and cannot tell "Mandarin" from "no markers",
+ * nor suppress Mandarin loanwords that merely LOOK like Mandarin features
+ * (剎那, 的士, 實事求是). Upstream solves both — MANDO_UNIQUE/MANDO_FEATURE give
+ * positive Mandarin evidence, and MANDO_LOAN spans suppress the false
+ * positives.
+ *
+ * Spec: docs/plans/transcription-language-observability.md
+ */
+
+/**
+ * Cantonese-unique characters. Verbatim from upstream CANTO_UNIQUE_CHAR.
+ *
+ * Deliberately NOT exported. The density metric in `language-signal.ts` counts
+ * over its own narrower hand-curated set (`CANTO_MARKER_CHARS`) and must not
+ * borrow this one: this class contains astral-plane characters, and a density
+ * numerator drawn from it against a BMP denominator exceeds its own 1000
+ * ceiling. Keeping it private is what stops that from being re-wired.
+ */
+const CANTO_UNIQUE_CHAR =
+  /[嘅嗰啲咗佢喺咁噉冇哋畀嚟諗惗乜嘢瞓睇餸𨋢摷嚿嚡嘥嗮啱喐逳噏攞𥄫攰癐冚孻冧𡃁嚫跣𨃩瀡氹凼嬲孭黐唞㪗埞忟𢛴踎脷厾]|[𢳂揾搵揦揈捹撳㩒掟揼抌揸㩧𢫏擳]|[撚閪𨳍𨳊𨶙𨳒]|[㗎𠺢喎噃啩𠿪啫嗱]/u
+
+/** Cantonese-unique words. Verbatim from upstream CANTO_UNIQUE_WORD. */
+const CANTO_UNIQUE_WORD =
+  /唔[係得會想好識使洗駛通知到去走掂該錯差多少]|點[樣會做得解知]|[琴尋噚聽第]日|[而依]家|[真就實梗緊堅又話都但淨剩只定一]係|邊[度個位科]|[嚇凍攝整揩逢淥浸激][親嚫]|[橫搞傾得唔好]掂|仲[有係話要得好衰唔]|返[學工去翻番到]|[好得]返|執[好生實返輸]|[癡痴][埋線住起身]|[同帶做整溝炒煮]埋|[剩淨坐留]低|傾[偈計]|屋企|收皮|慳錢|屈機|隔籬|幫襯|求其|家陣|仆街|是[但旦]|[濕溼]碎|零舍|肉[赤緊酸]|核突|[勁隻][秋抽]|[呃𧦠][鬼人秤稱錢]/u
+
+/** Mandarin-unique. Verbatim from upstream MANDO_UNIQUE. */
+const MANDO_UNIQUE = /[這哪您們唄咱啥甭她]|還[是好有]|[事門塊勁花那點會]兒/u
+
+/**
+ * Mandarin features. Verbatim from upstream MANDO_FEATURE.
+ * Upstream note: 在/不/把 are deliberately EXCLUDED — too many have been
+ * absorbed into Cantonese for them to discriminate.
+ */
+const MANDO_FEATURE = /[那是的他它看吧沒麼么些了卻説說吃弄也]|而已/gu
+
+/**
+ * Mandarin loanwords — spans where a MANDO_FEATURE character is innocent
+ * (剎那, 的士, 實事求是, 也門…). Verbatim from upstream MANDO_LOAN.
+ */
+const MANDO_LOAN =
+  /亞利桑那|剎那|巴塞羅那|薩那|沙那|哈瓦那|印第安那|那不勒斯|支那|是[否日次非但旦]|[利於]是|唯命是從|頭頭是道|似是而非|自以為是|俯拾皆是|撩是鬥非|莫衷一是|唯才是用|馬首是瞻|實事求是|[目綠藍紅中飛]的|的[士確式色]|波羅的海|眾矢之的|的而且確|大眼的度|些[微少許小]|[淹沉浸覆湮埋沒出]沒|沒[落頂收]|神出鬼沒|了[結無斷當然哥結得解事之]|[未明]了|不得了|大不了|他[信人國日殺鄉]|[其利無排維結]他|馬耳他|他加祿|他山之石|其[它]|[收查窺觀]看|看[守住好護]|刮目相看|[酒網水貼]吧|吧[務台臺枱檯]|[退忘阻]卻|卻步|[遊游小傳解學假淺眾衆訴論][説說]|[說説][話服明]|自圓其[説說]|長話短[說説]|不由分[說説]|吃[虧苦力醋]|口吃|弄[堂]|[賣擺嘲]弄|可[怒惱]也|如也|也門|之乎者也|天助我也/gu
+
+/** Four-way label, matching upstream's LanguageType. */
+export type ChineseVariant = 'cantonese' | 'mandarin' | 'mixed' | 'neutral'
+
+/** Upstream matches the cheap char class first, words only as fallback. */
+function hasCantoUnique(s: string): boolean {
+  return CANTO_UNIQUE_CHAR.test(s) || CANTO_UNIQUE_WORD.test(s)
+}
+
+function spans(re: RegExp, s: string): Array<[number, number]> {
+  const out: Array<[number, number]> = []
+  for (const m of s.matchAll(re)) out.push([m.index, m.index + m[0].length])
+  return out
+}
+
+/** True when EVERY Mandarin feature sits inside a loanword span. */
+function isAllLoan(s: string): boolean {
+  const features = spans(MANDO_FEATURE, s)
+  const loans = spans(MANDO_LOAN, s)
+  return features.every(([fs, fe]) => loans.some(([ls, le]) => fs >= ls && fe <= le))
+}
+
+/** Classify a string. Decision tree verbatim from upstream `judge`. */
+export function judgeChineseVariant(s: string): ChineseVariant {
+  const cantoUnique = hasCantoUnique(s)
+  const mandoUnique = MANDO_UNIQUE.test(s)
+  const mandoFeature = new RegExp(MANDO_FEATURE.source, 'u').test(s)
+
+  if (cantoUnique) {
+    if (!mandoUnique && !mandoFeature) return 'cantonese'
+    if (mandoUnique) return 'mixed'
+    // Cantonese + Mandarin features: innocent if every feature is a loanword.
+    return isAllLoan(s) ? 'cantonese' : 'mixed'
+  }
+  if (mandoUnique) return 'mandarin'
+  if (mandoFeature) return isAllLoan(s) ? 'neutral' : 'mandarin'
+  return 'neutral'
+}

--- a/packages/core/src/media/index.ts
+++ b/packages/core/src/media/index.ts
@@ -70,3 +70,9 @@ export {
   parseTranscriptionPrefs,
   type WorkspaceTranscriptionPrefs,
 } from './transcription-prefs.js'
+export {
+  languageSignal,
+  CANTO_MARKER_CHARS,
+  type LanguageSignal,
+} from './language-signal.js'
+export { judgeChineseVariant, type ChineseVariant } from './canto-filter.js'

--- a/packages/core/src/media/language-signal.ts
+++ b/packages/core/src/media/language-signal.ts
@@ -1,0 +1,96 @@
+/**
+ * Language signal over a finished transcript — the measurement half of
+ * transcription language observability.
+ *
+ * The failure this exists to make visible is silent: Cantonese and Mandarin
+ * share a writing system, so a provider asked to auto-detect does not report
+ * "wrong language" — it reports Chinese, returns 200, and emits fluent Standard
+ * Written Chinese where the speaker actually said 嘅/咗/唔. Nothing else in the
+ * pipeline distinguishes that from a genuine Mandarin recording.
+ *
+ * Pure over the FINAL utterance list (after chunk merge / continuation), so a
+ * recording produces exactly one measurement however it was transcribed.
+ *
+ * Spec: docs/plans/transcription-language-observability.md
+ */
+
+import { judgeChineseVariant, type ChineseVariant } from './canto-filter.js'
+
+/**
+ * Distinctly-Cantonese characters. Deliberately EXCLUDES 係/都 and friends,
+ * which occur commonly in Standard Written Chinese compounds (關係, 係數) — a
+ * Mandarin-normalized transcript must not be able to score as Cantonese.
+ *
+ * Do not "complete" this set without re-reading that constraint: adding
+ * SWC-common characters silently destroys its discriminating power, which is
+ * the entire point of the metric.
+ *
+ * This is the single definition — the eval harness imports it from here rather
+ * than keeping a copy, so harness output and production numbers are the same
+ * measurement rather than two drifting copies.
+ */
+export const CANTO_MARKER_CHARS = '嘅咗唔喺佢嗰啲冇睇嘢乜嚟㗎喇噉畀諗嗌攞郁掂靚嬲'
+
+const CANTO_MARKERS = new RegExp(`[${CANTO_MARKER_CHARS}]`, 'g')
+
+/**
+ * The density denominator. Covers CJK Extension A (U+3400-U+4DBF) as well as
+ * Unified (U+4E00-U+9FFF) because 㗎 (U+35CE) — a common sentence-final
+ * particle, and a marker above — lives in Extension A.
+ *
+ * **Every character in `CANTO_MARKER_CHARS` must fall inside this range.** The
+ * numerator and denominator are a ratio: count them over different ranges and
+ * the density exceeds its own 1000 ceiling. Widening one requires widening the
+ * other, and `language-signal.test.ts` fails if that ever stops holding.
+ */
+const CJK = /[㐀-䶿一-鿿]/g
+
+const LATIN_TOKEN = /[A-Za-z][A-Za-z'-]*/g
+
+export type LanguageSignal = {
+  /**
+   * Cantonese markers per 1000 CJK characters, or `null` when the transcript
+   * carries no CJK at all. Null and 0 are NOT interchangeable: null is "not a
+   * Chinese recording", 0 is "Chinese, carrying no Cantonese" — telling those
+   * apart is the point of the metric, and folding null into 0 would drag every
+   * English recording into the Cantonese statistics.
+   */
+  cantoDensityPerK: number | null
+  /**
+   * The raw counts the density was taken over. A ratio measured across 14
+   * characters carries nothing like the weight of one measured across 50,000,
+   * and storing both is what lets an aggregate weight recordings rather than
+   * average the averages.
+   */
+  markerCount: number
+  cjkCount: number
+  /** Latin-script tokens — the code-switch signal. Never counted as CJK. */
+  latinTokens: number
+  /**
+   * Four-way classification over the whole transcript, from the published
+   * CanCLID classifier (see `canto-filter.ts`).
+   *
+   * This deliberately runs over a DIFFERENT and much wider character set than
+   * the density above, and the two must not be merged. Density answers "how
+   * Cantonese does this read, on the hand-curated scale the eval harness
+   * scores with"; variant answers "which variety is this, by a citable
+   * third-party method that also weighs positive Mandarin evidence and
+   * suppresses loanword false positives". Collapsing them onto one set would
+   * cost whichever answer lost its character classes.
+   */
+  variant: ChineseVariant
+}
+
+/** Measure how Cantonese a transcript reads. Pure. */
+export function languageSignal(utterances: Array<{ text: string }>): LanguageSignal {
+  const text = utterances.map((u) => u.text).join('\n')
+  const cjkCount = (text.match(CJK) ?? []).length
+  const markerCount = (text.match(CANTO_MARKERS) ?? []).length
+  return {
+    cantoDensityPerK: cjkCount > 0 ? Math.round((markerCount / cjkCount) * 1000) : null,
+    markerCount,
+    cjkCount,
+    latinTokens: (text.match(LATIN_TOKEN) ?? []).length,
+    variant: judgeChineseVariant(text),
+  }
+}


### PR DESCRIPTION
Cantonese voice memos come back Mandarin-normalised: the speaker says 嘅/咗/唔 and the transcript reads 的/了/不.

The failure is **silent by construction**. Cantonese and Mandarin share a writing system, so a provider asked to auto-detect does not report "wrong language" — it reports Chinese, returns HTTP 200, and emits fluent Standard Written Chinese. Nothing in the pipeline distinguished "Mandarin audio, correctly transcribed" from "Cantonese audio, silently normalised", which left every downstream question unanswerable on real traffic: force a language code, or is auto-detect fine? Is the provider mishandling Cantonese? If we swap, did it help?

Public benchmarks don't settle it — they score whole systems on corpora that don't resemble this traffic. An eval on real recordings needs a metric that runs on real recordings. This is that metric.

## What lands

`languageSignal(utterances)` — a pure function over the **final** utterance list (after chunk merge / continuation, so one measurement per recording however it was transcribed):

| field | meaning |
|---|---|
| `cantoDensityPerK` | Cantonese markers per 1000 CJK chars, or `null` |
| `markerCount` / `cjkCount` | the raw counts the ratio was taken over |
| `latinTokens` | code-switch signal, never counted as CJK |
| `variant` | `cantonese` / `mandarin` / `mixed` / `neutral` |

Plus migration **354**'s seven nullable columns on `recordings` (with a partial index for slicing by variant and density), and the `updateRecording` patch fields that write them.

**Measurement only.** No forced language, no provider swap, no routing change.

## Two things worth a reviewer's eye

**NULL and 0 are different facts, kept that way end to end.** NULL is "no CJK present, ratio undefined" (an English recording); 0 is "Chinese carrying no Cantonese markers" — precisely the normalisation being hunted. Folding NULL into 0 would drag every English recording into the Cantonese statistics. The store guards on `!== undefined` rather than truthiness, because 0 is a real reading, and pre-ship rows stay NULL so a backfill gap can't masquerade as data.

**A live arithmetic defect is fixed, and pinned.** The density numerator and denominator are a ratio and must share a character range. They didn't: `㗎` (U+35CE) is a marker living in **CJK Extension A**, while the denominator covered only Unified (`一-鿿`). Density could therefore exceed its own ceiling — the test measured **1045 per 1000** before the fix. The denominator now covers Extension A, and a test asserts the ceiling over the whole marker set, so widening the markers without widening the range fails in CI rather than silently in production data.

## Design notes

- **Two character sets, deliberately not merged.** The density set is 23 hand-curated characters that *exclude* 係/都 and friends, ordinary in Standard Written Chinese compounds (關係, 首都) — including them would let a Mandarin-normalised transcript score as Cantonese, making the failure invisible in its own metric. The `variant` label comes from `canto-filter.ts`, a faithful port of the published CanCLID classifier (MIT; Lau, Lau & To, EURALI @ LREC-COLING 2024), which runs over a much wider set on purpose: density measures Cantonese *presence* and cannot tell "Mandarin" from "no markers here", and the classifier also weighs positive Mandarin evidence and suppresses loanword false positives (剎那, 的士).
- `CANTO_UNIQUE_CHAR` is intentionally **not** exported — it contains astral-plane characters, and keeping it private is what stops it being re-wired into the density numerator and reintroducing the ceiling bug.

## Not in this change

`detected_language` / `detected_language_confidence` land as **columns only** — provider-reported language threading is not wired here. The density and variant halves are live; the provider-reported half is not.

## Tests

`language-signal.test.ts` — 10 tests, built red-first one slice at a time. Covers the discriminating case (same sentence Cantonese vs normalised), the density ceiling, raw counts, multi-utterance aggregation, code-switching, the null-vs-zero pair, empty/whitespace input, and SWC-compound exclusion. Loanword suppression is pinned as characterization, since the classifier arrived as a whole port.

- core media: **107 tests / 9 files** green (was 97/8)
- `recordings-store`: 12 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)