### PR TITLE
feat(app-web): My Browser joins the app strip instead of a row beneath it

### DIFF
--- a/apps/app-web/src/components/doc/__tests__/connect-browser-button.test.tsx
+++ b/apps/app-web/src/components/doc/__tests__/connect-browser-button.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 /**
- * [COMP:app-web/connect-browser-row] "My Browser" sidebar row.
+ * [COMP:app-web/connect-browser-button] "My Browser" sidebar button.
  *
  * The row's whole value is that it never dead-ends: it hides where no relay
  * exists, pairs in one click where the extension answers, and hands off to the
@@ -38,7 +38,7 @@ vi.mock("@/components/settings-modal/settings-modal", () => ({
 import { I18nProvider } from "@/lib/i18n/client";
 import { en } from "@/lib/i18n/dictionaries/en";
 import type { Dictionary } from "@/lib/i18n/dictionaries";
-import { ConnectBrowserRow } from "../connect-browser-row";
+import { ConnectBrowserButton } from "../connect-browser-button";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -54,7 +54,7 @@ async function mount(): Promise<{ el: HTMLElement; root: Root }> {
   await act(async () => {
     root.render(
       <I18nProvider locale="en" dict={dict}>
-        <ConnectBrowserRow workspaceId="ws-1" />
+        <ConnectBrowserButton workspaceId="ws-1" />
       </I18nProvider>,
     );
   });
@@ -69,7 +69,21 @@ async function click(el: HTMLElement) {
   });
 }
 
-describe("[COMP:app-web/connect-browser-row] My Browser sidebar row", () => {
+/**
+ * The button carries no text - it is a 28px icon square in the app-bar strip -
+ * so its state reads off the accessible name and the corner dot.
+ */
+function labelOf(el: HTMLElement): string {
+  return el.querySelector("button")?.getAttribute("aria-label") ?? "";
+}
+/** "primary" = connected, "amber" = paired but not allowed, null = neither. */
+function dotOf(el: HTMLElement): "primary" | "amber" | null {
+  const dot = el.querySelector("button > span[class*=rounded-full]");
+  if (!dot) return null;
+  return dot.className.includes("bg-amber") ? "amber" : "primary";
+}
+
+describe("[COMP:app-web/connect-browser-button] My Browser sidebar button", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     pairBrowserExtension.mockResolvedValue(PAIRING);
@@ -87,8 +101,8 @@ describe("[COMP:app-web/connect-browser-row] My Browser sidebar row", () => {
   it("offers to connect once a configured-but-disconnected status resolves", async () => {
     getBrowserExtensionStatus.mockResolvedValue({ configured: true, connected: false });
     const { el } = await mount();
-    expect(el.textContent).toContain(c.connect);
-    expect(el.textContent).not.toContain(c.connectedBadge);
+    expect(labelOf(el)).toBe(c.connectAria);
+    expect(dotOf(el)).toBeNull();
   });
 
   it("pairs in one click and flips to connected without opening Settings", async () => {
@@ -104,8 +118,8 @@ describe("[COMP:app-web/connect-browser-row] My Browser sidebar row", () => {
       expect.objectContaining({ relayUrl: PAIRING.relayUrl, pairingToken: PAIRING.pairingToken }),
     );
     expect(openWorkspaceSettings).not.toHaveBeenCalled();
-    expect(el.textContent).toContain(c.connected);
-    expect(el.textContent).toContain(c.connectedBadge);
+    expect(labelOf(el)).toBe(c.manageAria);
+    expect(dotOf(el)).toBe("primary");
   });
 
   it("falls back to the Settings panel when no extension answers", async () => {
@@ -144,9 +158,10 @@ describe("[COMP:app-web/connect-browser-row] My Browser sidebar row", () => {
     extensionHasControl.mockResolvedValue(false);
     const { el } = await mount();
 
-    expect(el.textContent).toContain(c.allow);
+    expect(labelOf(el)).toBe(c.allowAria);
+    expect(dotOf(el)).toBe("amber");
     // "Connected" would be a lie here: the socket is up but nothing can run.
-    expect(el.textContent).not.toContain(c.connectedBadge);
+    expect(dotOf(el)).not.toBe("primary");
 
     await click(el);
 
@@ -173,14 +188,14 @@ describe("[COMP:app-web/connect-browser-row] My Browser sidebar row", () => {
     extensionHasControl.mockResolvedValue(null);
     const { el } = await mount();
 
-    expect(el.textContent).not.toContain(c.allow);
-    expect(el.textContent).toContain(c.connectedBadge);
+    expect(labelOf(el)).toBe(c.manageAria);
+    expect(dotOf(el)).toBe("primary");
   });
 
   it("opens the panel to manage an already-connected browser instead of re-pairing", async () => {
     getBrowserExtensionStatus.mockResolvedValue({ configured: true, connected: true });
     const { el } = await mount();
-    expect(el.textContent).toContain(c.connectedBadge);
+    expect(dotOf(el)).toBe("primary");
 
     await click(el);
 

--- a/apps/app-web/src/components/doc/connect-browser-button.tsx
+++ b/apps/app-web/src/components/doc/connect-browser-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 /**
- * "My Browser" sidebar row — connect or reconnect the local browser extension
+ * "My Browser" — connect, allow, or reconnect the local browser extension
  * from the persistent chrome, without going through Settings.
  *
  * The pairing machinery already exists (`connect-browser-panel.tsx` +
@@ -11,24 +11,36 @@
  * actually matter: connecting the first time, and reconnecting after Chrome
  * has been restarted and the relay socket is gone. Both are one click here.
  *
- * The row sits directly under the icon nav, so it is reachable from every
- * surface (the sidebar is mounted by `WorkspaceChrome`, above the surfaces).
+ * **Shape.** A 28px icon square in the operator app-bar strip, sitting after
+ * the apps — same square, same hover wash, same glyph weight, so the browser
+ * reads as one more thing the sidebar can take you to rather than a band of
+ * chrome bolted under the strip. It was a full-width labelled row first; that
+ * added a second horizontal band under an icon strip that had been through
+ * four iterations specifically to stay one fixed-height row.
+ *
+ * State lives in the glyph, since an icon has no room for a label: a primary
+ * dot when connected, an amber dot when paired but not yet allowed to drive,
+ * and no dot when there is nothing connected. The tooltip carries the words.
+ *
  * It renders nothing at all when the deployment has no relay configured
  * (`status.configured === false`) or before the first status resolves — a
- * permanently dead "Connect" button teaches people to ignore the row.
+ * permanently dead button teaches people to ignore that slot.
  *
  * Clicking while disconnected runs the same one-click path the panel uses:
- * mint a token, hand it straight to the extension. Anything other than a
- * clean pair (no extension, wrong build id, refused origin) falls back to
+ * mint a token, hand it straight to the extension. Paired-but-not-allowed
+ * asks the extension to raise Chrome's permission prompt. Anything other than
+ * a clean result (no extension, wrong build id, refused origin) falls back to
  * opening the panel, which owns the install CTA and the copy-paste fields —
- * this row never becomes a dead end. Clicking while connected opens the panel
- * to manage the connection.
+ * this button never becomes a dead end. Connected, it opens the panel to
+ * manage the connection.
  *
- * [COMP:app-web/connect-browser-row]
+ * [COMP:app-web/connect-browser-button]
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Globe } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Tooltip } from "@/components/ui/tooltip";
 import { useT } from "@/lib/i18n/client";
 import { openWorkspaceSettings } from "@/components/settings-modal/settings-modal";
 import {
@@ -52,7 +64,7 @@ import {
  */
 const STATUS_POLL_MS = 60_000;
 
-export function ConnectBrowserRow({ workspaceId }: { workspaceId: string }) {
+export function ConnectBrowserButton({ workspaceId }: { workspaceId: string }) {
   const c = useT().computer.connectBrowser.sidebarRow;
 
   const [status, setStatus] = useState<BrowserExtensionStatus | null>(null);
@@ -146,38 +158,52 @@ export function ConnectBrowserRow({ workspaceId }: { workspaceId: string }) {
   }, [busy, connected, needsControl, workspaceId, refreshStatus]);
 
   // No relay on this deployment (OSS, or unconfigured) — and nothing rendered
-  // until the first probe answers, so the label never flips under the cursor.
+  // until the first probe answers, so the slot never flips under the cursor.
   if (!status?.configured) return null;
 
+  // One label does the work a row's text used to: the icon carries only state.
+  const label = busy
+    ? c.connecting
+    : needsControl
+      ? c.allowAria
+      : connected
+        ? c.manageAria
+        : c.connectAria;
+
   return (
-    <div className="px-2 pb-1.5">
+    <Tooltip label={label}>
       <button
         type="button"
         onClick={() => void onClick()}
         disabled={busy}
-        aria-label={
-          needsControl ? c.allowAria : connected ? c.manageAria : c.connectAria
-        }
-        title={needsControl ? c.allowAria : connected ? c.manageAria : c.connectAria}
-        className="flex h-7 w-full items-center gap-2 rounded-md px-2 text-left text-[13px] text-sidebar-foreground/80 hover:bg-sidebar-accent hover:text-sidebar-foreground disabled:opacity-60"
+        aria-label={label}
+        className="group relative flex size-7 shrink-0 items-center justify-center rounded-md transition-colors hover:bg-sidebar-accent disabled:opacity-60"
       >
-        <Globe className="size-[15px] shrink-0" />
-        <span className="min-w-0 flex-1 truncate">
-          {busy
-            ? c.connecting
-            : needsControl
-              ? c.allow
-              : connected
-                ? c.connected
-                : c.connect}
-        </span>
-        {connected && !needsControl && !busy ? (
-          <span className="flex shrink-0 items-center gap-1 text-[10px] font-medium text-muted-foreground">
-            <span className="size-1.5 rounded-full bg-primary" aria-hidden />
-            {c.connectedBadge}
-          </span>
+        <Globe
+          className={cn(
+            "size-4 shrink-0",
+            connected && !needsControl
+              ? "text-primary"
+              : "text-sidebar-foreground/55 group-hover:text-sidebar-accent-foreground",
+          )}
+          strokeWidth={1.8}
+          aria-hidden
+        />
+        {/* State dot — the icon's only affordance for saying which of the
+            three states this is. Amber for "paired but not allowed to drive",
+            because it is the one state that looks connected from the relay's
+            side and still refuses every task. `ring-sidebar` keeps it legible
+            over the hover wash. */}
+        {!busy && (connected || needsControl) ? (
+          <span
+            aria-hidden
+            className={cn(
+              "absolute -right-0.5 -top-0.5 size-1.5 rounded-full ring-2 ring-sidebar",
+              needsControl ? "bg-amber-500" : "bg-primary",
+            )}
+          />
         ) : null}
       </button>
-    </div>
+    </Tooltip>
   );
 }

--- a/apps/app-web/src/components/doc/doc-sidebar.tsx
+++ b/apps/app-web/src/components/doc/doc-sidebar.tsx
@@ -79,7 +79,6 @@ import {
 import type { WorkspaceSurface } from "@/lib/doc-page-url";
 import { operatorAppFromSurface } from "@/lib/operator-apps";
 import { OperatorAppBar } from "./operator-app-bar";
-import { ConnectBrowserRow } from "./connect-browser-row";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -690,25 +689,20 @@ export function DocSidebar(props: Props) {
         )}
       </nav>
 
-      {/* Operator app-bar — the Home hub's second tier (Page / Tasks / Feed),
-          between the icon row and the surface body. Shown only while an
-          operator app is active; clicking a pill navigates AND persists the
-          per-workspace selection the Home icon resumes. See
-          operator-app-bar.tsx / lib/operator-apps.ts. */}
-      {activeOperatorApp && (
-        <OperatorAppBar
-          workspaceId={workspaceId}
-          active={activeOperatorApp}
-          feedEnabled={props.feedEnabled}
-        />
-      )}
-
-      {/* "My Browser" — connect / reconnect the local browser extension in one
-          click, from every surface. The pairing flow itself still lives in
-          Settings → Browser profiles; this row is the way in, and falls back to
-          opening that panel whenever one-click cannot finish. Renders nothing
-          where no relay is configured. See connect-browser-row.tsx. */}
-      <ConnectBrowserRow workspaceId={workspaceId} />
+      {/* Operator app-bar — the Home hub's second tier (Page / Tasks / CRM /
+          Feed), between the icon row and the surface body. Clicking an app
+          navigates AND persists the per-workspace selection the Home icon
+          resumes. It also carries "My Browser" as a trailing square: that is
+          workspace-wide chrome rather than an operator app, so the strip is
+          rendered unconditionally and `active` may be null (Brain / Studio /
+          Workflow), which hides the app switcher while keeping the browser
+          button reachable from every surface. See operator-app-bar.tsx /
+          lib/operator-apps.ts. */}
+      <OperatorAppBar
+        workspaceId={workspaceId}
+        active={activeOperatorApp}
+        feedEnabled={props.feedEnabled}
+      />
 
       {/* Search input — revealed by the Search icon (Home only). */}
       {searchOpen && props.activeSurface === "p" && (

--- a/apps/app-web/src/components/doc/operator-app-bar.tsx
+++ b/apps/app-web/src/components/doc/operator-app-bar.tsx
@@ -46,6 +46,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useT } from "@/lib/i18n/client";
 import { Tooltip } from "@/components/ui/tooltip";
+import { ConnectBrowserButton } from "./connect-browser-button";
 import {
   OPERATOR_APP_KEYS,
   operatorAppPath,
@@ -69,8 +70,14 @@ export function OperatorAppBar({
   feedEnabled,
 }: {
   workspaceId: string;
-  /** The operator app the current route belongs to. */
-  active: OperatorAppKey;
+  /**
+   * The operator app the current route belongs to, or `null` off the family
+   * (Brain / Studio / Workflow). The app SWITCHER stays scoped to the family —
+   * offering Page/Tasks/CRM/Feed from Studio would claim a relationship the
+   * routes do not have — but the strip itself still renders, because "My
+   * Browser" is workspace-wide chrome that belongs on every surface.
+   */
+  active: OperatorAppKey | null;
   /** Whether the Feed app is available for this workspace. */
   feedEnabled: boolean;
 }) {
@@ -81,9 +88,10 @@ export function OperatorAppBar({
     feed: t.feed,
     crm: t.crm,
   };
-  const apps = OPERATOR_APP_KEYS.filter(
-    (key) => key !== "feed" || feedEnabled,
-  );
+  const apps =
+    active === null
+      ? []
+      : OPERATOR_APP_KEYS.filter((key) => key !== "feed" || feedEnabled);
   return (
     <nav
       aria-label={t.aria}
@@ -120,6 +128,14 @@ export function OperatorAppBar({
           </Tooltip>
         );
       })}
+      {/* "My Browser" — same square, same hover wash, trailing the apps. It is
+          chrome rather than an operator app (it navigates nowhere; it connects
+          a browser), so it sits after them and takes no active state, but it
+          shares the strip because a second labelled band under a strip built
+          across four iterations to stay ONE fixed-height row is exactly what
+          that design was avoiding. Hides itself where no relay is configured,
+          which is what keeps the strip from ending in a dead square. */}
+      <ConnectBrowserButton workspaceId={workspaceId} />
     </nav>
   );
 }


### PR DESCRIPTION
Founder feedback: the button should sit **next to Feed**, not in a row underneath.

## Before / after

It shipped as a full-width labelled row directly under the operator app-bar - which put a second horizontal band under a strip that had been through four documented iterations specifically to stay **ONE fixed-height row**. It now lives *in* that strip as a trailing 28px icon square: same square, same hover wash, same glyph weight as the apps beside it.

## State without a label

An icon has no room for words, so state moved into the glyph and a corner dot:

- **primary dot** - connected
- **amber dot** - paired but not yet allowed to drive (the one state that looks healthy from the relay's side while every task refuses, so it earns its own colour)
- **no dot** - nothing connected

The tooltip and the accessible name carry what the row used to spell out. Tests now assert on `aria-label` and the dot rather than on rendered text.

## The strip now renders unconditionally

`active` became `OperatorAppKey | null`. Off the operator family (Brain / Studio / Workflow) the app **switcher** still stays hidden - offering Page/Tasks/CRM/Feed from Studio would claim a relationship the routes do not have - but the strip survives so the browser button stays reachable from every surface, which was the whole point of hoisting it out of Settings. When neither half has anything to show (no relay configured, no operator app), the strip collapses to nothing on its own.

## Rename

`connect-browser-row` → `connect-browser-button` (file, component, `[COMP:...]` tag). A component called `Row` that renders an icon square is exactly the drift that confuses the next session.

## Verified

`tsc --noEmit` clean; full app-web suite **2150 passing**. Confirmed in a browser against the local stack - the globe now sits fifth in the strip after Page / Tasks / CRM / Feed, and the separate band is gone.

Docs + KB move with it in brian-platform#250 and `brian-kb@fix/browser-debugger-detach` (`9ec9524`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)