### PR TITLE
fix(api): resolve assistant access through one predicate, not owner_user_id

### DIFF
--- a/packages/api/src/db/__tests__/users.assistant-access.test.ts
+++ b/packages/api/src/db/__tests__/users.assistant-access.test.ts
@@ -1,0 +1,148 @@
+/**
+ * [COMP:api/assistant-access] resolveAssistantAccess — unit tests.
+ *
+ * Mocks the pg pool so we assert the SQL shape + params without a database.
+ * This is THE assistant access predicate; every "can this user use / see /
+ * edit this assistant" decision resolves through it, so these guard the two
+ * defects that motivated collapsing seven per-route spellings into one:
+ *
+ *   1. Gating on `assistants.owner_user_id`, which is NULL for every
+ *      workspace-owned assistant post-089 — unsatisfiable by any human for
+ *      exactly the team assistants that matter most.
+ *   2. Nondeterministic role resolution from `UNION … LIMIT 1` with no
+ *      `ORDER BY`, on the path that gates every assistant write.
+ *
+ * See docs/architecture/platform/workspaces.md → "The access predicate".
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../client.js', () => ({
+  __esModule: true,
+  query: vi.fn(),
+  queryWithRLS: vi.fn(),
+  getPool: vi.fn(),
+}))
+
+import { query } from '../client.js'
+import { resolveAssistantAccess, getUserAssistant } from '../users.js'
+
+const mockQuery = vi.mocked(query)
+
+const USER = 'u-1'
+const ASSISTANT = 'a-1'
+
+function row(over: Record<string, unknown> = {}) {
+  return {
+    id: ASSISTANT,
+    name: 'DD',
+    telegramModelAlias: 'pro',
+    workspaceId: 'w-1',
+    systemPrompt: null,
+    kind: 'primary',
+    appType: null,
+    blockedUserIds: [],
+    clearance: 'confidential',
+    compartments: null,
+    defaultCompartments: [],
+    role: 'owner',
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  mockQuery.mockReset()
+})
+
+describe('[COMP:api/assistant-access] resolveAssistantAccess', () => {
+  it('never gates on owner_user_id', async () => {
+    // The regression that shipped: workspace-owned assistants carry
+    // owner_user_id NULL, so this predicate must not reference the column.
+    mockQuery.mockResolvedValueOnce({ rows: [row()], rowCount: 1 } as never)
+    await resolveAssistantAccess(USER, ASSISTANT)
+
+    const sql = String(mockQuery.mock.calls[0][0])
+    expect(sql).not.toMatch(/owner_user_id/)
+  })
+
+  it('gates on direct OR workspace membership', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [row()], rowCount: 1 } as never)
+    await resolveAssistantAccess(USER, ASSISTANT)
+
+    const sql = String(mockQuery.mock.calls[0][0])
+    expect(sql).toMatch(/LEFT JOIN assistant_members/)
+    expect(sql).toMatch(/LEFT JOIN workspace_members/)
+    expect(sql).toMatch(/am\.user_id IS NOT NULL/)
+    expect(sql).toMatch(/wm\.user_id IS NOT NULL/)
+    expect(mockQuery.mock.calls[0][1]).toEqual([USER, ASSISTANT])
+  })
+
+  it('resolves the role deterministically, not via UNION', async () => {
+    // The old spelling was `UNION … LIMIT 1` with no ORDER BY, so a caller
+    // whose two membership rows disagreed got whichever role the planner
+    // emitted first. A single CASE cannot be ambiguous.
+    mockQuery.mockResolvedValueOnce({ rows: [row()], rowCount: 1 } as never)
+    await resolveAssistantAccess(USER, ASSISTANT)
+
+    const sql = String(mockQuery.mock.calls[0][0])
+    expect(sql).not.toMatch(/UNION/i)
+    expect(sql).toMatch(/CASE/)
+    // owner wins over admin, admin over member — the precedence is in the SQL.
+    expect(sql.indexOf("THEN 'owner'")).toBeLessThan(sql.indexOf("THEN 'admin'"))
+  })
+
+  it('issues exactly one query', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [row()], rowCount: 1 } as never)
+    await resolveAssistantAccess(USER, ASSISTANT)
+    expect(mockQuery).toHaveBeenCalledTimes(1)
+  })
+
+  it('splits the row into assistant + role', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [row({ role: 'admin' })], rowCount: 1 } as never)
+    const access = await resolveAssistantAccess(USER, ASSISTANT)
+
+    expect(access?.role).toBe('admin')
+    expect(access?.assistant.id).toBe(ASSISTANT)
+    expect(access?.assistant.workspaceId).toBe('w-1')
+    // `role` is lifted out of the assistant view, not left on it.
+    expect(access?.assistant).not.toHaveProperty('role')
+  })
+
+  it('returns null when the caller has no access', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 } as never)
+    expect(await resolveAssistantAccess(USER, ASSISTANT)).toBeNull()
+  })
+
+  it('returns null for a nonexistent assistant — indistinguishable from no access', async () => {
+    // Callers must answer 403 for both; a 404 on "exists but no access" would
+    // disclose assistant existence across workspace boundaries.
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 } as never)
+    expect(await resolveAssistantAccess(USER, 'ghost')).toBeNull()
+  })
+
+  it('binds a workspace-owned assistant whose owner_user_id is NULL', async () => {
+    // The user's real case: assistant "DD" in a team workspace, reached via
+    // workspace_members with owner_user_id NULL on the row.
+    mockQuery.mockResolvedValueOnce({ rows: [row({ role: 'owner' })], rowCount: 1 } as never)
+    const access = await resolveAssistantAccess(USER, ASSISTANT)
+    expect(access).not.toBeNull()
+    expect(access?.assistant.name).toBe('DD')
+  })
+})
+
+describe('[COMP:api/assistant-access] getUserAssistant', () => {
+  it('delegates to the predicate and drops the role', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [row({ role: 'member' })], rowCount: 1 } as never)
+    const assistant = await getUserAssistant(USER, ASSISTANT)
+
+    expect(assistant?.id).toBe(ASSISTANT)
+    expect(assistant).not.toHaveProperty('role')
+    // One query — it is a wrapper, not a second lookup.
+    expect(mockQuery).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null when the predicate denies', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 } as never)
+    expect(await getUserAssistant(USER, ASSISTANT)).toBeNull()
+  })
+})

--- a/packages/api/src/db/users.ts
+++ b/packages/api/src/db/users.ts
@@ -656,12 +656,54 @@ export async function getWorkspacePrimaryAssistant(
   return result.rows[0] ?? null
 }
 
-/** Look up a specific assistant the user can access.
- *  Standard assistants: checked via assistant_members.
- *  Team assistants (workspace_id IS NOT NULL): checked via workspace_members.
- *  Returns null if the assistant doesn't exist or the user has no access. */
-export async function getUserAssistant(userId: string, assistantId: string): Promise<UserAssistantView | null> {
-  const result = await query<UserAssistantView>(
+/** The caller's effective role on an assistant, by precedence owner > admin > member. */
+export type AssistantRole = 'owner' | 'admin' | 'member'
+
+/** What `resolveAssistantAccess` returns: the assistant plus the caller's effective role. */
+export type AssistantAccess = {
+  assistant: UserAssistantView
+  role: AssistantRole
+}
+
+/**
+ * **The** assistant access predicate. Every "can this user use / see / edit this
+ * assistant" decision resolves here — do not hand-roll the membership join at a
+ * call site.
+ *
+ * A user reaches an assistant two ways: a direct `assistant_members` grant
+ * (legacy, and the Personal-workspace primary) or membership in the assistant's
+ * workspace (`workspace_members`, canonical post-089). The gate is
+ * `direct OR workspace`, and the returned `role` is the **effective** role — the
+ * higher-privilege of the two paths, by owner > admin > member.
+ *
+ * Never gate on `assistants.owner_user_id`. After the migration-089 ownership
+ * XOR flip that column is NULL for every workspace-owned assistant, so an
+ * `owner_user_id = $userId` predicate is unsatisfiable by any human for exactly
+ * the team assistants that matter most. That defect shipped twice: the Telegram
+ * `/switch` commit gate, and the unguarded Telegram link-code routes.
+ *
+ * The effective-role CASE is load-bearing and mirrors `listAccessibleAssistants`.
+ * The earlier per-route spelling was `UNION … LIMIT 1` with no `ORDER BY`, so
+ * when a user's direct and workspace roles disagreed the resolved role was
+ * whatever the planner emitted first — nondeterministic, on the path that gates
+ * every assistant write. Both membership tables key on `(…, user_id)`, so the
+ * LEFT JOINs match at most one row each: no fan-out, exactly one row out.
+ *
+ * System read (bare `query`): the membership JOINs are themselves the access
+ * gate, so no RLS context is needed — same pattern as `listAccessibleAssistants`.
+ *
+ * Returns null when the assistant does not exist OR the caller cannot reach it.
+ * Callers must not distinguish the two (a 404 on "exists but no access" leaks
+ * assistant existence across workspaces); respond 403 for both.
+ *
+ * See docs/architecture/platform/workspaces.md → "The assistant list" and
+ * component `[COMP:api/assistant-access]`.
+ */
+export async function resolveAssistantAccess(
+  userId: string,
+  assistantId: string,
+): Promise<AssistantAccess | null> {
+  const result = await query<UserAssistantView & { role: AssistantRole }>(
     `SELECT a.id, a.name, a.telegram_model_alias as "telegramModelAlias",
             a.workspace_id as "workspaceId",
             a.system_prompt as "systemPrompt",
@@ -670,26 +712,37 @@ export async function getUserAssistant(userId: string, assistantId: string): Pro
             a.blocked_user_ids as "blockedUserIds",
             a.clearance,
             a.compartments,
-            a.default_compartments as "defaultCompartments"
-     FROM assistants a
-     WHERE a.id = $2
-       AND (
-         EXISTS (
-           SELECT 1 FROM assistant_members am
-           WHERE am.assistant_id = a.id AND am.user_id = $1
-         )
-         OR (
-           a.workspace_id IS NOT NULL
-           AND EXISTS (
-             SELECT 1 FROM workspace_members tm
-             WHERE tm.workspace_id = a.workspace_id AND tm.user_id = $1
-           )
-         )
-       )
-     LIMIT 1`,
+            a.default_compartments as "defaultCompartments",
+            CASE
+              WHEN am.role = 'owner' OR wm.role = 'owner' THEN 'owner'
+              WHEN am.role = 'admin' OR wm.role = 'admin' THEN 'admin'
+              ELSE 'member'
+            END AS role
+       FROM assistants a
+       LEFT JOIN assistant_members am
+         ON am.assistant_id = a.id AND am.user_id = $1
+       LEFT JOIN workspace_members wm
+         ON wm.workspace_id = a.workspace_id AND wm.user_id = $1
+      WHERE a.id = $2
+        AND (
+              am.user_id IS NOT NULL
+              OR (a.workspace_id IS NOT NULL AND wm.user_id IS NOT NULL)
+            )
+      LIMIT 1`,
     [userId, assistantId],
   )
-  return result.rows[0] ?? null
+  const row = result.rows[0]
+  if (!row) return null
+  const { role, ...assistant } = row
+  return { assistant, role }
+}
+
+/** Look up a specific assistant the user can access, discarding the role.
+ *  Thin wrapper over `resolveAssistantAccess` — the predicate lives there, so
+ *  this can never drift from the role-aware path. Returns null if the assistant
+ *  doesn't exist or the user has no access. */
+export async function getUserAssistant(userId: string, assistantId: string): Promise<UserAssistantView | null> {
+  return (await resolveAssistantAccess(userId, assistantId))?.assistant ?? null
 }
 
 /**
@@ -789,7 +842,7 @@ export async function listAccessibleAssistants(
  * user is known, e.g. Slack BYO where the assistant_id comes from the URL
  * and the Slack user hasn't been mapped to a Use Brian user yet).
  */
-export type AssistantKind = 'standard' | 'app' | 'primary' | 'primary'
+export type AssistantKind = 'standard' | 'app' | 'primary'
 
 /**
  * App variant. Non-null iff `kind='app'`, per the constraint in migration 081

--- a/packages/api/src/routes/__tests__/assistants-connector-scoping.test.ts
+++ b/packages/api/src/routes/__tests__/assistants-connector-scoping.test.ts
@@ -8,10 +8,19 @@ vi.mock('../../db/client.js', () => ({
   getPool: vi.fn(),
 }))
 
+// verifyMembership now delegates to `resolveAssistantAccess` — the single access
+// predicate (see [COMP:api/assistant-access]). It is one call, not a route-local
+// membership join, so the gate is stubbed here instead of via queryWithRLS.
+vi.mock('../../db/users.js', () => ({
+  resolveAssistantAccess: vi.fn(),
+}))
+
 import { assistantRoutes } from '../assistants.js'
 import { queryWithRLS } from '../../db/client.js'
+import { resolveAssistantAccess } from '../../db/users.js'
 
 const mockQueryWithRLS = vi.mocked(queryWithRLS)
+const mockAccess = vi.mocked(resolveAssistantAccess)
 
 const connectorStore = { list: vi.fn() }
 const assistantConnectorStore = { listForAssistant: vi.fn() }
@@ -46,12 +55,18 @@ function makeApp(userId: string) {
   return app
 }
 
-// verifyMembership runs one queryWithRLS (role), then the endpoint runs a
-// second (the assistant's workspace_id). Queue both per request.
+// verifyMembership resolves through the access predicate (one call, no
+// queryWithRLS); the endpoint then runs a queryWithRLS for the assistant's
+// workspace_id. Queue both per request.
 function queueMembershipAndTeam(role: string, workspaceId: string | null) {
-  mockQueryWithRLS
-    .mockResolvedValueOnce({ rows: [{ role }], rowCount: 1 } as never) // membership
-    .mockResolvedValueOnce({ rows: [{ workspace_id: workspaceId }], rowCount: 1 } as never) // team
+  mockAccess.mockResolvedValueOnce({
+    assistant: { id: 'a-1', name: 'A', workspaceId },
+    role,
+  } as never)
+  mockQueryWithRLS.mockResolvedValueOnce({
+    rows: [{ workspace_id: workspaceId }],
+    rowCount: 1,
+  } as never) // team
 }
 
 describe('[COMP:routes/assistants-connector-scoping] GET /:assistantId/connectors workspace gate', () => {

--- a/packages/api/src/routes/__tests__/assistants-delete-rls-scope.test.ts
+++ b/packages/api/src/routes/__tests__/assistants-delete-rls-scope.test.ts
@@ -24,10 +24,19 @@ vi.mock('../../db/client.js', () => ({
   getPool: vi.fn(),
 }))
 
+// verifyMembership now delegates to `resolveAssistantAccess` — the single access
+// predicate (see [COMP:api/assistant-access]). It is one call, not a route-local
+// membership join, so the gate is stubbed here instead of via queryWithRLS.
+vi.mock('../../db/users.js', () => ({
+  resolveAssistantAccess: vi.fn(),
+}))
+
 import { assistantRoutes } from '../assistants.js'
 import { queryWithRLS, getPool } from '../../db/client.js'
+import { resolveAssistantAccess } from '../../db/users.js'
 
 const mockQueryWithRLS = vi.mocked(queryWithRLS)
+const mockAccess = vi.mocked(resolveAssistantAccess)
 const mockGetPool = vi.mocked(getPool)
 
 const capabilityStore = {
@@ -58,8 +67,8 @@ function makeApp(opts: { userId: string }) {
 describe('[COMP:api/assistants-delete-rls-scope] DELETE /:assistantId scopes RLS with SET LOCAL', () => {
   it('uses SET LOCAL after BEGIN and never leaves the connection at current_user_id = ""', async () => {
     // Pre-delete guards (all queryWithRLS): role=owner, kind=standard, no other members.
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'owner' } as never)
     mockQueryWithRLS
-      .mockResolvedValueOnce({ rows: [{ role: 'owner' }], rowCount: 1 } as never)
       .mockResolvedValueOnce({ rows: [{ kind: 'standard' }], rowCount: 1 } as never)
       .mockResolvedValueOnce({ rows: [], rowCount: 0 } as never)
 

--- a/packages/api/src/routes/__tests__/assistants-primary-guard.test.ts
+++ b/packages/api/src/routes/__tests__/assistants-primary-guard.test.ts
@@ -19,10 +19,19 @@ vi.mock('../../db/client.js', () => ({
   getPool: vi.fn(),
 }))
 
+// verifyMembership now delegates to `resolveAssistantAccess` — the single access
+// predicate (see [COMP:api/assistant-access]). It is one call, not a route-local
+// membership join, so the gate is stubbed here instead of via queryWithRLS.
+vi.mock('../../db/users.js', () => ({
+  resolveAssistantAccess: vi.fn(),
+}))
+
 import { assistantRoutes } from '../assistants.js'
 import { queryWithRLS } from '../../db/client.js'
+import { resolveAssistantAccess } from '../../db/users.js'
 
 const mockQueryWithRLS = vi.mocked(queryWithRLS)
+const mockAccess = vi.mocked(resolveAssistantAccess)
 
 const capabilityStore = {
   listActive: vi.fn(),
@@ -50,9 +59,9 @@ function makeApp(opts: { userId: string }) {
 
 describe("[COMP:api/primary-assistant-guard] DELETE /:assistantId refuses kind='primary'", () => {
   it('returns 409 primary_not_deletable when the assistant is the workspace primary', async () => {
+    // 1. verifyMembership: owner (the single access predicate)
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'owner' } as never)
     mockQueryWithRLS
-      // 1. verifyMembership: owner
-      .mockResolvedValueOnce({ rows: [{ role: 'owner' }], rowCount: 1 } as never)
       // 2. kind lookup → primary
       .mockResolvedValueOnce({ rows: [{ kind: 'primary' }], rowCount: 1 } as never)
 
@@ -61,14 +70,15 @@ describe("[COMP:api/primary-assistant-guard] DELETE /:assistantId refuses kind='
     expect(res.status).toBe(409)
     expect(res.body.error).toBe('primary_not_deletable')
     // Critically the member-fan-out check + the DELETE must never have run.
-    // verifyMembership = 1 call, kind lookup = 1 call → 2 total.
-    expect(mockQueryWithRLS).toHaveBeenCalledTimes(2)
+    // verifyMembership no longer spends a queryWithRLS (it delegates to the
+    // access predicate), so only the kind lookup remains → 1.
+    expect(mockQueryWithRLS).toHaveBeenCalledTimes(1)
   })
 
   it("falls through to the regular delete flow when the assistant is kind='standard'", async () => {
+    // 1. verifyMembership: owner (the single access predicate)
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'owner' } as never)
     mockQueryWithRLS
-      // 1. verifyMembership: owner
-      .mockResolvedValueOnce({ rows: [{ role: 'owner' }], rowCount: 1 } as never)
       // 2. kind lookup → standard (not primary)
       .mockResolvedValueOnce({ rows: [{ kind: 'standard' }], rowCount: 1 } as never)
       // 3. assistant_members fan-out: no other owners
@@ -92,6 +102,6 @@ describe("[COMP:api/primary-assistant-guard] DELETE /:assistantId refuses kind='
     expect(res.status).toBe(500)
     expect(res.body.error).not.toBe('primary_not_deletable')
     expect(res.body.error).not.toBe('transfer_ownership_required')
-    expect(mockQueryWithRLS).toHaveBeenCalledTimes(3)
+    expect(mockQueryWithRLS).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/api/src/routes/__tests__/assistants-primitive-grants.test.ts
+++ b/packages/api/src/routes/__tests__/assistants-primitive-grants.test.ts
@@ -8,12 +8,21 @@ vi.mock('../../db/client.js', () => ({
   getPool: vi.fn(),
 }))
 
+// verifyMembership now delegates to `resolveAssistantAccess` — the single access
+// predicate (see [COMP:api/assistant-access]). It is one call, not a route-local
+// membership join, so the gate is stubbed here instead of via queryWithRLS.
+vi.mock('../../db/users.js', () => ({
+  resolveAssistantAccess: vi.fn(),
+}))
+
 import { assistantRoutes } from '../assistants.js'
 import { query, queryWithRLS } from '../../db/client.js'
+import { resolveAssistantAccess } from '../../db/users.js'
 import { DuplicateGrantError } from '@use-brian/core'
 
 const mockQuery = vi.mocked(query)
 const mockQueryWithRLS = vi.mocked(queryWithRLS)
+const mockAccess = vi.mocked(resolveAssistantAccess)
 
 const capabilityStore = {
   listActive: vi.fn<(id: string) => Promise<string[]>>(),
@@ -44,7 +53,7 @@ function makeApp(opts: { userId: string }) {
 // §17 — Tasks/CRM toggles. Workspace-member auth, idempotent grant/revoke.
 describe('[COMP:routes/assistants-primitive-grants] GET /:assistantId/primitive-grants', () => {
   it('returns enabled=true for capabilities the assistant carries', async () => {
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'member' }], rowCount: 1 } as never)
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'member' } as never)
     capabilityStore.listActive.mockResolvedValueOnce(['tasks', 'crm', 'bug_triage'])
 
     const res = await request(makeApp({ userId: 'u-1' }))
@@ -60,7 +69,7 @@ describe('[COMP:routes/assistants-primitive-grants] GET /:assistantId/primitive-
   })
 
   it('returns enabled=false for missing capabilities (default-off kind=app)', async () => {
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'member' }], rowCount: 1 } as never)
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'member' } as never)
     capabilityStore.listActive.mockResolvedValueOnce([])
 
     const res = await request(makeApp({ userId: 'u-1' }))
@@ -88,7 +97,7 @@ describe('[COMP:routes/assistants-primitive-grants] GET /:assistantId/primitive-
 
 describe('[COMP:routes/assistants-primitive-grants] PATCH /:assistantId/primitive-grants/:capability', () => {
   it('grants when enabled=true and no active grant exists', async () => {
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'member' }], rowCount: 1 } as never)
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'member' } as never)
     capabilityStore.grant.mockResolvedValueOnce({ id: 'g-1' } as never)
     capabilityStore.listActive.mockResolvedValueOnce(['tasks'])
 
@@ -107,7 +116,7 @@ describe('[COMP:routes/assistants-primitive-grants] PATCH /:assistantId/primitiv
   })
 
   it('treats DuplicateGrantError as a no-op (idempotent on)', async () => {
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'member' }], rowCount: 1 } as never)
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'member' } as never)
     capabilityStore.grant.mockRejectedValueOnce(new DuplicateGrantError('a-1', 'tasks'))
     capabilityStore.listActive.mockResolvedValueOnce(['tasks'])
 
@@ -120,7 +129,7 @@ describe('[COMP:routes/assistants-primitive-grants] PATCH /:assistantId/primitiv
   })
 
   it('revokes the active grant when enabled=false', async () => {
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'member' }], rowCount: 1 } as never)
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'member' } as never)
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 'g-existing' }], rowCount: 1 } as never)
     capabilityStore.revoke.mockResolvedValueOnce({ id: 'g-existing' } as never)
     capabilityStore.listActive.mockResolvedValueOnce([])
@@ -139,7 +148,7 @@ describe('[COMP:routes/assistants-primitive-grants] PATCH /:assistantId/primitiv
   })
 
   it('enabled=false is a no-op when no active grant exists', async () => {
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'member' }], rowCount: 1 } as never)
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'member' } as never)
     mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 } as never)
     capabilityStore.listActive.mockResolvedValueOnce([])
 
@@ -152,7 +161,7 @@ describe('[COMP:routes/assistants-primitive-grants] PATCH /:assistantId/primitiv
   })
 
   it('grants the goals primitive (default-on, member-toggleable)', async () => {
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'member' }], rowCount: 1 } as never)
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'member' } as never)
     capabilityStore.grant.mockResolvedValueOnce({ id: 'g-goals' } as never)
     capabilityStore.listActive.mockResolvedValueOnce(['tasks', 'crm', 'goals'])
 
@@ -171,7 +180,7 @@ describe('[COMP:routes/assistants-primitive-grants] PATCH /:assistantId/primitiv
   })
 
   it('400 for an unknown capability name', async () => {
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'member' }], rowCount: 1 } as never)
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'member' } as never)
 
     const res = await request(makeApp({ userId: 'u-1' }))
       .patch('/api/assistants/a-1/primitive-grants/bug_triage')
@@ -182,7 +191,7 @@ describe('[COMP:routes/assistants-primitive-grants] PATCH /:assistantId/primitiv
   })
 
   it('400 when enabled is not a boolean', async () => {
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'member' }], rowCount: 1 } as never)
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'member' } as never)
 
     const res = await request(makeApp({ userId: 'u-1' }))
       .patch('/api/assistants/a-1/primitive-grants/tasks')
@@ -197,7 +206,7 @@ describe('[COMP:routes/assistants-primitive-grants] PATCH /:assistantId/primitiv
 // Off by default, owner/admin-gated, never self-grantable.
 describe('[COMP:routes/assistants-primitive-grants] configure capability (admin-gated)', () => {
   it('403 when a plain member toggles configure on', async () => {
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'member' }], rowCount: 1 } as never)
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'member' } as never)
 
     const res = await request(makeApp({ userId: 'u-member' }))
       .patch('/api/assistants/a-1/primitive-grants/configure')
@@ -208,7 +217,7 @@ describe('[COMP:routes/assistants-primitive-grants] configure capability (admin-
   })
 
   it('403 when a plain member toggles configure off', async () => {
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'member' }], rowCount: 1 } as never)
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'member' } as never)
 
     const res = await request(makeApp({ userId: 'u-member' }))
       .patch('/api/assistants/a-1/primitive-grants/configure')
@@ -219,7 +228,7 @@ describe('[COMP:routes/assistants-primitive-grants] configure capability (admin-
   })
 
   it('a workspace admin can grant configure (provenance-stamped reason)', async () => {
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'admin' }], rowCount: 1 } as never)
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'admin' } as never)
     capabilityStore.grant.mockResolvedValueOnce({ id: 'g-conf' } as never)
     capabilityStore.listActive.mockResolvedValueOnce(['configure'])
 
@@ -238,7 +247,7 @@ describe('[COMP:routes/assistants-primitive-grants] configure capability (admin-
   })
 
   it('an owner can revoke configure', async () => {
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'owner' }], rowCount: 1 } as never)
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'owner' } as never)
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 'g-conf' }], rowCount: 1 } as never)
     capabilityStore.revoke.mockResolvedValueOnce({ id: 'g-conf' } as never)
     capabilityStore.listActive.mockResolvedValueOnce([])
@@ -257,7 +266,7 @@ describe('[COMP:routes/assistants-primitive-grants] configure capability (admin-
   })
 
   it('configure appears in the GET listing for any member (visible, not toggleable)', async () => {
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'member' }], rowCount: 1 } as never)
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'member' } as never)
     capabilityStore.listActive.mockResolvedValueOnce(['configure'])
 
     const res = await request(makeApp({ userId: 'u-member' }))

--- a/packages/api/src/routes/__tests__/assistants-sharing-lock.test.ts
+++ b/packages/api/src/routes/__tests__/assistants-sharing-lock.test.ts
@@ -8,10 +8,19 @@ vi.mock('../../db/client.js', () => ({
   getPool: vi.fn(),
 }))
 
+// verifyMembership now delegates to `resolveAssistantAccess` — the single access
+// predicate (see [COMP:api/assistant-access]). It is one call, not a route-local
+// membership join, so the gate is stubbed here instead of via queryWithRLS.
+vi.mock('../../db/users.js', () => ({
+  resolveAssistantAccess: vi.fn(),
+}))
+
 import { assistantRoutes } from '../assistants.js'
 import { queryWithRLS } from '../../db/client.js'
+import { resolveAssistantAccess } from '../../db/users.js'
 
 const mockQueryWithRLS = vi.mocked(queryWithRLS)
+const mockAccess = vi.mocked(resolveAssistantAccess)
 
 const capabilityStore = {
   listActive: vi.fn(),
@@ -41,7 +50,7 @@ function makeApp(opts: { userId: string }) {
 describe('[COMP:routes/assistants-sharing-lock] PATCH /:assistantId sharing_mode hard-lock', () => {
   it('rejects enabling sharing when the assistant has active capability grants (409)', async () => {
     // 1. membership check: owner
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'owner' }], rowCount: 1 } as never)
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'owner' } as never)
     // hasActive: has grants
     capabilityStore.hasActive.mockResolvedValueOnce(true)
 
@@ -51,13 +60,14 @@ describe('[COMP:routes/assistants-sharing-lock] PATCH /:assistantId sharing_mode
 
     expect(res.status).toBe(409)
     expect(res.body.code).toBe('SHARING_LOCKED_BY_GRANTS')
-    // Critically, the UPDATE query must NOT have been issued.
-    expect(mockQueryWithRLS).toHaveBeenCalledTimes(1) // only the membership check
+    // Critically, the UPDATE query must NOT have been issued. The membership
+    // check no longer spends a queryWithRLS, so the count is 0.
+    expect(mockQueryWithRLS).toHaveBeenCalledTimes(0)
   })
 
   it('allows setting sharing_mode=off even when the assistant has active grants', async () => {
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'owner' } as never)
     mockQueryWithRLS
-      .mockResolvedValueOnce({ rows: [{ role: 'owner' }], rowCount: 1 } as never) // membership
       .mockResolvedValueOnce({ // UPDATE
         rows: [{ id: 'a-1', name: 'Bot', system_prompt: null, slack_model_alias: 'standard', telegram_model_alias: 'standard', whatsapp_model_alias: 'standard' }],
         rowCount: 1,
@@ -74,8 +84,8 @@ describe('[COMP:routes/assistants-sharing-lock] PATCH /:assistantId sharing_mode
   })
 
   it('allows enabling sharing when the assistant has no active grants', async () => {
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'owner' } as never)
     mockQueryWithRLS
-      .mockResolvedValueOnce({ rows: [{ role: 'owner' }], rowCount: 1 } as never) // membership
       .mockResolvedValueOnce({ // UPDATE
         rows: [{ id: 'a-1', name: 'Bot', system_prompt: null, slack_model_alias: 'standard', telegram_model_alias: 'standard', whatsapp_model_alias: 'standard' }],
         rowCount: 1,
@@ -91,7 +101,7 @@ describe('[COMP:routes/assistants-sharing-lock] PATCH /:assistantId sharing_mode
   })
 
   it('403 for non-owner members (hard-lock never runs)', async () => {
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'member' }], rowCount: 1 } as never)
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'member' } as never)
 
     const res = await request(makeApp({ userId: 'u-member' }))
       .patch('/api/assistants/a-1')

--- a/packages/api/src/routes/__tests__/assistants-system-prompt-access.test.ts
+++ b/packages/api/src/routes/__tests__/assistants-system-prompt-access.test.ts
@@ -8,10 +8,19 @@ vi.mock('../../db/client.js', () => ({
   getPool: vi.fn(),
 }))
 
+// verifyMembership now delegates to `resolveAssistantAccess` — the single access
+// predicate (see [COMP:api/assistant-access]). It is one call, not a route-local
+// membership join, so the gate is stubbed here instead of via queryWithRLS.
+vi.mock('../../db/users.js', () => ({
+  resolveAssistantAccess: vi.fn(),
+}))
+
 import { assistantRoutes } from '../assistants.js'
 import { query, queryWithRLS } from '../../db/client.js'
+import { resolveAssistantAccess } from '../../db/users.js'
 
 const mockQueryWithRLS = vi.mocked(queryWithRLS)
+const mockAccess = vi.mocked(resolveAssistantAccess)
 const mockQuery = vi.mocked(query)
 
 const capabilityStore = {
@@ -53,8 +62,8 @@ const updatedRow = {
 
 describe('[COMP:routes/assistants-system-prompt-access] PATCH /:assistantId system prompt edit right', () => {
   it('lets a non-owner member edit the system prompt (200, UPDATE issued)', async () => {
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'member' } as never)
     mockQueryWithRLS
-      .mockResolvedValueOnce({ rows: [{ role: 'member' }], rowCount: 1 } as never) // membership
       .mockResolvedValueOnce({ rows: [updatedRow], rowCount: 1 } as never) // UPDATE
 
     const res = await request(makeApp({ userId: 'u-member' }))
@@ -64,10 +73,11 @@ describe('[COMP:routes/assistants-system-prompt-access] PATCH /:assistantId syst
     expect(res.status).toBe(200)
     expect(res.body.systemPrompt).toBe('New persona')
 
-    // Exactly two RLS queries: membership check + the UPDATE.
-    expect(mockQueryWithRLS).toHaveBeenCalledTimes(2)
-    const updateSql = mockQueryWithRLS.mock.calls[1][1] as string
-    const updateValues = mockQueryWithRLS.mock.calls[1][2] as unknown[]
+    // One RLS query: just the UPDATE. The membership check resolves through
+    // the access predicate and spends no queryWithRLS.
+    expect(mockQueryWithRLS).toHaveBeenCalledTimes(1)
+    const updateSql = mockQueryWithRLS.mock.calls[0][1] as string
+    const updateValues = mockQueryWithRLS.mock.calls[0][2] as unknown[]
     expect(updateSql).toContain('system_prompt = $')
     expect(updateValues).toContain('New persona')
 
@@ -77,8 +87,8 @@ describe('[COMP:routes/assistants-system-prompt-access] PATCH /:assistantId syst
   })
 
   it('lets a non-owner member clear the system prompt with null', async () => {
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'member' } as never)
     mockQueryWithRLS
-      .mockResolvedValueOnce({ rows: [{ role: 'member' }], rowCount: 1 } as never) // membership
       .mockResolvedValueOnce({ rows: [{ ...updatedRow, system_prompt: null }], rowCount: 1 } as never) // UPDATE
 
     const res = await request(makeApp({ userId: 'u-member' }))
@@ -86,12 +96,12 @@ describe('[COMP:routes/assistants-system-prompt-access] PATCH /:assistantId syst
       .send({ systemPrompt: null })
 
     expect(res.status).toBe(200)
-    const updateValues = mockQueryWithRLS.mock.calls[1][2] as unknown[]
+    const updateValues = mockQueryWithRLS.mock.calls[0][2] as unknown[]
     expect(updateValues).toContain(null)
   })
 
   it('blocks a plain member from renaming (rename is owner-or-admin, 403, no UPDATE)', async () => {
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'member' }], rowCount: 1 } as never) // membership
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'member' } as never)
 
     const res = await request(makeApp({ userId: 'u-member' }))
       .patch('/api/assistants/a-1')
@@ -100,12 +110,12 @@ describe('[COMP:routes/assistants-system-prompt-access] PATCH /:assistantId syst
     expect(res.status).toBe(403)
     expect(res.body.error).toBe('Only the owner or a workspace admin can rename this assistant')
     // Only the membership check ran — no UPDATE.
-    expect(mockQueryWithRLS).toHaveBeenCalledTimes(1)
+    expect(mockQueryWithRLS).toHaveBeenCalledTimes(0)
   })
 
   it('lets a workspace admin rename the assistant (200, UPDATE issued, no team requery)', async () => {
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'admin' } as never)
     mockQueryWithRLS
-      .mockResolvedValueOnce({ rows: [{ role: 'admin' }], rowCount: 1 } as never) // membership
       .mockResolvedValueOnce({ rows: [{ ...updatedRow, name: 'Renamed by admin' }], rowCount: 1 } as never) // UPDATE
 
     const res = await request(makeApp({ userId: 'u-admin' }))
@@ -117,15 +127,15 @@ describe('[COMP:routes/assistants-system-prompt-access] PATCH /:assistantId syst
 
     // membership check + UPDATE only — rename authorizes off member.role, so no
     // separate team-role requery (unlike clearance).
-    expect(mockQueryWithRLS).toHaveBeenCalledTimes(2)
-    const updateSql = mockQueryWithRLS.mock.calls[1][1] as string
-    const updateValues = mockQueryWithRLS.mock.calls[1][2] as unknown[]
+    expect(mockQueryWithRLS).toHaveBeenCalledTimes(1)
+    const updateSql = mockQueryWithRLS.mock.calls[0][1] as string
+    const updateValues = mockQueryWithRLS.mock.calls[0][2] as unknown[]
     expect(updateSql).toContain('name = $')
     expect(updateValues).toContain('Renamed by admin')
   })
 
   it('still blocks an admin from owner-only fields, even bundled with a rename (bio stays owner-only)', async () => {
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'admin' }], rowCount: 1 } as never) // membership
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'admin' } as never)
 
     const res = await request(makeApp({ userId: 'u-admin' }))
       .patch('/api/assistants/a-1')
@@ -133,11 +143,11 @@ describe('[COMP:routes/assistants-system-prompt-access] PATCH /:assistantId syst
 
     expect(res.status).toBe(403)
     expect(res.body.error).toBe('Only the owner can update assistant settings')
-    expect(mockQueryWithRLS).toHaveBeenCalledTimes(1) // membership only, no UPDATE
+    expect(mockQueryWithRLS).toHaveBeenCalledTimes(0) // no UPDATE (gate spends no RLS query)
   })
 
   it('rejects a non-owner request that bundles the system prompt with an owner-only field (bio)', async () => {
-    mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ role: 'member' }], rowCount: 1 } as never) // membership
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'member' } as never)
 
     const res = await request(makeApp({ userId: 'u-member' }))
       .patch('/api/assistants/a-1')
@@ -145,12 +155,12 @@ describe('[COMP:routes/assistants-system-prompt-access] PATCH /:assistantId syst
 
     expect(res.status).toBe(403)
     expect(res.body.error).toBe('Only the owner can update assistant settings')
-    expect(mockQueryWithRLS).toHaveBeenCalledTimes(1) // membership only, no UPDATE
+    expect(mockQueryWithRLS).toHaveBeenCalledTimes(0) // no UPDATE (gate spends no RLS query)
   })
 
   it('still gates clearance behind owner / team admin for a plain member', async () => {
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'member' } as never)
     mockQueryWithRLS
-      .mockResolvedValueOnce({ rows: [{ role: 'member' }], rowCount: 1 } as never) // membership
       .mockResolvedValueOnce({ rows: [], rowCount: 0 } as never) // team admin/owner check → not privileged
 
     const res = await request(makeApp({ userId: 'u-member' }))
@@ -159,12 +169,12 @@ describe('[COMP:routes/assistants-system-prompt-access] PATCH /:assistantId syst
 
     expect(res.status).toBe(403)
     expect(res.body.error).toBe('Only the assistant owner or a team admin can change clearance')
-    expect(mockQueryWithRLS).toHaveBeenCalledTimes(2) // membership + team role, no UPDATE
+    expect(mockQueryWithRLS).toHaveBeenCalledTimes(1) // team role only, no UPDATE
   })
 
   it('still lets the owner edit the system prompt (regression)', async () => {
+    mockAccess.mockResolvedValueOnce({ assistant: { id: 'a-1', name: 'A', workspaceId: 'w-1' }, role: 'owner' } as never)
     mockQueryWithRLS
-      .mockResolvedValueOnce({ rows: [{ role: 'owner' }], rowCount: 1 } as never) // membership
       .mockResolvedValueOnce({ rows: [{ ...updatedRow, system_prompt: 'owner-set' }], rowCount: 1 } as never) // UPDATE
 
     const res = await request(makeApp({ userId: 'u-owner' }))

--- a/packages/api/src/routes/__tests__/auth-email.test.ts
+++ b/packages/api/src/routes/__tests__/auth-email.test.ts
@@ -26,6 +26,7 @@ const findOrCreateUserMock = vi.fn()
 const promoteChannelUserMock = vi.fn()
 const updateUserTimezoneMock = vi.fn()
 const findUserByIdMock = vi.fn()
+const getDefaultAssistantMock = vi.fn()
 
 vi.mock('../../db/users.js', () => ({
   findUserByEmail: (...a: unknown[]) => findUserByEmailMock(...a),
@@ -33,6 +34,7 @@ vi.mock('../../db/users.js', () => ({
   promoteChannelUser: (...a: unknown[]) => promoteChannelUserMock(...a),
   updateUserTimezone: (...a: unknown[]) => updateUserTimezoneMock(...a),
   findUserById: (...a: unknown[]) => findUserByIdMock(...a),
+  getDefaultAssistant: (...a: unknown[]) => getDefaultAssistantMock(...a),
 }))
 
 function makeStore(overrides?: Partial<MagicLinkStore>): MagicLinkStore {
@@ -114,6 +116,7 @@ beforeEach(() => {
   promoteChannelUserMock.mockReset()
   updateUserTimezoneMock.mockReset()
   findUserByIdMock.mockReset()
+  getDefaultAssistantMock.mockReset()
 })
 
 describe('[COMP:api/auth-email-request] POST /auth/email/request-link', () => {
@@ -598,9 +601,11 @@ describe('[COMP:api/auth-email-verify-code] POST /auth/email/verify-code', () =>
       authProviderId: 'tg@example.com',
       timezone: 'Asia/Hong_Kong',
     })
-    // First query() inside tryLinkTelegram is the first-owned-assistant
-    // lookup; anything after (mergeShadowUser) gets the empty fallback.
-    queryMock.mockResolvedValueOnce({ rows: [{ id: 'assistant-1' }] })
+    // tryLinkTelegram resolves the bind target via getDefaultAssistant (the
+    // user's Personal-workspace primary), not a raw owner_user_id lookup —
+    // that column is NULL for workspace-owned assistants. Remaining query()
+    // calls (mergeShadowUser) get the empty fallback.
+    getDefaultAssistantMock.mockResolvedValueOnce({ id: 'assistant-1' })
     queryMock.mockResolvedValue({ rows: [] })
 
     let captured: Parameters<LinkedAccountStore['upsert']>[0] | null = null

--- a/packages/api/src/routes/__tests__/auth.test.ts
+++ b/packages/api/src/routes/__tests__/auth.test.ts
@@ -9,6 +9,7 @@ const JWT_SECRET = 'test-jwt-secret'
 const USER_A = '11111111-1111-1111-1111-111111111111'
 const ASSISTANT_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
 const ASSISTANT_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+const WORKSPACE_A = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
 
 // query() in auth.ts runs raw SQL against the pool; mock it so tests don't
 // need a real DB. We return different rows per SQL pattern.
@@ -94,8 +95,9 @@ describe('[COMP:api/auth] POST /auth/telegram-link-update', () => {
       .expect(400)
   })
 
-  it('returns 403 when the user does not own the assistant', async () => {
-    // Ownership check query returns no rows.
+  it('returns 403 when the user cannot access the assistant', async () => {
+    // getUserAssistant's access query returns no rows — neither a direct
+    // assistant_members grant nor workspace_members membership.
     queryMock.mockResolvedValueOnce({ rows: [] })
     const app = makeApp(stubStore())
     await request(app)
@@ -105,9 +107,69 @@ describe('[COMP:api/auth] POST /auth/telegram-link-update', () => {
       .expect(403)
   })
 
+  // Regression: the gate must be ACCESS, not `assistants.owner_user_id`.
+  // Post-089 every workspace-owned assistant has owner_user_id NULL, so the
+  // old `WHERE id = $1 AND owner_user_id = $2` predicate was unsatisfiable by
+  // any human — the picker listed team assistants via workspace_members and
+  // every Switch onto one 403'd. See docs/architecture/channels/telegram-mini-app.md.
+  it('binds a workspace-owned assistant (owner_user_id NULL) for a workspace member', async () => {
+    queryMock
+      // getUserAssistant resolves via workspace_members; note owner_user_id is
+      // not selected at all, and this row has no owner.
+      .mockResolvedValueOnce({
+        rows: [{ id: ASSISTANT_B, name: 'DD', workspaceId: WORKSPACE_A, telegramModelAlias: 'pro' }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ provider_id: '880211324', provider_metadata: { chatId: '880211324' } }],
+      })
+
+    let captured: Parameters<LinkedAccountStore['upsert']>[0] | null = null
+    const store = stubStore({
+      upsert: async (p): Promise<LinkedAccount> => {
+        captured = p
+        return {
+          id: 'la-1',
+          userId: p.userId,
+          assistantId: p.assistantId,
+          provider: p.provider,
+          providerId: p.providerId,
+          providerMetadata: p.providerMetadata ?? null,
+          linkedAt: new Date(),
+        }
+      },
+    })
+
+    const app = makeApp(store)
+    const res = await request(app)
+      .post('/auth/telegram-link-update')
+      .set(authHeader(USER_A))
+      .send({ assistantId: ASSISTANT_B })
+      .expect(200)
+
+    expect(res.body).toEqual({ ok: true, assistant: { id: ASSISTANT_B, name: 'DD' } })
+    expect(captured!.assistantId).toBe(ASSISTANT_B)
+  })
+
+  it('does not gate on owner_user_id', async () => {
+    // Guards the predicate itself: whatever SQL runs first must not mention
+    // owner_user_id, or workspace assistants become unbindable again.
+    queryMock.mockResolvedValueOnce({ rows: [] })
+    const app = makeApp(stubStore())
+    await request(app)
+      .post('/auth/telegram-link-update')
+      .set(authHeader(USER_A))
+      .send({ assistantId: ASSISTANT_A })
+      .expect(403)
+
+    const sql = String(queryMock.mock.calls[0]?.[0] ?? '')
+    expect(sql).not.toMatch(/owner_user_id/)
+    expect(sql).toMatch(/assistant_members/)
+    expect(sql).toMatch(/workspace_members/)
+  })
+
   it('returns 404 when the user has no existing Telegram link', async () => {
     queryMock
-      .mockResolvedValueOnce({ rows: [{ id: ASSISTANT_A, name: 'My Assistant' }] }) // ownership
+      .mockResolvedValueOnce({ rows: [{ id: ASSISTANT_A, name: 'My Assistant' }] }) // access (getUserAssistant)
       .mockResolvedValueOnce({ rows: [] }) // existing linked row lookup
     const app = makeApp(stubStore())
     await request(app)
@@ -119,7 +181,7 @@ describe('[COMP:api/auth] POST /auth/telegram-link-update', () => {
 
   it('upserts the linked_accounts row on success', async () => {
     queryMock
-      .mockResolvedValueOnce({ rows: [{ id: ASSISTANT_B, name: 'Work' }] }) // ownership
+      .mockResolvedValueOnce({ rows: [{ id: ASSISTANT_B, name: 'Work' }] }) // access (getUserAssistant)
       .mockResolvedValueOnce({
         rows: [{ provider_id: '12345', provider_metadata: { firstName: 'Hinson', chatId: '12345' } }],
       })

--- a/packages/api/src/routes/__tests__/knowledge.test.ts
+++ b/packages/api/src/routes/__tests__/knowledge.test.ts
@@ -23,6 +23,14 @@ vi.mock('../../db/client.js', () => ({
 // The GitHub picker resolves the caller's clearance via this lookup; stub it
 // (effectiveReadClearance stays real). Deferred arrow dodges the hoist trap.
 const mockMembership = vi.fn()
+// The access gate is the single predicate now, not a route-local join. Mock it
+// explicitly so these tests drive authorization on purpose rather than through
+// whatever the generic `query` stub happens to return.
+// See [COMP:api/assistant-access].
+vi.mock('../../db/users.js', () => ({
+  resolveAssistantAccess: vi.fn(),
+}))
+
 vi.mock('../../db/workspace-store.js', async (io) => ({
   ...(await io<typeof import('../../db/workspace-store.js')>()),
   getWorkspaceMembershipWithClearanceSystem: (...a: unknown[]) => mockMembership(...a),
@@ -30,9 +38,11 @@ vi.mock('../../db/workspace-store.js', async (io) => ({
 
 import { knowledgeRoutes, workspaceKnowledgeRoutes } from '../knowledge.js'
 import { query, queryWithRLS } from '../../db/client.js'
+import { resolveAssistantAccess } from '../../db/users.js'
 
 const mockQuery = vi.mocked(query)
 const mockRls = vi.mocked(queryWithRLS)
+const mockAccess = vi.mocked(resolveAssistantAccess)
 
 const knowledgeStore = {
   search: vi.fn(),
@@ -87,6 +97,10 @@ beforeEach(() => {
     rowCount: 1,
   } as never)
   mockRls.mockResolvedValue({ rows: [{ role: 'member' }], rowCount: 1 } as never)
+  mockAccess.mockResolvedValue({
+    assistant: { id: 'a-1', name: 'A', workspaceId: 'ws-1', clearance: 'internal' },
+    role: 'member',
+  } as never)
   knowledgeStore.listSources.mockResolvedValue([])
   knowledgeStore.listSourcesForAssistant.mockResolvedValue([])
   knowledgeStore.listDisabledSourceIds.mockResolvedValue([])
@@ -139,17 +153,18 @@ describe('[COMP:api/knowledge-route] GET /entries', () => {
     expect((await request(app()).get('/api/assistants/a-1/knowledge/entries')).status).toBe(401)
   })
 
-  it('returns 404 when the assistant does not exist', async () => {
-    mockQuery.mockReset()
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 } as never)
+  it('returns 403, not 404, when the assistant does not exist', async () => {
+    // The predicate returns null for both "missing" and "exists but no access",
+    // and callers must not distinguish them — a 404 here would disclose
+    // assistant existence across workspace boundaries. This route used to 404.
+    mockAccess.mockResolvedValue(null as never)
     expect(
       (await request(app('u-1')).get('/api/assistants/ghost/knowledge/entries')).status,
-    ).toBe(404)
+    ).toBe(403)
   })
 
   it('returns 403 when the caller is not a member of the assistant or its team', async () => {
-    mockRls.mockReset()
-    mockRls.mockResolvedValue({ rows: [], rowCount: 0 } as never)
+    mockAccess.mockResolvedValue(null as never)
     expect(
       (await request(app('u-1')).get('/api/assistants/a-1/knowledge/entries')).status,
     ).toBe(403)

--- a/packages/api/src/routes/__tests__/memories.test.ts
+++ b/packages/api/src/routes/__tests__/memories.test.ts
@@ -31,6 +31,13 @@ vi.mock('../../db/client.js', () => ({
   queryWithRLS: vi.fn(),
 }))
 
+// Both verifyMembership and verifyTeamAccess now resolve through the single
+// access predicate (`direct OR workspace`, one query, effective role) instead of
+// each spelling their own membership join. See [COMP:api/assistant-access].
+vi.mock('../../db/users.js', () => ({
+  resolveAssistantAccess: vi.fn(),
+}))
+
 vi.mock('../../db/workspace-store.js', () => ({
   getWorkspaceRoleSystem: vi.fn(),
   // Fused read-ceiling resolver — echo the assistant clearance + compartments
@@ -65,6 +72,7 @@ import {
   markVerifiedDirect,
 } from '../../db/memories.js'
 import { query, queryWithRLS } from '../../db/client.js'
+import { resolveAssistantAccess } from '../../db/users.js'
 import { getWorkspaceRoleSystem } from '../../db/workspace-store.js'
 import { recordVerification } from '../../db/memory-verifications-store.js'
 import { notifyBrainInboxChange } from '../../brain-stream/notify.js'
@@ -81,17 +89,22 @@ const mockListTeamMemories = vi.mocked(listWorkspaceMemories)
 const mockMarkVerifiedDirect = vi.mocked(markVerifiedDirect)
 const mockQuery = vi.mocked(query)
 const mockQueryWithRLS = vi.mocked(queryWithRLS)
+const mockResolveAssistantAccess = vi.mocked(resolveAssistantAccess)
 const mockGetTeamRoleSystem = vi.mocked(getWorkspaceRoleSystem)
 const mockRecordVerification = vi.mocked(recordVerification)
 const mockNotifyBrainInboxChange = vi.mocked(notifyBrainInboxChange)
 
-/** Mock membership check — queryWithRLS for assistant_members. */
-function setupAuth() {
-  mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ user_id: 'u_1' }], rowCount: 1 } as never)
+/** Grant access for the next gate call — one `resolveAssistantAccess` hit. */
+function setupAuth(workspaceId: string | null = 'w_1', role: 'owner' | 'admin' | 'member' = 'owner') {
+  mockResolveAssistantAccess.mockResolvedValueOnce({
+    assistant: { id: 'a_1', name: 'A', workspaceId, telegramModelAlias: 'pro' },
+    role,
+  } as never)
 }
 
+/** Deny access — the predicate returns null for both "missing" and "no access". */
 function setupNoAuth() {
-  mockQueryWithRLS.mockResolvedValueOnce({ rows: [], rowCount: 0 } as never)
+  mockResolveAssistantAccess.mockResolvedValueOnce(null as never)
 }
 
 /**
@@ -627,10 +640,9 @@ describe('[COMP:api/memories-route] Memory routes', () => {
 
   describe('GET /team', () => {
     it('returns empty for assistant with no team', async () => {
-      // The route queries assistants table for workspace_id first
-      mockQuery.mockResolvedValueOnce({ rows: [{ workspaceId: null }], rowCount: 1 } as never)
-      // Then falls back to assistant_members membership check
-      mockQueryWithRLS.mockResolvedValueOnce({ rows: [{ user_id: 'u_1' }], rowCount: 1 } as never)
+      // Access granted via a direct assistant_members grant; the assistant
+      // carries no workspace, so the team route short-circuits to empty.
+      setupAuth(null)
 
       const app = createTestApp('/api/assistants/:assistantId/memories', memoryRoutes(), { userId: 'u_1' })
       const res = await request(app).get('/api/assistants/a_1/memories/team')
@@ -650,9 +662,11 @@ describe('[COMP:api/memories-route] Memory routes', () => {
       // assistant_members row for the team's distribution assistant.
       // After WU-4.2b the route also calls `resolveViewerCtx` to fetch
       // workspace + clearance for the universal predicate, so we prime
-      // a second `query` reply.
-      mockQuery.mockResolvedValueOnce({ rows: [{ workspaceId: 't_1' }], rowCount: 1 } as never)
-      mockGetTeamRoleSystem.mockResolvedValueOnce('admin')
+      // a `query` reply for it.
+      //
+      // The workspace arm is now inside `resolveAssistantAccess` itself — one
+      // predicate, one query, no assistant_members fallback round-trip.
+      setupAuth('t_1', 'admin')
       mockResolveViewerCtx('t_1')
       mockListTeamMemories.mockResolvedValueOnce({
         memories: [{ id: 'mem_1', summary: 'sign off with — the team' }],
@@ -664,19 +678,29 @@ describe('[COMP:api/memories-route] Memory routes', () => {
 
       expect(res.status).toBe(200)
       expect(res.body.memories).toHaveLength(1)
-      // queryWithRLS for assistant_members should NOT be consulted when team
-      // role is positive — no fallback mock was set, and the request still
-      // succeeded.
+      // The gate is a single predicate call — no separate assistant_members
+      // fallback query is issued at all.
       expect(mockQueryWithRLS).not.toHaveBeenCalled()
+      expect(mockResolveAssistantAccess).toHaveBeenCalledTimes(1)
     })
 
     it('returns 403 when user is neither team member nor assistant member', async () => {
-      mockQuery.mockResolvedValueOnce({ rows: [{ workspaceId: 't_1' }], rowCount: 1 } as never)
-      mockGetTeamRoleSystem.mockResolvedValueOnce(null)
       setupNoAuth()
 
       const app = createTestApp('/api/assistants/:assistantId/memories', memoryRoutes(), { userId: 'u_1' })
       const res = await request(app).get('/api/assistants/a_1/memories/team')
+
+      expect(res.status).toBe(403)
+    })
+
+    it('returns 403, not 404, for an assistant that does not exist', async () => {
+      // The predicate returns null for both "missing" and "exists but no
+      // access"; distinguishing them would disclose assistant existence across
+      // workspace boundaries. This route used to 404 here.
+      setupNoAuth()
+
+      const app = createTestApp('/api/assistants/:assistantId/memories', memoryRoutes(), { userId: 'u_1' })
+      const res = await request(app).get('/api/assistants/nope/memories/team')
 
       expect(res.status).toBe(403)
     })

--- a/packages/api/src/routes/__tests__/telegram-linking.test.ts
+++ b/packages/api/src/routes/__tests__/telegram-linking.test.ts
@@ -3,6 +3,14 @@ import request from 'supertest'
 import { createTestApp } from './helpers.js'
 import { telegramLinkingRoutes } from '../telegram-linking.js'
 
+// Both routes gate on getUserAssistant — `direct OR workspace` access to the
+// `:assistantId` in the URL. Default it to "has access" so the existing
+// behavioural cases below exercise their own logic; the access cases override it.
+const getUserAssistantMock = vi.fn()
+vi.mock('../../db/users.js', () => ({
+  getUserAssistant: (...args: unknown[]) => getUserAssistantMock(...args),
+}))
+
 describe('[COMP:api/telegram-linking-route] Telegram linking routes', () => {
   const linkedAccountStore = {
     findByProvider: vi.fn(),
@@ -20,6 +28,55 @@ describe('[COMP:api/telegram-linking-route] Telegram linking routes', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
+    getUserAssistantMock.mockResolvedValue({ id: 'a_1', name: 'DD', workspaceId: 'w_1' })
+  })
+
+  // ── Access gate ──────────────────────────────────────────────
+  //
+  // Regression: both routes take :assistantId straight from the URL and used to
+  // run with no access check at all. `/link-code` would mint a redeemable code
+  // binding the caller's Telegram to ANY assistant id (a cross-workspace bind);
+  // `/link-status` returned another user's linked_accounts row verbatim — their
+  // Telegram chat id and profile metadata. requireAuth proves *a* user is
+  // calling, never that they may touch *this* assistant.
+
+  it('returns 403 from /link-code when the caller cannot access the assistant', async () => {
+    getUserAssistantMock.mockResolvedValue(null)
+    const router = telegramLinkingRoutes({
+      linkedAccountStore: linkedAccountStore as never,
+      linkCodeStore: linkCodeStore as never,
+    })
+    const app = createTestApp('/api/assistants/:assistantId/telegram', router, { userId: 'u_1' })
+
+    const res = await request(app).post('/api/assistants/someone-elses/telegram/link-code')
+    expect(res.status).toBe(403)
+    expect(linkCodeStore.create).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 from /link-status without leaking the linked account', async () => {
+    getUserAssistantMock.mockResolvedValue(null)
+    const router = telegramLinkingRoutes({
+      linkedAccountStore: linkedAccountStore as never,
+      linkCodeStore: linkCodeStore as never,
+    })
+    const app = createTestApp('/api/assistants/:assistantId/telegram', router, { userId: 'u_1' })
+
+    const res = await request(app).get('/api/assistants/someone-elses/telegram/link-status')
+    expect(res.status).toBe(403)
+    expect(res.body.linkedAccount).toBeUndefined()
+    expect(linkedAccountStore.findByAssistant).not.toHaveBeenCalled()
+  })
+
+  it('gates on the URL assistantId, not the caller id', async () => {
+    const router = telegramLinkingRoutes({
+      linkedAccountStore: linkedAccountStore as never,
+      linkCodeStore: linkCodeStore as never,
+    })
+    const app = createTestApp('/api/assistants/:assistantId/telegram', router, { userId: 'u_1' })
+    linkCodeStore.create.mockResolvedValueOnce({ code: 'ABC123', expiresAt: '2026-04-10T12:00:00Z' })
+
+    await request(app).post('/api/assistants/a_9/telegram/link-code')
+    expect(getUserAssistantMock).toHaveBeenCalledWith('u_1', 'a_9')
   })
 
   // ── POST /link-code ──────────────────────────────────────────

--- a/packages/api/src/routes/assistants.ts
+++ b/packages/api/src/routes/assistants.ts
@@ -16,6 +16,7 @@
 
 import { Router } from 'express'
 import { queryWithRLS, query, getPool } from '../db/client.js'
+import { resolveAssistantAccess } from '../db/users.js'
 import type { AssistantConnectorStore } from '../db/assistant-connector-store.js'
 import type { ConnectorStore } from '../db/connector-store.js'
 import type { ConnectorInstanceStore } from '../db/connector-instance-store.js'
@@ -53,14 +54,21 @@ export function assistantRoutes(options: AssistantRouteOptions): Router {
   const router = Router()
 
   /**
-   * Verify the authenticated user is a member of this assistant.
+   * Verify the authenticated user can access this assistant.
    * Returns { userId, role } or sends 401/403 and returns null.
    *
-   * Post-089 (team-connector promotion): team-owned assistants have no
-   * `assistant_members` rows — access flows through `workspace_members`. We
-   * check both paths and return the first that matches.
-   *   - Personal assistant: the user's `assistant_members.role`
-   *   - Team assistant:    the user's `workspace_members.role` (in the team)
+   * Delegates to `resolveAssistantAccess` — the single access predicate (see its
+   * docstring). `role` here is the caller's **effective** role, the higher of
+   * their direct (`assistant_members`) and workspace (`workspace_members`) roles.
+   *
+   * That determinism is the point, because every write below branches on this
+   * value. The previous spelling was a local `UNION … LIMIT 1` with no
+   * `ORDER BY`: when a user's two membership rows disagreed, the role returned
+   * was whichever the planner happened to emit first. A workspace admin carrying
+   * a legacy `assistant_members.role='member'` row could be denied a rename they
+   * were entitled to, and — the direction that matters — a workspace `member`
+   * carrying a legacy `role='owner'` row could non-deterministically clear the
+   * owner-only gate on `bio`, `sharing_mode`, and the model aliases.
    */
   async function verifyMembership(
     req: { userId?: string; params: AssistantParams },
@@ -71,26 +79,13 @@ export function assistantRoutes(options: AssistantRouteOptions): Router {
       res.status(401).json({ error: 'Unauthorized' })
       return null
     }
-    const { assistantId } = req.params
 
-    const result = await queryWithRLS<{ role: string }>(
-      userId,
-      `SELECT am.role
-         FROM assistant_members am
-        WHERE am.assistant_id = $1 AND am.user_id = $2
-       UNION
-       SELECT tm.role
-         FROM assistants a
-         JOIN workspace_members tm ON tm.workspace_id = a.workspace_id
-        WHERE a.id = $1 AND tm.user_id = $2 AND a.workspace_id IS NOT NULL
-       LIMIT 1`,
-      [assistantId, userId],
-    )
-    if (result.rows.length === 0) {
+    const access = await resolveAssistantAccess(userId, req.params.assistantId)
+    if (!access) {
       res.status(403).json({ error: 'Not a member of this assistant' })
       return null
     }
-    return { userId, role: result.rows[0].role }
+    return { userId, role: access.role }
   }
 
   // ── GET /:assistantId — single assistant detail ────────────────

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -3,7 +3,7 @@ import { createTokens, verifyRefreshToken } from '../auth/jwt.js'
 import { requireAuth } from '../auth/middleware.js'
 import { verifyTgLinkToken } from '../auth/tg-link-token.js'
 import { isValidTimezone } from '../auth/client-timezone.js'
-import { backfillUserProfileFromProvider, findOrCreateUser, findUserById, findUserByEmail, promoteChannelUser, updateUserTimezone, type User } from '../db/users.js'
+import { backfillUserProfileFromProvider, findOrCreateUser, findUserById, findUserByEmail, getDefaultAssistant, getUserAssistant, promoteChannelUser, updateUserTimezone, type User } from '../db/users.js'
 import { query } from '../db/client.js'
 import { mergeShadowUser, type LinkedAccountStore } from '../db/linked-accounts.js'
 import type { ApiKeyStore } from '../db/api-key-store.js'
@@ -502,10 +502,23 @@ export function authRoutes(
    * official bot. Consumed by the Mini App `/tg-link/manage` page when a user
    * taps "switch to this assistant". See docs/architecture/channels/telegram-mini-app.md.
    *
-   * Preconditions: the user must own the target assistant, and they must have
-   * an existing `linked_accounts` row for `telegram` (i.e., they must have
-   * done the initial link via Mini App or 6-char code). A missing link means
-   * the user hit `/manage` without ever linking — 404 and direct them to /start.
+   * Preconditions: the user must be able to ACCESS the target assistant, and
+   * they must have an existing `linked_accounts` row for `telegram` (i.e., they
+   * must have done the initial link via Mini App or 6-char code). A missing link
+   * means the user hit `/manage` without ever linking — 404 and direct them
+   * to /start.
+   *
+   * The gate is access, NOT `assistants.owner_user_id`. After the migration-089
+   * ownership XOR flip that column is NULL for every workspace-owned assistant,
+   * so an `owner_user_id = $userId` predicate is unsatisfiable by any human for
+   * exactly the team assistants users most want on Telegram — it 403'd every
+   * Switch onto a workspace assistant while the picker happily listed them.
+   * `getUserAssistant` is the same `direct OR workspace` predicate the picker
+   * (`listAccessibleAssistants`) and the chat route already use; keep them
+   * aligned. Binding your own Telegram identity to an assistant you can already
+   * chat with on the web grants no new data access, so this is self-service for
+   * any member — provisioning the assistant is the admin-gated act, not this.
+   * See docs/architecture/channels/telegram-mini-app.md.
    */
   router.post('/telegram-link-update', requireAuth(jwtSecret), async (req, res) => {
     const userId = req.userId
@@ -524,12 +537,9 @@ export function authRoutes(
       return
     }
 
-    const assistantRow = await query<{ id: string; name: string }>(
-      `SELECT id, name FROM assistants WHERE id = $1 AND owner_user_id = $2`,
-      [assistantId, userId],
-    )
-    if (assistantRow.rows.length === 0) {
-      res.status(403).json({ error: 'Not the owner of that assistant' })
+    const assistant = await getUserAssistant(userId, assistantId)
+    if (!assistant) {
+      res.status(403).json({ error: 'No access to that assistant' })
       return
     }
 
@@ -563,7 +573,7 @@ export function authRoutes(
 
     res.json({
       ok: true,
-      assistant: { id: assistantRow.rows[0].id, name: assistantRow.rows[0].name },
+      assistant: { id: assistant.id, name: assistant.name },
     })
   })
 
@@ -816,14 +826,15 @@ async function tryLinkTelegram(
     return 'Telegram link token invalid or expired; please retry from Telegram'
   }
 
-  const assistantRow = await query<{ id: string }>(
-    `SELECT id FROM assistants
-     WHERE owner_user_id = $1
-     ORDER BY created_at ASC
-     LIMIT 1`,
-    [userId],
-  )
-  const assistantId = assistantRow.rows[0]?.id
+  // First-time link targets the user's Personal-workspace primary, resolved by
+  // `getDefaultAssistant` (workspace-anchored, with an `assistant_members`
+  // fallback). This used to be `SELECT id FROM assistants WHERE owner_user_id =
+  // $1 ORDER BY created_at ASC` — the same post-089 trap as the /switch commit
+  // gate: `owner_user_id` is NULL for every workspace-owned assistant, so a user
+  // whose personal primary predates the column being populated got "user has no
+  // assistant" and silently failed to link at all.
+  const defaultAssistant = await getDefaultAssistant(userId)
+  const assistantId = defaultAssistant?.id
   if (!assistantId) {
     return 'Telegram link skipped: user has no assistant'
   }

--- a/packages/api/src/routes/knowledge.ts
+++ b/packages/api/src/routes/knowledge.ts
@@ -18,6 +18,7 @@
 
 import { Router } from 'express'
 import { query, queryWithRLS } from '../db/client.js'
+import { resolveAssistantAccess } from '../db/users.js'
 import type { KnowledgeStore } from '../db/knowledge-store.js'
 import type { ConnectorInstance, ConnectorInstanceStore } from '../db/connector-instance-store.js'
 import type { ConnectorGrantStore } from '../db/connector-grant-store.js'
@@ -447,14 +448,17 @@ export function knowledgeRoutes({
 
   /**
    * Authorize access to team-level knowledge operations (picker + repo
-   * enumeration). Accepts either:
-   *   - direct `assistant_members` row (personal assistants), or
-   *   - `workspace_members` row for the assistant's owning team (team assistants).
+   * enumeration), returning the assistant's workspace.
    *
-   * The owning team's members are the right audience for configuring a
-   * team's KB sources — they may not be in `assistant_members` for every
-   * team-owned assistant. Returns the userId on success; writes a 4xx and
-   * returns null on denial.
+   * Delegates to `resolveAssistantAccess` — the single access predicate
+   * (`direct assistant_members grant OR workspace_members membership`). The
+   * owning workspace's members are the right audience for configuring a team's
+   * KB sources; they may not be in `assistant_members` for every team-owned
+   * assistant.
+   *
+   * **403, never 404.** This previously probed `SELECT workspace_id FROM
+   * assistants` first and 404'd on an unknown id, making a nonexistent assistant
+   * distinguishable from one the caller cannot reach. Both collapse to 403.
    */
   async function verifyTeamOrAssistantAccess(
     req: { userId?: string; params: { assistantId: string } },
@@ -463,37 +467,12 @@ export function knowledgeRoutes({
     const userId = req.userId
     if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return null }
 
-    // Resolve the assistant's team — system query because the caller might
-    // not yet have visibility into the assistant row.
-    const assistant = await query<{ workspace_id: string | null }>(
-      `SELECT workspace_id FROM assistants WHERE id = $1`, [req.params.assistantId],
-    )
-    if (assistant.rows.length === 0) {
-      res.status(404).json({ error: 'Assistant not found' })
+    const access = await resolveAssistantAccess(userId, req.params.assistantId)
+    if (!access) {
+      res.status(403).json({ error: 'Not a member of this assistant or its team' })
       return null
     }
-    const workspaceId = assistant.rows[0].workspace_id
-
-    // Direct assistant membership.
-    const direct = await queryWithRLS<{ role: string }>(
-      userId,
-      `SELECT role FROM assistant_members WHERE assistant_id = $1 AND user_id = $2`,
-      [req.params.assistantId, userId],
-    )
-    if (direct.rows.length > 0) return { userId, workspaceId }
-
-    // Team membership grants access to all team-owned assistants.
-    if (workspaceId) {
-      const teamMember = await queryWithRLS<{ role: string }>(
-        userId,
-        `SELECT role FROM workspace_members WHERE workspace_id = $1 AND user_id = $2`,
-        [workspaceId, userId],
-      )
-      if (teamMember.rows.length > 0) return { userId, workspaceId }
-    }
-
-    res.status(403).json({ error: 'Not a member of this assistant or its team' })
-    return null
+    return { userId, workspaceId: access.assistant.workspaceId }
   }
 
   // Resolve the assistant's team and clearance into an AccessContext.

--- a/packages/api/src/routes/memories.ts
+++ b/packages/api/src/routes/memories.ts
@@ -38,6 +38,7 @@ import {
 } from '../db/memories.js'
 import { query } from '../db/client.js'
 import { queryWithRLS } from '../db/client.js'
+import { resolveAssistantAccess } from '../db/users.js'
 import { getWorkspaceRoleSystem, resolveReadCeilingsSystem } from '../db/workspace-store.js'
 import { recordVerification } from '../db/memory-verifications-store.js'
 import { listMemoriesByRecentOutcome } from '../db/memory-recall-events-store.js'
@@ -93,8 +94,10 @@ export function memoryRoutes(): Router {
   const router = Router({ mergeParams: true })
 
   /**
-   * Verify the authenticated user is a member of this assistant.
+   * Verify the authenticated user can access this assistant.
    * Returns the userId or sends 401/403 and returns null.
+   *
+   * Delegates to `resolveAssistantAccess` — the single access predicate.
    */
   async function verifyMembership(
     req: { userId?: string; params: AssistantParams },
@@ -105,25 +108,8 @@ export function memoryRoutes(): Router {
       res.status(401).json({ error: 'Unauthorized' })
       return null
     }
-    const { assistantId } = req.params
 
-    const result = await queryWithRLS<{ ok: number }>(
-      userId,
-      // Personal: assistant_members. Team (post-089): workspace_members for
-      // the assistant's owning team.
-      `SELECT 1 AS ok
-       WHERE EXISTS (
-         SELECT 1 FROM assistant_members am
-         WHERE am.assistant_id = $1 AND am.user_id = $2
-       )
-       OR EXISTS (
-         SELECT 1 FROM assistants a
-         JOIN workspace_members tm ON tm.workspace_id = a.workspace_id
-         WHERE a.id = $1 AND tm.user_id = $2
-       )`,
-      [assistantId, userId],
-    )
-    if (result.rows.length === 0) {
+    if (!(await resolveAssistantAccess(userId, req.params.assistantId))) {
       res.status(403).json({ error: 'Not a member of this assistant' })
       return null
     }
@@ -131,15 +117,16 @@ export function memoryRoutes(): Router {
   }
 
   /**
-   * Verify access to team-scoped routes. Team-owned `kind='app'` assistants
-   * (e.g. the feed app) don't carry a row per team-member in
-   * `assistant_members` — access flows through `workspace_members`. Accept either
-   * direct assistant membership or team membership; fall back to 403 only
-   * when neither path matches.
+   * Verify access to team-scoped routes, returning the assistant's workspace.
    *
-   * Returns `{ userId, workspaceId }` on success (workspaceId is null when the
-   * assistant is not team-owned, in which case access required direct
-   * assistant membership). Sends 401/403/404 and returns null otherwise.
+   * Same predicate as `verifyMembership` (`resolveAssistantAccess`); this variant
+   * additionally hands back `workspaceId`, which the team-scoped handlers need.
+   *
+   * **403, never 404.** This used to `SELECT workspace_id FROM assistants` first
+   * and 404 when the id was unknown, which made a nonexistent assistant
+   * distinguishable from one the caller merely cannot reach — assistant-existence
+   * disclosure across workspace boundaries, and inconsistent with every sibling
+   * route. Both cases now collapse to 403.
    */
   async function verifyTeamAccess(
     req: { userId?: string; params: AssistantParams },
@@ -150,34 +137,13 @@ export function memoryRoutes(): Router {
       res.status(401).json({ error: 'Unauthorized' })
       return null
     }
-    const { assistantId } = req.params
 
-    const assistantResult = await query<{ workspaceId: string | null }>(
-      `SELECT workspace_id AS "workspaceId" FROM assistants WHERE id = $1`,
-      [assistantId],
-    )
-    if (assistantResult.rows.length === 0) {
-      res.status(404).json({ error: 'Assistant not found' })
-      return null
-    }
-    const workspaceId = assistantResult.rows[0].workspaceId
-
-    if (workspaceId) {
-      const role = await getWorkspaceRoleSystem(userId, workspaceId)
-      if (role) return { userId, workspaceId }
-    }
-
-    const memberResult = await queryWithRLS<{ user_id: string }>(
-      userId,
-      `SELECT user_id FROM assistant_members
-       WHERE assistant_id = $1 AND user_id = $2`,
-      [assistantId, userId],
-    )
-    if (memberResult.rows.length === 0) {
+    const access = await resolveAssistantAccess(userId, req.params.assistantId)
+    if (!access) {
       res.status(403).json({ error: 'Not a member of this assistant or its team' })
       return null
     }
-    return { userId, workspaceId }
+    return { userId, workspaceId: access.assistant.workspaceId }
   }
 
   // ── List memories (paginated, filterable) ──────────────────────

--- a/packages/api/src/routes/telegram-linking.ts
+++ b/packages/api/src/routes/telegram-linking.ts
@@ -9,11 +9,22 @@
  *
  *   POST /api/assistants/:assistantId/telegram/link-code   → generate code
  *   GET  /api/assistants/:assistantId/telegram/link-status  → poll for result
+ *
+ * Both routes take an `:assistantId` straight from the URL, so both must gate on
+ * it. `requireAuth` alone only proves *a* user is calling — it says nothing about
+ * whether that user may touch this assistant. Ungated, `/link-code` minted a
+ * redeemable code binding the caller's Telegram to ANY assistant id in the
+ * database (a cross-workspace bind), and `/link-status` returned another user's
+ * `linked_accounts` row verbatim — their Telegram chat id and profile metadata.
+ * The gate is `getUserAssistant` (`direct OR workspace` membership), identical to
+ * `POST /auth/telegram-link-update`; the two paths write the same binding and
+ * must not disagree on who may write it.
  */
 
 import { Router } from 'express'
 import type { LinkedAccountStore } from '../db/linked-accounts.js'
 import type { LinkCodeStore } from '../db/link-codes.js'
+import { getUserAssistant } from '../db/users.js'
 
 type TelegramLinkingRouteOptions = {
   linkedAccountStore: LinkedAccountStore
@@ -37,6 +48,11 @@ export function telegramLinkingRoutes(options: TelegramLinkingRouteOptions): Rou
     }
     const { assistantId } = req.params
 
+    if (!(await getUserAssistant(userId, assistantId))) {
+      res.status(403).json({ error: 'No access to that assistant' })
+      return
+    }
+
     try {
       const code = await linkCodeStore.create({ userId, assistantId })
       res.json({ code: code.code, expiresAt: code.expiresAt })
@@ -55,6 +71,11 @@ export function telegramLinkingRoutes(options: TelegramLinkingRouteOptions): Rou
       return
     }
     const { assistantId } = req.params
+
+    if (!(await getUserAssistant(userId, assistantId))) {
+      res.status(403).json({ error: 'No access to that assistant' })
+      return
+    }
 
     try {
       // Check if this assistant already has an official bot link (fast path)


### PR DESCRIPTION
## The bug

Telegram `/switch` 403'd on every workspace-owned assistant. The picker listed assistants by **membership** (`listAccessibleAssistants`), while the commit gate demanded `assistants.owner_user_id = $userId`.

That column is `NULL` for every workspace-owned assistant after the migration-089 ownership XOR flip, so the narrower gate was satisfiable by **nobody**. Verified against prod: of 36 assistants in team workspaces, 0 carry an `owner_user_id`.

The two gates lived in different packages, which is how they drifted.

## The fix

One predicate, every call site through it:

```ts
resolveAssistantAccess(userId, assistantId) -> { assistant, role } | null
```

`direct assistant_members grant OR workspace_members membership`, returning the caller's **effective** role (higher of the two, `owner > admin > member`). `getUserAssistant` is now a thin wrapper over it, so the two cannot drift.

## Carried by the same change

- **`routes/assistants.ts` gated every assistant write on `UNION … LIMIT 1` with no `ORDER BY`.** When a caller's direct and workspace roles disagreed, the resolved role was whichever the planner emitted first. A workspace `member` holding a legacy `assistant_members.role='owner'` row could non-deterministically clear the owner-only gate on `bio`, `sharing_mode` and the model aliases.
- **`routes/telegram-linking.ts` had no access check at all.** `POST /link-code` minted a redeemable code binding the caller's Telegram to *any* assistant id in the database, across workspaces. `GET /link-status` returned another user's `linked_accounts` row verbatim: their Telegram chat id and profile metadata. `requireAuth` proves *a* user is calling, never that they may touch *this* assistant.
- **`tryLinkTelegram` had the same `owner_user_id` trap** - it picked the caller's oldest owned assistant, so a user whose personal primary carries a NULL owner got "user has no assistant" and silently failed to link. Now resolves via `getDefaultAssistant`. This also covers the **new email-code sign-in path added on develop**, which calls the same helper.
- **404 -> 403** in `memories.ts` and `knowledge.ts`, which probed the assistant row first and 404'd on an unknown id, disclosing assistant existence across workspace boundaries.

## Permission model

Binding your own Telegram identity to an assistant you can already chat with on the web grants no new data access, so it is **self-service for any member**; provisioning the assistant stays admin-gated (`requireWorkspaceRole(…, 'admin')`).

This matches the industry norm - provisioning admin-gated, personal binding self-service - surveyed across nine products in `docs/research/external/integration-binding-permissions-2026.md` (platform repo). Anthropic's own connectors state it directly: *"Enabling a connector makes it available to your team, but it doesn't automatically grant anyone access. Each person still needs to authenticate individually."*

## Tests

New `[COMP:api/assistant-access]` suite pins the predicate: no `owner_user_id` in the SQL, both membership joins present, no `UNION`, one query, 403-not-404, and the exact workspace-assistant regression. Route suites updated to drive the gate explicitly rather than through an incidental `query` stub.

Verified green on base `5f5a7be` (3659 passed, smoke OK, typecheck clean). Rebased onto `develop` here with a clean 3-way apply; the `tryLinkTelegram` interaction with develop's new email-code path was checked by hand. Leaving final validation to CI on this base.

Paired KB update: use-brian/brian-kb#30. Platform-side docs + graded invariant follow in brian-platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)