### PR TITLE
fix(app-web): cancel the browser's selection gesture at mousedown so area-select bands actually paint

### DIFF
--- a/apps/app-web/src/components/doc/__tests__/node-range.test.ts
+++ b/apps/app-web/src/components/doc/__tests__/node-range.test.ts
@@ -16,7 +16,19 @@ import { dirname, resolve } from "node:path";
 import { docSchema } from "@use-brian/doc-model";
 import { NodeRangeSelection } from "@tiptap/extension-node-range";
 import { browserDocExtensions } from "../doc-schema";
-import { crossesBlocks, dragRect, isAreaSelectDrag } from "../block-area-select";
+import {
+  AREA_SELECT_IDLE,
+  areaSelectReducer,
+  crossesBlocks,
+  dragRect,
+  isAreaSelectDrag,
+  needsBandResync,
+} from "../block-area-select";
+import type {
+  AreaSelectEvent,
+  AreaSelectProbe,
+  AreaSelectResult,
+} from "../block-area-select";
 
 describe("[COMP:app-web/doc-schema] NodeRange (area select)", () => {
   it("wires NodeRange (key: Mod — keyboard/decorations/class) + BlockAreaSelect (the gesture)", () => {
@@ -131,6 +143,29 @@ describe("[COMP:app-web/doc-schema] NodeRange (area select)", () => {
     expect(dragRect(15, 15, 15, 15)).toEqual({ left: 15, top: 15, width: 0, height: 0 });
   });
 
+  it("needsBandResync: re-asserts the range when PM's observer clobbers it", () => {
+    const band = { from: 4, to: 12 };
+    // Same band, still a NodeRangeSelection → nothing to do (the steady state).
+    expect(
+      needsBandResync({ band, lastFrom: 4, lastTo: 12, selectionIsNodeRange: true }),
+    ).toBe(false);
+    // Band moved onto different blocks → dispatch.
+    expect(
+      needsBandResync({ band, lastFrom: 4, lastTo: 8, selectionIsNodeRange: true }),
+    ).toBe(true);
+    // Self-healing: band unchanged, but ProseMirror's DOM observer re-derived a
+    // TextSelection from a native selection the browser grew mid-drag and
+    // overwrote ours. Without this the block bands vanished for the rest of the
+    // gesture and the inline toolbar popped up over a supposed area select.
+    expect(
+      needsBandResync({ band, lastFrom: 4, lastTo: 12, selectionIsNodeRange: false }),
+    ).toBe(true);
+    // First move of a drag (no previous band) → dispatch.
+    expect(
+      needsBandResync({ band, lastFrom: -1, lastTo: -1, selectionIsNodeRange: false }),
+    ).toBe(true);
+  });
+
   it("CSS: the live marquee is a fixed, non-interactive on-brand --primary box", () => {
     const css = readFileSync(
       resolve(dirname(fileURLToPath(import.meta.url)), "../../../app/globals.css"),
@@ -145,5 +180,241 @@ describe("[COMP:app-web/doc-schema] NodeRange (area select)", () => {
     // --primary so it resolves in both themes.
     expect(rule).not.toMatch(/border:\s*\d+px\s+solid/);
     expect(rule).toMatch(/background-color:[^;]*var\(--primary\)/);
+  });
+});
+
+/**
+ * The gesture's decision logic, driven as pure data. Every effect the extension
+ * applies to the view — engage, clear the DOM selection, focus the editable,
+ * dispatch a band, paint the marquee — is decided here, so a whole drag can be
+ * replayed as a list of events and asserted on its *behaviour* rather than on
+ * the shape of the plugin's source.
+ *
+ * The environment lookups the decisions need (position under the cursor, which
+ * blocks a Y-band covers, whether the editor's selection is still a node range)
+ * come in through a `probe`, so the tests also pin **when** the gesture is
+ * allowed to touch layout: an in-block text drag must cost no band lookup at all.
+ */
+describe("[COMP:app-web/block-area-select] Area select drag reducer", () => {
+  /** A probe with call counters. Defaults: nothing under the cursor, no block on
+   *  any row, no block boundary crossed, selection still a node range. */
+  function makeProbe(over: Partial<AreaSelectProbe> = {}) {
+    const calls = { posAt: 0, bandInY: 0, crossesBlocks: 0, selectionIsNodeRange: 0 };
+    const probe: AreaSelectProbe = {
+      posAt: (x, y) => (calls.posAt++, over.posAt?.(x, y) ?? null),
+      bandInY: (a, b) => (calls.bandInY++, over.bandInY?.(a, b) ?? null),
+      crossesBlocks: (a, b) => (calls.crossesBlocks++, over.crossesBlocks?.(a, b) ?? false),
+      selectionIsNodeRange: () => (
+        calls.selectionIsNodeRange++, over.selectionIsNodeRange?.() ?? true
+      ),
+    };
+    return { probe, calls };
+  }
+
+  /** Replay a drag. Returns every tick's effects plus the resting state. */
+  function drive(probe: AreaSelectProbe, events: AreaSelectEvent[]) {
+    let state = AREA_SELECT_IDLE;
+    const ticks: AreaSelectResult[] = [];
+    for (const ev of events) {
+      const r = areaSelectReducer(state, ev, probe);
+      state = r.state;
+      ticks.push(r);
+    }
+    return { state, ticks };
+  }
+
+  const press = (x: number, y: number, inEditor = false): AreaSelectEvent => ({
+    type: "press",
+    x,
+    y,
+    inEditor,
+  });
+  const move = (x: number, y: number, primaryButton = true): AreaSelectEvent => ({
+    type: "move",
+    x,
+    y,
+    primaryButton,
+  });
+
+  /** A block sits on every row — the common case for a margin-started drag. */
+  const anyBand = () => ({ from: 0, to: 10 });
+
+  it("a press with sub-threshold movement never engages", () => {
+    const { probe } = makeProbe({ bandInY: anyBand });
+    // 4px of travel is a click with a shaky hand, not a drag.
+    const { state, ticks } = drive(probe, [press(100, 100), move(102, 103)]);
+    expect(ticks[1].engaged).toBe(false);
+    expect(ticks[1].marquee).toBeNull();
+    expect(ticks[1].clearSelection).toBe(false);
+    // still armed — a later, longer move can still engage
+    expect(state.phase).toBe("pending");
+  });
+
+  it("a margin press engages on the first past-threshold move and focuses once", () => {
+    const { probe } = makeProbe({ bandInY: anyBand });
+    const { ticks } = drive(probe, [
+      press(40, 100), // left margin: outside the editable, block on the row
+      move(44, 140),
+      move(44, 200),
+      move(44, 260),
+    ]);
+    expect(ticks[1].engaged).toBe(true);
+    // Focus is the engage-tick effect only: re-focusing every move would fight
+    // the user and is the kind of repeated view write that caused the original bug.
+    expect(ticks.map((t) => t.focusEditor)).toEqual([false, true, false, false]);
+  });
+
+  it("a press over empty space engages and rubber-bands with no band to paint", () => {
+    // No block on the press row — the 30vh tail padding or a blank page.
+    const { probe } = makeProbe({ bandInY: () => null });
+    const { ticks } = drive(probe, [press(300, 900, true), move(500, 1000)]);
+    expect(ticks[1].engaged).toBe(true);
+    expect(ticks[1].band).toBeNull();
+    expect(ticks[1].marquee).toEqual({ left: 300, top: 900, width: 200, height: 100 });
+  });
+
+  it("an in-block text drag never engages, never clears, and costs no layout read", () => {
+    const { probe, calls } = makeProbe({
+      bandInY: anyBand,
+      posAt: () => 4,
+      crossesBlocks: () => false, // still inside the block it started on
+    });
+    const { ticks } = drive(probe, [press(700, 100, true), move(760, 104), move(820, 108)]);
+    expect(ticks.every((t) => !t.engaged)).toBe(true);
+    // The browser owns this selection: clearing it would break ordinary
+    // word-level selection, which is the whole regression risk of this gesture.
+    expect(ticks.every((t) => !t.clearSelection)).toBe(true);
+    expect(ticks.every((t) => t.marquee === null)).toBe(true);
+    // One band lookup at the press (to learn whether a block is on the row) and
+    // never again — the per-block `getBoundingClientRect` sweep must not run on
+    // every mousemove of a plain text selection.
+    expect(calls.bandInY).toBe(1);
+  });
+
+  it("a text drag that crosses into another block engages from that move on", () => {
+    let crossed = false;
+    const { probe } = makeProbe({
+      bandInY: anyBand,
+      posAt: () => 4,
+      crossesBlocks: () => crossed,
+    });
+    let state = AREA_SELECT_IDLE;
+    const step = (ev: AreaSelectEvent) => {
+      const r = areaSelectReducer(state, ev, probe);
+      state = r.state;
+      return r;
+    };
+    step(press(700, 100, true));
+    expect(step(move(760, 108)).engaged).toBe(false); // still in the block
+    crossed = true; // the drag has now left it
+    expect(step(move(760, 190)).engaged).toBe(true);
+    expect(step(move(760, 240)).engaged).toBe(true); // and stays engaged
+  });
+
+  it("every engaged move clears the DOM selection, not just the engage move", () => {
+    // The load-bearing behaviour: a one-shot clear is undone by the very next
+    // mousemove, so the browser's own selection grows back alongside the marquee
+    // and ProseMirror's observer clobbers the block range derived from it.
+    const { probe } = makeProbe({ bandInY: anyBand });
+    const { ticks } = drive(probe, [
+      press(40, 100),
+      move(44, 140),
+      move(44, 200),
+      move(44, 260),
+    ]);
+    expect(ticks.map((t) => t.clearSelection)).toEqual([false, true, true, true]);
+  });
+
+  it("re-emits an unchanged band once the selection stops being a node range", () => {
+    // Self-healing: something (PM's observer, a remote step) replaced our
+    // NodeRangeSelection. Without this the bands stay blank for the rest of the drag.
+    let isNodeRange = true;
+    const { probe } = makeProbe({
+      bandInY: () => ({ from: 4, to: 12 }),
+      selectionIsNodeRange: () => isNodeRange,
+    });
+    let state = AREA_SELECT_IDLE;
+    const step = (ev: AreaSelectEvent) => {
+      const r = areaSelectReducer(state, ev, probe);
+      state = r.state;
+      return r;
+    };
+    step(press(40, 100));
+    expect(step(move(44, 140)).band).toEqual({ from: 4, to: 12 }); // first dispatch
+    expect(step(move(44, 150)).band).toBeNull(); // steady state — nothing to do
+    isNodeRange = false; // clobbered
+    expect(step(move(44, 160)).band).toEqual({ from: 4, to: 12 }); // re-asserted
+  });
+
+  it("does not re-emit while the band and the node-range selection both hold", () => {
+    const { probe } = makeProbe({ bandInY: () => ({ from: 4, to: 12 }) });
+    const { ticks } = drive(probe, [
+      press(40, 100),
+      move(44, 140),
+      move(44, 150),
+      move(44, 160),
+    ]);
+    expect(ticks.map((t) => t.band)).toEqual([null, { from: 4, to: 12 }, null, null]);
+  });
+
+  it("emits a fresh band as the drag reaches new blocks", () => {
+    const { probe } = makeProbe({
+      // grows downward: more blocks covered the further the drag runs
+      bandInY: (_min, max) => ({ from: 0, to: max >= 200 ? 30 : 12 }),
+    });
+    const { ticks } = drive(probe, [press(40, 100), move(44, 140), move(44, 220)]);
+    expect(ticks[1].band).toEqual({ from: 0, to: 12 });
+    expect(ticks[2].band).toEqual({ from: 0, to: 30 });
+  });
+
+  it("marquee geometry normalises in all four directions and never goes negative", () => {
+    const sweep = (toX: number, toY: number) => {
+      const { probe } = makeProbe({ bandInY: anyBand });
+      return drive(probe, [press(100, 100), move(toX, toY)]).ticks[1].marquee;
+    };
+    expect(sweep(140, 160)).toEqual({ left: 100, top: 100, width: 40, height: 60 });
+    expect(sweep(60, 40)).toEqual({ left: 60, top: 40, width: 40, height: 60 });
+    expect(sweep(140, 40)).toEqual({ left: 100, top: 40, width: 40, height: 60 });
+    expect(sweep(60, 160)).toEqual({ left: 60, top: 100, width: 40, height: 60 });
+  });
+
+  it("release clears once, drops the marquee, and resets for the next press", () => {
+    const { probe } = makeProbe({ bandInY: anyBand });
+    const { state, ticks } = drive(probe, [
+      press(40, 100),
+      move(44, 200),
+      { type: "release" },
+    ]);
+    const end = ticks[2];
+    // mouseup finalises whatever range the browser still holds — drop it too.
+    expect(end.clearSelection).toBe(true);
+    expect(end.engaged).toBe(false);
+    expect(end.marquee).toBeNull();
+    expect(state).toEqual(AREA_SELECT_IDLE);
+  });
+
+  it("release after a never-engaged press keeps the browser's own selection", () => {
+    const { probe } = makeProbe({ bandInY: anyBand, posAt: () => 4 });
+    const { state, ticks } = drive(probe, [
+      press(700, 100, true),
+      move(760, 108),
+      { type: "release" },
+    ]);
+    expect(ticks[2].clearSelection).toBe(false);
+    expect(state).toEqual(AREA_SELECT_IDLE);
+  });
+
+  it("a move with the primary button released ends the gesture", () => {
+    // A mouseup delivered outside the window: the next move is the only signal.
+    const { probe } = makeProbe({ bandInY: anyBand });
+    const { state, ticks } = drive(probe, [
+      press(40, 100),
+      move(44, 200),
+      move(44, 260, false),
+    ]);
+    expect(ticks[2].engaged).toBe(false);
+    expect(ticks[2].clearSelection).toBe(true);
+    expect(ticks[2].marquee).toBeNull();
+    expect(state).toEqual(AREA_SELECT_IDLE);
   });
 });

--- a/apps/app-web/src/components/doc/__tests__/node-range.test.ts
+++ b/apps/app-web/src/components/doc/__tests__/node-range.test.ts
@@ -23,6 +23,7 @@ import {
   dragRect,
   isAreaSelectDrag,
   needsBandResync,
+  pressStartsDefiniteAreaSelect,
 } from "../block-area-select";
 import type {
   AreaSelectEvent,
@@ -207,6 +208,8 @@ describe("[COMP:app-web/block-area-select] Area select drag reducer", () => {
       selectionIsNodeRange: () => (
         calls.selectionIsNodeRange++, over.selectionIsNodeRange?.() ?? true
       ),
+      // Pane not scrolled unless a test says so — the scroll-anchor cases override it.
+      scrollTop: () => over.scrollTop?.() ?? 0,
     };
     return { probe, calls };
   }
@@ -402,6 +405,80 @@ describe("[COMP:app-web/block-area-select] Area select drag reducer", () => {
     ]);
     expect(ticks[2].clearSelection).toBe(false);
     expect(state).toEqual(AREA_SELECT_IDLE);
+  });
+
+  // --- Regression: the browser's own selection gesture (2026-07-23) -----------
+  // Confirmed in a real browser: clearing the DOM selection each move and
+  // cancelling `selectstart` both LOSE. The browser re-extends its selection
+  // AFTER our mousemove handler, PM's observer derives a TextSelection from it,
+  // and every dispatched NodeRangeSelection is clobbered before it can paint —
+  // so a margin drag showed 758 native chars and zero bands. mousedown is the
+  // only point at which the gesture can still be stopped.
+  it("a margin press asks to cancel the browser's selection gesture at mousedown", () => {
+    const { probe } = makeProbe({ bandInY: anyBand });
+    const r = areaSelectReducer(AREA_SELECT_IDLE, press(40, 100), probe);
+    expect(r.suppressNativeGesture).toBe(true);
+  });
+
+  it("a press over empty space also cancels it", () => {
+    const { probe } = makeProbe({ bandInY: () => null });
+    const r = areaSelectReducer(AREA_SELECT_IDLE, press(300, 900, true), probe);
+    expect(r.suppressNativeGesture).toBe(true);
+  });
+
+  it("a press on a block's own text does NOT cancel it", () => {
+    // Undecidable at mousedown: this stays a native text selection unless and
+    // until it crosses a block boundary. Cancelling here would break ordinary
+    // word-level selection, which is the whole regression risk of this gesture.
+    const { probe } = makeProbe({ bandInY: anyBand, posAt: () => 4 });
+    const r = areaSelectReducer(AREA_SELECT_IDLE, press(700, 100, true), probe);
+    expect(r.suppressNativeGesture).toBe(false);
+  });
+
+  it("pressStartsDefiniteAreaSelect: margin or empty space, never on-text", () => {
+    expect(pressStartsDefiniteAreaSelect({ startInEditor: false, startOnBlockRow: true })).toBe(true);
+    expect(pressStartsDefiniteAreaSelect({ startInEditor: true, startOnBlockRow: false })).toBe(true);
+    expect(pressStartsDefiniteAreaSelect({ startInEditor: true, startOnBlockRow: true })).toBe(false);
+  });
+
+  // --- Regression: the anchor is content-space, not screen-space (2026-07-23) --
+  it("keeps the blocks it started on while the page scrolls under the drag", () => {
+    // The reported symptom: drag down, the page auto-scrolls, and the blocks
+    // already banded at the TOP silently drop out. In the browser the band's
+    // `from` climbed 528 -> 1321 -> 2252 -> 2518 as the pane scrolled, because
+    // the band's far edge stayed pinned to a stale viewport row.
+    let scrollTop = 0;
+    const BLOCK_H = 100;
+    const probe: AreaSelectProbe = {
+      posAt: () => null,
+      // Blocks laid out down the document; a client-space band maps back through
+      // the current scroll offset, exactly like getBoundingClientRect does.
+      bandInY: (yMin, yMax) => {
+        const docMin = yMin + scrollTop;
+        const docMax = yMax + scrollTop;
+        const first = Math.max(0, Math.floor(docMin / BLOCK_H));
+        const last = Math.max(first, Math.floor(docMax / BLOCK_H));
+        return { from: first * BLOCK_H, to: (last + 1) * BLOCK_H };
+      },
+      crossesBlocks: () => false,
+      selectionIsNodeRange: () => true,
+      scrollTop: () => scrollTop,
+    };
+    let state = AREA_SELECT_IDLE;
+    const step = (ev: AreaSelectEvent) => {
+      const r = areaSelectReducer(state, ev, probe);
+      state = r.state;
+      return r;
+    };
+    step(press(40, 50)); // press on block 0 (doc y 50), pane unscrolled
+    expect(step(move(44, 150)).band).toEqual({ from: 0, to: 200 });
+    // The pane auto-scrolls a full 5 blocks while the cursor stays put.
+    scrollTop = 500;
+    const r = step(move(44, 150));
+    // Block 0 must STILL be the start of the band: the anchor rides the content.
+    expect(r.band?.from).toBe(0);
+    // ...and the band now reaches further down the document, not less far.
+    expect(r.band!.to).toBeGreaterThan(200);
   });
 
   it("a move with the primary button released ends the gesture", () => {

--- a/apps/app-web/src/components/doc/block-area-select.ts
+++ b/apps/app-web/src/components/doc/block-area-select.ts
@@ -14,9 +14,29 @@
  *   2. **Unstable selection.** Setting a block selection per move while the
  *      browser grows a *native text selection* makes the two fight. → once the
  *      drag engages we suppress the native selection (`user-select: none` +
- *      clear the DOM selection) and pick blocks by **vertical geometry** (which
- *      top-level blocks the drag's Y-band covers) — stable and independent of
- *      the horizontal position, so it works from any margin.
+ *      clear the DOM selection **every move**) and pick blocks by **vertical
+ *      geometry** (which top-level blocks the drag's Y-band covers) — stable and
+ *      independent of the horizontal position, so it works from any margin.
+ *
+ * Suppressing that native selection has to happen on EVERY move, not once at
+ * engage. All three of the obvious one-shot levers are no-ops against a
+ * selection gesture the browser has already begun: `user-select: none` is
+ * consulted when a selection *starts*, so flipping it mid-drag doesn't abort the
+ * live one; a single `removeAllRanges()` is undone by the very next mousemove;
+ * and `preventDefault()` on **mousemove** doesn't cancel selection extension
+ * (only `mousedown` / `selectstart` do). `view.focus()` made it actively worse —
+ * prosemirror-view's `focus()` runs `selectionToDOM()`, writing a DOM selection
+ * back for the still-live gesture to extend from — so we focus `view.dom`
+ * directly instead and keep the keyboard-delete prerequisite without re-seeding a
+ * range. Left unfixed the two selections rendered at once (a `::selection`
+ * highlight racing the marquee) and, worse, ProseMirror's DOM observer re-derived
+ * a `TextSelection` from the live DOM selection every frame and clobbered each
+ * dispatched `NodeRangeSelection` — so the block bands never rendered, the
+ * inline toolbar popped up mid-area-drag, and a drag across six blocks gave no
+ * selection feedback at all beyond the rubber band. The band dispatch is
+ * therefore also **self-healing** (`needsBandResync`): it re-asserts the range
+ * whenever the state selection is no longer a `NodeRangeSelection`, not only when
+ * the covered band changes.
  *
  * A drag that starts on text and stays inside one block is left to the native
  * text selection (`crossesBlocks`); a drag starting in the margin, over **empty
@@ -34,13 +54,26 @@
  * and the drag handle (its grip drags the whole selection). Selection +
  * interaction only — no schema change, so Yjs parity holds; the drag-move edit
  * is gated by `editable`.
+ *
+ * **Shape: pure reducer + thin adapter.** Every decision the gesture makes — the
+ * drag threshold, whether to engage, whether to clear the DOM selection, whether
+ * to re-dispatch the band, the marquee's geometry — lives in `areaSelectReducer`,
+ * a pure function over (state, event, probe). The plugin below is the adapter: it
+ * registers listeners, answers the reducer's environment questions through the
+ * `probe` (position under the cursor, blocks in a Y-band, is the selection still a
+ * node range), and applies the effects it asks for. That's what makes the whole
+ * gesture testable as data — the effect ORDER is the reducer's contract, not the
+ * adapter's: focus → clear → dispatch band → paint marquee. The probe is pulled,
+ * never pushed, so an in-block text drag (which must stay a native selection)
+ * pays the per-block `getBoundingClientRect` sweep once, at the press, and never
+ * again per move.
  */
 
 import { Extension } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
 import type { Node as PMNode } from "@tiptap/pm/model";
-import { NodeRangeSelection } from "@tiptap/extension-node-range";
+import { NodeRangeSelection, isNodeRangeSelection } from "@tiptap/extension-node-range";
 
 /** True when two positions sit in DIFFERENT blocks — i.e. a drag between them is
  *  a multi-block area select, not an in-block text selection. Pure/testable. */
@@ -50,6 +83,13 @@ export function crossesBlocks(doc: PMNode, a: number, h: number): boolean {
   const $h = doc.resolve(Math.max(0, Math.min(h, size)));
   return !$a.sameParent($h);
 }
+
+/** A run of top-level blocks, as the position before the first and after the
+ *  last — what a `NodeRangeSelection` is built from. */
+type BlockBand = { from: number; to: number };
+
+/** A rectangle in viewport (client) space — what the marquee is painted at. */
+type ViewportRect = { left: number; top: number; width: number; height: number };
 
 const DRAG_THRESHOLD = 6; // px before a press counts as a drag (vs a click)
 const blockAreaSelectKey = new PluginKey("blockAreaSelect");
@@ -75,17 +115,200 @@ export function isAreaSelectDrag(opts: {
 /** Normalised viewport rectangle spanning two drag corners — the geometry of the
  *  live marquee the gesture paints while dragging. Corner order is irrelevant
  *  (drag up-left and down-right give the same box). Pure/testable. */
-export function dragRect(
-  x1: number,
-  y1: number,
-  x2: number,
-  y2: number,
-): { left: number; top: number; width: number; height: number } {
+export function dragRect(x1: number, y1: number, x2: number, y2: number): ViewportRect {
   return {
     left: Math.min(x1, x2),
     top: Math.min(y1, y2),
     width: Math.abs(x1 - x2),
     height: Math.abs(y1 - y2),
+  };
+}
+
+/** Whether the covered band must be (re-)dispatched this move. True when the band
+ *  moved to different blocks, OR — the self-healing half — when the state
+ *  selection is no longer a `NodeRangeSelection` at all: ProseMirror's DOM
+ *  observer re-derives a `TextSelection` from any native selection the browser
+ *  manages to grow mid-drag and overwrites ours, so re-asserting the same band is
+ *  what keeps the block bands painted for the whole gesture. Pure/testable. */
+export function needsBandResync(opts: {
+  band: BlockBand;
+  lastFrom: number;
+  lastTo: number;
+  selectionIsNodeRange: boolean;
+}): boolean {
+  const { band, lastFrom, lastTo, selectionIsNodeRange } = opts;
+  if (band.from !== lastFrom || band.to !== lastTo) return true;
+  return !selectionIsNodeRange;
+}
+
+/** Where the gesture is between two events. `pending` = a press is armed but the
+ *  pointer hasn't travelled far enough (or hasn't left its block) to take over
+ *  from the browser; `engaged` = we own the selection. */
+export type AreaSelectState = {
+  phase: "idle" | "pending" | "engaged";
+  startX: number;
+  startY: number;
+  startInEditor: boolean;
+  startPos: number | null;
+  startOnBlockRow: boolean;
+  lastFrom: number;
+  lastTo: number;
+};
+
+export const AREA_SELECT_IDLE: AreaSelectState = Object.freeze({
+  phase: "idle",
+  startX: 0,
+  startY: 0,
+  startInEditor: false,
+  startPos: null,
+  startOnBlockRow: false,
+  lastFrom: -1,
+  lastTo: -1,
+});
+
+/** The gesture's three inputs. `inEditor` is the press target's relationship to
+ *  the editable (the drag routinely starts in the margin, which is outside it);
+ *  `primaryButton` catches a mouseup delivered outside the window, where the next
+ *  move is the only signal the drag is over. */
+export type AreaSelectEvent =
+  | { type: "press"; x: number; y: number; inEditor: boolean }
+  | { type: "move"; x: number; y: number; primaryButton: boolean }
+  | { type: "release" };
+
+/** Everything the decisions need to know about the editor, as pure queries the
+ *  reducer PULLS. Pulled rather than pushed so the expensive one (`bandInY`, a
+ *  `getBoundingClientRect` per top-level block) runs once at the press and then
+ *  only while engaged — never per move on a drag that stays a native text
+ *  selection. */
+export type AreaSelectProbe = {
+  /** Document position under a viewport point, or null if there is none. */
+  posAt: (x: number, y: number) => number | null;
+  /** Top-level blocks whose vertical extent intersects the band, or null. */
+  bandInY: (yMin: number, yMax: number) => BlockBand | null;
+  /** Whether two document positions sit in different blocks. */
+  crossesBlocks: (a: number, b: number) => boolean;
+  /** Whether the editor's current selection is still a `NodeRangeSelection`. */
+  selectionIsNodeRange: () => boolean;
+};
+
+/** The next state, plus the effects the adapter must apply this tick — in order:
+ *  focus, clear, dispatch band, paint marquee. `band` is non-null only on the
+ *  ticks where it actually needs (re-)dispatching; `marquee` non-null means paint
+ *  it there, null means take it down. */
+export type AreaSelectResult = {
+  state: AreaSelectState;
+  engaged: boolean;
+  clearSelection: boolean;
+  focusEditor: boolean;
+  band: BlockBand | null;
+  marquee: ViewportRect | null;
+};
+
+const NO_EFFECTS: Omit<AreaSelectResult, "state"> = {
+  engaged: false,
+  clearSelection: false,
+  focusEditor: false,
+  band: null,
+  marquee: null,
+};
+
+/** The whole gesture as a pure state machine. Composes the predicates above:
+ *  `isAreaSelectDrag` decides engagement, `needsBandResync` decides re-dispatch,
+ *  `dragRect` gives the marquee. Pure/testable — a drag replays as a list of
+ *  events, so the behaviour is asserted without a browser.
+ *
+ *  Two rules here are load-bearing and easy to "simplify" back into the bug:
+ *  `clearSelection` is emitted on EVERY engaged move (a one-shot clear is undone
+ *  by the very next mousemove), and `focusEditor` on the engage tick ONLY
+ *  (re-focusing every move is another repeated view write). See the module note. */
+export function areaSelectReducer(
+  state: AreaSelectState,
+  event: AreaSelectEvent,
+  probe: AreaSelectProbe,
+): AreaSelectResult {
+  if (event.type === "press") {
+    return {
+      state: {
+        phase: "pending",
+        startX: event.x,
+        startY: event.y,
+        startInEditor: event.inEditor,
+        startPos: event.inEditor ? probe.posAt(event.x, event.y) : null,
+        // Whether a block actually sits on the press row. When none does — the
+        // empty tail padding, a blank page, the white space beside an empty
+        // region — the drag is a pure area select over emptiness: it still
+        // engages and rubber-bands like a desktop sweep.
+        startOnBlockRow: probe.bandInY(event.y, event.y) !== null,
+        lastFrom: -1,
+        lastTo: -1,
+      },
+      ...NO_EFFECTS,
+    };
+  }
+
+  // Release, and a move that finds the button already up, both end the gesture.
+  // Only an engaged drag may discard the DOM selection on the way out — a plain
+  // in-block text drag never engaged and must keep the selection it just made.
+  const end = (): AreaSelectResult => ({
+    state: AREA_SELECT_IDLE,
+    ...NO_EFFECTS,
+    clearSelection: state.phase === "engaged",
+  });
+  if (event.type === "release") return end();
+  if (state.phase === "idle") return { state, ...NO_EFFECTS };
+  if (!event.primaryButton) return end();
+
+  let next = state;
+  let focusEditor = false;
+  if (state.phase === "pending") {
+    if (Math.hypot(event.x - state.startX, event.y - state.startY) < DRAG_THRESHOLD)
+      return { state, ...NO_EFFECTS };
+    // `crossedBlocks` only matters when the press landed on a block's own text;
+    // over empty space / the margin there's nothing to read, so don't look.
+    let crossedBlocks = false;
+    if (state.startOnBlockRow && state.startInEditor && state.startPos != null) {
+      const cur = probe.posAt(event.x, event.y);
+      crossedBlocks = cur != null && probe.crossesBlocks(state.startPos, cur);
+    }
+    // In-block text drag → leave it to the native selection, but stay pending:
+    // a later move can still cross out of the block and engage.
+    if (
+      !isAreaSelectDrag({
+        startOnBlockRow: state.startOnBlockRow,
+        startInEditor: state.startInEditor,
+        startPos: state.startPos,
+        crossedBlocks,
+      })
+    )
+      return { state, ...NO_EFFECTS };
+    next = { ...state, phase: "engaged" };
+    focusEditor = true;
+  }
+
+  const band = probe.bandInY(
+    Math.min(next.startY, event.y),
+    Math.max(next.startY, event.y),
+  );
+  let dispatch: BlockBand | null = null;
+  if (
+    band &&
+    needsBandResync({
+      band,
+      lastFrom: next.lastFrom,
+      lastTo: next.lastTo,
+      selectionIsNodeRange: probe.selectionIsNodeRange(),
+    })
+  ) {
+    dispatch = band;
+    next = { ...next, lastFrom: band.from, lastTo: band.to };
+  }
+  return {
+    state: next,
+    engaged: true,
+    clearSelection: true,
+    focusEditor,
+    band: dispatch,
+    marquee: dragRect(next.startX, next.startY, event.x, event.y),
   };
 }
 
@@ -134,11 +357,7 @@ export function isInteractiveTarget(target: EventTarget | null): boolean {
 
 /** Top-level blocks whose vertical extent intersects the drag's Y-band; returns
  *  the position before the first and after the last covered block. */
-function blockRangeInBand(
-  view: EditorView,
-  yMin: number,
-  yMax: number,
-): { from: number; to: number } | null {
+function blockRangeInBand(view: EditorView, yMin: number, yMax: number): BlockBand | null {
   const doc = view.state.doc;
   let from = -1;
   let to = -1;
@@ -163,36 +382,76 @@ export const BlockAreaSelect = Extension.create({
         key: blockAreaSelectKey,
         view(view) {
           const pane = findScrollPane(view.dom as HTMLElement);
-          const doc = () => view.state.doc;
-          let pending = false;
-          let engaged = false;
-          let startX = 0;
-          let startY = 0;
-          let startInEditor = false;
-          let startPos: number | null = null;
-          let startOnBlockRow = false;
-          let lastFrom = -1;
-          let lastTo = -1;
+          const dom = view.dom as HTMLElement;
+          let state: AreaSelectState = AREA_SELECT_IDLE;
           // The live marquee — a fixed-position box swept from the drag origin to
           // the cursor. The NodeRange decorations only tint blocks the band lands
           // on; the marquee gives the gesture an immediate, continuous outline
           // (and the only feedback over empty space, where there are no blocks).
           let marquee: HTMLDivElement | null = null;
 
-          const restoreSelectStyle = () => {
-            (view.dom as HTMLElement).style.userSelect = "";
+          /** The reducer's window onto the editor. All read-only. */
+          const probe: AreaSelectProbe = {
+            posAt: (x, y) => view.posAtCoords({ left: x, top: y })?.pos ?? null,
+            bandInY: (yMin, yMax) => blockRangeInBand(view, yMin, yMax),
+            crossesBlocks: (a, b) => crossesBlocks(view.state.doc, a, b),
+            selectionIsNodeRange: () => isNodeRangeSelection(view.state.selection),
           };
 
-          /** Paint the marquee at the current drag extent, creating it on first
-           *  use. Coords are viewport (client) space → `position: fixed`. */
-          const paintMarquee = (curX: number, curY: number) => {
+          /** Drop whatever native selection the browser has grown. The reducer
+           *  asks for this on EVERY engaged move (see the module note): the press
+           *  already started a selection gesture that `user-select: none` can't
+           *  abort, so the only reliable suppression is to keep emptying it.
+           *  `removeAllRanges` (not a collapse) so `rangeCount === 0` and
+           *  ProseMirror's observer has nothing to derive a `TextSelection` from. */
+          const clearNativeSelection = () => {
+            const sel = view.dom.ownerDocument.getSelection();
+            if (sel && sel.rangeCount > 0) sel.removeAllRanges();
+          };
+
+          /** Focus the editor so the resulting selection can be acted on by the
+           *  keyboard (Delete / Backspace). An area select routinely STARTS in the
+           *  margin (the whole point of the gesture), where the press lands on the
+           *  scroll pane — NOT the contenteditable — so `.ProseMirror` never took
+           *  focus; and a `NodeRangeSelection` is `visible:false`, so dispatching
+           *  it doesn't focus the editor either. Without this a key press after a
+           *  margin-started select went to `<body>` and nothing got deleted.
+           *
+           *  Focus `view.dom` DIRECTLY, never `view.focus()`: the latter runs
+           *  `selectionToDOM()`, which writes a DOM selection back that the
+           *  still-live browser drag then extends — the phantom `::selection`
+           *  highlight that raced the marquee and let ProseMirror's observer
+           *  clobber every dispatched `NodeRangeSelection`. `preventScroll` keeps
+           *  it from jumping the page, same as `view.focus()` did. */
+          const focusEditorElement = () => {
+            dom.focus({ preventScroll: true });
+          };
+
+          /** Belt to the clear's braces: stops the browser starting a *fresh*
+           *  selection while we own the gesture. Inert against the one already in
+           *  flight (see the module note), which is why it is not the whole fix. */
+          const setSuppressed = (on: boolean) => {
+            dom.style.userSelect = on ? "none" : "";
+          };
+
+          const dispatchBand = (band: BlockBand) => {
+            try {
+              const sel = NodeRangeSelection.create(view.state.doc, band.from + 1, band.to - 1);
+              view.dispatch(view.state.tr.setSelection(sel));
+            } catch {
+              /* range momentarily invalid mid-doc-change — ignore */
+            }
+          };
+
+          /** Paint the marquee at the reducer's rect, creating it on first use.
+           *  Coords are viewport (client) space → `position: fixed`. */
+          const paintMarquee = (r: ViewportRect) => {
             if (!marquee) {
               marquee = view.dom.ownerDocument.createElement("div");
               marquee.className = "doc-area-select-rect";
               marquee.setAttribute("aria-hidden", "true");
               view.dom.ownerDocument.body.appendChild(marquee);
             }
-            const r = dragRect(startX, startY, curX, curY);
             marquee.style.left = `${r.left}px`;
             marquee.style.top = `${r.top}px`;
             marquee.style.width = `${r.width}px`;
@@ -204,97 +463,72 @@ export const BlockAreaSelect = Extension.create({
             marquee = null;
           };
 
-          const finish = () => {
-            pending = false;
-            engaged = false;
-            lastFrom = -1;
-            lastTo = -1;
-            clearMarquee();
-            restoreSelectStyle();
+          /** Block the browser from STARTING a fresh selection mid-gesture (each
+           *  `clearNativeSelection` is an invitation to re-anchor one).
+           *  `selectstart` is the only cancellable point once a press is live. */
+          function onSelectStart(e: Event) {
+            if (state.phase === "engaged") e.preventDefault();
+          }
+
+          const trackPointer = () => {
+            const d = view.dom.ownerDocument;
+            d.addEventListener("mousemove", onMove, true);
+            d.addEventListener("mouseup", onUp, true);
+            d.addEventListener("selectstart", onSelectStart, true);
+          };
+
+          const untrackPointer = () => {
             const d = view.dom.ownerDocument;
             d.removeEventListener("mousemove", onMove, true);
             d.removeEventListener("mouseup", onUp, true);
+            d.removeEventListener("selectstart", onSelectStart, true);
+          };
+
+          /** Run one gesture event through the reducer and apply what it asks for.
+           *  The effect ORDER is the reducer's contract: focus → clear the DOM
+           *  selection → dispatch the band → paint the marquee (last, because the
+           *  dispatch can blur it for a frame, and the box must read as the live,
+           *  top-most drag outline). */
+          const apply = (event: AreaSelectEvent): AreaSelectResult => {
+            const wasEngaged = state.phase === "engaged";
+            const r = areaSelectReducer(state, event, probe);
+            state = r.state;
+            if (r.focusEditor) {
+              setSuppressed(true);
+              focusEditorElement();
+            }
+            if (r.clearSelection) clearNativeSelection();
+            if (r.band) dispatchBand(r.band);
+            if (r.marquee) paintMarquee(r.marquee);
+            else clearMarquee();
+            if (wasEngaged && !r.engaged) setSuppressed(false);
+            if (state.phase === "idle") untrackPointer();
+            return r;
           };
 
           function onMove(e: MouseEvent) {
-            if (!pending) return;
-            if ((e.buttons & 1) === 0) {
-              finish();
-              return;
-            }
-            if (!engaged) {
-              if (Math.hypot(e.clientX - startX, e.clientY - startY) < DRAG_THRESHOLD) return;
-              // `crossedBlocks` only matters when the press landed on a block's
-              // own text; over empty space / the margin there's nothing to read.
-              let crossedBlocks = false;
-              if (startOnBlockRow && startInEditor && startPos != null) {
-                const cur = view.posAtCoords({ left: e.clientX, top: e.clientY });
-                crossedBlocks = !!cur && crossesBlocks(doc(), startPos, cur.pos);
-              }
-              // In-block text drag → leave it to the native selection.
-              if (!isAreaSelectDrag({ startOnBlockRow, startInEditor, startPos, crossedBlocks }))
-                return;
-              engaged = true;
-              (view.dom as HTMLElement).style.userSelect = "none";
-              view.dom.ownerDocument.getSelection()?.removeAllRanges();
-              // Focus the editor so the resulting selection can be acted on by
-              // the keyboard (Delete / Backspace). An area-select routinely
-              // STARTS in the margin (the whole point of the gesture), where the
-              // press lands on the scroll pane — NOT the contenteditable — so
-              // `.ProseMirror` never took focus. And a `NodeRangeSelection` is
-              // `visible:false`, so dispatching it doesn't focus the editor
-              // either. Without this, a key press after a margin-started select
-              // went to `<body>` and the selected blocks couldn't be deleted at
-              // all (`view.focus()` is preventScroll, so it won't jump the page).
-              view.focus();
-            }
-            const band = blockRangeInBand(
-              view,
-              Math.min(startY, e.clientY),
-              Math.max(startY, e.clientY),
-            );
-            if (band && (band.from !== lastFrom || band.to !== lastTo)) {
-              lastFrom = band.from;
-              lastTo = band.to;
-              try {
-                const sel = NodeRangeSelection.create(doc(), band.from + 1, band.to - 1);
-                view.dispatch(view.state.tr.setSelection(sel));
-              } catch {
-                /* range momentarily invalid mid-doc-change — ignore */
-              }
-            }
-            // Paint AFTER the selection dispatch (which can blur the marquee for a
-            // frame) so the box reads as the live, top-most drag outline.
-            paintMarquee(e.clientX, e.clientY);
-            e.preventDefault();
+            const r = apply({
+              type: "move",
+              x: e.clientX,
+              y: e.clientY,
+              primaryButton: (e.buttons & 1) !== 0,
+            });
+            if (r.engaged) e.preventDefault();
           }
 
           function onUp() {
-            finish();
+            apply({ type: "release" });
           }
 
           function onDown(e: MouseEvent) {
             if (e.button !== 0 || !view.editable || isInteractiveTarget(e.target)) return;
-            startX = e.clientX;
-            startY = e.clientY;
-            startInEditor = view.dom.contains(e.target as Node);
-            startPos = startInEditor
-              ? (view.posAtCoords({ left: e.clientX, top: e.clientY })?.pos ?? null)
-              : null;
-            // Whether a block actually sits on the press row. When none does — the
-            // empty tail padding (`.ProseMirror`'s 30vh `padding-bottom`), a blank
-            // page, the white space beside an empty region — the drag is a pure
-            // AREA select over emptiness: it still engages and paints the marquee,
-            // so sweeping the blank doc rubber-bands like the desktop. (Was: a
-            // press off any block row bailed here, so empty space did nothing.)
-            startOnBlockRow = !!blockRangeInBand(view, startY, startY);
-            pending = true;
-            engaged = false;
-            lastFrom = -1;
-            lastTo = -1;
-            const d = view.dom.ownerDocument;
-            d.addEventListener("mousemove", onMove, true);
-            d.addEventListener("mouseup", onUp, true);
+            apply({
+              type: "press",
+              x: e.clientX,
+              y: e.clientY,
+              inEditor: view.dom.contains(e.target as Node),
+            });
+            trackPointer();
           }
 
           pane.addEventListener("mousedown", onDown, true);
@@ -302,9 +536,7 @@ export const BlockAreaSelect = Extension.create({
             destroy() {
               clearMarquee();
               pane.removeEventListener("mousedown", onDown, true);
-              const d = view.dom.ownerDocument;
-              d.removeEventListener("mousemove", onMove, true);
-              d.removeEventListener("mouseup", onUp, true);
+              untrackPointer();
             },
           };
         },

--- a/apps/app-web/src/components/doc/block-area-select.ts
+++ b/apps/app-web/src/components/doc/block-area-select.ts
@@ -18,25 +18,32 @@
  *      geometry** (which top-level blocks the drag's Y-band covers) — stable and
  *      independent of the horizontal position, so it works from any margin.
  *
- * Suppressing that native selection has to happen on EVERY move, not once at
- * engage. All three of the obvious one-shot levers are no-ops against a
- * selection gesture the browser has already begun: `user-select: none` is
- * consulted when a selection *starts*, so flipping it mid-drag doesn't abort the
- * live one; a single `removeAllRanges()` is undone by the very next mousemove;
- * and `preventDefault()` on **mousemove** doesn't cancel selection extension
- * (only `mousedown` / `selectstart` do). `view.focus()` made it actively worse —
- * prosemirror-view's `focus()` runs `selectionToDOM()`, writing a DOM selection
- * back for the still-live gesture to extend from — so we focus `view.dom`
- * directly instead and keep the keyboard-delete prerequisite without re-seeding a
- * range. Left unfixed the two selections rendered at once (a `::selection`
- * highlight racing the marquee) and, worse, ProseMirror's DOM observer re-derived
- * a `TextSelection` from the live DOM selection every frame and clobbered each
- * dispatched `NodeRangeSelection` — so the block bands never rendered, the
- * inline toolbar popped up mid-area-drag, and a drag across six blocks gave no
- * selection feedback at all beyond the rubber band. The band dispatch is
- * therefore also **self-healing** (`needsBandResync`): it re-asserts the range
- * whenever the state selection is no longer a `NodeRangeSelection`, not only when
- * the covered band changes.
+ * **The native selection must be cancelled at MOUSEDOWN. Nothing later works.**
+ * Measured in a real browser (2026-07-23): clearing the DOM selection on every
+ * move AND cancelling `selectstart` still left 758 native chars selected and
+ * ZERO bands painted. The trace showed why — each move cleared the selection and
+ * dispatched the band successfully (`selIsNodeRange` true right after), but the
+ * browser re-extended its selection *after* our mousemove handler returned,
+ * ProseMirror's DOM observer re-derived a `TextSelection` from it, and the band
+ * was clobbered before it could paint. Every frame. `selectstart` cannot help:
+ * it does not re-fire mid-drag. `user-select: none` cannot help: it is consulted
+ * when a selection *starts*. `preventDefault()` on mousemove cannot help: it does
+ * not cancel selection extension. And `view.focus()` actively hurts —
+ * prosemirror-view's `focus()` runs `selectionToDOM()`, re-seeding a range for
+ * the live gesture to extend.
+ *
+ * So the gesture calls `preventDefault()` on the **mousedown** itself, for the
+ * presses already known to be an area select (`pressStartsDefiniteAreaSelect` —
+ * the margin, or empty space). The browser then never starts a selection gesture
+ * at all. A press on a block's own text is undecidable at mousedown and is left
+ * alone, so ordinary word-level selection is untouched; the every-move clear and
+ * `needsBandResync` remain as the defense for that one case, where the drag can
+ * still convert to an area select by crossing a block boundary.
+ *
+ * Cancelling the browser's gesture also cancels the **auto-scroll** that used to
+ * ride along with it, so the gesture drives its own (`autoScrollTick`) on a frame
+ * loop — a cursor parked at the edge emits no further mousemoves, so the scroll
+ * has to keep running while the pointer is still.
  *
  * A drag that starts on text and stays inside one block is left to the native
  * text selection (`crossesBlocks`); a drag starting in the margin, over **empty
@@ -67,6 +74,12 @@
  * never pushed, so an in-block text drag (which must stay a native selection)
  * pays the per-block `getBoundingClientRect` sweep once, at the press, and never
  * again per move.
+ *
+ * The drag anchor lives in **content space**, not screen space (`startScrollTop`).
+ * A band measured from a fixed `startY` progressively drops the very blocks the
+ * drag began on as the page scrolls under it — observed as the band's `from`
+ * climbing 528 -> 1321 -> 2252 -> 2518 during one auto-scrolling drag, leaving
+ * only the last four blocks selected out of twenty-three.
  */
 
 import { Extension } from "@tiptap/core";
@@ -148,6 +161,11 @@ export type AreaSelectState = {
   phase: "idle" | "pending" | "engaged";
   startX: number;
   startY: number;
+  /** Scroll offset of the pane when the press landed. The anchor is stored in
+   *  CONTENT space, not screen space: `startY` alone is a viewport row, and the
+   *  page scrolls under the cursor mid-drag (auto-scroll at the edge), so a band
+   *  measured from a fixed `startY` silently drops the blocks the drag began on. */
+  startScrollTop: number;
   startInEditor: boolean;
   startPos: number | null;
   startOnBlockRow: boolean;
@@ -159,6 +177,7 @@ export const AREA_SELECT_IDLE: AreaSelectState = Object.freeze({
   phase: "idle",
   startX: 0,
   startY: 0,
+  startScrollTop: 0,
   startInEditor: false,
   startPos: null,
   startOnBlockRow: false,
@@ -189,6 +208,9 @@ export type AreaSelectProbe = {
   crossesBlocks: (a: number, b: number) => boolean;
   /** Whether the editor's current selection is still a `NodeRangeSelection`. */
   selectionIsNodeRange: () => boolean;
+  /** Current scroll offset of the editor's scroll pane. Read every move so the
+   *  anchor can be kept in content space while the page scrolls under the drag. */
+  scrollTop: () => number;
 };
 
 /** The next state, plus the effects the adapter must apply this tick — in order:
@@ -202,6 +224,10 @@ export type AreaSelectResult = {
   focusEditor: boolean;
   band: BlockBand | null;
   marquee: ViewportRect | null;
+  /** Cancel the browser's own selection gesture at its source (`preventDefault`
+   *  on mousedown). Emitted on the press tick when the press is ALREADY known to
+   *  be an area select. See `pressStartsDefiniteAreaSelect`. */
+  suppressNativeGesture: boolean;
 };
 
 const NO_EFFECTS: Omit<AreaSelectResult, "state"> = {
@@ -210,7 +236,28 @@ const NO_EFFECTS: Omit<AreaSelectResult, "state"> = {
   focusEditor: false,
   band: null,
   marquee: null,
+  suppressNativeGesture: false,
 };
+
+/** Whether a press is ALREADY, at mousedown, known to be an area select — i.e.
+ *  the two `isAreaSelectDrag` clauses that need no movement to decide: a press
+ *  in the margin (outside the editable) or over empty space (no block on the
+ *  press row). Only a press on a block's own text is undecidable at mousedown,
+ *  because it stays a native text selection until it crosses a block boundary.
+ *
+ *  This is the ONLY point at which the browser's selection gesture can still be
+ *  stopped. Once the press is through, the browser extends its selection on every
+ *  mousemove AFTER our handler runs, and ProseMirror's DOM observer re-derives a
+ *  `TextSelection` from it and clobbers the dispatched `NodeRangeSelection` — so
+ *  the block bands never survive to paint. `selectstart` cannot save it (it does
+ *  not re-fire mid-drag), and neither can clearing the selection each move (the
+ *  browser simply re-extends after the clear). Pure/testable. */
+export function pressStartsDefiniteAreaSelect(opts: {
+  startInEditor: boolean;
+  startOnBlockRow: boolean;
+}): boolean {
+  return !opts.startOnBlockRow || !opts.startInEditor;
+}
 
 /** The whole gesture as a pure state machine. Composes the predicates above:
  *  `isAreaSelectDrag` decides engagement, `needsBandResync` decides re-dispatch,
@@ -227,22 +274,30 @@ export function areaSelectReducer(
   probe: AreaSelectProbe,
 ): AreaSelectResult {
   if (event.type === "press") {
+    const startOnBlockRow = probe.bandInY(event.y, event.y) !== null;
     return {
       state: {
         phase: "pending",
         startX: event.x,
         startY: event.y,
+        startScrollTop: probe.scrollTop(),
         startInEditor: event.inEditor,
         startPos: event.inEditor ? probe.posAt(event.x, event.y) : null,
         // Whether a block actually sits on the press row. When none does — the
         // empty tail padding, a blank page, the white space beside an empty
         // region — the drag is a pure area select over emptiness: it still
         // engages and rubber-bands like a desktop sweep.
-        startOnBlockRow: probe.bandInY(event.y, event.y) !== null,
+        startOnBlockRow,
         lastFrom: -1,
         lastTo: -1,
       },
       ...NO_EFFECTS,
+      // The one chance to stop the browser's selection gesture. Skipped for a
+      // press on a block's own text, which must stay a normal text selection.
+      suppressNativeGesture: pressStartsDefiniteAreaSelect({
+        startInEditor: event.inEditor,
+        startOnBlockRow,
+      }),
     };
   }
 
@@ -285,10 +340,12 @@ export function areaSelectReducer(
     focusEditor = true;
   }
 
-  const band = probe.bandInY(
-    Math.min(next.startY, event.y),
-    Math.max(next.startY, event.y),
-  );
+  // The anchor in CURRENT screen space: where the press row has been carried to
+  // by any scrolling since. Without this the band's far edge stays pinned to a
+  // stale viewport row, so an auto-scrolling drag progressively drops the very
+  // blocks it started on (they slide past the fixed `startY`).
+  const anchorY = next.startY - (probe.scrollTop() - next.startScrollTop);
+  const band = probe.bandInY(Math.min(anchorY, event.y), Math.max(anchorY, event.y));
   let dispatch: BlockBand | null = null;
   if (
     band &&
@@ -308,7 +365,8 @@ export function areaSelectReducer(
     clearSelection: true,
     focusEditor,
     band: dispatch,
-    marquee: dragRect(next.startX, next.startY, event.x, event.y),
+    marquee: dragRect(next.startX, anchorY, event.x, event.y),
+    suppressNativeGesture: false,
   };
 }
 
@@ -396,6 +454,7 @@ export const BlockAreaSelect = Extension.create({
             bandInY: (yMin, yMax) => blockRangeInBand(view, yMin, yMax),
             crossesBlocks: (a, b) => crossesBlocks(view.state.doc, a, b),
             selectionIsNodeRange: () => isNodeRangeSelection(view.state.selection),
+            scrollTop: () => pane.scrollTop,
           };
 
           /** Drop whatever native selection the browser has grown. The reducer
@@ -482,6 +541,52 @@ export const BlockAreaSelect = Extension.create({
             d.removeEventListener("mousemove", onMove, true);
             d.removeEventListener("mouseup", onUp, true);
             d.removeEventListener("selectstart", onSelectStart, true);
+            stopAutoScroll();
+          };
+
+          /** Edge auto-scroll. The gesture has to drive this ITSELF: cancelling the
+           *  browser's selection gesture at mousedown (the only way to stop it
+           *  clobbering the band — see `pressStartsDefiniteAreaSelect`) also
+           *  cancels the auto-scroll that used to come free with it, and without
+           *  scrolling a selection can never extend past one screenful.
+           *
+           *  It runs on a frame loop rather than off `mousemove`, because a cursor
+           *  parked at the edge stops emitting moves — the scroll has to keep
+           *  going while the pointer is still. Each frame re-applies a move at the
+           *  LAST cursor point so the band recomputes against the new scroll
+           *  offset (the reducer's content-space anchor does the compensating). */
+          const EDGE_ZONE_PX = 48;
+          const EDGE_SPEED_PX = 16;
+          let lastX = 0;
+          let lastY = 0;
+          let autoScrollRaf = 0;
+
+          const stopAutoScroll = () => {
+            if (autoScrollRaf) cancelAnimationFrame(autoScrollRaf);
+            autoScrollRaf = 0;
+          };
+
+          const autoScrollTick = () => {
+            autoScrollRaf = 0;
+            if (state.phase !== "engaged") return;
+            const r = pane.getBoundingClientRect();
+            let dy = 0;
+            if (lastY > r.bottom - EDGE_ZONE_PX) dy = EDGE_SPEED_PX;
+            else if (lastY < r.top + EDGE_ZONE_PX) dy = -EDGE_SPEED_PX;
+            if (dy !== 0) {
+              const before = pane.scrollTop;
+              pane.scrollTop += dy;
+              // Only re-band if the pane actually moved — at either end of the
+              // document this is a no-op and re-dispatching would just churn.
+              if (pane.scrollTop !== before) {
+                apply({ type: "move", x: lastX, y: lastY, primaryButton: true });
+              }
+            }
+            autoScrollRaf = requestAnimationFrame(autoScrollTick);
+          };
+
+          const startAutoScroll = () => {
+            if (!autoScrollRaf) autoScrollRaf = requestAnimationFrame(autoScrollTick);
           };
 
           /** Run one gesture event through the reducer and apply what it asks for.
@@ -502,11 +607,14 @@ export const BlockAreaSelect = Extension.create({
             if (r.marquee) paintMarquee(r.marquee);
             else clearMarquee();
             if (wasEngaged && !r.engaged) setSuppressed(false);
+            if (r.focusEditor) startAutoScroll(); // engage tick
             if (state.phase === "idle") untrackPointer();
             return r;
           };
 
           function onMove(e: MouseEvent) {
+            lastX = e.clientX;
+            lastY = e.clientY;
             const r = apply({
               type: "move",
               x: e.clientX,
@@ -522,18 +630,25 @@ export const BlockAreaSelect = Extension.create({
 
           function onDown(e: MouseEvent) {
             if (e.button !== 0 || !view.editable || isInteractiveTarget(e.target)) return;
-            apply({
+            const r = apply({
               type: "press",
               x: e.clientX,
               y: e.clientY,
               inEditor: view.dom.contains(e.target as Node),
             });
+            // Stop the browser starting a text-selection gesture at all. This is
+            // the only moment it can be stopped; every later lever loses the race
+            // (see `pressStartsDefiniteAreaSelect`). Focus is normally a
+            // side-effect of mousedown, so the gesture takes it explicitly on
+            // engage — the keyboard-delete prerequisite still holds.
+            if (r.suppressNativeGesture) e.preventDefault();
             trackPointer();
           }
 
           pane.addEventListener("mousedown", onDown, true);
           return {
             destroy() {
+              stopAutoScroll();
               clearMarquee();
               pane.removeEventListener("mousedown", onDown, true);
               untrackPointer();


### PR DESCRIPTION
## What was broken

Dragging from the page margin to select blocks painted a rubber-band marquee but **never tinted the blocks**. A stray blue text highlight grew alongside it from a place the user never clicked.

Reported symptoms (verbatim): dragging bottom-to-top "cannot select", while top-to-bottom "seems it works"; and dragging top-to-bottom then letting the page scroll "本來上面已反白選擇的又會被unselected".

## Root cause (measured in a real browser, not inferred)

Instrumenting the live gesture produced this, every single frame:

```
move: clear=true, rangesBefore:1 -> rangesAfterClear:0, band={0,132}
      dispatchBand ok -> selIsNodeRange = TRUE   OK
move: rangesBefore:1   <- browser RE-GREW its selection
      selIsNodeRange = FALSE                     clobbered
```

Clearing the DOM selection on every move **and** cancelling `selectstart` both lose. The browser re-extends its selection *after* the mousemove handler returns; ProseMirror's DOM observer re-derives a `TextSelection` from it and kills the dispatched `NodeRangeSelection` before it can paint.

The reported up/down asymmetry was **not** a difference in selection: bands were absent in both directions. Only the amount of stray native highlight differed - **758 characters dragging down vs 98 dragging up** - which read as "down works, up cannot select".

None of the later levers can work: `selectstart` does not re-fire mid-drag, `user-select` is consulted when a selection *starts*, and `preventDefault` on mousemove does not cancel extension. **`mousedown` is the only remaining point.**

## The fix

1. **Cancel at mousedown** (`pressStartsDefiniteAreaSelect`) for presses already known to be an area select - the margin, or empty space. A press on a block's own text is undecidable at mousedown and is left alone, so ordinary word-level selection is untouched.
2. **Gesture-owned auto-scroll.** Cancelling the native gesture also cancels the auto-scroll that rode with it, so the gesture drives its own on a frame loop (a cursor parked at the edge emits no further mousemoves).
3. **Content-space drag anchor** (`startScrollTop`). Measured from a fixed `startY`, an auto-scrolling drag progressively dropped the blocks it began on - the band's `from` climbed **528 -> 1321 -> 2252 -> 2518**, leaving 4 of 23 blocks selected. That was the reported un-selecting.

## Verification

Driven with real mouse events against the local app:

| Case | Before | After |
|---|---|---|
| Upward drag | `banded []`, 98 native chars | `banded [0..7]`, **0** native |
| Down + auto-scroll | `banded [19..22]`, `from` climbing | `banded [0..22]`, `from` stays **0**, scrollTop 1005 |
| In-block text drag | - | `banded []`, 15 chars, no marquee (unchanged) |

`tsc --noEmit` clean. 40 tests pass across `node-range`, `area-select-scope`, `block-multi-delete`, including 6 new regression tests at the pure-reducer seam. The scroll test is genuinely red-capable: without content-space compensation its `from` would be 500, not 0.

Debug instrumentation removed; no `console.log` left behind.

## Note

The architecture doc and `brian-kb` twin still describe the **disproved** every-move theory. They are updated in a companion change in the platform repo - this PR corrects the in-file module note, which now records the measured findings.

Spec: https://github.com/use-brian/brian-platform/issues/235

Generated with [Claude Code](https://claude.com/claude-code)