### PR TITLE
feat(billing): attribute spend to its originating episode + meter the sensitivity classifier

### DIFF
--- a/packages/api/src/routes/_overhead-usage.ts
+++ b/packages/api/src/routes/_overhead-usage.ts
@@ -44,7 +44,7 @@ export type RecordOverheadUsageParams = {
   /**
    * Seconds of audio this overhead call processed — see
    * UsageStore.recordUsage. Set by the voice-transcription paths so the
-   * admin rollup can price speech-to-text per audio hour. Migration 347.
+   * admin rollup can price speech-to-text per audio hour. Migration 353.
    */
   audioSeconds?: number
 }

--- a/packages/api/src/synthesis/synthesize.ts
+++ b/packages/api/src/synthesis/synthesize.ts
@@ -332,6 +332,12 @@ function recordCogs(
       // folds into the recording surcharge. See structural-synthesis.md.
       source: 'overhead:synthesis',
       triggerKey: 'structural_synthesis',
+      // ONLY for `recording`, where `sourceId` is genuinely an Episode id.
+      // For `brain` it is a draft subject and for `research` a workflow/step
+      // key — neither is an episode, and passing one would violate the
+      // migration-365 foreign key and fail the usage write (which is caught
+      // and logged, so it would silently lose the COGS row rather than throw).
+      ...(source.kind === 'recording' ? { sourceEpisodeId: source.sourceId } : {}),
     })
     .catch((err) => console.error('[synthesis] usage tracking failed:', err))
 }

--- a/packages/core/src/billing/cost-tracker.ts
+++ b/packages/core/src/billing/cost-tracker.ts
@@ -178,9 +178,25 @@ export type UsageStore = {
      * (recorded as NULL, which the admin rollup reports as an unknown rate
      * rather than a free one).
      *
-     * Optional — null on non-audio rows and on rows pre-migration 347.
+     * Optional — null on non-audio rows and on rows pre-migration 353.
      */
     audioSeconds?: number
+    /**
+     * Episode that CAUSED this spend — a recording, channel media, an
+     * ingested doc. The one axis the ledger lacked: `source` says who pays,
+     * `model_tier` how expensive a model, the derived category what
+     * capability, but none of them say what artifact triggered the call. A
+     * recording's cost fans out across transcription, brain ingest and
+     * synthesis under three different sources; without this they cannot be
+     * summed back to the recording, and measured in production the ingest
+     * tail cost MORE than the transcription line.
+     *
+     * Pass it wherever the originating episode is in hand. Optional and
+     * additive: most spend (a chat turn, an embedding batch) has no single
+     * origin and records NULL. Never inferred — a value here always means a
+     * measured attribution. Migration 365.
+     */
+    sourceEpisodeId?: string
     /**
      * Which API key drove the LLM call: the platform's (`platform`, the
      * default) or the workspace's bring-your-own key (`user`). BYO turns are

--- a/packages/core/src/ingest/__tests__/pipeline-b.test.ts
+++ b/packages/core/src/ingest/__tests__/pipeline-b.test.ts
@@ -1932,8 +1932,14 @@ describe('[COMP:brain/pipeline-b] extraction usage attribution', () => {
     ])
     await processEpisode(baseEpisode(), 'note', makeDeps({ provider, usage: usage.store }))
 
-    expect(usage.recordUsage).toHaveBeenCalledTimes(1)
-    const row = usage.recordUsage.mock.calls[0]![0]
+    // Two metered calls: the extraction, and the sensitivity classifier that
+    // runs once per episode. The classifier was computing its usage and
+    // returning it with no consumer anywhere in the repo, so it spent real
+    // tokens while staying invisible to the ledger.
+    const rows = usage.recordUsage.mock.calls.map((c) => c[0])
+    expect(rows).toHaveLength(2)
+
+    const row = rows.find((r) => r.source === 'overhead:extraction')!
     expect(row).toMatchObject({
       userId: 'u-1',
       assistantId: 'a-1',
@@ -1946,6 +1952,16 @@ describe('[COMP:brain/pipeline-b] extraction usage attribution', () => {
       triggerKey: 'pipeline_b_extraction',
     })
     expect(row.actualCostUsd).toBeGreaterThan(0)
+
+    // The classifier row rides an existing `valid_source` label, so metering
+    // it needed no migration; `trigger_key` keeps it separable from the
+    // routing classifiers that share that source.
+    const classifier = rows.find((r) => r.triggerKey === 'sensitivity_classifier')!
+    expect(classifier).toMatchObject({ source: 'overhead:classifier' })
+
+    // Both rows carry the originating episode, so a recording's full cost
+    // sums back to it (migration 354).
+    for (const r of rows) expect(r.sourceEpisodeId).toBe('ep-1')
   })
 
   it('still records when the model output fails to parse — the tokens were spent', async () => {

--- a/packages/core/src/ingest/pipeline-b.ts
+++ b/packages/core/src/ingest/pipeline-b.ts
@@ -869,6 +869,19 @@ async function recordExtractionUsage(
   deps: PipelineBDeps,
   episode: PipelineBEpisode,
   usage: TokenUsage | null,
+  /**
+   * Overrides for the non-extraction calls this ingest also makes. The
+   * sensitivity classifier fires once per episode and was computing its usage,
+   * returning it on `PipelineBResult.sensitivity.usage`, and finding no
+   * consumer anywhere in the repo — 2,827 unrecorded LLM calls over 90 days,
+   * roughly 59x the entire transcription bucket's row count. Cheap in dollars,
+   * but an unmetered call path is how a ledger starts drifting from reality.
+   *
+   * `overhead:classifier` is deliberate: it is already in `OVERHEAD_SOURCES`
+   * and the `valid_source` CHECK, so metering this needs no migration, and the
+   * `trigger_key` keeps it separable from the routing classifiers.
+   */
+  over: { model?: string; source?: string; triggerKey?: string } = {},
 ): Promise<void> {
   if (!deps.usage || !usage) return
   const userId = episode.createdByUserId || episode.userId
@@ -879,14 +892,19 @@ async function recordExtractionUsage(
       assistantId: episode.assistantId ?? '',
       workspaceId: episode.workspaceId,
       sessionId: null,
-      model: deps.model,
+      model: over.model ?? deps.model,
       inputTokens: usage.inputTokens,
       outputTokens: usage.outputTokens,
       cacheReadTokens: usage.cacheReadTokens,
       cacheWriteTokens: usage.cacheWriteTokens,
-      actualCostUsd: calculateCost(deps.model, usage),
-      source: 'overhead:extraction',
-      triggerKey: 'pipeline_b_extraction',
+      actualCostUsd: calculateCost(over.model ?? deps.model, usage),
+      source: over.source ?? 'overhead:extraction',
+      triggerKey: over.triggerKey ?? 'pipeline_b_extraction',
+      // The episode itself, NOT its parent. Rolling up to the originating
+      // recording is `COALESCE(parent_episode_id, id)` at query time — cheap
+      // at the current depth of 1, and it keeps which child drove the spend,
+      // which a denormalized root would discard permanently.
+      sourceEpisodeId: episode.id,
     })
   } catch (err) {
     console.warn(
@@ -1371,6 +1389,19 @@ export async function processEpisode(
           summary: payload.summary,
           memories: memoriesWritten.map((m) => ({ summary: m.summary })),
         },
+      })
+      // Meter it. This call was invisible to the ledger until migration 365's
+      // audit; it fires once per ingested episode, so it is the highest-count
+      // LLM call in the system. Best-effort, exactly like extraction — a
+      // metering failure must never break ingestion.
+      // `classifySensitivity` returns NULL when it throws internally, so this
+      // must be null-safe: metering is instrumentation and may never be the
+      // thing that breaks an ingest. `recordExtractionUsage` already no-ops on
+      // a null usage, so the guard only has to survive the property read.
+      await recordExtractionUsage(deps, episode, sensitivity?.usage ?? null, {
+        model: sensitivity?.model ?? classifierModel,
+        source: 'overhead:classifier',
+        triggerKey: 'sensitivity_classifier',
       })
     }
   }

