### PR TITLE
feat(recordings): preserve and expose processed transcripts

### DIFF
--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -143,7 +143,7 @@ import { localSessionRoutes, isOssEdition } from './routes/local-session.js'
 import { createDbMagicLinkStore } from './db/magic-link-store.js'
 import { createSmtpClient, createWorkspaceSmtpTransport } from './email/smtp-client.js'
 import { chatRoutes, runSessionResume, tryResolveLiveToolApproval } from './routes/chat.js'
-import { menuForClass } from '@use-brian/shared/model-registry'
+import { menuForClass, registryRow } from '@use-brian/shared/model-registry'
 import { BACKGROUND_MODEL, ensureServableModel } from './model-resolution.js'
 import { EXTRACTION_MODEL } from './build-episode-ingestors.js'
 import { createMailboxSyncWorker } from './mailbox/sync-worker.js'
@@ -3669,6 +3669,8 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
       getRole: (userId, workspaceId) => workspaceStore.getRole(userId, workspaceId),
       enqueueJob: enqueueRecordingJob,
       hasProcessed: hasCompletedRecordingJob,
+      resolvePageWorkspace: async (userId, pageId) =>
+        (await savedViewStore.getById(userId, pageId))?.workspaceId ?? null,
     }))
   }
 
@@ -4994,6 +4996,32 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
   if (runWorkers && fileIngestWorker) fileIngestWorker.start()
 
   // ── Recording worker ──
+  // Structural synthesis uses the already-resolved extraction model rather than
+  // assuming Gemini. This keeps the hosted callback reusable in OSS and allows
+  // Qwen-only deployments when their configured model supports tool calls.
+  const synthesisModelRow = registryRow(extractionModel)
+  const synthesisModel = synthesisModelRow?.capabilities.tools && configuredProviders.has(synthesisModelRow.provider)
+    ? extractionModel
+    : undefined
+  const recordingSynthesize: RecordingSynthesizeFn | undefined = synthesisModel
+    ? createRecordingSynthesizer({
+        provider,
+        model: synthesisModel,
+        savedViewStore,
+        docPageStore: createDbDocPageStore(),
+        crmStore,
+        taskStore,
+        memoryStore,
+        workflowRunStore,
+        workspaceDirectory: workspaceDirectoryStore,
+        embedder: sharedEmbedder,
+        usageStore,
+        pageTemplateStore,
+        blueprintRecordStore,
+        computeCostUsd: (model, usage) => calculateCost(model, usage),
+      })
+    : undefined
+
   // Always construct the drain when storage exists. If ffmpeg/ffprobe or a
   // transcriber is unavailable, the claimed job is retried then parked FAILED
   // with that explicit prerequisite error instead of remaining pending forever.
@@ -5009,7 +5037,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     : recordingTranscribers.length === 1
       ? recordingTranscribers[0]
       : withTranscriberFallback(recordingTranscribers[0], ...recordingTranscribers.slice(1))
-  const recordingProcessWorker = filesResolver && filesBlobClient
+  const recordingProcessWorker = filesResolver && filesBlobClient && filesApi
     ? createOpenRecordingProcessWorker({
         claim: claimNextRecordingJob,
         process: async (job) => {
@@ -5020,6 +5048,8 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
             fallbackStorage: filesBlobClient,
             transcriber: recordingTranscriber,
             brainIngestor: brainEpisodeIngestor,
+            filesApi,
+            synthesize: recordingSynthesize,
           })
           await updateRecording(job.recordingId, {
             status: 'processed',
@@ -5203,30 +5233,6 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
         .catch((err) => console.error('[worker-runs] cleanup sweep failed:', err))
     }, 24 * 60 * 60 * 1000)
   }
-
-  // Structural-synthesis callback for the recording path (blueprint → brief page
-  // + guided capture). Built here where the doc/CRM/task/directory stores live;
-  // the closed recording factory only holds the reference. Undefined without a
-  // Gemini key (the searchRecording vector arm needs the embedder). See
-  // docs/architecture/brain/structural-synthesis.md → "The first source".
-  const recordingSynthesize: RecordingSynthesizeFn | undefined = env.GEMINI_API_KEY
-    ? createRecordingSynthesizer({
-        provider,
-        model: 'gemini-flash',
-        savedViewStore,
-        docPageStore: createDbDocPageStore(),
-        crmStore,
-        taskStore,
-        memoryStore,
-        workflowRunStore,
-        workspaceDirectory: workspaceDirectoryStore,
-        embedder: sharedEmbedder,
-        usageStore,
-        pageTemplateStore,
-        blueprintRecordStore,
-        computeCostUsd: (model, usage) => calculateCost(model, usage),
-      })
-    : undefined
 
   // ════════════════════════════════════════════════════════════════
   // BootContext

