### PR TITLE
fix(app-web): assistant roster stays live after a create

### DIFF
--- a/apps/app-web/src/components/chrome/floating-chat.tsx
+++ b/apps/app-web/src/components/chrome/floating-chat.tsx
@@ -83,6 +83,10 @@ import {
 } from "@/lib/doc-page-url";
 import { DOC_COMMENTS_CHANGED_EVENT } from "@/lib/comment-events";
 import {
+  ASSISTANT_REFRESH_EVENT,
+  type AssistantRefreshDetail,
+} from "@/lib/assistant-events";
+import {
   derivePageIcon,
   getAssistantIdentity,
   listWorkspaceAssistants,
@@ -503,20 +507,32 @@ export function FloatingChat({
   const [workspaceAssistants, setWorkspaceAssistants] = useState<
     WorkspaceAssistantSummary[]
   >([]);
-  useEffect(() => {
+  const reloadWorkspaceAssistants = useCallback(() => {
     if (!workspaceId) return;
-    let cancelled = false;
     listWorkspaceAssistants(workspaceId)
-      .then((list) => {
-        if (!cancelled) setWorkspaceAssistants(list);
-      })
+      .then((list) => setWorkspaceAssistants(list))
       .catch(() => {
         /* switcher just stays single-option; the default still works */
       });
-    return () => {
-      cancelled = true;
-    };
   }, [workspaceId]);
+
+  useEffect(() => {
+    reloadWorkspaceAssistants();
+  }, [reloadWorkspaceAssistants]);
+
+  // Live refresh. This dock lives in the `/w/[workspaceId]` layout and never
+  // unmounts, so the effect above fires once per full page load — a create in
+  // Studio (or by a teammate, or in another tab) would otherwise stay invisible
+  // until an app restart. Signals arrive via the workspace event spine.
+  useEffect(() => {
+    const onRefresh = (event: Event) => {
+      const detail = (event as CustomEvent<AssistantRefreshDetail>).detail;
+      if (detail?.workspaceId && detail.workspaceId !== workspaceId) return;
+      reloadWorkspaceAssistants();
+    };
+    window.addEventListener(ASSISTANT_REFRESH_EVENT, onRefresh);
+    return () => window.removeEventListener(ASSISTANT_REFRESH_EVENT, onRefresh);
+  }, [workspaceId, reloadWorkspaceAssistants]);
 
   // The assistant's display identity — drives the collapsed launcher's avatar
   // (its creature icon) instead of a generic chat glyph. Only the floating

--- a/apps/app-web/src/components/doc/workspace-chrome.tsx
+++ b/apps/app-web/src/components/doc/workspace-chrome.tsx
@@ -54,6 +54,10 @@ import {
 import { useDocChatOthersRun } from "@/lib/doc-chat-relay";
 import { useOfflineSync } from "@/lib/offline/use-offline-sync";
 import { useWorkspaceEvents } from "@/lib/workspace-events";
+import {
+  ASSISTANT_REFRESH_EVENT,
+  type AssistantRefreshDetail,
+} from "@/lib/assistant-events";
 import { cn } from "@/lib/utils";
 import { listWorkspaceAssistants } from "@/lib/api/views";
 import { pickPrimaryAssistant } from "@/lib/primary-assistant";
@@ -178,21 +182,41 @@ export function WorkspaceChrome({
   // next message mints a new page. See docs/architecture/features/doc.md →
   // "One dock, every surface".
   const [chatAssistantId, setChatAssistantId] = useState<string | null>(null);
-  useEffect(() => {
+  const resolveChatAssistant = useCallback(() => {
     if (!workspaceId) return;
-    let cancelled = false;
     listWorkspaceAssistants(workspaceId)
       .then((list) => {
-        if (cancelled) return;
-        setChatAssistantId(pickPrimaryAssistant(list)?.id ?? null);
+        // Repair-only: seed when we have no interlocutor yet, or when the one
+        // we picked has left the workspace. Re-picking unconditionally would
+        // yank a live conversation to a different assistant whenever the
+        // roster reorders.
+        setChatAssistantId((current) =>
+          current && list.some((a) => a.id === current)
+            ? current
+            : (pickPrimaryAssistant(list)?.id ?? null),
+        );
       })
       .catch(() => {
         /* no list → no dock this load; a later workspace change retries */
       });
-    return () => {
-      cancelled = true;
-    };
   }, [workspaceId]);
+
+  useEffect(() => {
+    resolveChatAssistant();
+  }, [resolveChatAssistant]);
+
+  // Live refresh. This chrome never unmounts inside a workspace, so a
+  // first-ever assistant created after load would otherwise leave
+  // `chatAssistantId` null (no dock at all) until an app restart.
+  useEffect(() => {
+    const onRefresh = (event: Event) => {
+      const detail = (event as CustomEvent<AssistantRefreshDetail>).detail;
+      if (detail?.workspaceId && detail.workspaceId !== workspaceId) return;
+      resolveChatAssistant();
+    };
+    window.addEventListener(ASSISTANT_REFRESH_EVENT, onRefresh);
+    return () => window.removeEventListener(ASSISTANT_REFRESH_EVENT, onRefresh);
+  }, [workspaceId, resolveChatAssistant]);
 
   // Chat-seed routing — the default-viewer landing's chatter / inline AI box
   // hand the user into the dock with a pre-written prompt via the

--- a/apps/app-web/src/lib/__tests__/workspace-events.test.ts
+++ b/apps/app-web/src/lib/__tests__/workspace-events.test.ts
@@ -80,6 +80,21 @@ describe("[COMP:app-web/workspace-events] routeWorkspaceChange", () => {
     );
   });
 
+  // Regression: creating an assistant left every persistent surface stale —
+  // the FloatingChat dock's switcher only re-reads on `[workspaceId]`, which
+  // never changes during SPA navigation, so a new assistant stayed invisible
+  // until a full app restart.
+  it("routes assistant changes to the assistant bus with rowId", () => {
+    expect(
+      routeWorkspaceChange(payload("assistant", { rowId: "a-1", action: "create" })),
+    ).toEqual([
+      {
+        event: "sidan:assistant-refresh",
+        detail: { workspaceId: "ws-1", rowId: "a-1" },
+      },
+    ]);
+  });
+
   it("ignores unknown primitives — a newer server must never break an older client", () => {
     expect(
       routeWorkspaceChange(
@@ -96,6 +111,10 @@ describe("[COMP:app-web/workspace-events] routeWorkspaceChange", () => {
     expect(events).toContain(WORKFLOW_REFRESH_EVENT);
     expect(events).toContain(SKILL_REFRESH_EVENT);
     expect(events).toContain(SCHEDULED_JOB_REFRESH_EVENT);
+    // Catch-up must cover the roster too: a create that lands while the tab is
+    // asleep or the stream is down still has to reach the never-unmounting
+    // chrome on reconnect.
+    expect(events).toContain("sidan:assistant-refresh");
   });
 });
 

--- a/apps/app-web/src/lib/assistant-events.ts
+++ b/apps/app-web/src/lib/assistant-events.ts
@@ -1,0 +1,26 @@
+/**
+ * Tiny event bus telling every persistent assistant-list surface to re-fetch
+ * its roster. Mirrors `approvals-events.ts` / `deck-events.ts`.
+ *
+ * Load-bearing because the assistant roster is read by chrome that NEVER
+ * unmounts: `WorkspaceChrome` + the `FloatingChat` dock live in the
+ * `/w/[workspaceId]` layout, and both fetch on `useEffect(..., [workspaceId])`.
+ * `workspaceId` does not change during SPA navigation, so before this bus a
+ * newly created assistant stayed invisible in the bottom-right switcher until
+ * a full app restart. Worse, the switcher only renders at `length > 1`, so
+ * adding a second assistant produced no visible change at all.
+ *
+ * The shell-level workspace stream (`workspace-events.ts`) dispatches this for
+ * `assistant` change signals from ANY tab, device, or teammate — the server
+ * emits the primitive at the workspace assistant-roster routes. Payloads are
+ * signals, never data: subscribers re-fetch through their own authed loader.
+ */
+
+export const ASSISTANT_REFRESH_EVENT = "sidan:assistant-refresh";
+
+export type AssistantRefreshDetail = {
+  /** Scopes the refresh to a specific workspace. */
+  workspaceId: string | null;
+  /** The assistant row that changed, when the server knows it. */
+  rowId?: string;
+};

--- a/apps/app-web/src/lib/workspace-events.ts
+++ b/apps/app-web/src/lib/workspace-events.ts
@@ -18,6 +18,10 @@
  *   workflow, workflow_run → WORKFLOW_REFRESH_EVENT (detail carries primitive + rowId)
  *   skill           → SKILL_REFRESH_EVENT
  *   scheduled_job   → SCHEDULED_JOB_REFRESH_EVENT (no consumer yet — P2 surfaces)
+ *   assistant       → ASSISTANT_REFRESH_EVENT (the roster surfaces in chrome:
+ *                     WorkspaceChrome's default interlocutor + the FloatingChat
+ *                     switcher, both of which live in the never-unmounting
+ *                     workspace layout and so cannot self-heal on navigation)
  *
  * Catch-up without replay: on every EventSource `open` (first connect AND
  * each auto-reconnect) and on `visibilitychange → visible`, all domain
@@ -56,6 +60,10 @@ import {
   type WorkflowRefreshDetail,
 } from "@/lib/workflow-events";
 import { DECK_REFRESH_EVENT, type DeckRefreshDetail } from "@/lib/deck-events";
+import {
+  ASSISTANT_REFRESH_EVENT,
+  type AssistantRefreshDetail,
+} from "@/lib/assistant-events";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
 
@@ -75,7 +83,8 @@ type WorkspacePrimitive =
   | "approval"
   | "skill"
   | "scheduled_job"
-  | "deck";
+  | "deck"
+  | "assistant";
 
 export type WorkspaceChangePayload = {
   workspaceId: string;
@@ -174,6 +183,16 @@ export function routeWorkspaceChange(
           } satisfies DeckRefreshDetail,
         },
       ];
+    case "assistant":
+      return [
+        {
+          event: ASSISTANT_REFRESH_EVENT,
+          detail: {
+            workspaceId: payload.workspaceId,
+            rowId: payload.rowId,
+          } satisfies AssistantRefreshDetail,
+        },
+      ];
     default:
       return [];
   }
@@ -188,6 +207,7 @@ export function allDomainDispatches(workspaceId: string): DomainDispatch[] {
     { event: SKILL_REFRESH_EVENT, detail: { workspaceId } },
     { event: SCHEDULED_JOB_REFRESH_EVENT, detail: { workspaceId } },
     { event: DECK_REFRESH_EVENT, detail: { workspaceId } },
+    { event: ASSISTANT_REFRESH_EVENT, detail: { workspaceId } },
   ];
 }
 

--- a/packages/api/src/brain-stream/sse-fanout.ts
+++ b/packages/api/src/brain-stream/sse-fanout.ts
@@ -74,6 +74,7 @@ export type BrainPrimitive =
   | 'skill'
   | 'scheduled_job'
   | 'deck'
+  | 'assistant'
 
 /** Alias reflecting the widened, workspace-wide scope. */
 export type WorkspacePrimitive = BrainPrimitive

--- a/packages/api/src/routes/workspaces.ts
+++ b/packages/api/src/routes/workspaces.ts
@@ -41,6 +41,7 @@ import {
   setWorkspaceTranscriptionPrefs,
 } from '../db/workspace-store.js'
 import { flushWorkspaceData, WorkspaceFlushNotOwnerError } from '../db/workspace-flush.js'
+import { notifyWorkspaceChange } from '../brain-stream/notify.js'
 import { createConnectionStore } from '../db/connection-store.js'
 import type { WorkspaceAuditStore, WorkspaceAuditEventType } from '../db/workspace-audit-store.js'
 import type { WorkspaceInvitationStore } from '../db/workspace-invitation-store.js'
@@ -1144,6 +1145,13 @@ export function workspaceRoutes({
         console.warn('[workspaces] seedWorkspacePrimaryFollows (create) failed:', err),
       )
 
+      // The workspace roster changed. Chrome that never unmounts (the
+      // FloatingChat switcher + WorkspaceChrome's default interlocutor) reads
+      // the roster on a `[workspaceId]` effect, so without this signal a new
+      // assistant stays invisible in every open tab until a full app restart.
+      // Fire-and-forget — the write already committed.
+      notifyWorkspaceChange(workspaceId, 'assistant', 'create', assistantId)
+
       res.status(201).json({
         id: assistantId,
         name: assistantName,
@@ -1181,6 +1189,8 @@ export function workspaceRoutes({
       await connectionStore.seedWorkspacePrimaryFollows(workspaceId).catch((err) =>
         console.warn('[workspaces] seedWorkspacePrimaryFollows (adopt) failed:', err),
       )
+      // Adoption widens the workspace roster exactly like a create.
+      notifyWorkspaceChange(workspaceId, 'assistant', 'create', assistantId)
       res.json({ ok: true })
     } catch (err) {
       console.error('[workspaces] adopt assistant failed:', err)
@@ -1237,6 +1247,9 @@ export function workspaceRoutes({
         res.status(400).json({ error: 'Assistant not found in this team' })
         return
       }
+      // Detach narrows the roster — chrome still holding the removed
+      // assistant as its selected interlocutor must re-resolve.
+      notifyWorkspaceChange(workspaceId, 'assistant', 'delete', assistantId)
       res.json({ ok: true })
     } catch (err) {
       console.error('[workspaces] remove assistant failed:', err)


### PR DESCRIPTION
## Problem

Creating an assistant left the bottom-right chat dock stale. The new assistant only appeared after restarting the app.

## Root cause

Three links were missing — the roster had **no live-update path at all**:

1. **No server signal.** `POST /api/workspaces/:id/assistants` committed the row and returned. It emitted nothing.
2. **No client route.** `assistant` was not in the `WorkspacePrimitive` vocabulary, so nothing could route it.
3. **No consumer.** The dock's list has exactly one writer — `useEffect(..., [workspaceId])` in `floating-chat.tsx`. That dock is mounted by the `/w/[workspaceId]` **layout**, so it never unmounts, and `workspaceId` doesn't change during SPA navigation. The effect fires **once per full page load**; restarting the app was literally the only way to re-run it.

Two details made it worse than "slightly stale": the switcher only renders at `workspaceAssistants.length > 1`, so going 1 → 2 assistants produced **no visible change whatsoever**; and Studio's `handleCreated` only splices into its own local state, so the rail updating made the dock look selectively broken.

There is an existing `sidebar-cache` pub/sub, but nothing in the create path publishes to it, `floating-chat.tsx` never imports it, and its single subscriber is merge-only (maps over `prev`, so it structurally cannot add a row). A stale comment in `assistant-detail.tsx` claimed the dock subscribed to it — corrected in the docs.

## Fix

Adds `assistant` as a first-class realtime primitive, in the grain of the existing workspace event spine:

- **Server** emits `notifyWorkspaceChange` at the three routes that change roster membership: create, adopt, **remove**.
- **Client** routes the primitive to a new `ASSISTANT_REFRESH_EVENT` (`lib/assistant-events.ts`), including in `allDomainDispatches` so a create landing while the tab is asleep still repairs on reconnect.
- **Consumers** — `FloatingChat` and `WorkspaceChrome` — subscribe and refetch through their existing authed loader. Payloads stay signals, never data.

One server emit repairs every tab, device, and teammate.

`WorkspaceChrome`'s handler is deliberately **repair-only**: it re-resolves the default interlocutor only when it has none or its pick left the workspace. Re-picking unconditionally would yank a live conversation to a different assistant whenever the roster reordered.

## Testing

Verified on a clean install at this branch's base:

- `app-web` — **2066/2066 pass** (232 files)
- `packages/api` — **3724/3724 pass** (314 files)
- `app-web` + `packages/api` typecheck clean

Regression test pins the routing contract in `workspace-events.test.ts` — it went red on the bug before the fix.

## Scope note

Eight further surfaces share the identical mount-only pattern (Studio Channels, workflow editor + create-modal, approvals filter, browser profiles, Connectors, doc page, `p/` layout). Deliberately left for a follow-up; each is ~5 lines now that the signal exists. Recorded as an anti-pattern in the platform `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)