### PR TITLE
fix(app-web): keep the doc tab strip across a surface switch

### DIFF
--- a/apps/app-web/src/components/doc/doc-shell.tsx
+++ b/apps/app-web/src/components/doc/doc-shell.tsx
@@ -47,7 +47,6 @@ import {
   type PanelId,
 } from "@/lib/doc-page-url";
 import {
-  activePageId,
   back,
   blankActiveTab,
   canGoBack,
@@ -55,13 +54,12 @@ import {
   closeTab,
   dropPage,
   forward,
-  initTabs,
   newTab,
   openPage,
   switchTab,
   tabPageId,
-  type TabsState,
 } from "@/lib/doc-tabs";
+import { useDocTabs } from "@/lib/use-doc-tabs";
 import {
   createDraft,
   commitPageCreatedEvent,
@@ -299,54 +297,19 @@ export function DocShell({ workspaceId, assistantId }: ShellProps) {
   // ── Tab strip + per-tab browse history — the top "layer" (Row 1) ──────
   // The active tab's current ENTRY is the source of truth for what the pane
   // shows — a page id, a panel sentinel (`panel:<id>`, Approvals / Autopilot),
-  // or null (the Suggested-for-you home). It is mirrored into the URL
-  // (`/p/<id>` or `/p?panel=<id>`) by the sync effect below, and the
-  // pathname/query-keyed reads load the body. Seeded once from the URL;
-  // session-scoped (survives soft nav, resets on reload). `doc-tabs.ts` treats
-  // every entry as an opaque string, so panel entries flow through unchanged.
-  const [tabsState, setTabsState] = useState<TabsState>(() =>
-    initTabs(urlEntry),
-  );
-  const tabsActiveEntry = activePageId(tabsState);
-  const tabsActiveEntryRef = useRef(tabsActiveEntry);
-  tabsActiveEntryRef.current = tabsActiveEntry;
-  // Latest URL-derived entry, read by the tabs → URL effect for COMPARISON only
-  // (never as a trigger — see below). Updated every render so the effect sees
-  // the committed URL when it runs.
-  const urlEntryRef = useRef(urlEntry);
-  urlEntryRef.current = urlEntry;
-
-  // tabs → URL: mirror the active tab's current entry into the canonical URL.
-  // Triggered ONLY by the active entry (the tab side owns this direction); it
-  // reads the URL entry through a ref purely to no-op once they already match.
+  // or null (the Suggested-for-you home). `useDocTabs` owns the strip and both
+  // directions of the URL mirror (`/p/<id>` or `/p?panel=<id>`); the
+  // pathname/query-keyed reads below load the body. `doc-tabs.ts` treats every
+  // entry as an opaque string, so panel entries flow through unchanged.
   //
-  // The URL entry must NOT be a dependency. If it were, an EXTERNAL url change —
-  // the editor's "/"→Page `router.push`, floating-chat's `router.replace`, a
-  // deep link, browser back/forward — would re-fire this effect in the render
-  // where `urlEntry` has advanced but `tabsActiveEntry` still lags by one
-  // commit. It would then `router.replace` the URL back to the stale active
-  // entry, while the URL → tabs effect simultaneously adopts the new one, leaving
-  // the two a half-step out of phase forever: the page and its child page
-  // ping-pong endlessly. Reacting to the active entry alone lets the URL → tabs
-  // effect own external changes and this effect own tab-driven ones; both guard
-  // on equality, so they converge.
-  useEffect(() => {
-    if (urlEntryRef.current !== tabsActiveEntry) {
-      router.replace(docEntryPath(workspaceId, tabsActiveEntry));
-    }
-  }, [tabsActiveEntry, workspaceId, router]);
-
-  // URL → tabs: reconcile a URL change from OUTSIDE the tab actions — a
-  // chat-created draft auto-navigation (`floating-chat` calls `router.replace`
-  // directly), a page link, a `?panel=` deep link, a redirect from the legacy
-  // `/approvals` / `/goals` routes, a deep link followed in-session. Reacting to
-  // `urlEntry` alone (latest active entry read via the ref) keeps a tab switch's
-  // not-yet-synced URL from being mistaken for an external change; both effects
-  // guard on equality, so they converge with no ping-pong.
-  useEffect(() => {
-    if (urlEntry === tabsActiveEntryRef.current) return;
-    setTabsState((s) => (urlEntry ? openPage(s, urlEntry) : blankActiveTab(s)));
-  }, [urlEntry]);
+  // The strip is SESSION-scoped, not mount-scoped: this shell is mounted by
+  // `p/layout.tsx`, which Next tears down whenever the user steps out to a
+  // sibling surface (Brain / Studio / Workflow — they hang off the workspace
+  // layout, one level up), so the strip is held in `doc-tabs-session.ts` and
+  // restored on re-entry. It still resets on a hard reload.
+  const [tabsState, setTabsState] = useDocTabs(workspaceId, urlEntry, (entry) =>
+    router.replace(docEntryPath(workspaceId, entry)),
+  );
 
   const [activeError, setActiveError] = useState<string | null>(null);
   // Centre-pane errors (build / full-width / clearance) route through the

--- a/apps/app-web/src/components/doc/doc-sidebar-data.tsx
+++ b/apps/app-web/src/components/doc/doc-sidebar-data.tsx
@@ -82,6 +82,7 @@ import { isHostedEdition } from "@/lib/edition";
 import { fetchHomeDock, type ResolvedDock } from "@/lib/api/home-dock";
 import { isDesktopAuth } from "@/lib/desktop-auth-source";
 import { idbGet, idbSet } from "@/lib/offline/idb";
+import { dropPageFromDocTabsSession } from "@/lib/doc-tabs-session";
 import { offlineWrite, getOnline } from "@/lib/offline/offline-writes";
 import type { SidebarMove } from "./doc-sidebar";
 
@@ -646,13 +647,19 @@ export function DocSidebarDataProvider({
           b.dropFromTabs(id);
           b.setActiveView((v) => (v && v.id === id ? null : v));
         }
+        // The strip outlives the doc surface's mount (`doc-tabs-session.ts`),
+        // so deleting from a sibling surface — where there is no bridge — has
+        // to scrub the STORED copy too, or the page comes back as a live tab
+        // on re-entry. Redundant but harmless while mounted: the shell writes
+        // its own (already scrubbed) state back on the next commit.
+        dropPageFromDocTabsSession(workspaceId, id);
         reloadSidebar();
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         setTopError(format(t.saveFailed, { message }));
       }
     },
-    [reloadSidebar, t],
+    [reloadSidebar, t, workspaceId],
   );
 
   const handleMove = useCallback(

--- a/apps/app-web/src/lib/__tests__/use-doc-tabs.test.tsx
+++ b/apps/app-web/src/lib/__tests__/use-doc-tabs.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+/**
+ * [COMP:app-web/doc-tabs-session] Tab strip survival across a surface switch.
+ *
+ * `<DocShell>` is mounted by `/w/[id]/p/layout.tsx`, which is UNMOUNTED the
+ * moment the user leaves the doc surface for Brain / Studio / Workflow (those
+ * live under the workspace layout, a sibling of `p/`). These tests drive that
+ * exact lifecycle — mount, mutate the strip, unmount, remount — against the
+ * real hook, with a fake router that models `router.replace` the way Next does
+ * (the pathname changes, the component re-renders with a new `urlEntry`).
+ *
+ * The pure reducer behind the strip is covered in `doc-tabs.test.ts`; what is
+ * covered here is only the part a pure test cannot reach: the seed ⇄ URL
+ * reconciliation across a remount.
+ */
+
+import { describe, expect, it, beforeEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { activePageId, newTab, openPage, type TabsState } from "../doc-tabs";
+import { useDocTabs } from "../use-doc-tabs";
+import { resetDocTabsSession } from "../doc-tabs-session";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const WS = "ws-1";
+
+type Api = {
+  state: TabsState;
+  setState: React.Dispatch<React.SetStateAction<TabsState>>;
+};
+
+/**
+ * One mount of the doc surface, with a fake URL bar. `url` stands in for the
+ * pathname: the hook writes to it via `syncUrl`, and `settle()` re-renders
+ * until the two directions agree — the same convergence the real router +
+ * `usePathname()` produce.
+ */
+function mountSurface(workspaceId: string, initialUrl: string | null) {
+  const container = document.createElement("div");
+  const root: Root = createRoot(container);
+  let url = initialUrl;
+  let api: Api | null = null;
+
+  function Probe({ entry }: { entry: string | null }) {
+    const [state, setState] = useDocTabs(workspaceId, entry, (next) => {
+      url = next;
+    });
+    api = { state, setState };
+    return null;
+  }
+
+  function settle() {
+    for (let i = 0; i < 8; i += 1) {
+      const before = url;
+      act(() => {
+        root.render(<Probe entry={url} />);
+      });
+      if (url === before) return;
+    }
+    throw new Error("url never settled — tabs ⇄ URL are ping-ponging");
+  }
+
+  settle();
+
+  return {
+    get state() {
+      if (!api) throw new Error("not mounted");
+      return api.state;
+    },
+    get url() {
+      return url;
+    },
+    /** Apply a reducer action the way a top-bar button would, then converge. */
+    dispatch(fn: (s: TabsState) => TabsState) {
+      act(() => {
+        api!.setState(fn);
+      });
+      settle();
+    },
+    /** An EXTERNAL navigation (sidebar row, deep link) landing on this mount. */
+    navigate(entry: string | null) {
+      url = entry;
+      settle();
+    },
+    /** Leave the doc surface — Next tears `p/layout.tsx` down. */
+    unmount() {
+      act(() => {
+        root.unmount();
+      });
+    },
+  };
+}
+
+describe("[COMP:app-web/doc-tabs-session] Doc tab strip across a surface switch", () => {
+  beforeEach(() => {
+    resetDocTabsSession();
+  });
+
+  it("keeps the open tabs when the user goes to Brain and back to Home", () => {
+    // Home, then `+` and open a page in the new tab — two tabs open.
+    const first = mountSurface(WS, null);
+    first.dispatch(newTab);
+    first.dispatch((s) => openPage(s, "page-2"));
+    expect(first.state.tabs).toHaveLength(2);
+    expect(first.url).toBe("page-2");
+
+    // → Brain / Studio / Workflow: the doc surface unmounts.
+    first.unmount();
+
+    // ← Home. The nav rail targets `/w/<id>/p`, so the URL carries no page.
+    const back = mountSurface(WS, null);
+
+    expect(back.state.tabs).toHaveLength(2);
+    expect(activePageId(back.state)).toBe("page-2");
+    // The restored strip is the source of truth: the URL follows it back.
+    expect(back.url).toBe("page-2");
+  });
+
+  it("adopts a deep link into the restored strip instead of dropping it", () => {
+    const first = mountSurface(WS, null);
+    first.dispatch(newTab);
+    first.dispatch((s) => openPage(s, "page-2"));
+    first.unmount();
+
+    // Re-entering by clicking a sidebar page from Brain: the URL wins for the
+    // active tab, the strip still survives.
+    const back = mountSurface(WS, "page-9");
+
+    expect(back.state.tabs).toHaveLength(2);
+    expect(activePageId(back.state)).toBe("page-9");
+    expect(back.url).toBe("page-9");
+  });
+
+  it("scopes the strip to one workspace", () => {
+    const first = mountSurface(WS, null);
+    first.dispatch(newTab);
+    first.dispatch((s) => openPage(s, "page-2"));
+    first.unmount();
+
+    const other = mountSurface("ws-2", null);
+
+    expect(other.state.tabs).toHaveLength(1);
+    expect(activePageId(other.state)).toBeNull();
+  });
+
+  it("still blanks the active tab when Home is clicked from inside the surface", () => {
+    // Home is a live navigation while mounted — it must keep behaving like the
+    // browser's home button (blank the ACTIVE tab, keep the strip).
+    const s = mountSurface(WS, null);
+    s.dispatch(newTab);
+    s.dispatch((t) => openPage(t, "page-2"));
+
+    s.navigate(null);
+
+    expect(s.state.tabs).toHaveLength(2);
+    expect(activePageId(s.state)).toBeNull();
+    expect(s.url).toBeNull();
+  });
+});

--- a/apps/app-web/src/lib/doc-tabs-session.ts
+++ b/apps/app-web/src/lib/doc-tabs-session.ts
@@ -1,0 +1,102 @@
+/**
+ * Session-scoped home for the Doc tab strip, plus the seed rule that
+ * reconciles a restored strip with the URL the surface was re-entered on.
+ *
+ * **Why this exists.** The strip used to live in a `useState` inside
+ * `<DocShell>`, which `/w/[id]/p/layout.tsx` mounts. That layout survives
+ * `/p/<pageId>` soft swaps but NOT a move to a sibling surface — Brain,
+ * Studio, Workflow, Feed and Approvals are mounted by the *workspace* layout,
+ * one level up, so entering any of them tears the doc surface down. Every tab
+ * the user had open was lost, and returning Home re-seeded a single fresh tab.
+ *
+ * The strip is held here instead: a module-level map keyed by workspace, so it
+ * outlives the mount, is never shared between workspaces, and dies with the
+ * JS context. That is the same **session scope** the feature was specified
+ * with (`docs/architecture/features/doc.md` → "Top bar") — survives soft
+ * navigation, resets on a hard reload — which is why this is a plain in-memory
+ * map and not `sessionStorage`: cross-reload persistence would need stale-id
+ * pruning against pages deleted while away, and that is still out of scope.
+ *
+ * Kept IO-free and React-free so vitest can exercise the seed rule directly,
+ * the same seam as `doc-tabs.ts` itself.
+ *
+ * [COMP:app-web/doc-tabs-session]
+ */
+
+import {
+  activePageId,
+  dropPage,
+  initTabs,
+  openPage,
+  type TabsState,
+} from "./doc-tabs";
+
+/** The live strip per workspace. Module scope = one JS context = one session. */
+const sessions = new Map<string, TabsState>();
+
+/** The workspace's stored strip, or null when the surface hasn't been opened. */
+export function readDocTabsSession(workspaceId: string): TabsState | null {
+  return sessions.get(workspaceId) ?? null;
+}
+
+/** Remember the workspace's strip for the next mount of the doc surface. */
+export function writeDocTabsSession(
+  workspaceId: string,
+  state: TabsState,
+): void {
+  sessions.set(workspaceId, state);
+}
+
+/** Drop every trace of a deleted page from a stored (unmounted) strip. */
+export function dropPageFromDocTabsSession(
+  workspaceId: string,
+  pageId: string,
+): void {
+  const stored = sessions.get(workspaceId);
+  if (stored) sessions.set(workspaceId, dropPage(stored, pageId));
+}
+
+/** Test-only: forget every workspace's strip. */
+export function resetDocTabsSession(): void {
+  sessions.clear();
+}
+
+export type TabsSeed = {
+  /** The state the surface should mount with. */
+  state: TabsState;
+  /**
+   * Whether the URL already agrees with `state`'s active entry. `false` means
+   * the restored strip won and the URL is the stale side — the caller must let
+   * its tabs → URL sync rewrite the URL and must NOT adopt the stale URL back
+   * into the strip.
+   */
+  urlAgrees: boolean;
+};
+
+/**
+ * Decide what the doc surface mounts with, given the workspace's stored strip
+ * (if any) and the entry the URL points at.
+ *
+ * Three cases, in order:
+ *  1. **No stored strip** (first entry this session) — seed from the URL.
+ *  2. **Stored strip + a URL entry** (a deep link, a sidebar page click from
+ *     Brain) — the URL wins for the *active tab*; the rest of the strip is
+ *     kept. Same as any in-surface navigation.
+ *  3. **Stored strip + no URL entry** (the nav rail's Home targets a bare
+ *     `/w/<id>/p`) — the STRIP wins and the URL follows. The nav rail is a
+ *     surface switcher, not a browser home button: coming back to Home must
+ *     show the doc surface as it was left. Blanking the active tab stays the
+ *     behaviour of clicking Home while the surface is already mounted, which
+ *     is a live URL change and never routes through here.
+ */
+export function seedDocTabs(
+  stored: TabsState | null,
+  urlEntry: string | null,
+): TabsSeed {
+  if (!stored) return { state: initTabs(urlEntry), urlAgrees: true };
+  const active = activePageId(stored);
+  if (urlEntry !== null && active !== urlEntry) {
+    return { state: openPage(stored, urlEntry), urlAgrees: true };
+  }
+  return { state: stored, urlAgrees: active === urlEntry };
+}

--- a/apps/app-web/src/lib/use-doc-tabs.ts
+++ b/apps/app-web/src/lib/use-doc-tabs.ts
@@ -1,0 +1,120 @@
+"use client";
+
+/**
+ * Ownership of the Doc top bar's tab strip — seeding, the two URL sync
+ * effects, and (see `doc-tabs-session.ts`) survival across a surface switch.
+ *
+ * `doc-tabs.ts` is the pure reducer; this hook is the React half that binds it
+ * to the URL. It was lifted out of `doc-shell.tsx` so the seed ⇄ URL
+ * reconciliation has a test seam that can be mounted, unmounted, and remounted
+ * — which is exactly the lifecycle the tab strip has to survive.
+ *
+ * **Why the lifecycle matters.** `<DocShell>` is mounted by
+ * `/w/[workspaceId]/p/layout.tsx`. That layout persists across `/p/<pageId>`
+ * soft swaps but is torn down the moment the user leaves the doc surface for
+ * a sibling one (Brain / Studio / Workflow / Feed / Approvals live under the
+ * *workspace* layout, not under `p/`). React state in the shell therefore dies
+ * on every surface switch — so a strip held in a bare `useState` came back as
+ * a single fresh tab when the user returned to Home. The strip is restored
+ * from the session store instead; see `doc-tabs-session.ts` for the scope.
+ *
+ * [COMP:app-web/doc-tabs-session]
+ */
+
+import * as React from "react";
+import {
+  activePageId,
+  blankActiveTab,
+  openPage,
+  type TabsState,
+} from "./doc-tabs";
+import {
+  readDocTabsSession,
+  seedDocTabs,
+  writeDocTabsSession,
+} from "./doc-tabs-session";
+
+/**
+ * Own the tab strip for one mount of the doc surface.
+ *
+ * `urlEntry` is the entry the URL currently points at (a page id, a
+ * `panel:<id>` sentinel, or null at the `/p` index). `syncUrl` mirrors the
+ * active tab's entry back into the URL — `router.replace(docEntryPath(...))`
+ * in the shell, a plain assignment in tests.
+ */
+export function useDocTabs(
+  workspaceId: string,
+  urlEntry: string | null,
+  syncUrl: (entry: string | null) => void,
+): [TabsState, React.Dispatch<React.SetStateAction<TabsState>>] {
+  // Seeded once per mount from the workspace's session strip (`seedDocTabs`
+  // decides whether the restored strip or the URL wins — see its doc).
+  const seed = React.useRef<ReturnType<typeof seedDocTabs> | null>(null);
+  if (seed.current === null) {
+    seed.current = seedDocTabs(readDocTabsSession(workspaceId), urlEntry);
+  }
+  const [tabsState, setTabsState] = React.useState<TabsState>(
+    () => seed.current!.state,
+  );
+
+  // When the restored strip won, the URL is the stale side: the tabs → URL
+  // effect below rewrites it, and the URL → tabs effect must NOT adopt the
+  // stale value back on that first commit (it would blank the very tab we just
+  // restored). One-shot — every later URL change is a real navigation.
+  const skipFirstUrlAdopt = React.useRef(!seed.current.urlAgrees);
+
+  // Hand the strip back to the session store on every commit, so the state the
+  // surface is torn down with is the state it comes back with.
+  React.useEffect(() => {
+    writeDocTabsSession(workspaceId, tabsState);
+  }, [workspaceId, tabsState]);
+
+  const activeEntry = activePageId(tabsState);
+  // Latest active entry, read by the URL → tabs effect for COMPARISON only.
+  const activeEntryRef = React.useRef(activeEntry);
+  activeEntryRef.current = activeEntry;
+  // Latest URL-derived entry, read by the tabs → URL effect for COMPARISON
+  // only (never as a trigger — see below).
+  const urlEntryRef = React.useRef(urlEntry);
+  urlEntryRef.current = urlEntry;
+  // The router callback changes identity every render in the shell; hold it in
+  // a ref so it never widens the effect's dependency set.
+  const syncUrlRef = React.useRef(syncUrl);
+  syncUrlRef.current = syncUrl;
+
+  // tabs → URL: mirror the active tab's current entry into the canonical URL.
+  // Triggered ONLY by the active entry (the tab side owns this direction); it
+  // reads the URL entry through a ref purely to no-op once they already match.
+  //
+  // The URL entry must NOT be a dependency. If it were, an EXTERNAL url change —
+  // the editor's "/"→Page `router.push`, floating-chat's `router.replace`, a
+  // deep link, browser back/forward — would re-fire this effect in the render
+  // where `urlEntry` has advanced but `activeEntry` still lags by one commit.
+  // It would then replace the URL back to the stale active entry, while the
+  // URL → tabs effect simultaneously adopts the new one, leaving the two a
+  // half-step out of phase forever: the page and its child page ping-pong
+  // endlessly. Reacting to the active entry alone lets the URL → tabs effect
+  // own external changes and this effect own tab-driven ones; both guard on
+  // equality, so they converge.
+  React.useEffect(() => {
+    if (urlEntryRef.current !== activeEntry) syncUrlRef.current(activeEntry);
+  }, [activeEntry]);
+
+  // URL → tabs: reconcile a URL change from OUTSIDE the tab actions — a
+  // chat-created draft auto-navigation (`floating-chat` calls `router.replace`
+  // directly), a page link, a `?panel=` deep link, a redirect from the legacy
+  // `/approvals` / `/goals` routes, a deep link followed in-session. Reacting to
+  // `urlEntry` alone (latest active entry read via the ref) keeps a tab switch's
+  // not-yet-synced URL from being mistaken for an external change; both effects
+  // guard on equality, so they converge with no ping-pong.
+  React.useEffect(() => {
+    if (skipFirstUrlAdopt.current) {
+      skipFirstUrlAdopt.current = false;
+      return;
+    }
+    if (urlEntry === activeEntryRef.current) return;
+    setTabsState((s) => (urlEntry ? openPage(s, urlEntry) : blankActiveTab(s)));
+  }, [urlEntry]);
+
+  return [tabsState, setTabsState];
+}


### PR DESCRIPTION
## The bug

Open a page in a second tab on the doc surface, step out to **Brain / Studio / Workflow**, come back to **Home** - the strip is reset to a single blank tab.

## Root cause

The strip lived in a `useState` inside `DocShell`, which `app/w/[workspaceId]/p/layout.tsx` mounts. That layout persists across `/p/<pageId>` soft swaps - so it reads like the persistent shell - but Brain, Studio, Workflow, Feed and Approvals hang off the **workspace** layout one level up. Entering any of them unmounts the doc surface entirely, and returning re-seeded a single fresh tab via `initTabs(urlEntry)`.

Second half: the nav rail's Home targets a bare `/w/<id>/p`, so even with the strip restored the `URL -> tabs` effect would have blanked the restored tab.

## The fix

- **`lib/doc-tabs-session.ts`** (new) - module-level map keyed by workspace. Outlives the mount, never shared between workspaces, still dies with the JS context: the session scope the feature was specified with. In-memory rather than `sessionStorage` on purpose - cross-reload persistence would need stale-id pruning against pages deleted while away, still out of scope. Also holds the pure `seedDocTabs` rule.
- **`lib/use-doc-tabs.ts`** (new) - `useDocTabs(workspaceId, urlEntry, syncUrl)`. Seeds from the store, persists each commit, owns **both** URL sync directions. Lifted verbatim out of `doc-shell.tsx` so the reconciliation has a seam a test can mount, unmount and remount.
- **`doc-shell.tsx`** - ~50 lines of `useState` + two effects collapse to one hook call.
- **`doc-sidebar-data.tsx`** - deleting a page from a sibling surface (no active-page bridge there) now scrubs the *stored* strip, else the page returns as a live tab on re-entry.

`seedDocTabs`, three cases: no stored strip seeds from the URL; stored strip + a URL entry (deep link, sidebar click made from Brain) lets the URL win for the active tab and keeps the strip; stored strip + bare `/p` lets the strip win and the URL follow, suppressing exactly one `URL -> tabs` adoption. The rail is a surface switcher, not a browser home button.

**Behaviour note:** returning from Brain to Home now lands on your last active page, not the blank home - the surface restores as you left it. Clicking Home *while already on the doc surface* still blanks the active tab (browser home-button semantics), covered by a test.

## Evidence

`lib/__tests__/use-doc-tabs.test.tsx` drives mount -> mutate -> unmount -> remount against the real hook with a fake router modelling `router.replace`. Before the fix it failed with `expected [ { key: 't0', history: [] } ] to have a length of 2 but got 1`.

Confirmed in a real browser against the local stack: two tabs -> Brain -> Home kept both tabs and rewrote the URL back to the active page; temporarily stubbing the restore reproduced the original single-tab reset.

`pnpm typecheck` clean, all 1981 app-web tests pass, `pnpm smoke` OK.

Docs move with the code: `docs/architecture/features/doc.md` -> "Top bar" -> "Session scope", the paired `brian-kb/features/doc.md` entry, a `[COMP:app-web/doc-tabs-session]` component-map row, and a new CLAUDE.md anti-pattern (platform PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)