--- a/packages/api/src/recordings/__tests__/open-process-recording.test.ts
+++ b/packages/api/src/recordings/__tests__/open-process-recording.test.ts
@@ -88,4 +88,110 @@ describe('[COMP:recordings/open-process-recording] OSS recording processing', ()
     }))
     expect(storage.deleteBlob).toHaveBeenCalledWith(stagedKey)
   })
+
+  it('persists and links the transcript before brain ingest, then runs requested synthesis', async () => {
+    const order: string[] = []
+    const persistTranscript = vi.fn(async () => {
+      order.push('persist')
+      return { fileId: 'transcript-1', path: '/recordings/call.md', bytes: 42 }
+    })
+    const linkTranscriptFile = vi.fn(async () => {
+      order.push('link')
+    })
+    const brainIngestor = vi.fn(async () => {
+      order.push('brain')
+      return {} as never
+    })
+    const synthesize = vi.fn(async () => {
+      order.push('synthesize')
+      return { pageId: 'page-brief' }
+    })
+
+    await processOpenRecording(
+      {
+        recordingId: 'rec-1',
+        actingUserId: 'owner-1',
+        blueprintSlug: '  sales-call  ',
+        parentPageId: 'page-parent',
+      },
+      {
+        filesResolver: { forUri: vi.fn(), forWorkspace: vi.fn() },
+        fallbackStorage: { signedReadUrl: vi.fn(async () => 'https://signed.example/media') } as never,
+        transcriber: {
+          name: 'test',
+          transcribe: vi.fn(async () => ({
+            utterances: [{ startMs: 0, endMs: 1000, speaker: 'A', text: 'hello brain' }],
+            usages: [], windows: 1, truncated: false, degenerateWindows: 0,
+          })),
+        },
+        brainIngestor,
+        getEpisode: vi.fn(async () => ({
+          id: 'rec-1', workspaceId: 'ws-1', userId: null, assistantId: 'assistant-1',
+          sensitivity: 'confidential', sourceRef: { gcsKey: 'ws-1/recordings/id' },
+        }) as never),
+        getRecording: vi.fn(async () => ({ title: 'Sales call', fileName: 'call.m4a' }) as never),
+        probe: vi.fn(async () => 1000),
+        extract: vi.fn(async () => ({ buffer: Buffer.from('aac'), mime: 'audio/aac' })),
+        insertSegments: vi.fn(async () => {
+          order.push('segments')
+          return 1
+        }),
+        persistTranscript,
+        linkTranscriptFile,
+        synthesize,
+      },
+    )
+
+    expect(order).toEqual(['segments', 'persist', 'link', 'brain', 'synthesize'])
+    expect(persistTranscript).toHaveBeenCalledWith(expect.objectContaining({
+      recordingId: 'rec-1',
+      sensitivity: 'confidential',
+      title: 'Sales call',
+    }))
+    expect(linkTranscriptFile).toHaveBeenCalledWith('rec-1', 'transcript-1')
+    expect(synthesize).toHaveBeenCalledWith(expect.objectContaining({
+      blueprintSlug: 'sales-call',
+      parentPageId: 'page-parent',
+      sensitivity: 'confidential',
+    }))
+  })
+
+  it('keeps artifact and brain ingestion but skips synthesis for a truncated transcript', async () => {
+    const persistTranscript = vi.fn(async () => ({
+      fileId: 'transcript-1', path: '/recordings/call.md', bytes: 42,
+    }))
+    const synthesize = vi.fn(async () => ({ pageId: 'page-brief' }))
+    const brainIngestor = vi.fn(async () => ({}) as never)
+
+    await processOpenRecording(
+      { recordingId: 'rec-1', actingUserId: 'owner-1', blueprintSlug: 'sales-call' },
+      {
+        filesResolver: { forUri: vi.fn(), forWorkspace: vi.fn() },
+        fallbackStorage: { signedReadUrl: vi.fn(async () => 'https://signed.example/media') } as never,
+        transcriber: {
+          name: 'test',
+          transcribe: vi.fn(async () => ({
+            utterances: [{ startMs: 0, endMs: 1000, speaker: null, text: 'partial' }],
+            usages: [], windows: 1, truncated: true, degenerateWindows: 0,
+          })),
+        },
+        brainIngestor,
+        getEpisode: vi.fn(async () => ({
+          id: 'rec-1', workspaceId: 'ws-1', userId: null, assistantId: 'assistant-1',
+          sensitivity: 'internal', sourceRef: { gcsKey: 'ws-1/recordings/id' },
+        }) as never),
+        getRecording: vi.fn(async () => null),
+        probe: vi.fn(async () => 1000),
+        extract: vi.fn(async () => ({ buffer: Buffer.from('aac'), mime: 'audio/aac' })),
+        insertSegments: vi.fn(async () => 1),
+        persistTranscript,
+        linkTranscriptFile: vi.fn(async () => {}),
+        synthesize,
+      },
+    )
+
+    expect(persistTranscript).toHaveBeenCalled()
+    expect(brainIngestor).toHaveBeenCalled()
+    expect(synthesize).not.toHaveBeenCalled()
+  })
 })

