### PR TITLE
feat(telegram): add secure BYO account pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ The brain is the point: the more you drop in, the sharper the rest gets.
 Telegram and Slack bots are configured under **Studio → Channels** and need a
 public HTTPS tunnel to the local API webhook port (`4000`). Discord needs no
 inbound tunnel: the local launcher starts its open Gateway bridge on port `8090`.
+When an OSS Telegram bot is connected, Studio shows a one-time pairing code.
+Send it to that bot within 15 minutes; the first Telegram account to redeem it
+becomes the local owner's linked identity and the code cannot be reused.
 WhatsApp BYON also needs no tunnel: choose WhatsApp under **Studio → Channels**,
 scan the QR code, and the local bridge on port `8091` persists the pairing across
 restarts. Set `WA_CONNECTOR_URL` and `WA_CONNECTOR_SECRET` only when using an

--- a/apps/app-web/src/app/w/[workspaceId]/studio/channels/page.tsx
+++ b/apps/app-web/src/app/w/[workspaceId]/studio/channels/page.tsx
@@ -1570,7 +1570,11 @@ function AddChannelForm({
   const [success, setSuccess] = useState<
     | null
     | { kind: "slack"; webhookUrl: string }
-    | { kind: "telegram"; botUsername: string }
+    | {
+        kind: "telegram";
+        botUsername: string;
+        pairingCode: string | null;
+      }
     | { kind: "discord"; botUsername: string; inviteUrl: string; connectorError: string | null }
     | { kind: "email"; address: string }
     | { kind: "msteams"; webhookUrl: string }
@@ -1654,7 +1658,11 @@ function AddChannelForm({
           defaultAssistantId: defaultAssistantId || null,
         });
         await onCreated(result.channel);
-        setSuccess({ kind: "telegram", botUsername: result.botUsername });
+        setSuccess({
+          kind: "telegram",
+          botUsername: result.botUsername,
+          pairingCode: result.pairingCode,
+        });
         setTgBotToken("");
       } else if (platform === "msteams") {
         const result = await connectMsTeamsChannel(workspaceId, {
@@ -1713,7 +1721,8 @@ function AddChannelForm({
     (platform === "slack"
       ? slackBotToken.startsWith("xoxb-") && signingSecret.length >= 16
       : platform === "telegram"
-        ? tgBotToken.length > 0
+        ? tgBotToken.length > 0 &&
+          (isHostedEdition() || defaultAssistantId.length > 0)
         : platform === "msteams"
           ? msAppId.trim().length > 0 && msAppPassword.length > 0 && msTenantId.trim().length > 0
           : platform === "email"
@@ -2171,17 +2180,39 @@ function AddChannelForm({
         </div>
       )}
       {success?.kind === "telegram" && (
-        <div className="rounded-md border border-emerald-500/30 bg-emerald-500/5 p-3 flex items-center justify-between gap-2">
+        <div className="rounded-md border border-emerald-500/30 bg-emerald-500/5 p-3 flex flex-col gap-2">
           <p className="text-sm font-medium text-emerald-600 dark:text-emerald-400">
             {format(add.connectedTelegram, { username: success.botUsername })}
           </p>
-          <button
-            type="button"
-            onClick={onClose}
-            className="text-xs font-medium rounded-md border border-border px-2 py-1 hover:bg-muted"
-          >
-            {add.done}
-          </button>
+          {success.pairingCode && (
+            <>
+              <p className="text-xs text-muted-foreground">
+                {add.telegramPairingHint}
+              </p>
+              <code className="w-fit rounded bg-muted px-3 py-1.5 font-mono text-base font-semibold tracking-[0.2em]">
+                {success.pairingCode}
+              </code>
+            </>
+          )}
+          <div className="flex items-center gap-2">
+            {success.pairingCode && (
+              <a
+                href={`https://t.me/${encodeURIComponent(success.botUsername)}?start=${encodeURIComponent(success.pairingCode)}`}
+                target="_blank"
+                rel="noreferrer"
+                className="text-xs font-medium rounded-md bg-primary text-primary-foreground px-2 py-1"
+              >
+                {add.telegramPairingOpen}
+              </a>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-xs font-medium rounded-md border border-border px-2 py-1 hover:bg-muted"
+            >
+              {add.done}
+            </button>
+          </div>
         </div>
       )}
       {success?.kind === "discord" && (

--- a/apps/app-web/src/lib/api/channels.ts
+++ b/apps/app-web/src/lib/api/channels.ts
@@ -227,7 +227,7 @@ export type ConnectTelegramResult = {
   channel: Channel;
   reused: boolean;
   botUsername: string;
-  /** OSS owner-pairing code. Hosted deployments return null and use SSO. */
+  /** BYO account-pairing code; null when the channel has no default routing. */
   pairingCode: string | null;
   pairingCodeExpiresAt: string | null;
 };

--- a/apps/app-web/src/lib/api/channels.ts
+++ b/apps/app-web/src/lib/api/channels.ts
@@ -227,6 +227,9 @@ export type ConnectTelegramResult = {
   channel: Channel;
   reused: boolean;
   botUsername: string;
+  /** OSS owner-pairing code. Hosted deployments return null and use SSO. */
+  pairingCode: string | null;
+  pairingCodeExpiresAt: string | null;
 };
 
 /** Create or refresh a Telegram channel for a workspace. Auto-registers the webhook. */

--- a/apps/app-web/src/lib/i18n/dictionaries/en.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/en.ts
@@ -5199,6 +5199,8 @@ export const en = {
         connecting: "Creating…",
         connectedSlack: "Channel created. One more step: register this webhook URL in your Slack app's Event Subscriptions.",
         connectedTelegram: "Connected as @{username}. The bot is live in this workspace.",
+        telegramPairingHint: "Send this one-time code to the bot within 15 minutes. The first Telegram account to use it becomes the owner.",
+        telegramPairingOpen: "Open bot and pair",
         connectedDiscord: "Connected as {username}. Invite the bot to a Discord server so people can message it.",
         discordConnectorWarning: "Saved, but the Gateway connection didn't open yet. It will retry automatically.",
         discordInviteHint: "Open this URL to add the bot to your Discord server:",

--- a/apps/app-web/src/lib/i18n/dictionaries/en.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/en.ts
@@ -5199,7 +5199,7 @@ export const en = {
         connecting: "Creating…",
         connectedSlack: "Channel created. One more step: register this webhook URL in your Slack app's Event Subscriptions.",
         connectedTelegram: "Connected as @{username}. The bot is live in this workspace.",
-        telegramPairingHint: "Send this one-time code to the bot within 15 minutes. The first Telegram account to use it becomes the owner.",
+        telegramPairingHint: "Send this one-time code to the bot within 15 minutes to link your Telegram account.",
         telegramPairingOpen: "Open bot and pair",
         connectedDiscord: "Connected as {username}. Invite the bot to a Discord server so people can message it.",
         discordConnectorWarning: "Saved, but the Gateway connection didn't open yet. It will retry automatically.",

--- a/apps/app-web/src/lib/i18n/dictionaries/ja.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/ja.ts
@@ -4990,6 +4990,8 @@ export const ja: Dictionary = {
         connecting: "作成中…",
         connectedSlack: "チャネルを作成しました。あと一歩、下記の Webhook URL を Slack アプリの Event Subscriptions に登録してください。",
         connectedTelegram: "@{username} として接続しました。ボットがこのワークスペースで稼働しています。",
+        telegramPairingHint: "15分以内にこのワンタイムコードをボットへ送信してください。最初に使用したTelegramアカウントがオーナーになります。",
+        telegramPairingOpen: "ボットを開いてペアリング",
         connectedDiscord: "{username} として接続しました。ユーザーがメッセージを送れるよう、ボットを Discord サーバーに招待してください。",
         discordConnectorWarning: "保存しましたが、ゲートウェイ接続はまだ確立できていません。自動的に再試行します。",
         discordInviteHint: "次の URL を開いて、ボットを Discord サーバーに追加します:",

--- a/apps/app-web/src/lib/i18n/dictionaries/ja.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/ja.ts
@@ -4990,7 +4990,7 @@ export const ja: Dictionary = {
         connecting: "作成中…",
         connectedSlack: "チャネルを作成しました。あと一歩、下記の Webhook URL を Slack アプリの Event Subscriptions に登録してください。",
         connectedTelegram: "@{username} として接続しました。ボットがこのワークスペースで稼働しています。",
-        telegramPairingHint: "15分以内にこのワンタイムコードをボットへ送信してください。最初に使用したTelegramアカウントがオーナーになります。",
+        telegramPairingHint: "Telegramアカウントをリンクするには、15分以内にこのワンタイムコードをボットへ送信してください。",
         telegramPairingOpen: "ボットを開いてペアリング",
         connectedDiscord: "{username} として接続しました。ユーザーがメッセージを送れるよう、ボットを Discord サーバーに招待してください。",
         discordConnectorWarning: "保存しましたが、ゲートウェイ接続はまだ確立できていません。自動的に再試行します。",

--- a/apps/app-web/src/lib/i18n/dictionaries/zh.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh.ts
@@ -4944,6 +4944,8 @@ export const zh: Dictionary = {
         connecting: "建立中…",
         connectedSlack: "管道已建立。最後一步：將下方的 Webhook URL 註冊到 Slack 應用程式的 Event Subscriptions。",
         connectedTelegram: "已連結為 @{username}，bot 已在這個工作空間上線。",
+        telegramPairingHint: "請在 15 分鐘內將此一次性代碼傳送給 bot。第一個使用代碼的 Telegram 帳號將成為擁有者。",
+        telegramPairingOpen: "開啟 bot 並配對",
         connectedDiscord: "已連結為 {username}。請把 bot 邀請到 Discord 伺服器，這樣大家才能傳訊給它。",
         discordConnectorWarning: "已儲存，但 Gateway 連線尚未建立，系統會自動重試。",
         discordInviteHint: "開啟這個 URL，把 bot 加入你的 Discord 伺服器:",

--- a/apps/app-web/src/lib/i18n/dictionaries/zh.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh.ts
@@ -4944,7 +4944,7 @@ export const zh: Dictionary = {
         connecting: "建立中…",
         connectedSlack: "管道已建立。最後一步：將下方的 Webhook URL 註冊到 Slack 應用程式的 Event Subscriptions。",
         connectedTelegram: "已連結為 @{username}，bot 已在這個工作空間上線。",
-        telegramPairingHint: "請在 15 分鐘內將此一次性代碼傳送給 bot。第一個使用代碼的 Telegram 帳號將成為擁有者。",
+        telegramPairingHint: "請在 15 分鐘內將此一次性代碼傳送給 bot，以連結你的 Telegram 帳號。",
         telegramPairingOpen: "開啟 bot 並配對",
         connectedDiscord: "已連結為 {username}。請把 bot 邀請到 Discord 伺服器，這樣大家才能傳訊給它。",
         discordConnectorWarning: "已儲存，但 Gateway 連線尚未建立，系統會自動重試。",

--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -5429,7 +5429,11 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
       wechatConnector,
       // Fallback bot for naming sessions-derived telegram delivery destinations.
       telegramBotToken: env.TELEGRAM_BOT_TOKEN,
-      ownerPairing: { enabled: isOssEdition(), linkCodeStore },
+      ownerPairing: {
+        enabled: true,
+        requiredOnConnect: isOssEdition(),
+        linkCodeStore,
+      },
     }))
 
     if (integrationStore && env.WA_CONNECTOR_URL && env.WA_CONNECTOR_SECRET) {
@@ -5535,7 +5539,11 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
         provider, systemPrompt: LAYER_1_SYSTEM_PROMPT, tools: allTools, capabilityStore,
         memoryStore, usageStore, checkCreditBudget: ports.checkCreditBudget,
         appUrl: env.APP_URL, apiUrl: env.API_URL, integrationStore,
-        linkedAccountStore, ownerPairing: { enabled: isOssEdition(), linkCodeStore },
+        linkedAccountStore, ownerPairing: {
+          enabled: true,
+          standaloneOnboarding: isOssEdition(),
+          linkCodeStore,
+        },
         channelUserStore, workerManager, connectorStore, mcpSettingsStore,
         assistantConnectorStore, connectorGrantStore, connectorInstanceStore, knowledgeStore,
         gdriveFilesStore, workspaceFilesStore, filesApi: filesApi ?? undefined, analytics,

--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -5428,6 +5428,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
       wechatConnector,
       // Fallback bot for naming sessions-derived telegram delivery destinations.
       telegramBotToken: env.TELEGRAM_BOT_TOKEN,
+      ownerPairing: { enabled: isOssEdition(), linkCodeStore },
     }))
 
     if (integrationStore && env.WA_CONNECTOR_URL && env.WA_CONNECTOR_SECRET) {
@@ -5533,7 +5534,8 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
         provider, systemPrompt: LAYER_1_SYSTEM_PROMPT, tools: allTools, capabilityStore,
         memoryStore, usageStore, checkCreditBudget: ports.checkCreditBudget,
         appUrl: env.APP_URL, apiUrl: env.API_URL, integrationStore,
-        linkedAccountStore, channelUserStore, workerManager, connectorStore, mcpSettingsStore,
+        linkedAccountStore, ownerPairing: { enabled: isOssEdition(), linkCodeStore },
+        channelUserStore, workerManager, connectorStore, mcpSettingsStore,
         assistantConnectorStore, connectorGrantStore, connectorInstanceStore, knowledgeStore,
         gdriveFilesStore, workspaceFilesStore, filesApi: filesApi ?? undefined, analytics,
         skillStore, pendingMessageStore, deferredConfirmationStore, episodicStore,

--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -139,7 +139,7 @@ import { createBrowserSkillsStore } from './db/browser-skills-store.js'
 import { createDbConnectorActionStore } from './db/connector-actions-store.js'
 import { authRoutes } from './routes/auth.js'
 import { devAuthRoutes, isLocalDevEnv } from './routes/dev-auth.js'
-import { localSessionRoutes, isOssEdition } from './routes/local-session.js'
+import { localSessionRoutes, isOssEdition, isSelfHostedOssEnv } from './routes/local-session.js'
 import { createDbMagicLinkStore } from './db/magic-link-store.js'
 import { createSmtpClient, createWorkspaceSmtpTransport } from './email/smtp-client.js'
 import { chatRoutes, runSessionResume, tryResolveLiveToolApproval } from './routes/chat.js'
@@ -1456,15 +1456,16 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
   if (isLocalDevEnv()) {
     app.use('/auth', devAuthRoutes({ jwtSecret: env.JWT_SECRET }))
     console.warn('[dev-auth] LOCAL /auth/dev-login enabled — debug-only bypass.')
-    // The oss single-player edition's consumer front door (not a dev bypass):
-    // a neutral local-owner session the launcher opens. Gated to local + oss.
-    if (isOssEdition()) {
-      app.use(
-        '/auth',
-        localSessionRoutes({ jwtSecret: env.JWT_SECRET, ownerName: process.env.USEBRIAN_OWNER_NAME }),
-      )
-      console.log('[local-session] oss local-owner session enabled at /auth/local-session.')
-    }
+  }
+  // The OSS single-player edition's consumer front door (not a dev bypass):
+  // enabled for local launches and production-mode self-hosts, but never the
+  // hosted edition or Cloud Run. Debug /auth/dev-login remains local-dev-only.
+  if (isSelfHostedOssEnv()) {
+    app.use(
+      '/auth',
+      localSessionRoutes({ jwtSecret: env.JWT_SECRET, ownerName: process.env.USEBRIAN_OWNER_NAME }),
+    )
+    console.log('[local-session] oss local-owner session enabled at /auth/local-session.')
   }
 
   const { createConnectorGrantStore } = await import('./db/connector-grant-store.js')

--- a/packages/api/src/db/__tests__/link-codes.test.ts
+++ b/packages/api/src/db/__tests__/link-codes.test.ts
@@ -51,13 +51,13 @@ describe('[COMP:api/link-codes-store] create', () => {
     expect(code).toMatch(/^[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{6}$/)
   })
 
-  it('sets a 5-minute TTL on the inserted code', async () => {
+  it('sets a 15-minute TTL on the inserted code', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [], rowCount: 0 } as never)
       .mockResolvedValueOnce({ rows: [{ id: 'lc_1' }], rowCount: 1 } as never)
     await store.create({ userId: 'u_1', assistantId: 'a_1' })
     const sql = mockQuery.mock.calls[1][0] as string
-    expect(sql).toContain("interval '5 minutes'")
+    expect(sql).toContain("interval '15 minutes'")
   })
 })
 
@@ -79,13 +79,21 @@ describe('[COMP:api/link-codes-store] findValidCode', () => {
 })
 
 describe('[COMP:api/link-codes-store] claim', () => {
-  it('sets claimed_at and claimed_by_provider_id, gated on claimed_at IS NULL', async () => {
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 } as never)
-    await store.claim('ABC234', 'telegram_user_12345')
+  it('atomically claims only an unclaimed, unexpired code', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ code: 'ABC234' }], rowCount: 1 } as never)
+    const result = await store.claim('ABC234', 'telegram_user_12345')
     const [sql, params] = mockQuery.mock.calls[0]
     expect(sql).toContain('SET claimed_at = now()')
-    expect(sql).toContain('claimed_at IS NULL')  // race condition guard
+    expect(sql).toContain('claimed_at IS NULL')
+    expect(sql).toContain('expires_at > now()')
+    expect(sql).toContain('RETURNING')
     expect(params).toEqual(['ABC234', 'telegram_user_12345'])
+    expect(result?.code).toBe('ABC234')
+  })
+
+  it('returns null when another claimant already won', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 } as never)
+    await expect(store.claim('ABC234', 'telegram_user_2')).resolves.toBeNull()
   })
 })
 

--- a/packages/api/src/db/link-codes.ts
+++ b/packages/api/src/db/link-codes.ts
@@ -2,7 +2,7 @@
  * Telegram link code store — temporary 6-char codes for the linking handshake.
  *
  * Web UI generates a code, user sends it to the Telegram bot, bot verifies
- * and creates a linked account. Codes expire after 5 minutes.
+ * and creates a linked account. Codes expire after 15 minutes.
  *
  * See docs/architecture/platform/auth.md → "Linked Accounts".
  * Component tag: [COMP:api/link-codes-store].
@@ -37,8 +37,12 @@ export type LinkCodeStore = {
    */
   findValidCode(code: string): Promise<LinkCode | null>
 
-  /** Mark a code as claimed. No RLS. */
-  claim(code: string, providerIdThatClaimed: string): Promise<void>
+  /**
+   * Atomically claim an unexpired code. Returns the claimed row to the one
+   * winner, or null when the code is invalid, expired, or already claimed.
+   * No RLS.
+   */
+  claim(code: string, providerIdThatClaimed: string): Promise<LinkCode | null>
 
   /**
    * Get the most recent code for a (user, assistant) pair.
@@ -72,7 +76,7 @@ type TlcRow = {
 // Alphabet: uppercase alphanumeric without ambiguous chars (0/O, 1/I/L)
 const ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'
 const CODE_LENGTH = 6
-const TTL_MINUTES = 5
+const TTL_MINUTES = 15
 
 function generateCode(): string {
   let code = ''
@@ -117,12 +121,14 @@ export function createDbLinkCodeStore(): LinkCodeStore {
     },
 
     async claim(code, providerIdThatClaimed) {
-      await query(
+      const result = await query<TlcRow>(
         `UPDATE telegram_link_codes
          SET claimed_at = now(), claimed_by_provider_id = $2
-         WHERE code = $1 AND claimed_at IS NULL`,
+         WHERE code = $1 AND claimed_at IS NULL AND expires_at > now()
+         RETURNING ${TLC_COLS}`,
         [code, providerIdThatClaimed],
       )
+      return result.rows[0] ?? null
     },
 
     async getByUserAndAssistant(userId, assistantId) {

--- a/packages/api/src/routes/__tests__/channels.test.ts
+++ b/packages/api/src/routes/__tests__/channels.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../db/channels-store.js', () => ({
   listChannelAssistants: vi.fn(),
   attachAssistant: vi.fn(),
   detachAssistant: vi.fn(),
+  resolveRoutingForSurface: vi.fn(),
   // Pulled in transitively: channels.js → integrations.js (for the shared
   // `channelConfigSchema`) → channels-store.js. Not exercised by these tests.
   findOrCreateChannelForConnect: vi.fn(),
@@ -52,6 +53,7 @@ import {
   attachAssistant,
   detachAssistant,
   findOrCreateChannelForWorkspaceConnect,
+  resolveRoutingForSurface,
   type Channel,
 } from '../../db/channels-store.js'
 import {
@@ -67,6 +69,7 @@ import { queryWithRLS } from '../../db/client.js'
 import type { WorkspaceStore } from '../../db/workspace-store.js'
 import type { ChannelIntegrationStore } from '../../db/channel-integrations.js'
 import type { DiscordConnectorClient } from '../../discord/connector-client.js'
+import type { LinkCodeStore } from '../../db/link-codes.js'
 
 function makeChannel(over: Partial<Channel> = {}): Channel {
   return {
@@ -91,6 +94,7 @@ function buildApp(
     apiUrl?: string
     discordConnector?: DiscordConnectorClient
     telegramBotToken?: string
+    ownerPairing?: { enabled: boolean; linkCodeStore: LinkCodeStore }
   } = {},
 ) {
   const role = opts.role === undefined ? 'admin' : opts.role
@@ -104,6 +108,7 @@ function buildApp(
       apiUrl: opts.apiUrl,
       discordConnector: opts.discordConnector,
       telegramBotToken: opts.telegramBotToken,
+      ownerPairing: opts.ownerPairing,
     }),
     userId ? { userId } : undefined,
   )
@@ -522,6 +527,67 @@ describe('[COMP:api/channels-route] workspace-driven connect', () => {
       'https://api.example.com/webhook/telegram/chan-tg',
       expect.any(String),
     )
+    expect(res.body.pairingCode).toBeNull()
+  })
+
+  it('POST /telegram creates an OSS owner pairing code for the default assistant', async () => {
+    vi.mocked(validateTelegramCredentials).mockResolvedValue({
+      botId: 12345,
+      botUsername: 'mybot',
+      firstName: 'My Bot',
+    })
+    vi.mocked(findOrCreateChannelForWorkspaceConnect).mockResolvedValue({
+      channelId: 'chan-tg',
+      reused: false,
+    })
+    vi.mocked(resolveRoutingForSurface).mockResolvedValue({
+      id: 'route-1',
+      channelId: 'chan-tg',
+      assistantId: ASSISTANT_UUID,
+      externalSurfaceId: null,
+      modelAlias: 'standard',
+      createdAt: new Date(),
+    })
+    vi.mocked(createTelegramApi).mockReturnValue({ setWebhook: vi.fn() } as never)
+    vi.mocked(getChannelForUser).mockResolvedValue(
+      makeChannel({ id: 'chan-tg', channelType: 'telegram' }),
+    )
+    const integrationStore = {
+      upsert: vi.fn(),
+      listForWorkspace: vi.fn().mockResolvedValue([]),
+    } as unknown as ChannelIntegrationStore
+    const create = vi.fn().mockResolvedValue({
+      code: 'ABC234',
+      expiresAt: new Date('2026-07-25T12:15:00Z'),
+    })
+
+    const res = await request(buildApp({
+      integrationStore,
+      apiUrl: 'https://api.example.com',
+      ownerPairing: { enabled: true, linkCodeStore: { create } as never },
+    }))
+      .post('/api/workspaces/ws-1/channels/telegram')
+      .send({ botToken: '12345:ABC-token', defaultAssistantId: ASSISTANT_UUID })
+
+    expect(res.status).toBe(201)
+    expect(create).toHaveBeenCalledWith({ userId: 'user-1', assistantId: ASSISTANT_UUID })
+    expect(res.body).toMatchObject({
+      pairingCode: 'ABC234',
+      pairingCodeExpiresAt: '2026-07-25T12:15:00.000Z',
+    })
+  })
+
+  it('POST /telegram requires a default assistant for OSS owner pairing', async () => {
+    const res = await request(buildApp({
+      integrationStore: {} as ChannelIntegrationStore,
+      apiUrl: 'https://api.example.com',
+      ownerPairing: { enabled: true, linkCodeStore: {} as LinkCodeStore },
+    }))
+      .post('/api/workspaces/ws-1/channels/telegram')
+      .send({ botToken: '12345:ABC-token' })
+
+    expect(res.status).toBe(400)
+    expect(validateTelegramCredentials).not.toHaveBeenCalled()
   })
 
   it('POST /discord 503s when the connector is not configured', async () => {

--- a/packages/api/src/routes/__tests__/channels.test.ts
+++ b/packages/api/src/routes/__tests__/channels.test.ts
@@ -94,7 +94,11 @@ function buildApp(
     apiUrl?: string
     discordConnector?: DiscordConnectorClient
     telegramBotToken?: string
-    ownerPairing?: { enabled: boolean; linkCodeStore: LinkCodeStore }
+    ownerPairing?: {
+      enabled: boolean
+      requiredOnConnect?: boolean
+      linkCodeStore: LinkCodeStore
+    }
   } = {},
 ) {
   const role = opts.role === undefined ? 'admin' : opts.role
@@ -577,11 +581,49 @@ describe('[COMP:api/channels-route] workspace-driven connect', () => {
     })
   })
 
+  it('POST /telegram keeps hosted pairing optional without a default assistant', async () => {
+    vi.mocked(validateTelegramCredentials).mockResolvedValue({
+      botId: 12345,
+      botUsername: 'mybot',
+      firstName: 'My Bot',
+    })
+    vi.mocked(findOrCreateChannelForWorkspaceConnect).mockResolvedValue({
+      channelId: 'chan-tg',
+      reused: false,
+    })
+    vi.mocked(resolveRoutingForSurface).mockResolvedValue(null)
+    vi.mocked(createTelegramApi).mockReturnValue({ setWebhook: vi.fn() } as never)
+    vi.mocked(getChannelForUser).mockResolvedValue(
+      makeChannel({ id: 'chan-tg', channelType: 'telegram' }),
+    )
+    const integrationStore = {
+      upsert: vi.fn(),
+      listForWorkspace: vi.fn().mockResolvedValue([]),
+    } as unknown as ChannelIntegrationStore
+    const create = vi.fn()
+
+    const res = await request(buildApp({
+      integrationStore,
+      apiUrl: 'https://api.example.com',
+      ownerPairing: { enabled: true, linkCodeStore: { create } as never },
+    }))
+      .post('/api/workspaces/ws-1/channels/telegram')
+      .send({ botToken: '12345:ABC-token' })
+
+    expect(res.status).toBe(201)
+    expect(create).not.toHaveBeenCalled()
+    expect(res.body.pairingCode).toBeNull()
+  })
+
   it('POST /telegram requires a default assistant for OSS owner pairing', async () => {
     const res = await request(buildApp({
       integrationStore: {} as ChannelIntegrationStore,
       apiUrl: 'https://api.example.com',
-      ownerPairing: { enabled: true, linkCodeStore: {} as LinkCodeStore },
+      ownerPairing: {
+        enabled: true,
+        requiredOnConnect: true,
+        linkCodeStore: {} as LinkCodeStore,
+      },
     }))
       .post('/api/workspaces/ws-1/channels/telegram')
       .send({ botToken: '12345:ABC-token' })

--- a/packages/api/src/routes/__tests__/local-session.test.ts
+++ b/packages/api/src/routes/__tests__/local-session.test.ts
@@ -4,6 +4,7 @@ import request from 'supertest'
 import {
   localSessionRoutes,
   isOssEdition,
+  isSelfHostedOssEnv,
   type LocalSessionDeps,
 } from '../local-session.js'
 import { verifyAccessToken, verifyRefreshToken } from '../../auth/jwt.js'
@@ -87,6 +88,43 @@ describe('[COMP:api/local-session] isOssEdition gate', () => {
     } finally {
       if (prev.s !== undefined) process.env.USEBRIAN_EDITION = prev.s
       if (prev.n !== undefined) process.env.NEXT_PUBLIC_USEBRIAN_EDITION = prev.n
+    }
+  })
+})
+
+describe('[COMP:api/local-session] self-host gate', () => {
+  it('allows an explicit OSS production self-host', () => {
+    const prev = {
+      edition: process.env.USEBRIAN_EDITION,
+      nodeEnv: process.env.NODE_ENV,
+      cloudRun: process.env.K_SERVICE,
+    }
+    try {
+      process.env.USEBRIAN_EDITION = 'oss'
+      process.env.NODE_ENV = 'production'
+      delete process.env.K_SERVICE
+      expect(isSelfHostedOssEnv()).toBe(true)
+    } finally {
+      if (prev.edition === undefined) delete process.env.USEBRIAN_EDITION
+      else process.env.USEBRIAN_EDITION = prev.edition
+      if (prev.nodeEnv === undefined) delete process.env.NODE_ENV
+      else process.env.NODE_ENV = prev.nodeEnv
+      if (prev.cloudRun === undefined) delete process.env.K_SERVICE
+      else process.env.K_SERVICE = prev.cloudRun
+    }
+  })
+
+  it('rejects Cloud Run even when the edition flag is OSS', () => {
+    const prev = { edition: process.env.USEBRIAN_EDITION, cloudRun: process.env.K_SERVICE }
+    try {
+      process.env.USEBRIAN_EDITION = 'oss'
+      process.env.K_SERVICE = 'brian-api'
+      expect(isSelfHostedOssEnv()).toBe(false)
+    } finally {
+      if (prev.edition === undefined) delete process.env.USEBRIAN_EDITION
+      else process.env.USEBRIAN_EDITION = prev.edition
+      if (prev.cloudRun === undefined) delete process.env.K_SERVICE
+      else process.env.K_SERVICE = prev.cloudRun
     }
   })
 })

--- a/packages/api/src/routes/__tests__/telegram-byo.test.ts
+++ b/packages/api/src/routes/__tests__/telegram-byo.test.ts
@@ -339,7 +339,7 @@ describe('[COMP:api/telegram-byo-route] OSS owner pairing', () => {
       'telegram',
       expect.objectContaining({ reason: 'link-code' }),
     )
-    expect(adapterSendCalls.at(-1)?.text).toContain('recognized as the owner')
+    expect(adapterSendCalls.at(-1)?.text).toContain('linked to your Brian account')
     expect(pipelineCalls).toHaveLength(0)
   })
 

--- a/packages/api/src/routes/__tests__/telegram-byo.test.ts
+++ b/packages/api/src/routes/__tests__/telegram-byo.test.ts
@@ -29,6 +29,11 @@ const leaveChatCalls: string[] = []
 // Capture createTelegramApi().setWebhook calls so the legacy-URL self-heal
 // path can be asserted without touching api.telegram.org.
 const setWebhookCalls: Array<{ url: string; secret: string }> = []
+const { mergeShadowUser } = vi.hoisted(() => ({
+  mergeShadowUser: vi.fn(async () => ({ merged: false })),
+}))
+
+vi.mock('../../db/linked-accounts.js', () => ({ mergeShadowUser }))
 
 // Use the real Telegram adapter so parseIncoming runs the real topic-encoding
 // logic (we want to assert the route's behaviour on real parse output), but
@@ -58,7 +63,10 @@ vi.mock('@use-brian/channels', async () => {
     createTelegramAdapter: (opts: Parameters<typeof actual.createTelegramAdapter>[0]) => {
       const real = actual.createTelegramAdapter(opts)
       return Object.assign(real, {
-        sendMessage: vi.fn(async () => 'msg_stub'),
+        sendMessage: vi.fn(async (channelId: string, message: { text: string }) => {
+          adapterSendCalls.push({ channelId, text: message.text })
+          return 'msg_stub'
+        }),
         sendStatus: vi.fn(async () => 'status_stub'),
         sendTypingIndicator: vi.fn(async () => {}),
         editMessage: vi.fn(async () => {}),
@@ -267,6 +275,116 @@ beforeEach(() => {
   teamRoleCalls.length = 0
   teamRoleResponse = null
   setWebhookCalls.length = 0
+  mergeShadowUser.mockClear()
+})
+
+describe('[COMP:api/telegram-byo-route] OSS owner pairing', () => {
+  it('claims a setup code once and links the Telegram sender to the local owner', async () => {
+    const code = {
+      id: 'code-1',
+      userId: 'owner_1',
+      assistantId: 'assistant_1',
+      code: 'ABC234',
+      expiresAt: new Date(Date.now() + 60_000),
+      claimedAt: null,
+      claimedByProviderId: null,
+      createdAt: new Date(),
+    }
+    const linkCodeStore = {
+      findValidCode: vi.fn().mockResolvedValue(code),
+      claim: vi.fn().mockResolvedValue(code),
+    }
+    const linkedAccountStore = {
+      upsert: vi.fn().mockResolvedValue({}),
+      findByProvider: vi.fn().mockResolvedValue(null),
+    }
+    const app = createTestApp(
+      '/webhook/telegram-byo',
+      telegramByoRoutes({
+        provider: {} as never,
+        systemPrompt: '',
+        tools: new Map(),
+        memoryStore: {} as never,
+        integrationStore: makeIntegrationStore() as never,
+        linkedAccountStore: linkedAccountStore as never,
+        ownerPairing: { enabled: true, linkCodeStore: linkCodeStore as never },
+        capabilityStore: {} as never,
+        apiUrl: 'http://test',
+      }),
+    )
+
+    await postUpdate(app, {
+      update_id: 1,
+      message: {
+        message_id: 10,
+        from: { id: 42, first_name: 'Owner', username: 'localowner' },
+        chat: { id: 42, type: 'private' },
+        date: Math.floor(Date.now() / 1000),
+        text: '/start ABC234',
+      },
+    })
+    await flushMicrotasks()
+    await flushMicrotasks()
+
+    expect(linkCodeStore.claim).toHaveBeenCalledWith('ABC234', '42')
+    expect(linkedAccountStore.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'owner_1',
+      assistantId: 'assistant_1',
+      provider: 'telegram',
+      providerId: '42',
+    }))
+    expect(mergeShadowUser).toHaveBeenCalledWith(
+      'owner_1',
+      '42',
+      'telegram',
+      expect.objectContaining({ reason: 'link-code' }),
+    )
+    expect(adapterSendCalls.at(-1)?.text).toContain('recognized as the owner')
+    expect(pipelineCalls).toHaveLength(0)
+  })
+
+  it('does not link when the atomic claim has already been won', async () => {
+    const candidate = {
+      id: 'code-1', userId: 'owner_1', assistantId: 'assistant_1', code: 'ABC234',
+    }
+    const linkCodeStore = {
+      findValidCode: vi.fn().mockResolvedValue(candidate),
+      claim: vi.fn().mockResolvedValue(null),
+    }
+    const linkedAccountStore = {
+      upsert: vi.fn(),
+      findByProvider: vi.fn().mockResolvedValue(null),
+    }
+    const app = createTestApp(
+      '/webhook/telegram-byo',
+      telegramByoRoutes({
+        provider: {} as never,
+        systemPrompt: '',
+        tools: new Map(),
+        memoryStore: {} as never,
+        integrationStore: makeIntegrationStore() as never,
+        linkedAccountStore: linkedAccountStore as never,
+        ownerPairing: { enabled: true, linkCodeStore: linkCodeStore as never },
+        capabilityStore: {} as never,
+        apiUrl: 'http://test',
+      }),
+    )
+
+    await postUpdate(app, {
+      update_id: 2,
+      message: {
+        message_id: 11,
+        from: { id: 43, first_name: 'Imposter' },
+        chat: { id: 43, type: 'private' },
+        date: Math.floor(Date.now() / 1000),
+        text: 'ABC234',
+      },
+    })
+    await flushMicrotasks()
+    await flushMicrotasks()
+
+    expect(linkedAccountStore.upsert).not.toHaveBeenCalled()
+  })
 })
 
 describe('[COMP:api/telegram-byo-route] OSS audio intake fallback', () => {

--- a/packages/api/src/routes/channels.ts
+++ b/packages/api/src/routes/channels.ts
@@ -29,6 +29,7 @@ import {
   createSlackApi,
 } from '@use-brian/channels'
 import type { WorkspaceStore } from '../db/workspace-store.js'
+import type { LinkCodeStore } from '../db/link-codes.js'
 import type { DiscordConnectorClient } from '../discord/connector-client.js'
 import type { WhatsappConnectorClient } from '../whatsapp/connector-client.js'
 import type { WechatConnectorClient } from '../wechat/connector-client.js'
@@ -43,6 +44,7 @@ import {
   detachAssistant,
   updateChannelAssistant,
   findOrCreateChannelForWorkspaceConnect,
+  resolveRoutingForSurface,
   type Channel,
   type ChannelAssistant,
 } from '../db/channels-store.js'
@@ -116,6 +118,11 @@ export type ChannelsRouteOptions = {
    * the picker shows raw chat ids.
    */
   telegramBotToken?: string
+  /** OSS-only owner pairing. Hosted Telegram continues to use its SSO flow. */
+  ownerPairing?: {
+    enabled: boolean
+    linkCodeStore: LinkCodeStore
+  }
 }
 
 const updateSchema = z.object({
@@ -677,6 +684,10 @@ export function channelsRoutes(opts: ChannelsRouteOptions): Router {
       res.status(400).json({ error: 'Invalid input', detail: parsed.error.message })
       return
     }
+    if (opts.ownerPairing?.enabled && !parsed.data.defaultAssistantId) {
+      res.status(400).json({ error: 'Select a default assistant to pair the Telegram owner' })
+      return
+    }
 
     let info
     try {
@@ -748,10 +759,33 @@ export function channelsRoutes(opts: ChannelsRouteOptions): Router {
       return
     }
     const integrations = await loadIntegrations(userId, workspaceId)
+    let pairingCode: string | null = null
+    let pairingCodeExpiresAt: Date | null = null
+    if (opts.ownerPairing?.enabled) {
+      const routing = await resolveRoutingForSurface(provisioned.channelId, null)
+      if (!routing) {
+        res.status(500).json({ error: 'Telegram channel has no default assistant for owner pairing' })
+        return
+      }
+      try {
+        const code = await opts.ownerPairing.linkCodeStore.create({
+          userId,
+          assistantId: routing.assistantId,
+        })
+        pairingCode = code.code
+        pairingCodeExpiresAt = code.expiresAt
+      } catch (err) {
+        console.error('[channels] telegram owner pairing code creation failed:', err)
+        res.status(500).json({ error: 'Failed to create Telegram owner pairing code' })
+        return
+      }
+    }
     res.status(provisioned.reused ? 200 : 201).json({
       channel: serializeChannel(channel, integrations.get(provisioned.channelId)),
       reused: provisioned.reused,
       botUsername: info.botUsername,
+      pairingCode,
+      pairingCodeExpiresAt,
     })
   })
 

--- a/packages/api/src/routes/channels.ts
+++ b/packages/api/src/routes/channels.ts
@@ -118,9 +118,11 @@ export type ChannelsRouteOptions = {
    * the picker shows raw chat ids.
    */
   telegramBotToken?: string
-  /** OSS-only owner pairing. Hosted Telegram continues to use its SSO flow. */
+  /** One-time BYO Telegram account pairing. */
   ownerPairing?: {
     enabled: boolean
+    /** OSS setup cannot finish without an owner route; hosted keeps routing optional. */
+    requiredOnConnect?: boolean
     linkCodeStore: LinkCodeStore
   }
 }
@@ -684,7 +686,7 @@ export function channelsRoutes(opts: ChannelsRouteOptions): Router {
       res.status(400).json({ error: 'Invalid input', detail: parsed.error.message })
       return
     }
-    if (opts.ownerPairing?.enabled && !parsed.data.defaultAssistantId) {
+    if (opts.ownerPairing?.enabled && opts.ownerPairing.requiredOnConnect && !parsed.data.defaultAssistantId) {
       res.status(400).json({ error: 'Select a default assistant to pair the Telegram owner' })
       return
     }
@@ -763,21 +765,23 @@ export function channelsRoutes(opts: ChannelsRouteOptions): Router {
     let pairingCodeExpiresAt: Date | null = null
     if (opts.ownerPairing?.enabled) {
       const routing = await resolveRoutingForSurface(provisioned.channelId, null)
-      if (!routing) {
+      if (!routing && opts.ownerPairing.requiredOnConnect) {
         res.status(500).json({ error: 'Telegram channel has no default assistant for owner pairing' })
         return
       }
-      try {
-        const code = await opts.ownerPairing.linkCodeStore.create({
-          userId,
-          assistantId: routing.assistantId,
-        })
-        pairingCode = code.code
-        pairingCodeExpiresAt = code.expiresAt
-      } catch (err) {
-        console.error('[channels] telegram owner pairing code creation failed:', err)
-        res.status(500).json({ error: 'Failed to create Telegram owner pairing code' })
-        return
+      if (routing) {
+        try {
+          const code = await opts.ownerPairing.linkCodeStore.create({
+            userId,
+            assistantId: routing.assistantId,
+          })
+          pairingCode = code.code
+          pairingCodeExpiresAt = code.expiresAt
+        } catch (err) {
+          console.error('[channels] telegram owner pairing code creation failed:', err)
+          res.status(500).json({ error: 'Failed to create Telegram owner pairing code' })
+          return
+        }
       }
     }
     res.status(provisioned.reused ? 200 : 201).json({

--- a/packages/api/src/routes/local-session.ts
+++ b/packages/api/src/routes/local-session.ts
@@ -1,7 +1,6 @@
 import { Router } from 'express'
 import { createTokens } from '../auth/jwt.js'
 import { findOrCreateUser, type User } from '../db/users.js'
-import { isLocalDevEnv } from './dev-auth.js'
 
 /**
  * OSS LOCAL-OWNER SESSION — `GET|POST /auth/local-session`.
@@ -19,9 +18,10 @@ import { isLocalDevEnv } from './dev-auth.js'
  * session. The only differences from `dev-auth` are the identity and the gate.
  *
  * ## Gate (two independent layers)
- *   1. Mounted in `boot.ts` only when `isLocalDevEnv() && isOssEdition()`.
+ *   1. Mounted in `boot.ts` only for an explicitly OSS, non-Cloud-Run process.
  *   2. Every request re-checks both — so it can never mint a token in the hosted
- *      cloud (`K_SERVICE`/`NODE_ENV=production`) or in the hosted edition.
+ *      cloud (`K_SERVICE`) or in the hosted edition. Production-mode self-hosts
+ *      are allowed because they run the built app with `next start`.
  *
  * The owner's display name is local config, not user-editable server state: the
  * launcher prompts once, persists it to `~/.usebrian/config.json`, and passes
@@ -45,6 +45,11 @@ export function isOssEdition(): boolean {
   )
 }
 
+/** OSS single-owner auth is valid in local and production-mode self-hosts. */
+export function isSelfHostedOssEnv(): boolean {
+  return isOssEdition() && !process.env.K_SERVICE
+}
+
 /** The neutral owner identity. No real email — `@local` is never shown in oss UI. */
 const OWNER_PROVIDER = 'local'
 const OWNER_PROVIDER_ID = 'local-owner'
@@ -63,7 +68,7 @@ export type LocalSessionDeps = {
 
 export function localSessionRoutes(deps: LocalSessionDeps): Router {
   const createUser = deps.createUser ?? findOrCreateUser
-  const isEnabled = deps.isEnabled ?? (() => isLocalDevEnv() && isOssEdition())
+  const isEnabled = deps.isEnabled ?? isSelfHostedOssEnv
   const router = Router()
 
   const handler = async (

--- a/packages/api/src/routes/slack.ts
+++ b/packages/api/src/routes/slack.ts
@@ -572,9 +572,11 @@ export function slackRoutes(options: SlackRouteOptions): Router {
     ) {
       const trimmed = incoming.text.trim().toUpperCase()
       if (/^[A-Z0-9]{6}$/.test(trimmed)) {
-        const code = await options.linkCodeStore.findValidCode(trimmed)
-        if (code) {
+        const candidate = await options.linkCodeStore.findValidCode(trimmed)
+        if (candidate) {
           try {
+            const code = await options.linkCodeStore.claim(trimmed, incoming.userId)
+            if (!code) return
             await options.linkedAccountStore.upsert({
               userId: code.userId,
               assistantId: code.assistantId,
@@ -582,7 +584,6 @@ export function slackRoutes(options: SlackRouteOptions): Router {
               providerId: incoming.userId,
               providerMetadata: { channelId: incoming.channelId },
             })
-            await options.linkCodeStore.claim(trimmed, incoming.userId)
             mergeShadowUser(code.userId, incoming.userId, 'slack', {
               reason: 'link-code',
               evidence: { codeId: code.id, channelId: incoming.channelId },

--- a/packages/api/src/routes/telegram-byo.ts
+++ b/packages/api/src/routes/telegram-byo.ts
@@ -96,9 +96,11 @@ type TelegramByoRouteOptions = {
   apiUrl: string
   integrationStore: ChannelIntegrationStore
   linkedAccountStore?: LinkedAccountStore
-  /** OSS-only one-time owner pairing; hosted BYO bots keep the SSO flow. */
+  /** One-time account pairing for OSS and hosted BYO Telegram bots. */
   ownerPairing?: {
     enabled: boolean
+    /** Replace hosted SSO redirect copy with standalone Studio pairing copy. */
+    standaloneOnboarding?: boolean
     linkCodeStore: LinkCodeStore
   }
   channelUserStore?: ChannelUserStore
@@ -696,7 +698,7 @@ export function telegramByoRoutes(options: TelegramByoRouteOptions): Router {
         }
       }
 
-      // OSS owner pairing. The code is generated while connecting this BYO bot
+      // BYO account pairing. The code is generated while connecting this bot
       // and is bound to its default assistant. Claim is atomic, so only one
       // Telegram account can win even if the same code is sent concurrently.
       if (
@@ -738,7 +740,7 @@ export function telegramByoRoutes(options: TelegramByoRouteOptions): Router {
                 console.error('[telegram-byo] owner pairing shadow merge failed:', err)
               })
               await adapter.sendMessage(incoming.channelId, {
-                text: 'Telegram connected. You are now recognized as the owner of this Brian instance.',
+                text: 'Telegram connected. This Telegram account is now linked to your Brian account.',
               }).catch((err) => {
                 console.error('[telegram-byo] owner pairing confirmation failed:', err)
               })
@@ -765,7 +767,7 @@ export function telegramByoRoutes(options: TelegramByoRouteOptions): Router {
           ? await options.linkedAccountStore.findByProvider('telegram', telegramUserIdStr)
           : null
         const isOwner = !!linked && linked.userId === ownerId
-        if (options.ownerPairing?.enabled && !linked) {
+        if (options.ownerPairing?.standaloneOnboarding && !linked) {
           await adapter.sendMessage(incoming.channelId, {
             text: 'This bot is not paired yet. Reconnect it in Studio, then send the one-time owner code shown there.',
           }).catch((err) => {
@@ -920,7 +922,7 @@ export function telegramByoRoutes(options: TelegramByoRouteOptions): Router {
 
       if (privateChatRedirect) {
         await adapter.sendMessage(incoming.channelId, {
-          text: options.ownerPairing?.enabled
+          text: options.ownerPairing?.standaloneOnboarding
             ? 'This private bot is not paired with your Telegram account. Reconnect it in Studio and send the new one-time owner code here.'
             : 'This is a private bot. To try Use Brian, DM @use_brian_bot to sign in and link your account.',
         }).catch((err) => {

--- a/packages/api/src/routes/telegram-byo.ts
+++ b/packages/api/src/routes/telegram-byo.ts
@@ -34,7 +34,8 @@ import { getWorkspaceRoleSystem } from '../db/workspace-store.js'
 import { query } from '../db/client.js'
 import { resolveChannelUser, fetchTelegramProfile, type ChannelUserStore } from '../db/channel-user-store.js'
 import { resolveAssistantForSurface, resolveRoutingForSurface, getChannelForWebhook } from '../db/channels-store.js'
-import type { LinkedAccountStore } from '../db/linked-accounts.js'
+import { mergeShadowUser, type LinkedAccountStore } from '../db/linked-accounts.js'
+import type { LinkCodeStore } from '../db/link-codes.js'
 import { withChatLock } from '../db/chat-lock.js'
 import { buildDocumentFiledReply, buildOversizeDocReply, classifyMedia } from '../ingest/channel-media-intake.js'
 import type { ConfirmationDecision, ConfirmationResolver, ContentBlock } from '@use-brian/core'
@@ -95,6 +96,11 @@ type TelegramByoRouteOptions = {
   apiUrl: string
   integrationStore: ChannelIntegrationStore
   linkedAccountStore?: LinkedAccountStore
+  /** OSS-only one-time owner pairing; hosted BYO bots keep the SSO flow. */
+  ownerPairing?: {
+    enabled: boolean
+    linkCodeStore: LinkCodeStore
+  }
   channelUserStore?: ChannelUserStore
   workerManager?: import('@use-brian/core').WorkerManager
   connectorStore?: ConnectorStore
@@ -690,6 +696,64 @@ export function telegramByoRoutes(options: TelegramByoRouteOptions): Router {
         }
       }
 
+      // OSS owner pairing. The code is generated while connecting this BYO bot
+      // and is bound to its default assistant. Claim is atomic, so only one
+      // Telegram account can win even if the same code is sent concurrently.
+      if (
+        options.ownerPairing?.enabled &&
+        options.linkedAccountStore &&
+        !incoming.isGroupChat &&
+        incoming.text
+      ) {
+        const pairingMatch = incoming.text.trim().toUpperCase().match(/^(?:\/START\s+)?([A-Z0-9]{6})$/)
+        if (pairingMatch) {
+          const candidate = await options.ownerPairing.linkCodeStore.findValidCode(pairingMatch[1])
+          if (candidate?.assistantId === boundAssistant.id) {
+            const code = await options.ownerPairing.linkCodeStore.claim(pairingMatch[1], incoming.userId)
+            if (!code) {
+              await adapter.sendMessage(incoming.channelId, {
+                text: 'This pairing code has expired or was already used. Reconnect the bot in Studio to generate a new one.',
+              }).catch(() => {})
+              return
+            }
+            const raw = incoming.raw as {
+              from?: { username?: string; first_name?: string; last_name?: string }
+            }
+            try {
+              await options.linkedAccountStore.upsert({
+                userId: code.userId,
+                assistantId: code.assistantId,
+                provider: 'telegram',
+                providerId: incoming.userId,
+                providerMetadata: {
+                  username: raw.from?.username ?? null,
+                  firstName: raw.from?.first_name ?? null,
+                  lastName: raw.from?.last_name ?? null,
+                },
+              })
+              mergeShadowUser(code.userId, incoming.userId, 'telegram', {
+                reason: 'link-code',
+                evidence: { codeId: code.id, channelId: boundIntegration.channelId },
+              }).catch((err) => {
+                console.error('[telegram-byo] owner pairing shadow merge failed:', err)
+              })
+              await adapter.sendMessage(incoming.channelId, {
+                text: 'Telegram connected. You are now recognized as the owner of this Brian instance.',
+              }).catch((err) => {
+                console.error('[telegram-byo] owner pairing confirmation failed:', err)
+              })
+              return
+            } catch (err) {
+              console.error('[telegram-byo] owner pairing failed after code claim:', err)
+              await adapter.sendMessage(incoming.channelId, {
+                text: 'Pairing failed. Generate a new code from Studio and try again.',
+              }).catch(() => {})
+              return
+            }
+          }
+        }
+      }
+
       // 4b.2. /connect intercept — hand the user off to web Settings via
       //       a Mini App button. BYO bots are pinned to a specific assistant,
       //       so only the owner can manage connectors here; non-owners get a
@@ -701,6 +765,14 @@ export function telegramByoRoutes(options: TelegramByoRouteOptions): Router {
           ? await options.linkedAccountStore.findByProvider('telegram', telegramUserIdStr)
           : null
         const isOwner = !!linked && linked.userId === ownerId
+        if (options.ownerPairing?.enabled && !linked) {
+          await adapter.sendMessage(incoming.channelId, {
+            text: 'This bot is not paired yet. Reconnect it in Studio, then send the one-time owner code shown there.',
+          }).catch((err) => {
+            console.error('[telegram-byo] unpaired /connect reply failed:', err)
+          })
+          return
+        }
         const { message, handled } = handleConnectCommand({
           text: incoming.text ?? '',
           isLinked: !!linked,
@@ -848,7 +920,9 @@ export function telegramByoRoutes(options: TelegramByoRouteOptions): Router {
 
       if (privateChatRedirect) {
         await adapter.sendMessage(incoming.channelId, {
-          text: "This is a private bot. To try Use Brian, DM @use_brian_bot to sign in and link your account.",
+          text: options.ownerPairing?.enabled
+            ? 'This private bot is not paired with your Telegram account. Reconnect it in Studio and send the new one-time owner code here.'
+            : 'This is a private bot. To try Use Brian, DM @use_brian_bot to sign in and link your account.',
         }).catch((err) => {
           console.error('[telegram-byo] redirect message send failed:', err)
         })


### PR DESCRIPTION
## Summary

- generate 15-minute single-use pairing codes when connecting routed BYO Telegram bots
- redeem codes in private bot chats and link the Telegram identity through the existing account model
- require owner pairing for OSS while preserving hosted Google SSO and adding OTP as an alternative
- allow production OSS self-hosts to mint their local-owner session outside Cloud Run
- surface pairing instructions and deep links in Studio across supported locales

## Security

- claims are atomic and reject expired or previously used codes
- redemption is restricted to private chats and the assistant bound to the BYO bot
- unrelated bots cannot redeem a valid code

## Verification

- full test suite: 23 tasks passed
- API tests: 4,092 passed
- API and app-web typechecks passed
- core smoke test passed