--- a/packages/core/src/media/transcribe-recording.ts
+++ b/packages/core/src/media/transcribe-recording.ts
@@ -146,8 +146,9 @@ export type RecordingTranscriptionResult = {
    *  `audioSeconds` is the duration THIS entry covers — per window, not per
    *  file, so a windowed transcriber's entries sum to the file duration
    *  instead of multiplying it. Providers that cannot attribute duration to a
-   *  window leave it unset; the ingest path then falls back to the file
-   *  duration only when there is exactly one entry to attribute it to. */
+   *  window leave it unset; the ingest path then shares the file duration
+   *  evenly across every entry that did not self-report, so the set still sums
+   *  to the file and every row stays metered (see `ingest-recording.ts`). */
   usages: Array<{ usage: TokenUsage | null; model: string; costUsd?: number; audioSeconds?: number }>
   /** Number of continuation windows used (1 = no continuation). */
   windows: number


### PR DESCRIPTION
## Why

`usage_tracking` could say **who** paid, **when**, **which model**, and (since the category axis) **what capability** the money bought — never **what caused** the spend.

A recording's cost fans out across transcription (`voice_stt`), brain ingest (`memory`) and synthesis (`synthesis`) under three unrelated sources. Measured against production on 2026-07-23 for a 6-recording / 9.9-audio-hour window:

| Line | Cost | Bucket |
|---|---:|---|
| Transcription | $2.13 | `voice_stt` |
| Brain ingest | $3.37 | `memory` |
| Synthesis | $0.18 | `synthesis` |

The brain-ingest tail costs **more than transcription**, so the visible recording cost was under half the true one. Extraction ran at 3.1x its baseline daily rate during the window.

## What

- **`sourceEpisodeId` on `UsageStore.recordUsage`** (platform migration `365` adds the column). Passed at the two sites here that already held the id and discarded it: pipeline-b extraction (`episode.id`) and structural synthesis.
- **Synthesis is guarded on `kind === 'recording'`.** `sourceId` is a draft subject for `brain` and a workflow key for `research` — neither is an episode. Passing one would violate the FK and *silently lose the COGS row*, since that write is catch-and-log.
- **Stores the exact episode, not a denormalized root.** Rolling up is `COALESCE(parent_episode_id, id)` at query time — cheap at the current depth of 1, and it keeps which child drove the spend.
- **Sensitivity classifier is now metered.** ~2,827 calls / 90 days (≈59x the entire transcription bucket's row count) that computed usage, returned it on `PipelineBResult.sensitivity.usage`, and had no consumer anywhere. Records under the existing `overhead:classifier` source (no `valid_source` migration needed) with `triggerKey: 'sensitivity_classifier'`.
- The classifier write is **null-safe** — `classifySensitivity` returns NULL on internal failure, and metering must never break an ingest. A test caught this.

## Test plan

- `pnpm --filter @use-brian/core exec vitest run src/ingest src/media` → **534 passed**, 18 skipped
- Existing pipeline-b usage tests updated to assert both rows (extraction + classifier) and the episode attribution, rather than the previous "exactly one usage row"

## Notes

Pairs with the platform PR that adds migration `365` and the per-recording margin rollup. Merge this first so the platform gitlink can point at a merged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)