### PR TITLE
fix(app-web): stop the realtime SSE reconnect storm (drop withCredentials)

### DIFF
--- a/apps/app-web/src/lib/__tests__/feed-sse.test.ts
+++ b/apps/app-web/src/lib/__tests__/feed-sse.test.ts
@@ -54,7 +54,10 @@ describe("[COMP:app-web/feed-sse] openFeedStream", () => {
     expect(url.pathname).toBe("/api/distribution/t/ws-1/events");
     expect(url.searchParams.get("access_token")).toBe("tok-1");
     expect(url.searchParams.has("lastEventId")).toBe(false);
-    expect(source.withCredentials).toBe(true);
+    // Auth rides the URL token, not cookies — a credentialed cross-origin
+    // EventSource would demand `Access-Control-Allow-Credentials: true` (the
+    // API doesn't send it) and reconnect-storm. Must stay uncredentialed.
+    expect(source.withCredentials).toBe(false);
     handle.close();
   });
 

--- a/apps/app-web/src/lib/feed-sse.ts
+++ b/apps/app-web/src/lib/feed-sse.ts
@@ -66,10 +66,16 @@ export function openFeedStream(opts: {
     );
     if (lastEventId) url.searchParams.set("lastEventId", lastEventId);
     // EventSource can't set headers — pass the access_token as a query
-    // param. The SSE route accepts both Bearer and `?access_token=`.
+    // param. The SSE route accepts both Bearer and `?access_token=`. Auth
+    // rides the URL token, NOT cookies, so this MUST NOT set
+    // `withCredentials: true`: a credentialed cross-origin EventSource needs
+    // the server to answer `Access-Control-Allow-Credentials: true` (the API
+    // does not), and without it the browser rejects every connection before
+    // `open` and retries forever — a reconnect storm that silently kills the
+    // stream. See workspace-events.ts for the same fix + rationale.
     const token = getAccessToken();
     if (token) url.searchParams.set("access_token", token);
-    source = new EventSource(url.toString(), { withCredentials: true });
+    source = new EventSource(url.toString());
 
     source.addEventListener("feed-event", (ev) => {
       try {

--- a/apps/app-web/src/lib/workspace-events.ts
+++ b/apps/app-web/src/lib/workspace-events.ts
@@ -277,10 +277,18 @@ function openWorkspaceStream(opts: {
     const url = new URL(`${API_URL}/api/brain/stream`, window.location.origin);
     url.searchParams.set("workspaceId", opts.workspaceId);
     // EventSource cannot set custom headers — the SSE route accepts both
-    // `Authorization: Bearer` and `?access_token=`.
+    // `Authorization: Bearer` and `?access_token=`. Auth rides the URL token,
+    // NOT cookies (the route never reads them), so this MUST NOT set
+    // `withCredentials: true`: a credentialed cross-origin EventSource
+    // (:3003 → :4000, or app.usebrian.ai → api.usebrian.ai) requires the
+    // server to answer `Access-Control-Allow-Credentials: true`, which the
+    // API does not send. Without it the browser rejects every connection
+    // before `open`, and EventSource retries forever — a reconnect storm that
+    // silently kills ALL realtime (the roster switcher, brain, approvals, …),
+    // forcing a full page reload to see any change.
     const token = getAccessToken();
     if (token) url.searchParams.set("access_token", token);
-    source = new EventSource(url.toString(), { withCredentials: true });
+    source = new EventSource(url.toString());
 
     source.addEventListener("open", () => {
       // First connect AND every auto-reconnect: refetch what we missed.


### PR DESCRIPTION
## The bug behind the bug

The assistant-roster fix ([#81](https://github.com/use-brian/use-brian/pull/81)) routed correctly but appeared not to work — because the realtime stream it rides was **never staying connected**. Found by driving the local app in a real browser and watching `/api/brain/stream`: **24 EventSource connections in 8 seconds of idle time**, a reconnect storm delivering zero events.

## Root cause

Both SSE clients opened with `withCredentials: true`:
- `workspace-events.ts` (the workspace realtime spine — brain, approvals, workflow, skills, assistant roster)
- `feed-sse.ts` (the Feed operator stream)

app-web talks to the API **cross-origin** (`:3003 → :4000` in dev; `app.usebrian.ai → api.usebrian.ai` in prod). The API's CORS (`boot.ts`) echoes the request origin into `Access-Control-Allow-Origin` but **never sends `Access-Control-Allow-Credentials: true`**. A credentialed cross-origin EventSource requires **both** — so the browser rejects every connection **before `open`**, and EventSource retries forever.

The SSE routes authenticate via the `?access_token=` URL param and **never read a cookie** (`extractUserId` in `brain-stream.ts`), so `withCredentials` was unnecessary *and* fatal. The CORS gap is in shared `boot.ts`, so this is **identical in dev and prod**.

## Fix

Drop `withCredentials: true` from both streams (`new EventSource(url)`). Auth is unchanged (token stays in the URL).

## Proof (real browser, local stack)

| | before | after |
|---|---|---|
| `/api/brain/stream` connections in 8s idle | **24** (storm) | **0** (stable) |
| `sidan:assistant-refresh` on create | never fired | fires with correct `rowId` |
| new assistant in switcher | needs full reload | **appears live** |

A/B in-browser: `withCredentials:true` → 0 opens / 1 error; `false` → 1 open / 0 errors.

Tests: `feed-sse` + `workspace-events` pass (16/16); the `feed-sse` test that asserted `withCredentials === true` now asserts `false`. app-web typecheck clean.

## Follow-up options (not in this PR)

If credentialed cross-origin streams are ever genuinely needed, the correct fix is server-side: emit `Access-Control-Allow-Credentials: true` alongside the exact-origin echo in `boot.ts`. A graded invariant grepping for `new EventSource(..., { withCredentials: true })` against the API origin would catch regressions.

Docs: platform `realtime-sync.md` updated (separate platform PR, same as #81's flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)