--- a/packages/api/src/recordings/__tests__/transcript-artifact.test.ts
+++ b/packages/api/src/recordings/__tests__/transcript-artifact.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTranscriptArtifactWriter } from '../transcript-artifact.js'
+
+const input = {
+  recordingId: 'rec-1',
+  workspaceId: 'ws-1',
+  actingUserId: 'user-1',
+  assistantId: 'assistant-1',
+  sensitivity: 'confidential',
+  title: 'Weekly call.m4a',
+  utterances: [
+    { startMs: 0, speaker: 'Ken', text: 'kicking off' },
+    { startMs: 2_841_000, speaker: 'Priya', text: 'pushed back on pricing' },
+  ],
+}
+
+function filesApi(overrides: Record<string, unknown> = {}) {
+  return {
+    writeBytes: vi.fn(async () => ({
+      ok: true as const,
+      value: { id: 'file-1', path: '/recordings/2026-07-16T12-00-00-Weekly-call.md' },
+    })),
+    setMeta: vi.fn(async () => ({ ok: true as const, value: {} })),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('[COMP:recordings/transcript-artifact] OSS transcript artifact', () => {
+  it('writes the shared timestamp format and marks duplicate indexing skipped', async () => {
+    const api = filesApi()
+    const persist = createTranscriptArtifactWriter({
+      filesApi: api as never,
+      now: () => new Date('2026-07-16T12:00:00Z'),
+    })
+
+    await expect(persist(input)).resolves.toMatchObject({ fileId: 'file-1' })
+    const [, params] = (api.writeBytes.mock.calls as unknown as Array<[
+      unknown,
+      { bytes: Buffer; mime: string; sensitivity: string; path: string },
+    ]>)[0]!
+    expect(params.bytes.toString('utf8')).toBe(
+      '[0:00:00] Ken: kicking off\n[0:47:21] Priya: pushed back on pricing',
+    )
+    expect(params).toMatchObject({
+      mime: 'text/markdown',
+      sensitivity: 'confidential',
+      path: '/recordings/2026-07-16T12-00-00-Weekly-call.md',
+    })
+    expect(api.setMeta).toHaveBeenCalledWith(
+      expect.anything(),
+      'file-1',
+      expect.objectContaining({
+        metadata: {
+          recording_id: 'rec-1',
+          indexing: { status: 'skipped', reason: 'transcript_segments' },
+        },
+      }),
+    )
+  })
+
+  it('returns null instead of failing recording processing on a storage error', async () => {
+    const api = filesApi({
+      writeBytes: vi.fn(async () => {
+        throw new Error('storage unavailable')
+      }),
+    })
+    const persist = createTranscriptArtifactWriter({ filesApi: api as never })
+    await expect(persist(input)).resolves.toBeNull()
+  })
+})

--- a/packages/api/src/recordings/process-recording.ts
+++ b/packages/api/src/recordings/process-recording.ts
@@ -1,18 +1,33 @@
 // [COMP:recordings/open-process-recording] - generic OSS recording processor.
 
-import type { RecordingTranscriber } from '@use-brian/core'
+import type { FilesApi, RecordingTranscriber } from '@use-brian/core'
 import { getEpisodeByIdSystem } from '../db/episodes-store.js'
-import { getRecordingSystem } from '../db/recordings-store.js'
-import { insertTranscriptSegments, segmentTranscript } from '../db/transcript-segments-store.js'
+import { getRecordingSystem, updateRecording } from '../db/recordings-store.js'
+import {
+  insertTranscriptSegments,
+  linkTranscriptSegmentsFile,
+  segmentTranscript,
+} from '../db/transcript-segments-store.js'
 import type { FilesClientResolver } from '../files/files-api.js'
 import type { GcsFilesClient } from '../files/gcs-client.js'
 import type { BrainEpisodeIngestor } from '../ingest-port.js'
+import type { RecordingSynthesizeFn } from '../synthesis/recording-synthesizer.js'
 import { extractRecordingAudio, probeRecordingDuration } from './ffmpeg.js'
+import {
+  createTranscriptArtifactWriter,
+  type PersistTranscriptInput,
+  type PersistedTranscript,
+} from './transcript-artifact.js'
 
 export type OpenRecordingProcessResult = { truncated: boolean; segmentsInserted: number; durationMs: number }
 
 export async function processOpenRecording(
-  job: { recordingId: string; actingUserId: string },
+  job: {
+    recordingId: string
+    actingUserId: string
+    blueprintSlug?: string | null
+    parentPageId?: string | null
+  },
   deps: {
     filesResolver: FilesClientResolver
     fallbackStorage: GcsFilesClient
@@ -23,6 +38,10 @@ export async function processOpenRecording(
     probe?: typeof probeRecordingDuration
     extract?: typeof extractRecordingAudio
     insertSegments?: typeof insertTranscriptSegments
+    filesApi?: FilesApi
+    persistTranscript?: (input: PersistTranscriptInput) => Promise<PersistedTranscript | null>
+    linkTranscriptFile?: (recordingId: string, transcriptFileId: string) => Promise<void>
+    synthesize?: RecordingSynthesizeFn
   },
 ): Promise<OpenRecordingProcessResult> {
   if (!deps.transcriber) {
@@ -83,6 +102,36 @@ export async function processOpenRecording(
     sensitivity: episode.sensitivity,
     segments,
   })
+
+  // Hosted parity step 3.5: the durable transcript is additive and isolated.
+  // transcript_segments remains the retrieval substrate, so the file is marked
+  // as deliberately unindexed by the shared artifact writer.
+  const persistTranscript = deps.persistTranscript ?? (deps.filesApi
+    ? createTranscriptArtifactWriter({ filesApi: deps.filesApi })
+    : undefined)
+  if (persistTranscript) {
+    try {
+      const artifact = await persistTranscript({
+        recordingId: episode.id,
+        workspaceId: episode.workspaceId,
+        actingUserId: job.actingUserId,
+        assistantId: episode.assistantId,
+        sensitivity: episode.sensitivity,
+        utterances: transcription.utterances,
+        title: recording?.title ?? recording?.fileName ?? null,
+      })
+      if (artifact) {
+        const linkTranscriptFile = deps.linkTranscriptFile ?? (async (recordingId, transcriptFileId) => {
+          await updateRecording(recordingId, { transcriptFileId })
+          await linkTranscriptSegmentsFile(recordingId, transcriptFileId)
+        })
+        await linkTranscriptFile(episode.id, artifact.fileId)
+      }
+    } catch (err) {
+      console.error('[process-recording] transcript artifact failed (non-fatal):', err)
+    }
+  }
+
   const text = transcription.utterances
     .map((utterance) => `${utterance.speaker ? `${utterance.speaker}: ` : ''}${utterance.text}`)
     .join('\n')
@@ -98,5 +147,25 @@ export async function processOpenRecording(
     parentEpisodeId: episode.id,
     sensitivity: episode.sensitivity,
   })
+
+  // Blueprint synthesis is opt-in, additive to Pipeline B, and never runs over
+  // a partial transcript. Its failure cannot turn successful ingestion into a
+  // failed/retried recording job.
+  const blueprintSlug = job.blueprintSlug?.trim()
+  if (blueprintSlug && deps.synthesize && !transcription.truncated) {
+    try {
+      await deps.synthesize({
+        recordingId: episode.id,
+        workspaceId: episode.workspaceId,
+        userId: job.actingUserId,
+        assistantId: episode.assistantId ?? '',
+        sensitivity: episode.sensitivity,
+        blueprintSlug,
+        parentPageId: job.parentPageId ?? null,
+      })
+    } catch (err) {
+      console.error(`[process-recording] synthesis failed for ${episode.id} (non-fatal):`, err)
+    }
+  }
   return { truncated: transcription.truncated, segmentsInserted, durationMs }
 }

--- a/packages/api/src/recordings/transcript-artifact.ts
+++ b/packages/api/src/recordings/transcript-artifact.ts
@@ -1,0 +1,80 @@
+// [COMP:recordings/transcript-artifact] - persist a recording transcript as a
+// durable workspace file without duplicating it into file_segments.
+
+import type { FilesApi, FilesContext } from '@use-brian/core'
+import { formatTranscript, type TranscriptLineSource } from '@use-brian/shared'
+
+export type PersistTranscriptInput = {
+  recordingId: string
+  workspaceId: string
+  actingUserId: string
+  assistantId: string | null
+  sensitivity: string
+  utterances: readonly TranscriptLineSource[]
+  title?: string | null
+}
+
+export type PersistedTranscript = { fileId: string; path: string; bytes: number }
+
+function slug(name: string): string {
+  return (
+    name
+      .replace(/\.[^.]+$/, '')
+      .replace(/[^\p{L}\p{N}._-]+/gu, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '')
+      .slice(0, 120) || 'recording'
+  )
+}
+
+export function createTranscriptArtifactWriter(deps: {
+  filesApi: FilesApi
+  now?: () => Date
+}) {
+  return async function persistTranscript(
+    input: PersistTranscriptInput,
+  ): Promise<PersistedTranscript | null> {
+    try {
+      if (input.utterances.length === 0) return null
+
+      const text = formatTranscript(input.utterances)
+      if (!text.trim()) return null
+
+      const stamp = (deps.now?.() ?? new Date()).toISOString().replace(/[:.]/g, '-').slice(0, 19)
+      const path = `/recordings/${stamp}-${slug(input.title ?? 'recording')}.md`
+      const ctx: FilesContext = {
+        workspaceId: input.workspaceId,
+        userId: input.actingUserId,
+        ...(input.assistantId ? { assistantId: input.assistantId } : {}),
+      }
+      const bytes = Buffer.from(text, 'utf8')
+      const stored = await deps.filesApi.writeBytes(ctx, {
+        path,
+        bytes,
+        mime: 'text/markdown',
+        title: input.title ? `Transcript - ${input.title}` : 'Transcript',
+        sensitivity: input.sensitivity as never,
+      })
+      if (!stored.ok) {
+        console.warn('[transcript-artifact] writeBytes failed (non-fatal):', stored.error)
+        return null
+      }
+
+      await deps.filesApi
+        .setMeta(ctx, stored.value.id, {
+          metadata: {
+            recording_id: input.recordingId,
+            indexing: { status: 'skipped', reason: 'transcript_segments' },
+          },
+        } as never)
+        .catch((err: unknown) =>
+          console.warn('[transcript-artifact] setMeta failed (artifact still durable):', err),
+        )
+
+      return { fileId: stored.value.id, path: stored.value.path, bytes: bytes.length }
+    } catch (err) {
+      console.error('[transcript-artifact] persist failed (non-fatal):', err)
+      return null
+    }
+  }
+}

--- a/packages/api/src/routes/__tests__/recordings-open.test.ts
+++ b/packages/api/src/routes/__tests__/recordings-open.test.ts
@@ -21,6 +21,39 @@ function makeApp(overrides: Record<string, unknown> = {}) {
     createdByUserId: 'user-1',
     sourceRef: { gcsKey: 'ws-1/recordings/file-1', storageUri: 'file:///data/files/ws-1/recordings/file-1' },
   }
+  const recording = {
+    id: 'rec-1',
+    workspaceId: 'ws-1',
+    title: 'Weekly sync',
+    kind: 'meeting',
+    status: 'processed',
+    fileName: 'sync.mp4',
+    storageUri: 'file:///data/files/ws-1/recordings/file-1',
+    gcsKey: 'ws-1/recordings/file-1',
+    mime: 'video/mp4',
+    bytes: 1234,
+    durationMs: 65_000,
+    transcriptFileId: 'file-transcript',
+    mediaFileId: null,
+    participants: [{ speaker: 'A', name: 'Alice' }],
+    truncated: false,
+    lastError: null,
+    deleteAfter: null,
+    userId: null,
+    assistantId: 'assistant-1',
+    sensitivity: 'internal',
+    createdByUserId: 'user-1',
+    createdAt: new Date('2026-07-20T10:00:00.000Z'),
+    updatedAt: new Date('2026-07-20T10:01:00.000Z'),
+  }
+  const viewpoint = {
+    workspaceId: 'ws-1',
+    userId: 'user-1',
+    assistantId: 'assistant-1',
+    assistantKind: 'primary',
+    clearance: 'internal',
+    compartments: [],
+  }
   const deps = {
     filesResolver: {
       forWorkspace: vi.fn(async () => ({ gcs: storage, bucket: '/data/files', uriScheme: 'file' as const })),
@@ -32,14 +65,18 @@ function makeApp(overrides: Record<string, unknown> = {}) {
     probe: vi.fn(async () => 65_000),
     createEpisode: vi.fn(async () => episode),
     createRecording: vi.fn(async () => ({})),
-    getRecording: vi.fn(async () => ({
-      id: 'rec-1',
-      workspaceId: 'ws-1',
-      storageUri: 'file:///data/files/ws-1/recordings/file-1',
-      gcsKey: 'ws-1/recordings/file-1',
-      mime: 'video/mp4',
-      durationMs: 65_000,
-    })),
+    getRecording: vi.fn(async () => recording),
+    listRecordings: vi.fn(async () => [recording]),
+    resolveViewpoint: vi.fn(async () => viewpoint),
+    readTranscript: vi.fn(async () => [{
+      segment_index: 0,
+      start_ms: 0,
+      end_ms: 1000,
+      speaker: 'A',
+      segment_text: 'Hello brain',
+    }]),
+    listTasks: vi.fn(async () => []),
+    resolvePageWorkspace: vi.fn(async () => 'ws-1'),
     getEpisode: vi.fn(async () => episode),
     updateRecording: vi.fn(async () => undefined),
     mergeEpisodeSourceRef: vi.fn(async () => undefined),
@@ -56,6 +93,101 @@ function makeApp(overrides: Record<string, unknown> = {}) {
 }
 
 describe('[COMP:recordings/open-routes] OSS recordings routes', () => {
+  it('lists recordings with filters and the app-web projection', async () => {
+    const { app, deps } = makeApp()
+    const response = await request(app).get(
+      '/api/recordings?workspaceId=ws-1&kind=meeting&status=processed&q=weekly&limit=500',
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.body.recordings).toEqual([expect.objectContaining({
+      recordingId: 'rec-1',
+      title: 'Weekly sync',
+      occurredAt: '2026-07-20T10:00:00.000Z',
+      hasTranscript: true,
+      participants: [{ speaker: 'A', name: 'Alice' }],
+    })])
+    expect(deps.listRecordings).toHaveBeenCalledWith(
+      'user-1',
+      'ws-1',
+      { kind: 'meeting', status: 'processed', q: 'weekly' },
+      { limit: 100 },
+    )
+  })
+
+  it('returns recording detail without exposing storage coordinates', async () => {
+    const { app } = makeApp()
+    const response = await request(app).get('/api/recordings/rec-1')
+
+    expect(response.status).toBe(200)
+    expect(response.body).toEqual(expect.objectContaining({
+      recordingId: 'rec-1',
+      mime: 'video/mp4',
+      durationMs: 65_000,
+    }))
+    expect(response.body).not.toHaveProperty('gcsKey')
+    expect(response.body).not.toHaveProperty('storageUri')
+  })
+
+  it('reads a bounded transcript page using the caller viewpoint', async () => {
+    const { app, deps } = makeApp()
+    const response = await request(app).get(
+      '/api/recordings/rec-1/transcript?fromIndex=10&toIndex=9999',
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.body).toEqual(expect.objectContaining({
+      recordingId: 'rec-1',
+      fromIndex: 10,
+      toIndex: 209,
+      hasMore: false,
+    }))
+    expect(deps.resolveViewpoint).toHaveBeenCalledWith('user-1', 'ws-1')
+    expect(deps.readTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-1', clearance: 'internal' }),
+      { recordingId: 'rec-1', fromIndex: 10, toIndex: 209 },
+    )
+  })
+
+  it('denies list access to a non-member and hides inaccessible detail', async () => {
+    const deniedList = makeApp({ getRole: vi.fn(async () => null) })
+    const listResponse = await request(deniedList.app).get('/api/recordings?workspaceId=ws-1')
+    expect(listResponse.status).toBe(403)
+    expect(deniedList.deps.listRecordings).not.toHaveBeenCalled()
+
+    const hiddenDetail = makeApp({ getRecording: vi.fn(async () => null) })
+    const detailResponse = await request(hiddenDetail.app).get('/api/recordings/rec-other')
+    expect(detailResponse.status).toBe(404)
+  })
+
+  it('denies transcript access when no caller viewpoint can be resolved', async () => {
+    const { app, deps } = makeApp({ resolveViewpoint: vi.fn(async () => null) })
+    const response = await request(app).get('/api/recordings/rec-1/transcript')
+
+    expect(response.status).toBe(403)
+    expect(deps.readTranscript).not.toHaveBeenCalled()
+  })
+
+  it('lists recording tasks through the same caller viewpoint', async () => {
+    const tasks = [{
+      id: 'task-1',
+      title: 'Send the proposal',
+      status: 'todo',
+      assigneeId: null,
+      sourceStartMs: 42_000,
+      verified: false,
+    }]
+    const { app, deps } = makeApp({ listTasks: vi.fn(async () => tasks) })
+    const response = await request(app).get('/api/recordings/rec-1/tasks')
+
+    expect(response.status).toBe(200)
+    expect(response.body).toEqual({ recordingId: 'rec-1', tasks })
+    expect(deps.listTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-1', clearance: 'internal' }),
+      'rec-1',
+    )
+  })
+
   it('returns a short-lived public signed read URL for playback and provider fetches', async () => {
     const { app } = makeApp()
     const response = await request(app).get('/api/recordings/rec-1/media-url')
@@ -125,6 +257,35 @@ describe('[COMP:recordings/open-routes] OSS recordings routes', () => {
       recordingId: 'rec-1',
       workspaceId: 'ws-1',
       actingUserId: 'user-1',
+      blueprintSlug: null,
+      parentPageId: null,
     })
+  })
+
+  it('validates and threads blueprint and destination fields when processing', async () => {
+    const { app, deps } = makeApp()
+    const response = await request(app).post('/api/recordings/rec-1/process').send({
+      blueprintSlug: '  sales-call  ',
+      parentPageId: '  page-1  ',
+    })
+
+    expect(response.status).toBe(202)
+    expect(deps.resolvePageWorkspace).toHaveBeenCalledWith('user-1', 'page-1')
+    expect(deps.enqueueJob).toHaveBeenCalledWith(expect.objectContaining({
+      blueprintSlug: 'sales-call',
+      parentPageId: 'page-1',
+    }))
+  })
+
+  it('rejects an inaccessible process destination before enqueueing', async () => {
+    const { app, deps } = makeApp({ resolvePageWorkspace: vi.fn(async () => null) })
+    const response = await request(app).post('/api/recordings/rec-1/process').send({
+      blueprintSlug: 'sales-call',
+      parentPageId: 'page-other',
+    })
+
+    expect(response.status).toBe(400)
+    expect(response.body.error).toBe('invalid_destination')
+    expect(deps.enqueueJob).not.toHaveBeenCalled()
   })
 })

--- a/packages/api/src/routes/recordings.ts
+++ b/packages/api/src/routes/recordings.ts
@@ -7,12 +7,23 @@ import {
   getEpisodeByIdSystem,
   mergeEpisodeSourceRef,
 } from '../db/episodes-store.js'
-import { createRecording, getRecording, updateRecording } from '../db/recordings-store.js'
+import {
+  createRecording,
+  getRecording,
+  listRecordings,
+  LIST_RECORDINGS_LIMIT_MAX,
+  updateRecording,
+  type Recording,
+} from '../db/recordings-store.js'
+import { readRecordingRange } from '../db/retrieval-store.js'
+import { listTasksBySourceEpisode } from '../db/tasks.js'
+import { resolveWorkspaceViewpoint } from '../db/workspace-viewpoint.js'
 import type { FilesClientResolver } from '../files/files-api.js'
 import { buildStorageKey, buildStorageUri } from '../files/gcs-client.js'
 import { probeRecordingDuration } from '../recordings/ffmpeg.js'
 
 const MAX_RECORDING_DURATION_MS = 180 * 60 * 1000
+export const TRANSCRIPT_PAGE = 200
 
 type RouteDeps = {
   filesResolver: FilesClientResolver
@@ -21,15 +32,41 @@ type RouteDeps = {
     recordingId: string
     workspaceId: string
     actingUserId: string
+    blueprintSlug?: string | null
+    parentPageId?: string | null
   }) => Promise<{ enqueued: boolean; jobId: string | null }>
   hasProcessed: (recordingId: string) => Promise<boolean>
+  resolvePageWorkspace?: (userId: string, pageId: string) => Promise<string | null>
   probe?: typeof probeRecordingDuration
   createEpisode?: typeof createEpisode
   createRecording?: typeof createRecording
   getRecording?: typeof getRecording
+  listRecordings?: typeof listRecordings
+  resolveViewpoint?: typeof resolveWorkspaceViewpoint
+  readTranscript?: typeof readRecordingRange
+  listTasks?: typeof listTasksBySourceEpisode
   getEpisode?: typeof getEpisodeByIdSystem
   updateRecording?: typeof updateRecording
   mergeEpisodeSourceRef?: typeof mergeEpisodeSourceRef
+}
+
+function toClientRecording(recording: Recording) {
+  return {
+    recordingId: recording.id,
+    title: recording.title ?? recording.fileName,
+    fileName: recording.fileName,
+    kind: recording.kind,
+    status: recording.status,
+    mime: recording.mime,
+    durationMs: recording.durationMs,
+    bytes: recording.bytes,
+    occurredAt: recording.createdAt,
+    truncated: recording.truncated,
+    lastError: recording.lastError,
+    hasTranscript: recording.transcriptFileId != null,
+    transcriptFileId: recording.transcriptFileId,
+    participants: recording.participants,
+  }
 }
 
 function userIdOf(req: unknown): string | undefined {
@@ -55,6 +92,31 @@ async function recordingStorage(
 
 export function openRecordingsRoutes(deps: RouteDeps): Router {
   const router = Router()
+
+  router.get('/', async (req, res) => {
+    const userId = userIdOf(req)
+    if (!userId) return void res.status(401).json({ error: 'Unauthorized' })
+    const { workspaceId, kind, status, q, limit } = req.query as Record<string, string | undefined>
+    if (!workspaceId) return void res.status(400).json({ error: 'workspaceId is required' })
+    if (!(await deps.getRole(userId, workspaceId))) {
+      return void res.status(403).json({ error: 'Not a member of this workspace' })
+    }
+    const parsedLimit = limit ? Number(limit) : undefined
+    if (parsedLimit !== undefined && (!Number.isFinite(parsedLimit) || parsedLimit < 1)) {
+      return void res.status(400).json({ error: 'limit must be a positive number' })
+    }
+    const rows = await (deps.listRecordings ?? listRecordings)(
+      userId,
+      workspaceId,
+      {
+        ...(kind === 'memo' || kind === 'meeting' ? { kind } : {}),
+        ...(status ? { status: status as Recording['status'] } : {}),
+        ...(q?.trim() ? { q: q.trim() } : {}),
+      },
+      { limit: Math.min(parsedLimit ?? 20, LIST_RECORDINGS_LIMIT_MAX) },
+    )
+    res.json({ recordings: rows.map(toClientRecording) })
+  })
 
   router.get('/:recordingId/media-url', async (req, res) => {
     const userId = userIdOf(req)
@@ -129,6 +191,63 @@ export function openRecordingsRoutes(deps: RouteDeps): Router {
     res.json({ recordingId: episode.id, uploadUrl, key })
   })
 
+  router.get('/:recordingId/transcript', async (req, res) => {
+    const userId = userIdOf(req)
+    if (!userId) return void res.status(401).json({ error: 'Unauthorized' })
+    const recording = await (deps.getRecording ?? getRecording)(userId, req.params.recordingId)
+    if (!recording) return void res.status(404).json({ error: 'Recording not found' })
+
+    const actor = await (deps.resolveViewpoint ?? resolveWorkspaceViewpoint)(userId, recording.workspaceId)
+    if (!actor) return void res.status(403).json({ error: 'Forbidden' })
+
+    const from = Number((req.query.fromIndex as string) ?? 0)
+    const rawTo = req.query.toIndex as string | undefined
+    if (!Number.isFinite(from) || from < 0) {
+      return void res.status(400).json({ error: 'fromIndex must be a non-negative number' })
+    }
+    const to = Math.min(
+      rawTo !== undefined ? Number(rawTo) : from + TRANSCRIPT_PAGE - 1,
+      from + TRANSCRIPT_PAGE - 1,
+    )
+    if (!Number.isFinite(to) || to < from) {
+      return void res.status(400).json({ error: 'toIndex must be >= fromIndex' })
+    }
+
+    const segments = await (deps.readTranscript ?? readRecordingRange)(actor, {
+      recordingId: recording.id,
+      fromIndex: from,
+      toIndex: to,
+    })
+    res.json({
+      recordingId: recording.id,
+      fromIndex: from,
+      toIndex: to,
+      segments,
+      hasMore: segments.length === to - from + 1,
+    })
+  })
+
+  router.get('/:recordingId/tasks', async (req, res) => {
+    const userId = userIdOf(req)
+    if (!userId) return void res.status(401).json({ error: 'Unauthorized' })
+    const recording = await (deps.getRecording ?? getRecording)(userId, req.params.recordingId)
+    if (!recording) return void res.status(404).json({ error: 'Recording not found' })
+    const actor = await (deps.resolveViewpoint ?? resolveWorkspaceViewpoint)(userId, recording.workspaceId)
+    if (!actor) return void res.status(403).json({ error: 'Forbidden' })
+    const tasks = await (deps.listTasks ?? listTasksBySourceEpisode)(actor, recording.id)
+    res.json({ recordingId: recording.id, tasks })
+  })
+
+  // Keep the bare parameter route after every GET suffix so it cannot shadow
+  // media, transcript, tasks, or future static read endpoints.
+  router.get('/:recordingId', async (req, res) => {
+    const userId = userIdOf(req)
+    if (!userId) return void res.status(401).json({ error: 'Unauthorized' })
+    const recording = await (deps.getRecording ?? getRecording)(userId, req.params.recordingId)
+    if (!recording) return void res.status(404).json({ error: 'Recording not found' })
+    res.json(toClientRecording(recording))
+  })
+
   router.post('/:recordingId/estimate', async (req, res) => {
     const userId = userIdOf(req)
     if (!userId) return void res.status(401).json({ error: 'Unauthorized' })
@@ -168,7 +287,26 @@ export function openRecordingsRoutes(deps: RouteDeps): Router {
     if (!(await deps.getRole(userId, episode.workspaceId))) return void res.status(403).json({ error: 'Forbidden' })
     const source = (episode.sourceRef ?? {}) as { gcsKey?: string; storageUri?: string | null }
     if (!source.gcsKey) return void res.status(400).json({ error: 'Recording has no stored audio' })
-    if (req.body?.confirm !== true && (await deps.hasProcessed(episode.id))) {
+    const { blueprintSlug, confirm, parentPageId } = (req.body ?? {}) as {
+      blueprintSlug?: string
+      confirm?: boolean
+      parentPageId?: string | null
+    }
+    let destinationPageId: string | null = null
+    if (typeof parentPageId === 'string' && parentPageId.trim()) {
+      const pageId = parentPageId.trim()
+      const pageWorkspace = deps.resolvePageWorkspace
+        ? await deps.resolvePageWorkspace(userId, pageId)
+        : null
+      if (pageWorkspace !== episode.workspaceId) {
+        return void res.status(400).json({
+          error: 'invalid_destination',
+          detail: 'The destination page does not exist in this workspace, or you cannot access it.',
+        })
+      }
+      destinationPageId = pageId
+    }
+    if (confirm !== true && (await deps.hasProcessed(episode.id))) {
       return void res.status(409).json({
         requiresConfirmation: true,
         reason: 'already_processed',
@@ -191,6 +329,9 @@ export function openRecordingsRoutes(deps: RouteDeps): Router {
       recordingId: episode.id,
       workspaceId: episode.workspaceId,
       actingUserId: episode.createdByUserId,
+      blueprintSlug:
+        typeof blueprintSlug === 'string' && blueprintSlug.trim() ? blueprintSlug.trim() : null,
+      parentPageId: destinationPageId,
     })
     await (deps.updateRecording ?? updateRecording)(episode.id, { status: 'queued', durationMs })
     await (deps.mergeEpisodeSourceRef ?? mergeEpisodeSourceRef)(episode.createdByUserId, episode.id, { status: 'queued' })


### PR DESCRIPTION
## Summary
- expose OSS recording list, detail, media, transcript, and task read routes
- persist processed transcripts as durable workspace files and link them to recordings and segments
- run requested blueprint synthesis in OSS while preserving local Qwen media staging

## Verification
- 3,991 API tests passed
- API typecheck passed
- focused recording pipeline tests passed