### PR TITLE
feat(ext): ask for browser control instead of taking it at install

### DIFF
--- a/apps/app-web/src/components/doc/__tests__/connect-browser-row.test.tsx
+++ b/apps/app-web/src/components/doc/__tests__/connect-browser-row.test.tsx
@@ -21,9 +21,13 @@ vi.mock("@/lib/api/computer", () => ({
 }));
 
 const pairViaExtension = vi.fn();
+const extensionHasControl = vi.fn();
+const requestBrowserControl = vi.fn();
 vi.mock("@/lib/browser-extension-bridge", () => ({
   chromeMessenger: () => null,
   pairViaExtension: (...a: unknown[]) => pairViaExtension(...a),
+  extensionHasControl: (...a: unknown[]) => extensionHasControl(...a),
+  requestBrowserControl: (...a: unknown[]) => requestBrowserControl(...a),
 }));
 
 const openWorkspaceSettings = vi.fn();
@@ -70,6 +74,8 @@ describe("[COMP:app-web/connect-browser-row] My Browser sidebar row", () => {
     vi.clearAllMocks();
     pairBrowserExtension.mockResolvedValue(PAIRING);
     pairViaExtension.mockResolvedValue("paired");
+    extensionHasControl.mockResolvedValue(true);
+    requestBrowserControl.mockResolvedValue("prompted");
   });
 
   it("renders nothing where the deployment has no relay configured", async () => {
@@ -131,6 +137,44 @@ describe("[COMP:app-web/connect-browser-row] My Browser sidebar row", () => {
 
     expect(pairViaExtension).not.toHaveBeenCalled();
     expect(openWorkspaceSettings).toHaveBeenCalledWith("ws-browser-profiles");
+  });
+
+  it("asks for browser control when the extension is paired but not allowed", async () => {
+    getBrowserExtensionStatus.mockResolvedValue({ configured: true, connected: true });
+    extensionHasControl.mockResolvedValue(false);
+    const { el } = await mount();
+
+    expect(el.textContent).toContain(c.allow);
+    // "Connected" would be a lie here: the socket is up but nothing can run.
+    expect(el.textContent).not.toContain(c.connectedBadge);
+
+    await click(el);
+
+    expect(requestBrowserControl).toHaveBeenCalled();
+    expect(pairBrowserExtension).not.toHaveBeenCalled();
+    expect(openWorkspaceSettings).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the panel if the extension stops answering before the allow click", async () => {
+    getBrowserExtensionStatus.mockResolvedValue({ configured: true, connected: true });
+    extensionHasControl.mockResolvedValue(false);
+    requestBrowserControl.mockResolvedValue("not_installed");
+    const { el } = await mount();
+
+    await click(el);
+
+    expect(openWorkspaceSettings).toHaveBeenCalledWith("ws-browser-profiles");
+  });
+
+  it("never shows the allow state when no extension answered the control probe", async () => {
+    // `null` is "we could not ask", not "not granted" — nagging someone to
+    // allow something on a machine with no extension is worse than silence.
+    getBrowserExtensionStatus.mockResolvedValue({ configured: true, connected: true });
+    extensionHasControl.mockResolvedValue(null);
+    const { el } = await mount();
+
+    expect(el.textContent).not.toContain(c.allow);
+    expect(el.textContent).toContain(c.connectedBadge);
   });
 
   it("opens the panel to manage an already-connected browser instead of re-pairing", async () => {

--- a/apps/app-web/src/components/doc/connect-browser-row.tsx
+++ b/apps/app-web/src/components/doc/connect-browser-row.tsx
@@ -33,7 +33,9 @@ import { useT } from "@/lib/i18n/client";
 import { openWorkspaceSettings } from "@/components/settings-modal/settings-modal";
 import {
   chromeMessenger,
+  extensionHasControl,
   pairViaExtension,
+  requestBrowserControl,
 } from "@/lib/browser-extension-bridge";
 import {
   getBrowserExtensionStatus,
@@ -54,13 +56,29 @@ export function ConnectBrowserRow({ workspaceId }: { workspaceId: string }) {
   const c = useT().computer.connectBrowser.sidebarRow;
 
   const [status, setStatus] = useState<BrowserExtensionStatus | null>(null);
+  /**
+   * Whether the extension holds the optional `debugger` grant. `null` means no
+   * extension answered, which is NOT the same as "not granted" — nagging a user
+   * to allow something on a machine with no extension installed is worse than
+   * saying nothing, so only an explicit `false` shows the allow state.
+   */
+  const [hasControl, setHasControl] = useState<boolean | null>(null);
   const [busy, setBusy] = useState(false);
   // Survives the await in `onConnect` — an unmount mid-pair must not set state.
   const alive = useRef(true);
 
   const refreshStatus = useCallback(async () => {
     const next = await getBrowserExtensionStatus();
-    if (alive.current) setStatus(next);
+    if (!alive.current) return;
+    setStatus(next);
+    // Only worth asking the extension once the relay says this user has one
+    // connected; off that path the probe is a guaranteed null.
+    if (!next.connected) {
+      setHasControl(null);
+      return;
+    }
+    const control = await extensionHasControl({ send: chromeMessenger() });
+    if (alive.current) setHasControl(control);
   }, []);
 
   useEffect(() => {
@@ -77,9 +95,26 @@ export function ConnectBrowserRow({ workspaceId }: { workspaceId: string }) {
   }, [refreshStatus]);
 
   const connected = status?.connected === true;
+  // Paired, but the user has not granted browser control. Only an explicit
+  // `false` counts — see `hasControl`.
+  const needsControl = connected && hasControl === false;
 
   const onClick = useCallback(async () => {
     if (busy) return;
+    // Paired but not allowed to drive: the one thing worth doing is asking for
+    // the permission. Chrome will not let a web page raise its own prompt, so
+    // the extension opens the window that can and the user clicks Allow there.
+    if (needsControl) {
+      setBusy(true);
+      const result = await requestBrowserControl({ send: chromeMessenger() });
+      if (alive.current) setBusy(false);
+      // `not_installed` here means the extension stopped answering between the
+      // probe and the click. The panel is the honest fallback: it owns the
+      // install CTA, which is the actual remedy.
+      if (result === "not_installed") openWorkspaceSettings("ws-browser-profiles");
+      else await refreshStatus();
+      return;
+    }
     // Connected: nothing to pair, so the click is "let me look at this" —
     // hand it to the panel, which owns profiles + disconnect.
     if (connected || !workspaceId) {
@@ -108,7 +143,7 @@ export function ConnectBrowserRow({ workspaceId }: { workspaceId: string }) {
     // Not installed, wrong build id, or refused: the panel has the install CTA
     // and the copy fields, and the token we just minted is still valid there.
     openWorkspaceSettings("ws-browser-profiles");
-  }, [busy, connected, workspaceId, refreshStatus]);
+  }, [busy, connected, needsControl, workspaceId, refreshStatus]);
 
   // No relay on this deployment (OSS, or unconfigured) — and nothing rendered
   // until the first probe answers, so the label never flips under the cursor.
@@ -120,15 +155,23 @@ export function ConnectBrowserRow({ workspaceId }: { workspaceId: string }) {
         type="button"
         onClick={() => void onClick()}
         disabled={busy}
-        aria-label={connected ? c.manageAria : c.connectAria}
-        title={connected ? c.manageAria : c.connectAria}
+        aria-label={
+          needsControl ? c.allowAria : connected ? c.manageAria : c.connectAria
+        }
+        title={needsControl ? c.allowAria : connected ? c.manageAria : c.connectAria}
         className="flex h-7 w-full items-center gap-2 rounded-md px-2 text-left text-[13px] text-sidebar-foreground/80 hover:bg-sidebar-accent hover:text-sidebar-foreground disabled:opacity-60"
       >
         <Globe className="size-[15px] shrink-0" />
         <span className="min-w-0 flex-1 truncate">
-          {busy ? c.connecting : connected ? c.connected : c.connect}
+          {busy
+            ? c.connecting
+            : needsControl
+              ? c.allow
+              : connected
+                ? c.connected
+                : c.connect}
         </span>
-        {connected && !busy ? (
+        {connected && !needsControl && !busy ? (
           <span className="flex shrink-0 items-center gap-1 text-[10px] font-medium text-muted-foreground">
             <span className="size-1.5 rounded-full bg-primary" aria-hidden />
             {c.connectedBadge}

--- a/apps/app-web/src/lib/browser-extension-bridge.ts
+++ b/apps/app-web/src/lib/browser-extension-bridge.ts
@@ -75,6 +75,54 @@ export async function detectExtension(opts: {
   return response?.ok === true;
 }
 
+/**
+ * Ask the extension to open its browser-control permission window.
+ *
+ * A web page can never raise Chrome's permission prompt itself:
+ * `chrome.permissions.request()` is extension-only and must run inside a user
+ * gesture in an extension context. So this asks the extension to open the one
+ * page with a button that can. The user still clicks Allow there and then
+ * accepts Chrome's own dialog; sending this grants nothing on its own.
+ *
+ * `already_granted` is kept distinct from `prompted` on purpose - telling
+ * someone to go and allow something they already allowed is how a working
+ * feature reads as broken.
+ */
+export type ControlPromptResult = "prompted" | "already_granted" | "not_installed";
+
+export async function requestBrowserControl(opts: {
+  extensionId?: string;
+  send: ExtensionMessenger | null;
+}): Promise<ControlPromptResult> {
+  const extensionId = opts.extensionId ?? EXTENSION_ID;
+  if (!extensionId || !opts.send) return "not_installed";
+  const response = (await ask(opts.send, extensionId, { type: "request-control" })) as
+    | { ok?: boolean; hasControl?: boolean }
+    | null;
+  if (response === null || response.ok !== true) return "not_installed";
+  return response.hasControl === true ? "already_granted" : "prompted";
+}
+
+/**
+ * Whether the extension currently holds the browser-control grant. `null` when
+ * nothing answered — a caller must not read "no answer" as "not granted" and
+ * start nagging about an install that is not there.
+ */
+export async function extensionHasControl(opts: {
+  extensionId?: string;
+  send: ExtensionMessenger | null;
+}): Promise<boolean | null> {
+  const extensionId = opts.extensionId ?? EXTENSION_ID;
+  if (!extensionId || !opts.send) return null;
+  const response = (await ask(opts.send, extensionId, { type: "status" })) as
+    | { ok?: boolean; hasControl?: boolean }
+    | null;
+  if (response === null || response.ok !== true) return null;
+  // An older extension build has no `hasControl` and held the permission from
+  // install, so absence means granted — never "missing".
+  return response.hasControl !== false;
+}
+
 export async function pairViaExtension(opts: {
   extensionId?: string;
   relayUrl: string;

--- a/apps/app-web/src/lib/i18n/dictionaries/en.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/en.ts
@@ -5931,6 +5931,8 @@ export const en = {
         connected: "My Browser",
         connectedBadge: "Connected",
         connectAria: "Connect your own Chrome to Use Brian",
+        allow: "Allow browser control",
+        allowAria: "Allow Use Brian to manage this browser",
         manageAria: "Manage the My Browser connection",
       },
     },

--- a/apps/app-web/src/lib/i18n/dictionaries/ja.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/ja.ts
@@ -5712,6 +5712,8 @@ export const ja: Dictionary = {
         connected: "マイブラウザ",
         connectedBadge: "接続済み",
         connectAria: "自分の Chrome を Use Brian に接続します",
+        allow: "ブラウザの操作を許可",
+        allowAria: "Use Brian にこのブラウザの操作を許可します",
         manageAria: "マイブラウザの接続を管理します",
       },
     },

--- a/apps/app-web/src/lib/i18n/dictionaries/zh.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh.ts
@@ -5653,6 +5653,8 @@ export const zh: Dictionary = {
         connected: "我的瀏覽器",
         connectedBadge: "已連接",
         connectAria: "將你自己的 Chrome 連接到 Use Brian",
+        allow: "允許操作瀏覽器",
+        allowAria: "允許 Use Brian 操作這個瀏覽器",
         manageAria: "管理我的瀏覽器連接",
       },
     },

--- a/apps/browser-extension/src/__tests__/browser-control-permission.test.ts
+++ b/apps/browser-extension/src/__tests__/browser-control-permission.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  BROWSER_CONTROL_PERMISSIONS,
+  hasBrowserControl,
+  requestBrowserControl,
+} from '../browser-control-permission.js'
+
+/**
+ * The grant check has to fail SAFE in both directions, and the two directions
+ * are opposites: an unreadable state must not claim the user granted control
+ * (we would then drive a browser we have no permission for and surface a raw
+ * Chrome error), and a failed ask must not be mistaken for a grant.
+ */
+describe('[COMP:ext/browser-control-permission] Optional debugger permission', () => {
+  it('asks Chrome for exactly the debugger permission, nothing bundled', async () => {
+    const request = vi.fn(async () => true)
+    await requestBrowserControl({ contains: async () => false, request })
+    expect(request).toHaveBeenCalledWith({ permissions: ['debugger'] })
+    expect([...BROWSER_CONTROL_PERMISSIONS]).toEqual(['debugger'])
+  })
+
+  it('reports a granted permission', async () => {
+    const granted = await hasBrowserControl({ contains: async () => true, request: async () => true })
+    expect(granted).toBe(true)
+  })
+
+  it('reports a missing permission', async () => {
+    const granted = await hasBrowserControl({ contains: async () => false, request: async () => true })
+    expect(granted).toBe(false)
+  })
+
+  it('treats an unreadable permission state as NOT granted', async () => {
+    const granted = await hasBrowserControl({
+      contains: async () => {
+        throw new Error('no permissions API')
+      },
+      request: async () => true,
+    })
+    expect(granted).toBe(false)
+  })
+
+  it('treats a throwing request (no user gesture) as a refusal, never a grant', async () => {
+    const ok = await requestBrowserControl({
+      contains: async () => false,
+      request: async () => {
+        throw new Error('This function must be called during a user gesture')
+      },
+    })
+    expect(ok).toBe(false)
+  })
+
+  it('passes the user’s refusal straight through', async () => {
+    const ok = await requestBrowserControl({ contains: async () => false, request: async () => false })
+    expect(ok).toBe(false)
+  })
+})

--- a/apps/browser-extension/src/__tests__/manifest.test.ts
+++ b/apps/browser-extension/src/__tests__/manifest.test.ts
@@ -14,7 +14,9 @@ const manifest = JSON.parse(
   readFileSync(fileURLToPath(new URL('../../static/manifest.json', import.meta.url)), 'utf8'),
 ) as {
   permissions?: string[]
+  optional_permissions?: string[]
   host_permissions?: string[]
+  optional_host_permissions?: string[]
   externally_connectable?: { matches?: string[] }
   content_scripts?: unknown[]
 }
@@ -24,17 +26,50 @@ describe('[COMP:ext/agent] Manifest — narrow permissions (my-browser.md §6)',
     expect(manifest.host_permissions ?? []).toEqual([])
   })
 
+  it('requests no OPTIONAL host permissions either', () => {
+    // An optional host grant is still a host grant once accepted, and it would
+    // be asked for at the moment a user is most inclined to say yes to
+    // anything. The §6 refusal has to cover both lists or it covers neither.
+    expect(manifest.optional_host_permissions ?? []).toEqual([])
+  })
+
   it('never grants <all_urls> in any permission list', () => {
-    const all = [...(manifest.permissions ?? []), ...(manifest.host_permissions ?? [])]
+    const all = [
+      ...(manifest.permissions ?? []),
+      ...(manifest.optional_permissions ?? []),
+      ...(manifest.host_permissions ?? []),
+      ...(manifest.optional_host_permissions ?? []),
+    ]
     expect(all).not.toContain('<all_urls>')
   })
 
   it('keeps only the narrow permission set', () => {
-    expect(new Set(manifest.permissions)).toEqual(new Set(['debugger', 'tabs', 'storage']))
+    expect(new Set(manifest.permissions)).toEqual(new Set(['tabs', 'storage']))
   })
 
   it('declares no content scripts', () => {
     expect(manifest.content_scripts ?? []).toEqual([])
+  })
+})
+
+/**
+ * Browser control is asked for, not assumed. `debugger` is the capability that
+ * actually drives the browser, so it is the one a user should grant
+ * deliberately, be able to refuse while keeping the extension, and take back
+ * from chrome://extensions without losing their pairing. At install it bought
+ * them nothing to accept — nothing works until they pair anyway — while making
+ * the scariest grant the price of entry.
+ *
+ * Locks both halves: `debugger` stays out of the install-time set, and the
+ * optional list does not quietly become a second place grants accumulate.
+ */
+describe('[COMP:ext/browser-control-permission] Manifest — debugger is opt-in', () => {
+  it('does not take browser control at install time', () => {
+    expect(manifest.permissions ?? []).not.toContain('debugger')
+  })
+
+  it('offers browser control as the only optional permission', () => {
+    expect(new Set(manifest.optional_permissions)).toEqual(new Set(['debugger']))
   })
 })
 

--- a/apps/browser-extension/src/__tests__/popup-status.test.ts
+++ b/apps/browser-extension/src/__tests__/popup-status.test.ts
@@ -34,6 +34,25 @@ describe('[COMP:ext/agent] Popup status line', () => {
     )
   })
 
+  it('outranks a healthy socket when browser control has not been granted', () => {
+    // The exact lie this status line exists to stop telling: the relay is up so
+    // the socket reads "Connected", while every task refuses.
+    const line = statusLine({ state: 'ready', hasControl: false })
+    expect(line).not.toContain('Connected.')
+    expect(line.toLowerCase()).toContain('not allowed to manage this browser')
+    // It outranks the stopped label too — a grant the user never gave is the
+    // thing they have to fix first.
+    expect(statusLine({ state: 'ready', stopped: true, hasControl: false })).toBe(line)
+  })
+
+  it('treats an older background with no hasControl field as granted', () => {
+    // The field is absent when the popup is newer than the service worker
+    // mid-upgrade. Inventing a permission warning there would send the user
+    // hunting for a button to grant something they already have.
+    expect(statusLine({ state: 'ready' })).toContain('Connected.')
+    expect(statusLine({ state: 'ready', hasControl: true })).toContain('Connected.')
+  })
+
   it('falls back to the raw state rather than rendering nothing', () => {
     expect(statusLine({ state: 'some-future-state' })).toContain('some-future-state')
     expect(statusLine({})).toContain('Not paired')

--- a/apps/browser-extension/src/background.ts
+++ b/apps/browser-extension/src/background.ts
@@ -9,8 +9,25 @@ import { TabExecutor, ExecutorError, isDetachedError, retryableAfterReattach } f
 import { TaskGate, CONSENT_PROMPT_TIMEOUT_MS, type ConsentOutcome } from './task-gate.js'
 import { eligibilityOf } from './tab-eligibility.js'
 import { credentialsForConfigure, isTrustedPairingOrigin, type PairRequest } from './pairing.js'
+import { hasBrowserControl } from './browser-control-permission.js'
 
 const executor = new TabExecutor()
+
+/**
+ * Open the browser-control permission window. The prompt itself cannot be
+ * raised from here — `chrome.permissions.request()` needs a user gesture in an
+ * extension context — so this opens the one page that has a button to do it.
+ * Sized like the consent window so the two read as the same family.
+ */
+async function openGrantWindow(): Promise<void> {
+  await chrome.windows.create({
+    url: chrome.runtime.getURL('grant.html'),
+    type: 'popup',
+    width: 400,
+    height: 250,
+    focused: true,
+  })
+}
 
 // ── Consent prompt: a small extension window with Allow / Deny ──
 
@@ -141,6 +158,18 @@ async function executeOp(op: string, args: Record<string, unknown>): Promise<unk
 }
 
 async function dispatch(op: string, args: Record<string, unknown>): Promise<unknown> {
+  // Browser control is an OPTIONAL permission now, so it can genuinely be
+  // absent here. Say so in the one word the assistant can act on; without this
+  // the first CDP call fails with Chrome's own "Cannot access" wording, which
+  // reads like the website blocked us rather than "you have not allowed this
+  // yet" — the same misdiagnosis the detach path exists to prevent.
+  if (!(await hasBrowserControl())) {
+    void openGrantWindow()
+    throw new ExecutorError(
+      'Use Brian is not allowed to manage this browser yet. Allow it in the window that just opened, or from the extension popup.',
+      'no_browser_permission',
+    )
+  }
   const tabId = await gate.requireTab()
   await executor.attach(tabId)
   switch (op) {
@@ -208,14 +237,21 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     client.stop()
     sendResponse({ ok: true })
   } else if (msg.type === 'status') {
-    sendResponse({
-      state: client.getState(),
-      controlledTab: gate.currentTab(),
-      stopped: gate.isStopped(),
-      // Shown in the popup so a self-hoster can point their own deployment at
-      // this install without digging through chrome://extensions.
-      extensionId: chrome.runtime.id,
-    })
+    void (async () => {
+      sendResponse({
+        state: client.getState(),
+        controlledTab: gate.currentTab(),
+        stopped: gate.isStopped(),
+        // Whether the user has granted browser control. The popup paints its
+        // Allow button off this, so a paired-but-not-allowed install stops
+        // claiming it is ready to work.
+        hasControl: await hasBrowserControl(),
+        // Shown in the popup so a self-hoster can point their own deployment at
+        // this install without digging through chrome://extensions.
+        extensionId: chrome.runtime.id,
+      })
+    })()
+    return true // async sendResponse
   }
   return undefined
 })
@@ -246,9 +282,35 @@ chrome.runtime.onMessageExternal.addListener((message, sender, sendResponse) => 
   }
   if (msg.type === 'status') {
     // Lets the connect panel say "installed but not paired" instead of
-    // guessing from the relay's server-side view alone.
-    sendResponse({ ok: true, state: client.getState(), stopped: gate.isStopped() })
-    return undefined
+    // guessing from the relay's server-side view alone. `hasControl` adds the
+    // third state the web app needs: paired, but not yet allowed to drive.
+    void (async () => {
+      sendResponse({
+        ok: true,
+        state: client.getState(),
+        stopped: gate.isStopped(),
+        hasControl: await hasBrowserControl(),
+      })
+    })()
+    return true // async sendResponse
+  }
+  /**
+   * The web app cannot raise Chrome's permission prompt itself — the API is
+   * extension-only and needs a user gesture in an extension context. So the
+   * sidebar's "Allow browser control" asks us to open the window that can.
+   * This grants the sender nothing: it opens our own page and the user still
+   * has to click Allow and then accept Chrome's own dialog.
+   */
+  if (msg.type === 'request-control') {
+    void (async () => {
+      if (await hasBrowserControl()) {
+        sendResponse({ ok: true, hasControl: true })
+        return
+      }
+      await openGrantWindow()
+      sendResponse({ ok: true, hasControl: false, prompted: true })
+    })()
+    return true // async sendResponse
   }
   sendResponse({ ok: false, error: 'unsupported' })
   return undefined

--- a/apps/browser-extension/src/browser-control-permission.ts
+++ b/apps/browser-extension/src/browser-control-permission.ts
@@ -1,0 +1,68 @@
+/**
+ * The `debugger` permission — "may Use Brian manage this browser" — asked for
+ * at the moment the user chooses it, not silently granted at install.
+ *
+ * It used to sit in the manifest's required `permissions`, so accepting the
+ * install accepted browser control forever, bundled with everything else and
+ * revocable only by uninstalling. It is now an **optional** permission: Chrome
+ * shows its own prompt when we ask, the user can say no and still keep the
+ * extension, and they can revoke it later from chrome://extensions without
+ * losing their pairing. That is a narrower grant than before, in the same
+ * spirit as the §6 refusal of `<all_urls>` (my-browser.md).
+ *
+ * Two Chrome constraints shape every caller:
+ *  - `permissions.request()` works ONLY from an extension context, so our web
+ *    app can never raise this prompt itself. It asks the background to open
+ *    `grant.html`, and the click in THAT window does the asking.
+ *  - `permissions.request()` must run inside a real user gesture. Calling it
+ *    from a message handler or on load throws; it has to hang off a click.
+ *
+ * The API is injected so the decision logic is testable outside Chrome.
+ */
+
+/** The slice of `chrome.permissions` this module needs. */
+export type PermissionsApi = {
+  contains(p: { permissions: string[] }): Promise<boolean>;
+  request(p: { permissions: string[] }): Promise<boolean>;
+};
+
+/** The one capability that means "can drive this browser". */
+export const BROWSER_CONTROL_PERMISSIONS = ['debugger'] as const;
+
+function api(explicit?: PermissionsApi): PermissionsApi | null {
+  if (explicit) return explicit;
+  const p = (globalThis as { chrome?: { permissions?: PermissionsApi } }).chrome?.permissions;
+  return p && typeof p.contains === 'function' ? p : null;
+}
+
+/**
+ * Has the user granted browser control? A missing `chrome.permissions` (an old
+ * Chrome, a non-extension context) answers **false** rather than throwing: the
+ * callers use this to decide whether to offer the prompt, and offering it
+ * needlessly is a far smaller harm than crashing the popup.
+ */
+export async function hasBrowserControl(explicit?: PermissionsApi): Promise<boolean> {
+  const p = api(explicit);
+  if (!p) return false;
+  try {
+    return await p.contains({ permissions: [...BROWSER_CONTROL_PERMISSIONS] });
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Ask Chrome to show the permission prompt. MUST be called from inside a user
+ * gesture (a click handler) — see the module note. Returns whether the user
+ * granted it; a throw (no gesture, no API) is reported as "not granted" so a
+ * caller never treats a failed ask as a grant.
+ */
+export async function requestBrowserControl(explicit?: PermissionsApi): Promise<boolean> {
+  const p = api(explicit);
+  if (!p) return false;
+  try {
+    return await p.request({ permissions: [...BROWSER_CONTROL_PERMISSIONS] });
+  } catch {
+    return false;
+  }
+}

--- a/apps/browser-extension/src/grant.ts
+++ b/apps/browser-extension/src/grant.ts
@@ -1,0 +1,45 @@
+/**
+ * Browser-control permission window: the one place Chrome's own permission
+ * prompt can be raised.
+ *
+ * `chrome.permissions.request()` only runs from an extension context, inside a
+ * real user gesture — so neither our web app nor the background service worker
+ * can ask on the user's behalf. The sidebar's "Allow browser control" opens
+ * THIS window, and the click below is the gesture Chrome requires.
+ *
+ * Closing on grant is deliberate: the prompt is the whole content of the
+ * window, and leaving a dead "Allow" button on screen after a grant reads as
+ * "it didn't work".
+ */
+import { hasBrowserControl, requestBrowserControl } from './browser-control-permission.js'
+
+function note(text: string, isError = false): void {
+  const el = document.getElementById('note')
+  if (!el) return
+  el.textContent = text
+  el.classList.toggle('error', isError)
+}
+
+document.getElementById('grant')?.addEventListener('click', () => {
+  // No `await` before the request: anything asynchronous here would spend the
+  // user gesture Chrome requires, and the prompt would throw instead of open.
+  void requestBrowserControl().then(async (granted) => {
+    if (granted) {
+      window.close()
+      return
+    }
+    // Distinguish "you said no" from "Chrome would not ask" — only the first is
+    // something the user can change their mind about right here.
+    const already = await hasBrowserControl()
+    if (already) {
+      window.close()
+      return
+    }
+    note(
+      'Not allowed. Use Brian cannot drive your browser until you allow it. You can press Allow again.',
+      true,
+    )
+  })
+})
+
+document.getElementById('cancel')?.addEventListener('click', () => window.close())

--- a/apps/browser-extension/src/popup-status.ts
+++ b/apps/browser-extension/src/popup-status.ts
@@ -12,6 +12,12 @@ export type PopupStatus = {
   state?: string
   controlledTab?: number | null
   stopped?: boolean
+  /**
+   * Whether the user has granted the optional `debugger` permission. Undefined
+   * from an older background build; treated as granted there so an upgrade
+   * cannot invent a permission warning the user cannot act on.
+   */
+  hasControl?: boolean
 }
 
 const STATE_LABELS: Record<string, string> = {
@@ -28,7 +34,15 @@ const STATE_LABELS: Record<string, string> = {
 const STOPPED_LABEL =
   'Task stopped. The next request will ask your permission again — no need to reload the extension.'
 
+const NO_CONTROL_LABEL =
+  'Not allowed to manage this browser yet. Press Allow below — Chrome will ask you to confirm.'
+
 export function statusLine(status: PopupStatus): string {
+  // A missing browser-control grant outranks everything, including a healthy
+  // socket: the relay says "connected" while every task refuses, which is the
+  // same lie the Stop case below exists to stop telling. `undefined` means an
+  // older background that had the permission at install, so it is not a gap.
+  if (status.hasControl === false) return NO_CONTROL_LABEL
   // A stopped gate wins over every socket state: nothing is being controlled,
   // so the tab note would be wrong as well as the "Connected" line.
   if (status.stopped) return STOPPED_LABEL

--- a/apps/browser-extension/src/popup.ts
+++ b/apps/browser-extension/src/popup.ts
@@ -1,5 +1,6 @@
 /** Popup UI: connect/disconnect the relay pairing + the persistent Stop (P1.7). */
 import { statusLine, type PopupStatus } from './popup-status.js'
+import { requestBrowserControl } from './browser-control-permission.js'
 
 function el<T extends HTMLElement>(id: string): T {
   const node = document.getElementById(id)
@@ -11,19 +12,29 @@ const statusBox = el<HTMLDivElement>('status')
 const statusText = el<HTMLSpanElement>('status-text')
 const relayUrlInput = el<HTMLInputElement>('relay-url')
 const tokenInput = el<HTMLInputElement>('pairing-token')
+const grantRow = el<HTMLDivElement>('grant-row')
 
 async function refreshStatus(): Promise<void> {
   const status = ((await chrome.runtime.sendMessage({ type: 'status' })) ?? {}) as PopupStatus
-  // "Ready" is the socket AND the gate: a held Stop is not a working browser,
-  // so it must not paint the green state either.
-  statusBox.classList.toggle('ready', status.state === 'ready' && !status.stopped)
+  // "Ready" is the socket AND the gate AND the grant: a held Stop or a missing
+  // browser-control permission is not a working browser, so neither may paint
+  // the green state.
+  const granted = status.hasControl !== false
+  statusBox.classList.toggle('ready', status.state === 'ready' && !status.stopped && granted)
   statusText.textContent = statusLine(status)
+  grantRow.hidden = granted
 }
 
 async function loadStored(): Promise<void> {
   const stored = await chrome.storage.local.get(['relayUrl'])
   if (typeof stored.relayUrl === 'string') relayUrlInput.value = stored.relayUrl
 }
+
+el<HTMLButtonElement>('grant').addEventListener('click', () => {
+  // Nothing may be awaited before the request: an await spends the user gesture
+  // Chrome requires, and the prompt throws instead of opening.
+  void requestBrowserControl().then(() => refreshStatus())
+})
 
 el<HTMLButtonElement>('connect').addEventListener('click', () => {
   void (async () => {

--- a/apps/browser-extension/static/grant.html
+++ b/apps/browser-extension/static/grant.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body { font: 13px/1.5 -apple-system, system-ui, sans-serif; margin: 0; padding: 18px; color: #111; }
+      h1 { font-size: 14px; margin: 0 0 8px; }
+      p { margin: 0 0 14px; color: #334155; }
+      .actions { display: flex; gap: 8px; }
+      button { padding: 8px 14px; border-radius: 6px; border: 1px solid #cbd5e1; background: #fff; cursor: pointer; font-size: 13px; }
+      button.primary { background: #111; color: #fff; border-color: #111; }
+      .note { color: #64748b; font-size: 11px; margin-top: 12px; }
+      .error { color: #b91c1c; }
+    </style>
+  </head>
+  <body>
+    <h1>Allow Use Brian to manage this browser?</h1>
+    <p id="detail">
+      Chrome will ask you to confirm. Your assistant can then drive a tab you allow, one task at a
+      time, and you can stop it or take this permission back at any time.
+    </p>
+    <div class="actions">
+      <button id="grant" class="primary">Allow</button>
+      <button id="cancel">Not now</button>
+    </div>
+    <p class="note" id="note">
+      Use Brian never gets access to your sites on its own: every task still asks which tab it may
+      use.
+    </p>
+    <script type="module" src="grant.js"></script>
+  </body>
+</html>

--- a/apps/browser-extension/static/manifest.json
+++ b/apps/browser-extension/static/manifest.json
@@ -3,7 +3,8 @@
   "name": "Use Brian Browser Agent",
   "version": "0.1.0",
   "description": "Lets your Use Brian assistant act in your own browser: consent-gated, approval-gated sends, always stoppable.",
-  "permissions": ["debugger", "tabs", "storage"],
+  "permissions": ["tabs", "storage"],
+  "optional_permissions": ["debugger"],
   "externally_connectable": {
     "matches": ["https://app.usebrian.ai/*", "http://localhost/*"]
   },

--- a/apps/browser-extension/static/popup.html
+++ b/apps/browser-extension/static/popup.html
@@ -21,6 +21,12 @@
   <body>
     <h1>Use Brian Browser Agent</h1>
     <div id="status" class="status"><span class="dot"></span><span id="status-text">Checking...</span></div>
+    <!-- Shown only while browser control is NOT granted. The click here is the
+         user gesture Chrome requires before it will open its own dialog, which
+         is why this button lives in the extension and not in the web app. -->
+    <div class="row" id="grant-row" hidden>
+      <button id="grant" class="primary" style="width: 100%">Allow Use Brian to manage this browser</button>
+    </div>
     <div class="row">
       <label for="relay-url">Relay URL</label>
       <input id="relay-url" placeholder="wss://relay.usebrian.ai/ext" />


### PR DESCRIPTION
Adds the thing the sidebar row was missing: a button that makes **Chrome itself** ask the user for permission to manage their browser.

## The change

`debugger` - the permission that actually drives the browser - moves out of the manifest's install-time `permissions` into **`optional_permissions`**.

At install it bought the user nothing to accept: nothing works until they pair anyway, so install-time consent only made the scariest grant the price of entry, bundled with everything else and revocable only by uninstalling. As an optional permission they grant it when they choose to, can refuse and keep the extension, and can take it back from `chrome://extensions` without losing their pairing.

`optional_host_permissions` stays **empty** - an optional host grant is still a host grant once accepted, asked for at the moment a user is most inclined to say yes - and `manifest.test.ts` now locks both lists plus the `<all_urls>` refusal across all four.

## Why the button lives where it does

Two Chrome constraints (verified against the `chrome.permissions` reference):

1. `chrome.permissions.request()` runs **only in an extension context**.
2. It runs **only inside a real user gesture**.

So a web page can never raise the prompt. The sidebar's "Allow browser control" sends `request-control` over `externally_connectable`; the background opens `grant.html` (a sibling of the per-task `allow.html`); the click *in that window* is the gesture Chrome requires. The same button sits in the extension popup for anyone who starts there. Neither path awaits anything before calling `request()`, because an await spends the gesture and the prompt throws instead of opening.

## Failing safe

- An **unreadable** grant state reads as *not granted* - never drive a browser we have no permission for.
- A **throwing** request (no gesture, no API) reads as a *refusal* - a failed ask is never mistaken for a grant.
- A **null** answer from the extension is "could not ask", not "not granted", so the sidebar row never nags a machine with no extension installed.
- `dispatch` checks the grant and throws `no_browser_permission` while opening the window, instead of letting the first CDP call fail with Chrome's own "Cannot access" wording - the same misdiagnosis the detach path exists to prevent, where a Chrome-side problem reads as the website blocking us.
- The popup status ranks a missing grant **above** a healthy socket, for the same reason the Stop case does: "Connected" while every task refuses is the lie that status line was built to stop telling.
- `hasControl: undefined` (an older background mid-upgrade) counts as granted, so an upgrade cannot invent a warning the user cannot act on.

## Migration

Existing installs must grant once after updating. That is the point of the change, and it is visible rather than silent: both the popup and the sidebar row say so and offer the button.

## Tests

72 extension tests (6 new for the permission module, 2 new manifest guardrails, 2 new status-precedence cases) and 10 sidebar-row tests (3 new: asks for control when paired-but-not-allowed, falls back to the panel if the extension stops answering, and never shows the allow state on a null probe). `tsc --noEmit` clean in both apps; full app-web suite 2149 passing.

## Not verified live

The Chrome prompt itself needs an unpacked reload of `apps/browser-extension/dist` - `npm run build` there, then reload at `chrome://extensions`. Worth one manual pass before this reaches users, since the gesture requirement is exactly the kind of thing a unit test cannot prove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)