### PR TITLE
refactor(app-web): keep EXTENSION_ID module-local

### DIFF
--- a/apps/app-web/src/lib/browser-extension-bridge.ts
+++ b/apps/app-web/src/lib/browser-extension-bridge.ts
@@ -22,7 +22,12 @@ export type ExtensionPairResult =
 
 export type ExtensionMessenger = (extensionId: string, message: unknown) => Promise<unknown>;
 
-export const EXTENSION_ID = process.env.NEXT_PUBLIC_BROWSER_EXTENSION_ID ?? "";
+/**
+ * Module-local on purpose. Every caller reaches it through the `extensionId`
+ * option's default, and anything wanting a different build passes one. An
+ * export would only invite a second opinion on which extension we talk to.
+ */
+const EXTENSION_ID = process.env.NEXT_PUBLIC_BROWSER_EXTENSION_ID ?? "";
 
 type ChromeRuntime = {
   sendMessage?: (id: string, message: unknown, cb: (response: unknown) => void) => void;


### PR DESCRIPTION
Clears a `dead-exports` violation surfaced by the platform's `pnpm check`.

`EXTENSION_ID` is exported from `browser-extension-bridge.ts` but imported nowhere: all four call sites already reach it through the `extensionId` option's default, and anything wanting a different build passes one explicitly. The export only invited a second opinion on which extension we talk to.

`tsc --noEmit` clean; the 10 `connect-browser-row` tests still pass.

Pairs with brian-platform#249, which declares `grant.ts` as a knip entry and adds the missing `[COMP:ext/pairing]` component-map row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)