### PR TITLE
feat(kb): write assistant edits back to local filesystem knowledge sources

### DIFF
--- a/apps/app-web/src/components/chrome/floating-chat.tsx
+++ b/apps/app-web/src/components/chrome/floating-chat.tsx
@@ -135,6 +135,7 @@ import {
   type PendingConfirmation,
   type ToolUsed,
 } from "@use-brian/chat-ui";
+import remarkGfm from "remark-gfm";
 import { ChatFileAttachments } from "@/components/chrome/chat-file-attachment";
 import { ChatCodeBlock } from "@/components/chrome/chat-code-block";
 import { ChatConfirmationCard } from "@/components/chrome/chat-confirmation-card";
@@ -3337,6 +3338,8 @@ function ChatPageLink({
   return <>{children}</>;
 }
 
+const CHAT_REMARK_PLUGINS = [remarkGfm];
+
 /**
  * `ChatMarkdown` with in-app page links wired up (see {@link ChatPageLink}).
  * Used for both finalised assistant messages and the live streaming buffer so
@@ -3361,7 +3364,7 @@ function ChatMarkdownWithLinks({
     }),
     [workspaceId, onOpenPage],
   );
-  return <ChatMarkdown text={text} components={components} />;
+  return <ChatMarkdown text={text} components={components} remarkPlugins={CHAT_REMARK_PLUGINS} />;
 }
 
 function MessageBubble({

--- a/packages/api/src/knowledge/__tests__/repo-writer.test.ts
+++ b/packages/api/src/knowledge/__tests__/repo-writer.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createKnowledgeRepoWriter, type RepoWriterGithubOps, type RepoWriterStore } from '../repo-writer.js'
 
 const SOURCE = {
   id: 'src1',
   workspaceId: 'w1',
+  sourceType: 'github' as const,
   repo: 'acme/kb',
   branch: 'main',
   rootPath: 'docs/kb',
@@ -41,6 +45,11 @@ function makeOps(overrides?: Partial<RepoWriterGithubOps>): RepoWriterGithubOps 
 const syncCredentials = { getPat: vi.fn(async () => 'ghp_pat') }
 
 beforeEach(() => { vi.clearAllMocks() })
+
+const tempDirs: string[] = []
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })))
+})
 
 const UPDATE_PARAMS = {
   workspaceId: 'w1',
@@ -214,6 +223,121 @@ describe('[COMP:knowledge/repo-writer] createKnowledgeRepoWriter', () => {
       const result = await writer.commitEntryCreate(CREATE_PARAMS)
 
       expect(result).toMatchObject({ ok: false, reason: 'no_credentials' })
+    })
+  })
+
+  describe('local source parity', () => {
+    async function makeLocalSource() {
+      const base = await fs.mkdtemp(path.join(os.tmpdir(), 'brian-kb-writer-'))
+      tempDirs.push(base)
+      const root = path.join(base, 'docs', 'kb')
+      await fs.mkdir(root, { recursive: true })
+      const source = {
+        ...SOURCE,
+        sourceType: 'local' as const,
+        repo: base,
+        branch: 'local',
+        rootPath: 'docs/kb',
+        connectorInstanceId: null,
+        writeAccess: null,
+      }
+      return { base, root, source }
+    }
+
+    it('updates the local file atomically, preserves frontmatter, and writes through', async () => {
+      const { root, source } = await makeLocalSource()
+      const filePath = path.join(root, 'products', 'vault.md')
+      await fs.mkdir(path.dirname(filePath), { recursive: true })
+      await fs.writeFile(filePath, RAW_FILE)
+      const store = makeStore({ getSource: vi.fn(async () => source) })
+      const ops = makeOps()
+      const events: unknown[] = []
+      const writer = createKnowledgeRepoWriter({
+        store,
+        githubOps: ops,
+        recordEvent: (event) => events.push(event),
+      })
+
+      const result = await writer.commitEntryUpdate(UPDATE_PARAMS)
+
+      expect(result).toMatchObject({ ok: true, sourceType: 'local', commitSha: null, commitUrl: null })
+      expect(await fs.readFile(filePath, 'utf8')).toBe('---\ntitle: "Vault"\nsensitivity: internal\n---\nNew body\n')
+      expect(ops.getBranchHead).not.toHaveBeenCalled()
+      expect(store.upsertByPath).toHaveBeenCalledWith(expect.objectContaining({
+        path: 'products/vault', content: 'New body', sourceId: 'src1', sourceSha: null,
+      }))
+      expect(events[0]).toMatchObject({
+        eventName: 'kb_repo_write', metadata: expect.objectContaining({ sourceType: 'local', op: 'update' }),
+      })
+    })
+
+    it('rejects a stale local body without changing the file', async () => {
+      const { root, source } = await makeLocalSource()
+      const filePath = path.join(root, 'products', 'vault', 'index.md')
+      await fs.mkdir(path.dirname(filePath), { recursive: true })
+      const changed = '---\ntitle: "Vault"\n---\nExternal edit\n'
+      await fs.writeFile(filePath, changed)
+      const store = makeStore({ getSource: vi.fn(async () => source) })
+      const writer = createKnowledgeRepoWriter({ store })
+
+      const result = await writer.commitEntryUpdate(UPDATE_PARAMS)
+
+      expect(result).toMatchObject({ ok: false, reason: 'stale_entry' })
+      expect(await fs.readFile(filePath, 'utf8')).toBe(changed)
+      expect(store.upsertByPath).not.toHaveBeenCalled()
+    })
+
+    it('creates a local markdown file beneath rootPath with no GitHub calls', async () => {
+      const { root, source } = await makeLocalSource()
+      const store = makeStore({
+        getSource: vi.fn(async () => source),
+        upsertByPath: vi.fn(async () => ({ id: 'local-new', path: 'guides/start' })),
+      })
+      const ops = makeOps()
+      const writer = createKnowledgeRepoWriter({ store, githubOps: ops })
+
+      const result = await writer.commitEntryCreate({
+        workspaceId: 'w1', sourceId: 'src1', path: 'guides/start',
+        fileContent: '---\ntitle: "Start"\n---\nBody\n', changeSummary: 'add guide',
+      })
+
+      expect(result).toMatchObject({ ok: true, sourceType: 'local', commitSha: null })
+      expect(await fs.readFile(path.join(root, 'guides', 'start.md'), 'utf8')).toContain('title: "Start"')
+      expect(ops.createOrUpdateFile).not.toHaveBeenCalled()
+      expect(store.upsertByPath).toHaveBeenCalledWith(expect.objectContaining({ path: 'guides/start' }))
+    })
+
+    it('rejects local path traversal and existing index variants', async () => {
+      const { root, source } = await makeLocalSource()
+      await fs.mkdir(path.join(root, 'guides', 'start'), { recursive: true })
+      await fs.writeFile(path.join(root, 'guides', 'start', 'index.md'), '# Existing\n')
+      const store = makeStore({ getSource: vi.fn(async () => source) })
+      const writer = createKnowledgeRepoWriter({ store })
+      const params = {
+        workspaceId: 'w1', sourceId: 'src1', fileContent: '# New\n', changeSummary: 'add',
+      }
+
+      await expect(writer.commitEntryCreate({ ...params, path: '../outside' }))
+        .resolves.toMatchObject({ ok: false, reason: 'error' })
+      await expect(writer.commitEntryCreate({ ...params, path: 'guides/start' }))
+        .resolves.toMatchObject({ ok: false, reason: 'file_exists' })
+      await expect(fs.stat(path.join(root, '..', 'outside.md'))).rejects.toMatchObject({ code: 'ENOENT' })
+    })
+
+    it('rejects a local root symlink that escapes the configured source', async () => {
+      const { base, source } = await makeLocalSource()
+      const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'brian-kb-outside-'))
+      tempDirs.push(outside)
+      await fs.rm(path.join(base, 'docs', 'kb'), { recursive: true })
+      await fs.symlink(outside, path.join(base, 'docs', 'kb'))
+      const writer = createKnowledgeRepoWriter({ store: makeStore({ getSource: vi.fn(async () => source) }) })
+
+      const result = await writer.commitEntryCreate({
+        workspaceId: 'w1', sourceId: 'src1', path: 'escape', fileContent: '# Escape\n', changeSummary: 'add',
+      })
+
+      expect(result).toMatchObject({ ok: false, reason: 'source_missing' })
+      await expect(fs.stat(path.join(outside, 'escape.md'))).rejects.toMatchObject({ code: 'ENOENT' })
     })
   })
 })

--- a/packages/api/src/knowledge/repo-files.ts
+++ b/packages/api/src/knowledge/repo-files.ts
@@ -34,9 +34,27 @@ export function resolveRepoFilePath(
   const prefix = rootPath.replace(/\/+$/, '')
   for (const p of treePaths) {
     if (!p.endsWith('.md')) continue
-    if (prefix && !p.startsWith(prefix)) continue
+    if (prefix && p !== prefix && !p.startsWith(`${prefix}/`)) continue
     const relative = prefix ? p.slice(prefix.length).replace(/^\//, '') : p
     if (normalisePath(relative) === entryPath) return p
   }
   return null
+}
+
+/** Validate and canonicalise a model-supplied logical KB entry path. */
+export function validateKnowledgeEntryPath(input: string): string | null {
+  const candidate = input.trim()
+  if (
+    !candidate
+    || candidate.includes('\0')
+    || candidate.includes('\\')
+    || candidate.startsWith('/')
+    || /^[A-Za-z]:/.test(candidate)
+    || candidate.includes('//')
+  ) return null
+
+  const entryPath = normalisePath(candidate)
+  const segments = entryPath.split('/')
+  if (segments.some((segment) => !segment || segment === '.' || segment === '..')) return null
+  return entryPath
 }

--- a/packages/api/src/knowledge/repo-writer.ts
+++ b/packages/api/src/knowledge/repo-writer.ts
@@ -1,5 +1,5 @@
 /**
- * Knowledge repo writer — the assistant KB write tools' GitHub write-back.
+ * Knowledge source writer — assistant KB write-back for GitHub and local sources.
  * [COMP:knowledge/repo-writer]
  *
  * Implements the core `KnowledgeRepoWriter` port: direct commits to a
@@ -23,10 +23,13 @@
  *   write tools drop out of injection on the next turn.
  */
 
-import { parseMarkdownFile, normalisePath } from '@use-brian/core'
+import { randomUUID } from 'node:crypto'
+import fs from 'node:fs/promises'
+import nodePath from 'node:path'
+import { parseMarkdownFile } from '@use-brian/core'
 import type { KnowledgeRepoWriter, KnowledgeRepoWriteResult, Sensitivity } from '@use-brian/core'
 import * as github from '../github/client.js'
-import { splitFrontmatterBlock, resolveRepoFilePath } from './repo-files.js'
+import { splitFrontmatterBlock, resolveRepoFilePath, validateKnowledgeEntryPath } from './repo-files.js'
 
 /** The GitHub calls the writer makes. Injectable so tests run without the network. */
 export type RepoWriterGithubOps = {
@@ -53,6 +56,7 @@ export type RepoWriterStore = {
   getSource(id: string): Promise<{
     id: string
     workspaceId: string
+    sourceType: 'github' | 'local'
     repo: string
     branch: string
     rootPath: string
@@ -71,7 +75,7 @@ export type RepoWriterStore = {
 export type KnowledgeRepoWriterDeps = {
   store: RepoWriterStore
   /** Same bound-instance PAT resolution the sync worker uses. */
-  syncCredentials: { getPat(workspaceId: string, connectorInstanceId: string | null): Promise<string> }
+  syncCredentials?: { getPat(workspaceId: string, connectorInstanceId: string | null): Promise<string> }
   /** Test seam. Defaults to the real fetch-based client. */
   githubOps?: RepoWriterGithubOps
   /** Metadata-only audit emit (`kb_repo_write` into analytics_events). */
@@ -79,7 +83,8 @@ export type KnowledgeRepoWriterDeps = {
 }
 
 type ResolvedTarget =
-  | { ok: true; source: NonNullable<Awaited<ReturnType<RepoWriterStore['getSource']>>>; owner: string; repo: string; pat: string }
+  | { ok: true; kind: 'github'; source: NonNullable<Awaited<ReturnType<RepoWriterStore['getSource']>>>; owner: string; repo: string; pat: string }
+  | { ok: true; kind: 'local'; source: NonNullable<Awaited<ReturnType<RepoWriterStore['getSource']>>>; root: string }
   | { ok: false; result: KnowledgeRepoWriteResult }
 
 export function createKnowledgeRepoWriter(deps: KnowledgeRepoWriterDeps): KnowledgeRepoWriter {
@@ -94,6 +99,23 @@ export function createKnowledgeRepoWriter(deps: KnowledgeRepoWriterDeps): Knowle
     if (!source || source.workspaceId !== workspaceId) {
       return fail('source_missing', 'The knowledge source backing this entry no longer exists.')
     }
+    if (source.sourceType === 'local') {
+      try {
+        const base = await fs.realpath(source.repo)
+        const root = await fs.realpath(nodePath.resolve(base, source.rootPath || '.'))
+        const relative = nodePath.relative(base, root)
+        if (relative === '..' || relative.startsWith(`..${nodePath.sep}`) || nodePath.isAbsolute(relative)) {
+          return fail('source_missing', 'The local knowledge root escapes its configured source directory.')
+        }
+        const stat = await fs.stat(root)
+        if (!stat.isDirectory()) return fail('source_missing', 'The local knowledge root is not a directory.')
+        return { ok: true, kind: 'local', source, root }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        return fail('not_writable', `The local knowledge directory is unavailable: ${message}`)
+      }
+    }
+
     // Defense-in-depth behind the injection gate: the cached probe is the
     // authority even if a stale tool instance survives a capability flip.
     if (source.writeAccess !== true) {
@@ -105,11 +127,12 @@ export function createKnowledgeRepoWriter(deps: KnowledgeRepoWriterDeps): Knowle
     }
     let pat: string
     try {
+      if (!deps.syncCredentials) throw new Error('GitHub credentials are not configured')
       pat = await deps.syncCredentials.getPat(source.workspaceId, source.connectorInstanceId)
     } catch {
       return fail('no_credentials', `The GitHub connector backing ${source.repo} has no credentials. Reconnect it in Studio → Connectors.`)
     }
-    return { ok: true, source, owner, repo, pat }
+    return { ok: true, kind: 'github', source, owner, repo, pat }
   }
 
   /**
@@ -137,6 +160,73 @@ export function createKnowledgeRepoWriter(deps: KnowledgeRepoWriterDeps): Knowle
       }
     }
     return { ok: false, reason: 'error', message: `GitHub write failed: ${message}` }
+  }
+
+  function classifyLocalWriteError(source: { repo: string }, err: unknown): KnowledgeRepoWriteResult {
+    const code = (err as NodeJS.ErrnoException | null)?.code
+    const message = err instanceof Error ? err.message : String(err)
+    if (code === 'EACCES' || code === 'EPERM' || code === 'EROFS') {
+      return { ok: false, reason: 'not_writable', message: `The local knowledge directory is not writable: ${source.repo}` }
+    }
+    return { ok: false, reason: 'error', message: `Local knowledge write failed: ${message}` }
+  }
+
+  function toPosixPath(value: string): string {
+    return value.split(nodePath.sep).join('/')
+  }
+
+  async function listLocalMarkdownFiles(root: string): Promise<Array<{ absolute: string; relative: string }>> {
+    const files: Array<{ absolute: string; relative: string }> = []
+    async function walk(dir: string): Promise<void> {
+      const entries = await fs.readdir(dir, { withFileTypes: true })
+      for (const entry of entries) {
+        if (entry.isSymbolicLink()) continue
+        const absolute = nodePath.join(dir, entry.name)
+        if (entry.isDirectory()) {
+          if (entry.name.startsWith('.') || entry.name === 'node_modules') continue
+          await walk(absolute)
+        } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.md')) {
+          files.push({ absolute, relative: toPosixPath(nodePath.relative(root, absolute)) })
+        }
+      }
+    }
+    await walk(root)
+    return files
+  }
+
+  async function replaceLocalFile(filePath: string, content: string): Promise<void> {
+    const stat = await fs.lstat(filePath)
+    if (!stat.isFile() || stat.isSymbolicLink()) throw new Error('The local knowledge file is not a regular file.')
+    const tempPath = nodePath.join(nodePath.dirname(filePath), `.${nodePath.basename(filePath)}.${randomUUID()}.tmp`)
+    try {
+      await fs.writeFile(tempPath, content, { flag: 'wx', mode: stat.mode })
+      await fs.rename(tempPath, filePath)
+    } finally {
+      await fs.rm(tempPath, { force: true }).catch(() => {})
+    }
+  }
+
+  async function ensureLocalCreateParent(root: string, entryPath: string): Promise<string> {
+    const segments = entryPath.split('/')
+    let current = root
+    for (const segment of segments.slice(0, -1)) {
+      current = nodePath.join(current, segment)
+      try {
+        const stat = await fs.lstat(current)
+        if (!stat.isDirectory() || stat.isSymbolicLink()) {
+          throw new Error(`Local knowledge path parent is not a regular directory: ${segment}`)
+        }
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+        await fs.mkdir(current)
+      }
+    }
+    const target = nodePath.join(root, ...segments) + '.md'
+    const relative = nodePath.relative(root, target)
+    if (relative === '..' || relative.startsWith(`..${nodePath.sep}`) || nodePath.isAbsolute(relative)) {
+      throw new Error('Local knowledge path escapes its configured root.')
+    }
+    return target
   }
 
   function relativeRepoPath(rootPath: string, filePath: string): string {
@@ -172,11 +262,11 @@ export function createKnowledgeRepoWriter(deps: KnowledgeRepoWriterDeps): Knowle
    */
   async function writeThrough(
     source: { id: string; workspaceId: string; rootPath: string },
-    filePath: string,
+    relativePath: string,
     fileContent: string,
     commitSha: string | null,
   ): Promise<{ id: string; path: string }> {
-    const parsed = parseMarkdownFile(relativeRepoPath(source.rootPath, filePath), fileContent)
+    const parsed = parseMarkdownFile(relativePath, fileContent)
     return await deps.store.upsertByPath({
       workspaceId: source.workspaceId,
       path: parsed.path,
@@ -191,12 +281,14 @@ export function createKnowledgeRepoWriter(deps: KnowledgeRepoWriterDeps): Knowle
     })
   }
 
-  function mirrorFailure(commitSha: string | null, err: unknown): KnowledgeRepoWriteResult {
-    console.error('[kb-repo-writer] write-through failed after a successful commit:', err)
+  function mirrorFailure(sourceType: 'github' | 'local', commitSha: string | null, err: unknown): KnowledgeRepoWriteResult {
+    console.error('[kb-repo-writer] write-through failed after a successful source write:', err)
     return {
       ok: false,
       reason: 'error',
-      message: `The change was committed to GitHub${commitSha ? ` (${commitSha.slice(0, 7)})` : ''}, but the local mirror update failed — it will appear after the next sync (within ~15 minutes).`,
+      message: sourceType === 'github'
+        ? `The change was committed to GitHub${commitSha ? ` (${commitSha.slice(0, 7)})` : ''}, but the local mirror update failed — it will appear after the next sync (within ~15 minutes).`
+        : 'The local knowledge file was updated, but the database mirror failed — it will recover after the next sync (within ~15 minutes).',
     }
   }
 
@@ -204,106 +296,148 @@ export function createKnowledgeRepoWriter(deps: KnowledgeRepoWriterDeps): Knowle
     async commitEntryUpdate({ workspaceId, entry, newBody, changeSummary, requestedBy }) {
       const target = await resolveTarget(workspaceId, entry.sourceId)
       if (!target.ok) return target.result
-      const { source, owner, repo, pat } = target
+      const { source } = target
 
       let filePath: string
+      let relativePath: string
       let newFile: string
-      let commitSha: string | null
-      let commitUrl: string | null
-      try {
-        const headSha = await ops.getBranchHead(pat, owner, repo, source.branch)
-        const tree = await ops.getRepoTree(pat, owner, repo, headSha)
-        const resolved = resolveRepoFilePath(tree.map((t) => t.path), source.rootPath, entry.path)
-        if (!resolved) {
-          return { ok: false, reason: 'file_missing', message: 'The file behind this entry was not found in the repository — it may have been moved or deleted. Try again after the next sync.' }
-        }
-        filePath = resolved
+      let commitSha: string | null = null
+      let commitUrl: string | null = null
 
-        const fileData = await ops.getFileContents(pat, owner, repo, filePath, headSha)
-        const rawFile = Array.isArray(fileData) ? null : (fileData.content ?? null)
-        if (rawFile === null) {
-          return { ok: false, reason: 'file_missing', message: 'Could not read the current file from the repository.' }
-        }
+      if (target.kind === 'github') {
+        try {
+          const headSha = await ops.getBranchHead(target.pat, target.owner, target.repo, source.branch)
+          const tree = await ops.getRepoTree(target.pat, target.owner, target.repo, headSha)
+          const resolved = resolveRepoFilePath(tree.map((t) => t.path), source.rootPath, entry.path)
+          if (!resolved) {
+            return { ok: false, reason: 'file_missing', message: 'The file behind this entry was not found in the repository — it may have been moved or deleted. Try again after the next sync.' }
+          }
+          filePath = resolved
+          relativePath = relativeRepoPath(source.rootPath, filePath)
 
-        // Staleness guard: the DB stores the frontmatter-stripped, trimmed
-        // body. If the live repo body differs, the model edited a stale copy
-        // — committing would silently overwrite someone else's change.
-        const { frontmatter, body: repoBody } = splitFrontmatterBlock(rawFile)
-        if (repoBody.trim() !== entry.content.trim()) {
-          return { ok: false, reason: 'stale_entry', message: 'The repository moved ahead of the synced copy. Retry after the next sync (within ~15 minutes), then re-read the entry before editing.' }
+          const fileData = await ops.getFileContents(target.pat, target.owner, target.repo, filePath, headSha)
+          const rawFile = Array.isArray(fileData) ? null : (fileData.content ?? null)
+          if (rawFile === null) {
+            return { ok: false, reason: 'file_missing', message: 'Could not read the current file from the repository.' }
+          }
+          const { frontmatter, body: liveBody } = splitFrontmatterBlock(rawFile)
+          if (liveBody.trim() !== entry.content.trim()) {
+            return { ok: false, reason: 'stale_entry', message: 'The repository moved ahead of the synced copy. Retry after the next sync (within ~15 minutes), then re-read the entry before editing.' }
+          }
+          const body = newBody.endsWith('\n') ? newBody : `${newBody}\n`
+          newFile = `${frontmatter}${body}`
+          const res = await ops.createOrUpdateFile(target.pat, target.owner, target.repo, {
+            path: filePath,
+            content: newFile,
+            message: commitMessage(changeSummary, entry.path, requestedBy),
+            branch: source.branch,
+          })
+          ;({ sha: commitSha, url: commitUrl } = commitRef(res))
+        } catch (err) {
+          return classifyWriteError(source, err)
         }
-
-        const body = newBody.endsWith('\n') ? newBody : `${newBody}\n`
-        newFile = `${frontmatter}${body}`
-        const res = await ops.createOrUpdateFile(pat, owner, repo, {
-          path: filePath,
-          content: newFile,
-          message: commitMessage(changeSummary, entry.path, requestedBy),
-          branch: source.branch,
-        })
-        ;({ sha: commitSha, url: commitUrl } = commitRef(res))
-      } catch (err) {
-        return classifyWriteError(source, err)
+      } else {
+        try {
+          const files = await listLocalMarkdownFiles(target.root)
+          const resolved = files.find((file) => validateKnowledgeEntryPath(file.relative) === entry.path)
+          if (!resolved) {
+            return { ok: false, reason: 'file_missing', message: 'The file behind this entry was not found in the local knowledge directory. Try again after the next sync.' }
+          }
+          filePath = resolved.absolute
+          relativePath = resolved.relative
+          const rawFile = await fs.readFile(filePath, 'utf8')
+          const { frontmatter, body: liveBody } = splitFrontmatterBlock(rawFile)
+          if (liveBody.trim() !== entry.content.trim()) {
+            return { ok: false, reason: 'stale_entry', message: 'The local knowledge file moved ahead of the synced copy. Retry after the next sync, then re-read the entry before editing.' }
+          }
+          const body = newBody.endsWith('\n') ? newBody : `${newBody}\n`
+          newFile = `${frontmatter}${body}`
+          await replaceLocalFile(filePath, newFile)
+        } catch (err) {
+          return classifyLocalWriteError(source, err)
+        }
       }
 
       let row: { id: string; path: string }
       try {
-        row = await writeThrough(source, filePath, newFile, commitSha)
+        row = await writeThrough(source, relativePath, newFile, commitSha)
       } catch (err) {
-        return mirrorFailure(commitSha, err)
+        return mirrorFailure(source.sourceType, commitSha, err)
       }
       emitAudit(requestedBy, {
-        workspaceId, sourceId: source.id, entryId: row.id, op: 'update', repo: source.repo, commitSha,
+        workspaceId, sourceId: source.id, sourceType: source.sourceType, entryId: row.id, op: 'update', repo: source.repo, commitSha,
       })
-      return { ok: true, entryId: row.id, path: row.path, commitSha, commitUrl }
+      return { ok: true, entryId: row.id, path: row.path, sourceType: source.sourceType, commitSha, commitUrl }
     },
 
     async commitEntryCreate({ workspaceId, sourceId, path, fileContent, changeSummary, requestedBy }) {
       const target = await resolveTarget(workspaceId, sourceId)
       if (!target.ok) return target.result
-      const { source, owner, repo, pat } = target
+      const { source } = target
 
-      const entryPath = normalisePath(path)
+      const entryPath = validateKnowledgeEntryPath(path)
       if (!entryPath) {
         return { ok: false, reason: 'error', message: `Invalid entry path: "${path}"` }
       }
 
       let filePath: string
+      let relativePath: string
       let newFile: string
-      let commitSha: string | null
-      let commitUrl: string | null
-      try {
-        const headSha = await ops.getBranchHead(pat, owner, repo, source.branch)
-        const tree = await ops.getRepoTree(pat, owner, repo, headSha)
-        const existing = resolveRepoFilePath(tree.map((t) => t.path), source.rootPath, entryPath)
-        if (existing) {
-          return { ok: false, reason: 'file_exists', message: `An entry already exists at "${entryPath}" (${existing}). Use updateKnowledgeEntry to change it.` }
-        }
+      let commitSha: string | null = null
+      let commitUrl: string | null = null
 
-        const prefix = source.rootPath.replace(/\/+$/, '')
-        filePath = prefix ? `${prefix}/${entryPath}.md` : `${entryPath}.md`
-        newFile = fileContent.endsWith('\n') ? fileContent : `${fileContent}\n`
-        const res = await ops.createOrUpdateFile(pat, owner, repo, {
-          path: filePath,
-          content: newFile,
-          message: commitMessage(changeSummary, entryPath, requestedBy),
-          branch: source.branch,
-        })
-        ;({ sha: commitSha, url: commitUrl } = commitRef(res))
-      } catch (err) {
-        return classifyWriteError(source, err)
+      if (target.kind === 'github') {
+        try {
+          const headSha = await ops.getBranchHead(target.pat, target.owner, target.repo, source.branch)
+          const tree = await ops.getRepoTree(target.pat, target.owner, target.repo, headSha)
+          const existing = resolveRepoFilePath(tree.map((t) => t.path), source.rootPath, entryPath)
+          if (existing) {
+            return { ok: false, reason: 'file_exists', message: `An entry already exists at "${entryPath}" (${existing}). Use updateKnowledgeEntry to change it.` }
+          }
+
+          const prefix = source.rootPath.replace(/\/+$/, '')
+          filePath = prefix ? `${prefix}/${entryPath}.md` : `${entryPath}.md`
+          relativePath = relativeRepoPath(source.rootPath, filePath)
+          newFile = fileContent.endsWith('\n') ? fileContent : `${fileContent}\n`
+          const res = await ops.createOrUpdateFile(target.pat, target.owner, target.repo, {
+            path: filePath,
+            content: newFile,
+            message: commitMessage(changeSummary, entryPath, requestedBy),
+            branch: source.branch,
+          })
+          ;({ sha: commitSha, url: commitUrl } = commitRef(res))
+        } catch (err) {
+          return classifyWriteError(source, err)
+        }
+      } else {
+        try {
+          const files = await listLocalMarkdownFiles(target.root)
+          const existing = files.find((file) => validateKnowledgeEntryPath(file.relative) === entryPath)
+          if (existing) {
+            return { ok: false, reason: 'file_exists', message: `An entry already exists at "${entryPath}" (${existing.relative}). Use updateKnowledgeEntry to change it.` }
+          }
+          filePath = await ensureLocalCreateParent(target.root, entryPath)
+          relativePath = toPosixPath(nodePath.relative(target.root, filePath))
+          newFile = fileContent.endsWith('\n') ? fileContent : `${fileContent}\n`
+          await fs.writeFile(filePath, newFile, { flag: 'wx' })
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+            return { ok: false, reason: 'file_exists', message: `An entry already exists at "${entryPath}". Use updateKnowledgeEntry to change it.` }
+          }
+          return classifyLocalWriteError(source, err)
+        }
       }
 
       let row: { id: string; path: string }
       try {
-        row = await writeThrough(source, filePath, newFile, commitSha)
+        row = await writeThrough(source, relativePath, newFile, commitSha)
       } catch (err) {
-        return mirrorFailure(commitSha, err)
+        return mirrorFailure(source.sourceType, commitSha, err)
       }
       emitAudit(requestedBy, {
-        workspaceId, sourceId: source.id, entryId: row.id, op: 'create', repo: source.repo, commitSha,
+        workspaceId, sourceId: source.id, sourceType: source.sourceType, entryId: row.id, op: 'create', repo: source.repo, commitSha,
       })
-      return { ok: true, entryId: row.id, path: row.path, commitSha, commitUrl }
+      return { ok: true, entryId: row.id, path: row.path, sourceType: source.sourceType, commitSha, commitUrl }
     },
   }
 }

--- a/packages/api/src/mcp/__tests__/inject.test.ts
+++ b/packages/api/src/mcp/__tests__/inject.test.ts
@@ -103,7 +103,9 @@ describe('[COMP:api/mcp-inject] injectMcpTools', () => {
 })
 
 describe('[COMP:api/mcp-inject] KB write-tool exposure gate', () => {
-  function kbStoreStub(sources: Array<{ id: string; repo: string; writeAccess?: boolean | null }>) {
+  type KbSource = { id: string; repo: string; sourceType: 'github' | 'local'; writeAccess?: boolean | null }
+
+  function kbStoreStub(sources: KbSource[]) {
     return {
       hasEntriesForAssistant: vi.fn().mockResolvedValue(true),
       listSourcesForAssistant: vi.fn().mockResolvedValue(sources),
@@ -116,7 +118,7 @@ describe('[COMP:api/mcp-inject] KB write-tool exposure gate', () => {
   }
 
   async function inject(params: {
-    sources: Array<{ id: string; repo: string; writeAccess?: boolean | null }>
+    sources: KbSource[]
     allowKnowledgeWrites?: boolean
     withWriter?: boolean
     keepBuiltinsDirect?: boolean
@@ -136,13 +138,20 @@ describe('[COMP:api/mcp-inject] KB write-tool exposure gate', () => {
     return { tools, result }
   }
 
-  const WRITABLE = [{ id: 's1', repo: 'acme/kb', writeAccess: true }]
-  const READ_ONLY = [{ id: 's1', repo: 'acme/kb', writeAccess: null }]
+  const WRITABLE: KbSource[] = [{ id: 's1', repo: 'acme/kb', sourceType: 'github', writeAccess: true }]
+  const READ_ONLY: KbSource[] = [{ id: 's1', repo: 'acme/kb', sourceType: 'github', writeAccess: null }]
+  const LOCAL: KbSource[] = [{ id: 'local1', repo: '/srv/kb', sourceType: 'local', writeAccess: null }]
 
   it('exposes updateKnowledgeEntry on an interactive surface with a writable source', async () => {
     const { tools, result } = await inject({ sources: WRITABLE, allowKnowledgeWrites: true })
     expect([...tools.keys()]).toContain('updateKnowledgeEntry')
     expect(result.unavailable.join(' ')).not.toContain('knowledge base editing')
+  })
+
+  it('treats a local source as writable without a GitHub capability probe', async () => {
+    const { tools, result } = await inject({ sources: LOCAL, allowKnowledgeWrites: true })
+    expect([...tools.keys()]).toContain('updateKnowledgeEntry')
+    expect(result.unavailable.join(' ')).not.toContain('GitHub token')
   })
 
   it('keeps write tools out on non-interactive surfaces (default), with no unavailable advert', async () => {

--- a/packages/api/src/mcp/inject.ts
+++ b/packages/api/src/mcp/inject.ts
@@ -1088,15 +1088,12 @@ export async function injectMcpTools(params: {
       if (hasEntries || sources.length > 0) {
         const repoConnected = sources.length > 0
 
-        // KB write exposure (docs/architecture/features/knowledge-base.md →
-        // "Assistant direct edits"): repo write tools exist only when this
-        // surface allows knowledge writes (interactive chat), the writer
-        // port is wired, AND a source's cached PAT probe says push access
-        // (`write_access` — migration 310; NULL/false = read-only, fail
-        // closed). Not injected ⇒ not `mcp_search`-discoverable.
+        // KB write exposure: GitHub sources require a cached push-capability
+        // probe; local sources are writable through the filesystem writer.
+        // The interactive-surface and writer-port gates apply to both.
         const writableSources = sources
-          .filter((s) => s.writeAccess === true)
-          .map((s) => ({ id: s.id, repo: s.repo }))
+          .filter((s) => s.sourceType === 'local' || s.writeAccess === true)
+          .map((s) => ({ id: s.id, repo: s.repo, sourceType: s.sourceType }))
         const writeEnabled =
           allowKnowledgeWrites && !!knowledgeRepoWriter && writableSources.length > 0
 
@@ -1112,15 +1109,16 @@ export async function injectMcpTools(params: {
           kbToolNames.push(tool.name)
         }
 
-        // Capability honesty: on a write-capable surface with a repo-synced
-        // KB but no writable source, say so precisely — the model can then
-        // explain the fix instead of hunting for a tool that isn't there.
+        // Capability honesty: explain why source write-back is unavailable
+        // instead of letting the model hunt for a tool that is not present.
         if (allowKnowledgeWrites && repoConnected && !writeEnabled) {
-          const repos = sources.map((s) => s.repo).join(', ')
+          const githubRepos = sources.filter((s) => s.sourceType !== 'local').map((s) => s.repo).join(', ')
           unavailable.push(
-            knowledgeRepoWriter
-              ? `knowledge base editing (the GitHub token backing ${repos} is read-only — needs push permission; reconnect it with a read-write token in Studio → Connectors to enable assistant edits)`
-              : 'knowledge base editing (not configured on this server)',
+            !knowledgeRepoWriter
+              ? 'knowledge base editing (source write-back is not configured on this server)'
+              : githubRepos
+                ? `knowledge base editing (the GitHub token backing ${githubRepos} is read-only — needs push permission; reconnect it with a read-write token in Studio → Connectors to enable assistant edits)`
+                : 'knowledge base editing (no writable source is available)',
           )
         }
 

--- a/packages/api/src/routes/__tests__/knowledge-proposals.test.ts
+++ b/packages/api/src/routes/__tests__/knowledge-proposals.test.ts
@@ -25,6 +25,7 @@ vi.mock('../../db/client.js', () => ({
 }))
 
 import { workspaceKnowledgeRoutes, splitFrontmatterBlock, resolveRepoFilePath } from '../knowledge.js'
+import { validateKnowledgeEntryPath } from '../../knowledge/repo-files.js'
 import { query, queryWithRLS } from '../../db/client.js'
 
 const mockQuery = vi.mocked(query)
@@ -269,9 +270,19 @@ describe('[COMP:api/knowledge-proposals] helpers', () => {
   })
 
   it('resolveRepoFilePath honours rootPath and the index.md convention', () => {
-    const tree = ['docs/kb/products/vault.md', 'docs/kb/products/fees/index.md', 'docs/other.md']
+    const tree = ['docs/kb/products/vault.md', 'docs/kb/products/fees/index.md', 'docs/kb-other/products/leak.md', 'docs/other.md']
     expect(resolveRepoFilePath(tree, 'docs/kb', 'products/vault')).toBe('docs/kb/products/vault.md')
     expect(resolveRepoFilePath(tree, 'docs/kb', 'products/fees')).toBe('docs/kb/products/fees/index.md')
+    expect(resolveRepoFilePath(tree, 'docs/kb', 'products/leak')).toBeNull()
     expect(resolveRepoFilePath(tree, 'docs/kb', 'missing')).toBeNull()
+  })
+
+  it('validateKnowledgeEntryPath rejects filesystem traversal and ambiguous paths', () => {
+    expect(validateKnowledgeEntryPath('products/vault.md')).toBe('products/vault')
+    expect(validateKnowledgeEntryPath('products/vault/index.md')).toBe('products/vault')
+    expect(validateKnowledgeEntryPath('../outside')).toBeNull()
+    expect(validateKnowledgeEntryPath('products//vault')).toBeNull()
+    expect(validateKnowledgeEntryPath('/absolute')).toBeNull()
+    expect(validateKnowledgeEntryPath('products\\vault')).toBeNull()
   })
 })

--- a/packages/api/src/routes/channel-pipeline.ts
+++ b/packages/api/src/routes/channel-pipeline.ts
@@ -1089,25 +1089,24 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
   const connectorUserId = await getConnectorUserId(ownerId, assistant.workspaceId)
   let unavailableCapabilities: string[] = []
   if (connectorStore && mcpSettingsStore) {
-    // Assistant KB repo writer — built per turn (pure closures, no I/O) over
-    // the same closed credential resolution the sync worker uses. Channel
-    // chats have a live Approve/Deny loop (`confirmationResolver` below), so
-    // this surface qualifies for `allowKnowledgeWrites` (D2 — chat-only).
-    const knowledgeRepoWriter = connectorInstanceStore && connectorGrantStore
-      ? createKnowledgeRepoWriter({
-          store: createDbKnowledgeStore(),
-          syncCredentials: createSyncCredentialProvider(connectorInstanceStore, connectorGrantStore),
-          recordEvent: ({ userId: eventUserId, eventName, metadata }) => {
-            const safe: Record<string, number | boolean | undefined | ReturnType<typeof sanitizeAnalytics>> = {}
-            for (const [k, v] of Object.entries(metadata)) {
-              if (typeof v === 'number' || typeof v === 'boolean' || v === undefined) safe[k] = v
-              else if (v === null) safe[k] = undefined
-              else safe[k] = sanitizeAnalytics(String(v))
-            }
-            analytics?.logEvent({ userId: eventUserId, eventName, channelType, metadata: safe })
-          },
-        })
-      : undefined
+    // Built every turn so local filesystem sources remain writable even when
+    // GitHub credential stores are absent. GitHub targets fail closed without
+    // the optional credential provider.
+    const knowledgeRepoWriter = createKnowledgeRepoWriter({
+      store: createDbKnowledgeStore(),
+      syncCredentials: connectorInstanceStore && connectorGrantStore
+        ? createSyncCredentialProvider(connectorInstanceStore, connectorGrantStore)
+        : undefined,
+      recordEvent: ({ userId: eventUserId, eventName, metadata }) => {
+        const safe: Record<string, number | boolean | undefined | ReturnType<typeof sanitizeAnalytics>> = {}
+        for (const [k, v] of Object.entries(metadata)) {
+          if (typeof v === 'number' || typeof v === 'boolean' || v === undefined) safe[k] = v
+          else if (v === null) safe[k] = undefined
+          else safe[k] = sanitizeAnalytics(String(v))
+        }
+        analytics?.logEvent({ userId: eventUserId, eventName, channelType, metadata: safe })
+      },
+    })
     try {
       const injection = await injectMcpTools({
         userId: connectorUserId,

--- a/packages/core/src/knowledge/__tests__/sync-worker.test.ts
+++ b/packages/core/src/knowledge/__tests__/sync-worker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createKnowledgeSyncWorker, type SyncGitHubApi, type SyncStore, type SyncCredentials } from '../sync-worker.js'
@@ -292,6 +292,36 @@ describe('[COMP:knowledge/sync-worker] createKnowledgeSyncWorker', () => {
         expect(mockStore.updateSourceSync).toHaveBeenCalledWith('src1', expect.stringMatching(/^[a-f0-9]{40}$/))
       } finally {
         await rm(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('rejects a rootPath symlink that escapes the local source', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'brian-kb-contained-'))
+      const outside = await mkdtemp(join(tmpdir(), 'brian-kb-outside-'))
+      try {
+        await mkdir(join(dir, 'docs'))
+        await writeFile(join(outside, 'secret.md'), '# Outside\n')
+        await symlink(outside, join(dir, 'docs', 'kb'))
+        vi.mocked(mockStore.getSourcesDueForSync).mockResolvedValueOnce([{
+          ...SOURCE,
+          sourceType: 'local',
+          repo: dir,
+          branch: 'local',
+          rootPath: 'docs/kb',
+        }])
+
+        const worker = createKnowledgeSyncWorker({ store: mockStore, api: mockApi, credentials: mockCreds })
+        await worker.tick()
+
+        expect(mockStore.upsertByPath).not.toHaveBeenCalled()
+        expect(mockStore.updateSourceSync).toHaveBeenCalledWith(
+          'src1', '', expect.stringContaining('escapes its source directory'),
+        )
+      } finally {
+        await Promise.all([
+          rm(dir, { recursive: true, force: true }),
+          rm(outside, { recursive: true, force: true }),
+        ])
       }
     })
   })

--- a/packages/core/src/knowledge/sync-worker.ts
+++ b/packages/core/src/knowledge/sync-worker.ts
@@ -302,10 +302,10 @@ export function createKnowledgeSyncWorker(options: {
   }
 
   async function syncLocalSource(source: SyncSource) {
-    const baseDir = nodePath.resolve(source.repo)
-    const root = nodePath.resolve(baseDir, source.rootPath || '.')
+    const baseDir = await fs.realpath(nodePath.resolve(source.repo))
+    const root = await fs.realpath(nodePath.resolve(baseDir, source.rootPath || '.'))
     const relativeRoot = nodePath.relative(baseDir, root)
-    if (relativeRoot === '..' || relativeRoot.startsWith(`..${nodePath.sep}`)) {
+    if (relativeRoot === '..' || relativeRoot.startsWith(`..${nodePath.sep}`) || nodePath.isAbsolute(relativeRoot)) {
       throw new Error(`Local knowledge root escapes its source directory: ${source.rootPath}`)
     }
 

--- a/packages/core/src/knowledge/types.ts
+++ b/packages/core/src/knowledge/types.ts
@@ -64,6 +64,7 @@ export type KnowledgeStoreInterface = {
   listSourcesForAssistant(assistantId: string): Promise<Array<{
     id: string
     repo: string
+    sourceType: 'github' | 'local'
     /**
      * Cached PAT write-capability probe (migration 310). `true` = the bound
      * PAT can push; `false`/`null`/absent = read-only (fail closed). Drives
@@ -87,6 +88,7 @@ export type KnowledgeRepoWriteResult =
       ok: true
       entryId: string
       path: string
+      sourceType: 'github' | 'local'
       commitSha: string | null
       commitUrl: string | null
     }

--- a/packages/core/src/tools/__tests__/knowledge.test.ts
+++ b/packages/core/src/tools/__tests__/knowledge.test.ts
@@ -17,10 +17,10 @@ const mockStore: KnowledgeStoreInterface = {
 function makeWriter(): KnowledgeRepoWriter {
   return {
     commitEntryUpdate: vi.fn(async () => ({
-      ok: true as const, entryId: 'e1', path: 'products/vault', commitSha: 'abc1234', commitUrl: 'https://github.com/o/r/commit/abc1234',
+      ok: true as const, entryId: 'e1', path: 'products/vault', sourceType: 'github' as const, commitSha: 'abc1234', commitUrl: 'https://github.com/o/r/commit/abc1234',
     })),
     commitEntryCreate: vi.fn(async () => ({
-      ok: true as const, entryId: 'e2', path: 'docs/new', commitSha: 'def5678', commitUrl: null,
+      ok: true as const, entryId: 'e2', path: 'docs/new', sourceType: 'github' as const, commitSha: 'def5678', commitUrl: null,
     })),
   }
 }
@@ -244,7 +244,7 @@ describe('[COMP:tools/knowledge] createKnowledgeTools', () => {
       )
 
       expect(result.isError).toBe(true)
-      expect(result.data).toContain('synced from a GitHub repository')
+      expect(result.data).toContain('No writable knowledge source')
       expect(mockStore.create).not.toHaveBeenCalled()
     })
 
@@ -266,7 +266,7 @@ describe('[COMP:tools/knowledge] createKnowledgeTools', () => {
         repoConnected: true,
         allowWrites: true,
         repoWriter: writer,
-        writableSources: [{ id: 'src1', repo: 'acme/kb' }],
+        writableSources: [{ id: 'src1', repo: 'acme/kb', sourceType: 'github' }],
         requesterLabel: 'neal@example.com',
       })
       const result = await byName(tools, 'addKnowledgeEntry').execute(
@@ -292,6 +292,27 @@ describe('[COMP:tools/knowledge] createKnowledgeTools', () => {
       expect(mockStore.create).not.toHaveBeenCalled()
     })
 
+    it('writes through the same tool for a local source without commit metadata', async () => {
+      const writer = makeWriter()
+      vi.mocked(writer.commitEntryCreate).mockResolvedValueOnce({
+        ok: true, entryId: 'e-local', path: 'docs/local', sourceType: 'local', commitSha: null, commitUrl: null,
+      })
+      const tools = createKnowledgeTools(mockStore, {
+        repoConnected: true,
+        allowWrites: true,
+        repoWriter: writer,
+        writableSources: [{ id: 'local1', repo: '/srv/kb', sourceType: 'local' }],
+      })
+
+      const result = await byName(tools, 'addKnowledgeEntry').execute(
+        { path: 'docs/local', title: 'Local', content: 'Body' },
+        ctx,
+      )
+
+      expect(writer.commitEntryCreate).toHaveBeenCalledWith(expect.objectContaining({ sourceId: 'local1' }))
+      expect(result.data).toMatchObject({ id: 'e-local', message: 'Knowledge entry created in the local source directory.' })
+    })
+
     it('requires a repo argument when several sources are writable', async () => {
       const writer = makeWriter()
       const tools = createKnowledgeTools(mockStore, {
@@ -299,8 +320,8 @@ describe('[COMP:tools/knowledge] createKnowledgeTools', () => {
         allowWrites: true,
         repoWriter: writer,
         writableSources: [
-          { id: 'src1', repo: 'acme/kb' },
-          { id: 'src2', repo: 'acme/kb-two' },
+          { id: 'src1', repo: 'acme/kb', sourceType: 'github' },
+          { id: 'src2', repo: 'acme/kb-two', sourceType: 'github' },
         ],
       })
       const missing = await byName(tools, 'addKnowledgeEntry').execute(
@@ -328,7 +349,7 @@ describe('[COMP:tools/knowledge] createKnowledgeTools', () => {
         repoConnected: true,
         allowWrites: true,
         repoWriter: writer,
-        writableSources: [{ id: 'src1', repo: 'acme/kb' }],
+        writableSources: [{ id: 'src1', repo: 'acme/kb', sourceType: 'github' }],
       })
       await byName(tools, 'addKnowledgeEntry').execute(
         { path: 'docs/x', title: 'X', content: 'Body', sensitivity: 'public' },
@@ -344,7 +365,7 @@ describe('[COMP:tools/knowledge] createKnowledgeTools', () => {
       repoConnected: true,
       allowWrites: true,
       repoWriter: makeWriter(),
-      writableSources: [{ id: 'src1', repo: 'acme/kb' }],
+      writableSources: [{ id: 'src1', repo: 'acme/kb', sourceType: 'github' as const }],
       requesterLabel: 'neal@example.com',
     })
 
@@ -446,7 +467,7 @@ describe('[COMP:tools/knowledge] createKnowledgeTools', () => {
         ctx,
       )
       expect(result.isError).toBe(true)
-      expect(result.data).toContain('read-only')
+      expect(result.data).toContain('source write-back is unavailable')
     })
 
     it('describes the confirmation with entry title, repo, and preview', async () => {

--- a/packages/core/src/tools/base/knowledge.ts
+++ b/packages/core/src/tools/base/knowledge.ts
@@ -4,10 +4,11 @@
  * Built-in tools injected directly into the tool map (no MCP indirection).
  *
  * Write surface (docs/architecture/features/knowledge-base.md → "Assistant
- * direct edits"): repo-synced knowledge bases are assistant-editable only
+ * direct edits"): source-backed knowledge bases are assistant-editable only
  * when the injector passes a `repoWriter` — which it does only on
- * interactive, confirmation-capable surfaces AND when a source's cached
- * PAT write-capability probe passed. Every write carries
+ * interactive, confirmation-capable surfaces AND when a source is writable.
+ * GitHub uses its cached PAT probe; local sources use the filesystem writer.
+ * Every write carries
  * `requiresConfirmation` (per-edit Approve/Deny) and the descriptions
  * forbid proactive use: the assistant edits the KB only when the user
  * explicitly asked in the conversation.
@@ -20,7 +21,7 @@ import { RANK, researchWriteFloor, type Sensitivity } from '../../security/sensi
 import { unionCompartments } from '../../security/compartments.js'
 
 export type KnowledgeToolOptions = {
-  /** Whether any GitHub sync source is connected for this workspace. */
+  /** Whether any sync source is connected for this workspace. */
   repoConnected?: boolean
   /**
    * Repo write-back port. Present ONLY when the surface allows knowledge
@@ -29,8 +30,8 @@ export type KnowledgeToolOptions = {
    * repo routing in `updateKnowledgeEntry`.
    */
   repoWriter?: KnowledgeRepoWriter
-  /** Sources whose cached write probe passed — creates target one of these. */
-  writableSources?: Array<{ id: string; repo: string }>
+  /** Writable source targets. Local sources do not require a PAT probe. */
+  writableSources?: Array<{ id: string; repo: string; sourceType: 'github' | 'local' }>
   /**
    * Interactive-surface flag: gates emission of `updateKnowledgeEntry`
    * entirely. Non-interactive surfaces (workflow, scheduled, A2A, public
@@ -242,7 +243,9 @@ export function createKnowledgeTools(
   }
 
   /** Pick the create target among writable sources; string = error message. */
-  function pickWritableSource(requestedRepo: string | undefined): { id: string; repo: string } | string {
+  function pickWritableSource(
+    requestedRepo: string | undefined,
+  ): NonNullable<KnowledgeToolOptions['writableSources']>[number] | string {
     const writable = opts?.writableSources ?? []
     if (writable.length === 0) return 'No writable knowledge source is available.'
     if (requestedRepo) {
@@ -260,7 +263,7 @@ export function createKnowledgeTools(
     description:
       `Add a new entry to the knowledge base. ${EXPLICIT_ASK_RULE} ` +
       'Requires a path (directory-like), title, and content. The knowledge base is for curated, reusable information — not personal notes. ' +
-      'When the knowledge base is synced from a GitHub repository, the entry is committed directly to the repository on approval. ' +
+      'When the knowledge base is synced from a source, the entry is written directly to that source on approval. ' +
       'Sensitivity controls which assistants can read the entry: `public` (safe for external output), `internal` (team-wide, default), `confidential` (restricted to high-clearance assistants only). ' +
       'If the turn has drawn on confidential sources, the entry will be stamped `confidential` even if a lower tier was requested — no silent downgrade.',
     inputSchema: z.object({
@@ -272,7 +275,7 @@ export function createKnowledgeTools(
         'Access tier for this entry. Defaults to `internal`. Use `public` only for customer-facing content.',
       ),
       repo: z.string().optional().describe(
-        'Target repository (owner/name). Only needed when more than one knowledge source is writable.',
+        'Target source (GitHub owner/name or local directory). Only needed when more than one source is writable.',
       ),
     }),
     isConcurrencySafe: true,
@@ -286,7 +289,7 @@ export function createKnowledgeTools(
       const lines = [
         `Create knowledge entry "${args.title ?? ''}" at ${args.path ?? ''}`,
         target && typeof target !== 'string'
-          ? `Commits directly to ${target.repo}`
+          ? target.sourceType === 'local' ? `Writes directly to ${target.repo}` : `Commits directly to ${target.repo}`
           : 'Saves to the workspace knowledge base',
         `Sensitivity: ${args.sensitivity ?? 'internal'} (raised automatically if this turn used higher-tier sources)`,
       ]
@@ -323,7 +326,7 @@ export function createKnowledgeTools(
         // edits"); its absence here is a normal, explainable state.
         if (!opts.repoWriter || (opts.writableSources ?? []).length === 0) {
           return {
-            data: 'This knowledge base is synced from a GitHub repository and cannot be edited from here — the connected GitHub token is read-only (or knowledge editing is not available on this surface). Edits land in the repository and sync automatically; to enable direct edits, reconnect the source with a read-write token in Studio → Connectors.',
+            data: 'No writable knowledge source is available on this surface. GitHub sources require a read-write token; local sources require filesystem write-back to be enabled.',
             isError: true,
           }
         }
@@ -355,7 +358,9 @@ export function createKnowledgeTools(
             sensitivity: stamp,
             commit: result.commitSha ?? undefined,
             commitUrl: result.commitUrl ?? undefined,
-            message: 'Knowledge entry created and committed to the repository.',
+            message: result.sourceType === 'local'
+              ? 'Knowledge entry created in the local source directory.'
+              : 'Knowledge entry created and committed to the repository.',
           },
         }
       }
@@ -406,13 +411,15 @@ export function createKnowledgeTools(
       try {
         const entry = await readEntry(context, args.id)
         if (!entry) return null
-        const repo = entry.sourceId
-          ? opts?.writableSources?.find((s) => s.id === entry.sourceId)?.repo
+        const target = entry.sourceId
+          ? opts?.writableSources?.find((s) => s.id === entry.sourceId)
           : null
         const lines = [
           `Update knowledge entry "${entry.title}" (${entry.path})`,
           entry.sourceId
-            ? `Commits directly to ${repo ?? 'the knowledge repository'}`
+            ? target?.sourceType === 'local'
+              ? `Writes directly to ${target.repo}`
+              : `Commits directly to ${target?.repo ?? 'the knowledge repository'}`
             : 'Manual entry — updates the workspace knowledge base',
         ]
         if (args.changeSummary) lines.push(`Change: ${args.changeSummary}`)
@@ -456,7 +463,7 @@ export function createKnowledgeTools(
         // Repo-synced entry — direct commit through the write-back port.
         if (!opts?.repoWriter) {
           return {
-            data: 'This entry is synced from a GitHub repository and cannot be edited from here — the connected GitHub token is read-only (or knowledge editing is not available on this surface). Reconnect the source with a read-write token in Studio → Connectors to enable direct edits.',
+            data: 'This source-backed entry cannot be edited from here because source write-back is unavailable on this surface.',
             isError: true,
           }
         }
@@ -476,7 +483,9 @@ export function createKnowledgeTools(
             path: result.path,
             commit: result.commitSha ?? undefined,
             commitUrl: result.commitUrl ?? undefined,
-            message: 'Entry updated and committed to the repository.',
+            message: result.sourceType === 'local'
+              ? 'Entry updated in the local source directory.'
+              : 'Entry updated and committed to the repository.',
           },
         }
       }


### PR DESCRIPTION
## What

Makes **local filesystem knowledge sources** assistant-editable and hardens the KB write path. Previously a local KB was read-only from chat — `addKnowledgeEntry` errored at runtime and `updateKnowledgeEntry` was never emitted. Now assistant edits write back to the source directory on approval, matching the GitHub-source behavior.

## Changes

**Local KB write-back** (`feat(kb)`)
- `repo-writer.ts`: filesystem writer that creates/updates `.md` files in the local source directory (frontmatter-preserving updates, commit-style change summaries).
- `inject.ts` + `channel-pipeline.ts`: wire the writer into the tool surface on interactive surfaces, including channel chats that have no GitHub connector.
- `knowledge.ts` tools / `knowledge/types.ts`: carry `sourceType` so add/update route to the filesystem writer for local sources.

**Security hardening** (`fix(kb)`)
- Resolve local source roots through `realpath` to block symlink escape (`sync-worker.ts`).
- Scope entry-path resolution to the exact `rootPath` prefix and reject directory traversal (`repo-files.ts`).

**Chat rendering** (`feat(chat)`)
- Wire `remark-gfm` into `ChatMarkdownWithLinks` so GFM tables, strikethrough, and task lists render in assistant messages instead of raw `| … |` text. Table CSS already existed in `globals.css`.

## Verification

- `app-web` typecheck clean.
- Affected unit tests pass (repo-writer, inject, knowledge tools, sync-worker, knowledge-proposals).
- Manually verified end-to-end against a local KB source: search / browse / read plus add / update write-back, and table rendering in chat.