### PR TITLE
feat(app-web): connect My Browser from the sidebar, not four levels deep

### DIFF
--- a/apps/app-web/src/components/doc/__tests__/connect-browser-row.test.tsx
+++ b/apps/app-web/src/components/doc/__tests__/connect-browser-row.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+/**
+ * [COMP:app-web/connect-browser-row] "My Browser" sidebar row.
+ *
+ * The row's whole value is that it never dead-ends: it hides where no relay
+ * exists, pairs in one click where the extension answers, and hands off to the
+ * Settings panel in every other case. Those branches are what is asserted here
+ * — jsdom (not the SSR shape the panel test uses), because all of them live
+ * behind an effect and a click.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+const getBrowserExtensionStatus = vi.fn();
+const pairBrowserExtension = vi.fn();
+vi.mock("@/lib/api/computer", () => ({
+  getBrowserExtensionStatus: (...a: unknown[]) => getBrowserExtensionStatus(...a),
+  pairBrowserExtension: (...a: unknown[]) => pairBrowserExtension(...a),
+}));
+
+const pairViaExtension = vi.fn();
+vi.mock("@/lib/browser-extension-bridge", () => ({
+  chromeMessenger: () => null,
+  pairViaExtension: (...a: unknown[]) => pairViaExtension(...a),
+}));
+
+const openWorkspaceSettings = vi.fn();
+vi.mock("@/components/settings-modal/settings-modal", () => ({
+  openWorkspaceSettings: (...a: unknown[]) => openWorkspaceSettings(...a),
+}));
+
+import { I18nProvider } from "@/lib/i18n/client";
+import { en } from "@/lib/i18n/dictionaries/en";
+import type { Dictionary } from "@/lib/i18n/dictionaries";
+import { ConnectBrowserRow } from "../connect-browser-row";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const dict = en as unknown as Dictionary;
+const c = en.computer.connectBrowser.sidebarRow;
+
+const PAIRING = { relayUrl: "wss://relay.example", pairingToken: "tok-1", expiresInSeconds: 600 };
+
+async function mount(): Promise<{ el: HTMLElement; root: Root }> {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  const root = createRoot(el);
+  await act(async () => {
+    root.render(
+      <I18nProvider locale="en" dict={dict}>
+        <ConnectBrowserRow workspaceId="ws-1" />
+      </I18nProvider>,
+    );
+  });
+  return { el, root };
+}
+
+async function click(el: HTMLElement) {
+  const button = el.querySelector("button");
+  if (!button) throw new Error("no button rendered");
+  await act(async () => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("[COMP:app-web/connect-browser-row] My Browser sidebar row", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pairBrowserExtension.mockResolvedValue(PAIRING);
+    pairViaExtension.mockResolvedValue("paired");
+  });
+
+  it("renders nothing where the deployment has no relay configured", async () => {
+    getBrowserExtensionStatus.mockResolvedValue({ configured: false, connected: false });
+    const { el } = await mount();
+    expect(el.querySelector("button")).toBeNull();
+  });
+
+  it("offers to connect once a configured-but-disconnected status resolves", async () => {
+    getBrowserExtensionStatus.mockResolvedValue({ configured: true, connected: false });
+    const { el } = await mount();
+    expect(el.textContent).toContain(c.connect);
+    expect(el.textContent).not.toContain(c.connectedBadge);
+  });
+
+  it("pairs in one click and flips to connected without opening Settings", async () => {
+    getBrowserExtensionStatus
+      .mockResolvedValueOnce({ configured: true, connected: false })
+      .mockResolvedValue({ configured: true, connected: true });
+    const { el } = await mount();
+
+    await click(el);
+
+    expect(pairBrowserExtension).toHaveBeenCalledWith("ws-1");
+    expect(pairViaExtension).toHaveBeenCalledWith(
+      expect.objectContaining({ relayUrl: PAIRING.relayUrl, pairingToken: PAIRING.pairingToken }),
+    );
+    expect(openWorkspaceSettings).not.toHaveBeenCalled();
+    expect(el.textContent).toContain(c.connected);
+    expect(el.textContent).toContain(c.connectedBadge);
+  });
+
+  it("falls back to the Settings panel when no extension answers", async () => {
+    getBrowserExtensionStatus.mockResolvedValue({ configured: true, connected: false });
+    pairViaExtension.mockResolvedValue("not_installed");
+    const { el } = await mount();
+
+    await click(el);
+
+    expect(openWorkspaceSettings).toHaveBeenCalledWith("ws-browser-profiles");
+  });
+
+  it("falls back to the Settings panel when the extension refuses", async () => {
+    getBrowserExtensionStatus.mockResolvedValue({ configured: true, connected: false });
+    pairViaExtension.mockResolvedValue("refused");
+    const { el } = await mount();
+
+    await click(el);
+
+    expect(openWorkspaceSettings).toHaveBeenCalledWith("ws-browser-profiles");
+  });
+
+  it("falls back to the Settings panel when the token mint itself fails", async () => {
+    getBrowserExtensionStatus.mockResolvedValue({ configured: true, connected: false });
+    pairBrowserExtension.mockResolvedValue(null);
+    const { el } = await mount();
+
+    await click(el);
+
+    expect(pairViaExtension).not.toHaveBeenCalled();
+    expect(openWorkspaceSettings).toHaveBeenCalledWith("ws-browser-profiles");
+  });
+
+  it("opens the panel to manage an already-connected browser instead of re-pairing", async () => {
+    getBrowserExtensionStatus.mockResolvedValue({ configured: true, connected: true });
+    const { el } = await mount();
+    expect(el.textContent).toContain(c.connectedBadge);
+
+    await click(el);
+
+    expect(pairBrowserExtension).not.toHaveBeenCalled();
+    expect(openWorkspaceSettings).toHaveBeenCalledWith("ws-browser-profiles");
+  });
+});

--- a/apps/app-web/src/components/doc/connect-browser-row.tsx
+++ b/apps/app-web/src/components/doc/connect-browser-row.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+/**
+ * "My Browser" sidebar row — connect or reconnect the local browser extension
+ * from the persistent chrome, without going through Settings.
+ *
+ * The pairing machinery already exists (`connect-browser-panel.tsx` +
+ * `lib/browser-extension-bridge.ts`, my-browser.md P1); what it lacked was a
+ * way in. The panel lives four levels deep — Settings → Workspace → Browser
+ * profiles → scroll — which is a long way to travel for the two moments that
+ * actually matter: connecting the first time, and reconnecting after Chrome
+ * has been restarted and the relay socket is gone. Both are one click here.
+ *
+ * The row sits directly under the icon nav, so it is reachable from every
+ * surface (the sidebar is mounted by `WorkspaceChrome`, above the surfaces).
+ * It renders nothing at all when the deployment has no relay configured
+ * (`status.configured === false`) or before the first status resolves — a
+ * permanently dead "Connect" button teaches people to ignore the row.
+ *
+ * Clicking while disconnected runs the same one-click path the panel uses:
+ * mint a token, hand it straight to the extension. Anything other than a
+ * clean pair (no extension, wrong build id, refused origin) falls back to
+ * opening the panel, which owns the install CTA and the copy-paste fields —
+ * this row never becomes a dead end. Clicking while connected opens the panel
+ * to manage the connection.
+ *
+ * [COMP:app-web/connect-browser-row]
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Globe } from "lucide-react";
+import { useT } from "@/lib/i18n/client";
+import { openWorkspaceSettings } from "@/components/settings-modal/settings-modal";
+import {
+  chromeMessenger,
+  pairViaExtension,
+} from "@/lib/browser-extension-bridge";
+import {
+  getBrowserExtensionStatus,
+  pairBrowserExtension,
+  type BrowserExtensionStatus,
+} from "@/lib/api/computer";
+
+/**
+ * The row is mounted for the whole session on every surface, so it polls far
+ * more slowly than the Settings panel (5s) — a socket that dropped is not
+ * urgent until someone looks. A window focus re-checks immediately, which is
+ * the moment that actually matters: the user has just come back from the
+ * extension popup or from restarting Chrome.
+ */
+const STATUS_POLL_MS = 60_000;
+
+export function ConnectBrowserRow({ workspaceId }: { workspaceId: string }) {
+  const c = useT().computer.connectBrowser.sidebarRow;
+
+  const [status, setStatus] = useState<BrowserExtensionStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  // Survives the await in `onConnect` — an unmount mid-pair must not set state.
+  const alive = useRef(true);
+
+  const refreshStatus = useCallback(async () => {
+    const next = await getBrowserExtensionStatus();
+    if (alive.current) setStatus(next);
+  }, []);
+
+  useEffect(() => {
+    alive.current = true;
+    void refreshStatus();
+    const id = setInterval(() => void refreshStatus(), STATUS_POLL_MS);
+    const onFocus = () => void refreshStatus();
+    window.addEventListener("focus", onFocus);
+    return () => {
+      alive.current = false;
+      clearInterval(id);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [refreshStatus]);
+
+  const connected = status?.connected === true;
+
+  const onClick = useCallback(async () => {
+    if (busy) return;
+    // Connected: nothing to pair, so the click is "let me look at this" —
+    // hand it to the panel, which owns profiles + disconnect.
+    if (connected || !workspaceId) {
+      openWorkspaceSettings("ws-browser-profiles");
+      return;
+    }
+    setBusy(true);
+    const pairing = await pairBrowserExtension(workspaceId);
+    if (!pairing) {
+      // The mint failed (relay down, 503). The panel surfaces the error copy;
+      // repeating it in a sidebar row would only shout the same thing twice.
+      if (alive.current) setBusy(false);
+      openWorkspaceSettings("ws-browser-profiles");
+      return;
+    }
+    const result = await pairViaExtension({
+      relayUrl: pairing.relayUrl,
+      pairingToken: pairing.pairingToken,
+      send: chromeMessenger(),
+    });
+    if (alive.current) setBusy(false);
+    if (result === "paired") {
+      await refreshStatus();
+      return;
+    }
+    // Not installed, wrong build id, or refused: the panel has the install CTA
+    // and the copy fields, and the token we just minted is still valid there.
+    openWorkspaceSettings("ws-browser-profiles");
+  }, [busy, connected, workspaceId, refreshStatus]);
+
+  // No relay on this deployment (OSS, or unconfigured) — and nothing rendered
+  // until the first probe answers, so the label never flips under the cursor.
+  if (!status?.configured) return null;
+
+  return (
+    <div className="px-2 pb-1.5">
+      <button
+        type="button"
+        onClick={() => void onClick()}
+        disabled={busy}
+        aria-label={connected ? c.manageAria : c.connectAria}
+        title={connected ? c.manageAria : c.connectAria}
+        className="flex h-7 w-full items-center gap-2 rounded-md px-2 text-left text-[13px] text-sidebar-foreground/80 hover:bg-sidebar-accent hover:text-sidebar-foreground disabled:opacity-60"
+      >
+        <Globe className="size-[15px] shrink-0" />
+        <span className="min-w-0 flex-1 truncate">
+          {busy ? c.connecting : connected ? c.connected : c.connect}
+        </span>
+        {connected && !busy ? (
+          <span className="flex shrink-0 items-center gap-1 text-[10px] font-medium text-muted-foreground">
+            <span className="size-1.5 rounded-full bg-primary" aria-hidden />
+            {c.connectedBadge}
+          </span>
+        ) : null}
+      </button>
+    </div>
+  );
+}

--- a/apps/app-web/src/components/doc/doc-sidebar.tsx
+++ b/apps/app-web/src/components/doc/doc-sidebar.tsx
@@ -79,6 +79,7 @@ import {
 import type { WorkspaceSurface } from "@/lib/doc-page-url";
 import { operatorAppFromSurface } from "@/lib/operator-apps";
 import { OperatorAppBar } from "./operator-app-bar";
+import { ConnectBrowserRow } from "./connect-browser-row";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -701,6 +702,13 @@ export function DocSidebar(props: Props) {
           feedEnabled={props.feedEnabled}
         />
       )}
+
+      {/* "My Browser" — connect / reconnect the local browser extension in one
+          click, from every surface. The pairing flow itself still lives in
+          Settings → Browser profiles; this row is the way in, and falls back to
+          opening that panel whenever one-click cannot finish. Renders nothing
+          where no relay is configured. See connect-browser-row.tsx. */}
+      <ConnectBrowserRow workspaceId={workspaceId} />
 
       {/* Search input — revealed by the Search icon (Home only). */}
       {searchOpen && props.activeSurface === "p" && (

--- a/apps/app-web/src/lib/i18n/dictionaries/en.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/en.ts
@@ -5925,6 +5925,14 @@ export const en = {
       copy: "Copy",
       copied: "Copied",
       refresh: "Refresh status",
+      sidebarRow: {
+        connect: "Connect my browser",
+        connecting: "Connecting...",
+        connected: "My Browser",
+        connectedBadge: "Connected",
+        connectAria: "Connect your own Chrome to Use Brian",
+        manageAria: "Manage the My Browser connection",
+      },
     },
     profiles: {
       title: "Browser profiles",

--- a/apps/app-web/src/lib/i18n/dictionaries/ja.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/ja.ts
@@ -5706,6 +5706,14 @@ export const ja: Dictionary = {
       copy: "コピー",
       copied: "コピーしました",
       refresh: "状態を更新",
+      sidebarRow: {
+        connect: "自分のブラウザを接続",
+        connecting: "接続中...",
+        connected: "マイブラウザ",
+        connectedBadge: "接続済み",
+        connectAria: "自分の Chrome を Use Brian に接続します",
+        manageAria: "マイブラウザの接続を管理します",
+      },
     },
     profiles: {
       title: "ブラウザプロフィール",

--- a/apps/app-web/src/lib/i18n/dictionaries/zh.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh.ts
@@ -5647,6 +5647,14 @@ export const zh: Dictionary = {
       copy: "複製",
       copied: "已複製",
       refresh: "重新整理狀態",
+      sidebarRow: {
+        connect: "連接我的瀏覽器",
+        connecting: "連接中...",
+        connected: "我的瀏覽器",
+        connectedBadge: "已連接",
+        connectAria: "將你自己的 Chrome 連接到 Use Brian",
+        manageAria: "管理我的瀏覽器連接",
+      },
     },
     profiles: {
       title: "瀏覽器身分",


### PR DESCRIPTION
## Why

One-click pairing landed in #83. What it lacked was a way in: the connect surface is at **Settings → Workspace → Browser profiles → scroll**, which is a long way to travel for the two moments that actually matter - connecting the first time, and **reconnecting** after Chrome restarts and the relay socket is gone.

## What

A **"My Browser"** row directly under the sidebar icon nav, so it is reachable from every surface (the sidebar is mounted above them by `WorkspaceChrome`).

- **Disconnected** - the row runs the same one-click path the panel uses: `pairBrowserExtension` mints a token, `pairViaExtension` hands it straight to the extension. No copying, no modal.
- **Connected** - status dot + "Connected"; clicking opens the panel to manage the connection.
- **Never a dead end** - no extension, a different build id, a refused origin, or a failed mint all fall back to opening the panel, which owns the install CTA and the copy-paste fields, with the freshly minted token still valid there.
- **Hidden where it would be dead** - renders nothing when the deployment has no relay configured (`status.configured === false`), and nothing before the first probe answers, so the label cannot flip under the cursor.
- **Polls at 60s**, not the panel's 5s: the row is mounted for the whole session on every surface, and a dropped socket is not urgent until someone looks. A **window focus** re-checks immediately, which is the moment that actually matters - the user has just come back from the extension popup or from restarting Chrome.

The pairing flow itself is not duplicated; this is an entry point to it.

## Tests

`components/doc/__tests__/connect-browser-row.test.tsx` (jsdom, 7 cases) covers every branch: hidden when unconfigured, offers connect when disconnected, one-click pair flips to connected without opening Settings, and the three fallbacks (`not_installed`, `refused`, failed mint) plus the connected-click manage path.

Copy added to `en.ts` / `ja.ts` / `zh.ts` in the same commit.

## Not yet verified live

Built against `origin/develop`. The reviewer's local checkout is worth a look in a browser with the extension installed - I could not drive that here because this machine's `use-brian` checkout predates `lib/browser-extension-bridge.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)