### PR TITLE
feat: remove hosted plan restrictions from OSS

### DIFF
--- a/apps/app-web/src/app/w/[workspaceId]/studio/channels/page.tsx
+++ b/apps/app-web/src/app/w/[workspaceId]/studio/channels/page.tsx
@@ -64,6 +64,7 @@ import {
   type WhatsappOfficialBinding,
 } from "@/lib/api/whatsapp-ingest";
 import { isHostedEdition } from "@/lib/edition";
+import { modelTierPlanGateApplies } from "@/lib/plan-gate";
 import { confirmDialog } from "@/components/ui/confirm-dialog";
 import {
   API_URL,
@@ -933,10 +934,9 @@ function ChannelDetail({
 
 /**
  * Per-routing model picker. Patches `channel_assistants.model_alias` so each
- * routed surface can run on its own LLM tier (migration 197). Pro is gated
- * behind the Pro plan, Max behind Pro+Max — same gate as the Assistant →
- * Settings → Channel Models row in `assistant-detail.tsx`. The backend
- * re-validates the plan, so this is a UX guard not a security boundary.
+ * routed surface can run on its own LLM tier (migration 197). Hosted Pro is
+ * gated behind the Pro plan and Max behind Pro+Max; OSS has no plans. The
+ * backend re-validates the same edition-aware policy.
  *
  * Gates on the *workspace* plan (billing is per-workspace, migration 143) —
  * the legacy `users.plan` cookie field is stale post-migration and would
@@ -956,8 +956,9 @@ function RoutingModelPicker({
   const t = useT();
   const { workspaces } = useWorkspaces();
   const plan = workspaces.find((w) => w.id === workspaceId)?.plan ?? "free";
-  const proDisabled = plan === "free";
-  const maxDisabled = plan === "free" || plan === "pro";
+  const edition = isHostedEdition() ? "hosted" : "oss";
+  const proDisabled = modelTierPlanGateApplies(edition, plan, "pro");
+  const maxDisabled = modelTierPlanGateApplies(edition, plan, "max");
   const [saving, setSaving] = useState(false);
   const [value, setValue] = useState<ChannelModelAlias>(routing.modelAlias);
 

--- a/apps/app-web/src/components/chrome/floating-chat.tsx
+++ b/apps/app-web/src/components/chrome/floating-chat.tsx
@@ -82,6 +82,8 @@ import {
   pageIdFromPathname,
 } from "@/lib/doc-page-url";
 import { DOC_COMMENTS_CHANGED_EVENT } from "@/lib/comment-events";
+import { isHostedEdition } from "@/lib/edition";
+import { modelTierPlanGateApplies } from "@/lib/plan-gate";
 import {
   ASSISTANT_REFRESH_EVENT,
   type AssistantRefreshDetail,
@@ -587,7 +589,7 @@ export function FloatingChat({
       const saved = localStorage.getItem(MODEL_STORAGE_KEY);
       if (saved === "standard" || saved === "pro" || saved === "max") return saved;
     }
-    return "standard";
+    return isHostedEdition() ? "standard" : "pro";
   });
   const [workspacePlan, setWorkspacePlan] = useState<string | null>(null);
   // Research mode — ON adds `mode:'research'` to the next send (coordinator +
@@ -831,7 +833,7 @@ export function FloatingChat({
 
   // Resolve the workspace plan for model-tier gating (per-workspace billing).
   useEffect(() => {
-    if (!workspaceId) return;
+    if (!workspaceId || !isHostedEdition()) return;
     let cancelled = false;
     authFetch(`${API_URL}/api/usage?workspace_id=${encodeURIComponent(workspaceId)}`)
       .then((r) => (r.ok ? r.json() : null))
@@ -941,8 +943,10 @@ export function FloatingChat({
   );
 
   useEffect(() => {
-    if (workspacePlan === "free" && model !== "standard") setModel("standard");
-    else if (workspacePlan === "pro" && model === "max") setModel("pro");
+    if (!isHostedEdition()) return;
+    if (modelTierPlanGateApplies("hosted", workspacePlan, model)) {
+      setModel(model === "max" && workspacePlan === "pro" ? "pro" : "standard");
+    }
   }, [workspacePlan, model]);
 
   // Paid workspaces default to Pro (cost-and-pricing → "Default chat is Pro").

--- a/apps/app-web/src/components/doc/composer-controls.tsx
+++ b/apps/app-web/src/components/doc/composer-controls.tsx
@@ -35,6 +35,8 @@ import {
 } from "@/components/ui/select";
 import { useChatModelTier, type ModelTier } from "@/lib/chat-model";
 import { webAppUrl } from "@/lib/primary-auth";
+import { isHostedEdition } from "@/lib/edition";
+import { modelTierPlanGateApplies, planGateApplies } from "@/lib/plan-gate";
 
 /** Remaining free-research quota the server reports on a research turn. */
 type ResearchQuota = { used: number; quota: number; isPaid: boolean };
@@ -127,6 +129,10 @@ export function ComposerControls({
   className,
 }: Props) {
   const t = useT().chat;
+  const edition = isHostedEdition() ? "hosted" : "oss";
+  const proDisabled = modelTierPlanGateApplies(edition, plan, "pro");
+  const maxDisabled = modelTierPlanGateApplies(edition, plan, "max");
+  const meteredDisabled = planGateApplies(edition, plan);
   const tc = useT().comments;
   // The AI-reply toggle shows only where a host wires it (the comment
   // composers). When the AI won't reply, the research + model controls — which
@@ -228,13 +234,13 @@ export function ComposerControls({
               <span className="text-[11px] text-muted-foreground">{t.modelStandardDesc}</span>
             </div>
           </SelectItem>
-          <SelectItem value="pro" disabled={plan === "free"}>
+          <SelectItem value="pro" disabled={proDisabled}>
             <div className="flex flex-col gap-0.5 py-0.5">
               <span className="text-sm font-medium">{t.modelPro}</span>
               <span className="text-[11px] text-muted-foreground">{t.modelProDesc}</span>
             </div>
           </SelectItem>
-          <SelectItem value="max" disabled={plan === "free" || plan === "pro"}>
+          <SelectItem value="max" disabled={maxDisabled}>
             <div className="flex flex-col gap-0.5 py-0.5">
               <span className="text-sm font-medium">{t.modelMax}</span>
               <span className="text-[11px] text-muted-foreground">{t.modelMaxDesc}</span>
@@ -246,7 +252,7 @@ export function ComposerControls({
                 {t.modelMeteredGroup}
               </div>
               {meteredOptions.map((o) => (
-                <SelectItem key={o.key} value={`metered:${o.key}`} disabled={plan === "free"}>
+                <SelectItem key={o.key} value={`metered:${o.key}`} disabled={meteredDisabled}>
                   <div className="flex flex-col gap-0.5 py-0.5">
                     <span className="text-sm font-medium">{o.label}</span>
                     <span className="text-[11px] text-muted-foreground">{o.sublabel}</span>

--- a/apps/app-web/src/components/studio/assistant-detail.tsx
+++ b/apps/app-web/src/components/studio/assistant-detail.tsx
@@ -21,6 +21,8 @@ import { RecordingUploadButton } from "@/components/recordings/recording-upload-
 import { useT } from "@/lib/i18n/client";
 import type { Dictionary } from "@/lib/i18n";
 import { format } from "@/lib/i18n";
+import { isHostedEdition } from "@/lib/edition";
+import { modelTierPlanGateApplies } from "@/lib/plan-gate";
 
 /**
  * Assistant detail (app-web) — the tabbed editor for one assistant.
@@ -1205,8 +1207,8 @@ function Section({
 }
 
 // Per-platform model picker row used in SettingsTab → Channel Models.
-// Pro is disabled on the free plan; Max is disabled on free + pro. The
-// backend re-validates the plan on PATCH, so this is purely a UX guard.
+// Hosted plan access matches the backend resolver. OSS has no plans, so all
+// built-in tiers remain selectable.
 //
 // `plan` is the *workspace* plan (billing is per-workspace, migration 143);
 // the parent reads it from the workspace context. The legacy `users.plan`
@@ -1228,8 +1230,9 @@ function ChannelModelRow({
   plan: string;
 }) {
   const t = useT();
-  const proDisabled = plan === "free";
-  const maxDisabled = plan === "free" || plan === "pro";
+  const edition = isHostedEdition() ? "hosted" : "oss";
+  const proDisabled = modelTierPlanGateApplies(edition, plan, "pro");
+  const maxDisabled = modelTierPlanGateApplies(edition, plan, "max");
   return (
     <div className="px-5 py-3 flex items-center justify-between gap-3">
       <span className="text-[14px] font-medium text-foreground">{label}</span>
@@ -2534,4 +2537,3 @@ function PrimitiveGrantsPanel({ assistantId }: { assistantId: string }) {
     </section>
   );
 }
-

--- a/apps/app-web/src/lib/__tests__/plan-gate.test.ts
+++ b/apps/app-web/src/lib/__tests__/plan-gate.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { planGateApplies, planGateDismissKey } from "../plan-gate";
+import {
+  modelTierPlanGateApplies,
+  planGateApplies,
+  planGateDismissKey,
+} from "../plan-gate";
 
 describe("[COMP:app-web/plan-gate] Plan gate decision", () => {
   it("gates a hosted workspace with no active plan ('free')", () => {
@@ -21,6 +25,20 @@ describe("[COMP:app-web/plan-gate] Plan gate decision", () => {
   it("does not gate while the plan is unknown (usage fetch in flight)", () => {
     expect(planGateApplies("hosted", null)).toBe(false);
     expect(planGateApplies("hosted", undefined)).toBe(false);
+  });
+
+  it("gates model tiers by plan only in hosted", () => {
+    expect(modelTierPlanGateApplies("hosted", "free", "pro")).toBe(true);
+    expect(modelTierPlanGateApplies("hosted", "free", "max")).toBe(true);
+    expect(modelTierPlanGateApplies("hosted", "pro", "pro")).toBe(false);
+    expect(modelTierPlanGateApplies("hosted", "pro", "max")).toBe(true);
+    expect(modelTierPlanGateApplies("hosted", "max_5x", "max")).toBe(false);
+  });
+
+  it("never gates OSS model tiers even when its persisted plan is free", () => {
+    expect(modelTierPlanGateApplies("oss", "free", "standard")).toBe(false);
+    expect(modelTierPlanGateApplies("oss", "free", "pro")).toBe(false);
+    expect(modelTierPlanGateApplies("oss", "free", "max")).toBe(false);
   });
 
   it("scopes the dismissal key per workspace", () => {

--- a/apps/app-web/src/lib/chat-model.ts
+++ b/apps/app-web/src/lib/chat-model.ts
@@ -17,6 +17,8 @@
 
 import { useEffect, useState } from "react";
 import { authFetch } from "@/lib/auth-fetch";
+import { isHostedEdition } from "@/lib/edition";
+import { modelTierPlanGateApplies } from "@/lib/plan-gate";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
 
@@ -51,6 +53,7 @@ export function useChatModelTier(
   workspaceId: string,
   defaultTier: ModelTier,
 ): ChatModelState {
+  const edition = isHostedEdition() ? "hosted" : "oss";
   const [model, setModel] = useState<ModelTier>(
     () => readCachedTier() ?? defaultTier,
   );
@@ -68,7 +71,7 @@ export function useChatModelTier(
 
   // Resolve the workspace plan for tier gating (per-workspace billing).
   useEffect(() => {
-    if (!workspaceId) return;
+    if (!workspaceId || edition === "oss") return;
     let cancelled = false;
     authFetch(
       `${API_URL}/api/usage?workspace_id=${encodeURIComponent(workspaceId)}`,
@@ -84,13 +87,14 @@ export function useChatModelTier(
     return () => {
       cancelled = true;
     };
-  }, [workspaceId]);
+  }, [edition, workspaceId]);
 
   // Snap an over-tier selection down once the plan resolves.
   useEffect(() => {
-    if (plan === "free" && model !== "standard") setModel("standard");
-    else if (plan === "pro" && model === "max") setModel("pro");
-  }, [plan, model]);
+    if (modelTierPlanGateApplies(edition, plan, model)) {
+      setModel(model === "max" && plan === "pro" ? "pro" : "standard");
+    }
+  }, [edition, plan, model]);
 
   // Paid workspaces default to Pro (cost-and-pricing → "Default chat is Pro").
   // The legacy default was Standard, so on the first paid plan-load (once per

--- a/apps/app-web/src/lib/plan-gate.ts
+++ b/apps/app-web/src/lib/plan-gate.ts
@@ -22,6 +22,16 @@ export function planGateApplies(
   return edition === "hosted" && plan === "free";
 }
 
+export function modelTierPlanGateApplies(
+  edition: "oss" | "hosted",
+  plan: string | null | undefined,
+  tier: "standard" | "pro" | "max",
+): boolean {
+  if (edition === "oss" || tier === "standard") return false;
+  if (tier === "pro") return plan === "free";
+  return plan === "free" || plan === "pro";
+}
+
 /**
  * Session-storage key for the per-workspace "Continue browsing" dismissal.
  * Session-scoped on purpose: browsing stays reachable, but the gate

--- a/packages/api/src/__tests__/model-resolution.test.ts
+++ b/packages/api/src/__tests__/model-resolution.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect } from 'vitest'
 import {
   MODEL_MAP,
   STANDARD_TIER_MODELS,
@@ -29,6 +29,11 @@ const RESEARCH = 'gemini-3-pro-research'
 // Pro. Flash Lite stays the background/extraction workhorse and is still
 // classified as Standard tier for analytics.
 const STANDARD = 'gemini-3-flash-standard'
+
+afterEach(() => {
+  delete process.env.USEBRIAN_EDITION
+  delete process.env.NEXT_PUBLIC_USEBRIAN_EDITION
+})
 
 describe('[COMP:api/model-resolution] MODEL_MAP', () => {
   it('points the Standard chat tier at the synthetic Flash 3 id', () => {
@@ -120,6 +125,11 @@ describe('[COMP:api/model-resolution] defaultTierForPlan', () => {
     expect(defaultTierForPlan('max_10x')).toBe('pro')
     expect(defaultTierForPlan('enterprise')).toBe('pro')
   })
+
+  it('defaults OSS to Pro regardless of the persisted workspace plan', () => {
+    process.env.USEBRIAN_EDITION = 'oss'
+    expect(defaultTierForPlan('free')).toBe('pro')
+  })
 })
 
 describe('[COMP:api/model-resolution] resolveModel', () => {
@@ -142,6 +152,14 @@ describe('[COMP:api/model-resolution] resolveModel', () => {
     // Free plan can only use 'standard'
     expect(resolveModel('pro', 'free')).toBe(STANDARD)
     expect(resolveModel('max', 'free')).toBe(STANDARD)
+  })
+
+  it('honours every built-in tier in OSS regardless of the persisted plan', () => {
+    process.env.USEBRIAN_EDITION = 'oss'
+    expect(resolveModel('standard', 'free')).toBe(STANDARD)
+    expect(resolveModel('pro', 'free')).toBe('gemini-flash-3')
+    expect(resolveModel('max', 'free')).toBe('gemini-3.5-flash')
+    expect(resolveModel('research', 'free')).toBe(RESEARCH)
   })
 
   it('forces Standard when the budget is downgraded, regardless of alias', () => {

--- a/packages/api/src/edition.ts
+++ b/packages/api/src/edition.ts
@@ -1,0 +1,7 @@
+/** Server-side build edition. Hosted is the safe default when unset. */
+export function isOssEdition(): boolean {
+  return (
+    process.env.USEBRIAN_EDITION === 'oss' ||
+    process.env.NEXT_PUBLIC_USEBRIAN_EDITION === 'oss'
+  )
+}

--- a/packages/api/src/model-resolution.ts
+++ b/packages/api/src/model-resolution.ts
@@ -23,6 +23,7 @@ import {
   type ModelClass,
   type ModelTier,
 } from '@use-brian/shared/model-registry'
+import { isOssEdition } from './edition.js'
 
 /**
  * The background-lane workhorse: extraction / classification / structured
@@ -222,8 +223,9 @@ export const MODEL_TIER_SQL_CASE = tierCaseExpression('model')
 export const MODEL_TIER_CLASSIFIER_SQL = tierClassifierExpression('model', 'model_tier')
 
 /**
- * Models each plan tier is allowed to use (plan = `workspaces.plan`).
- * Free → Standard only. Paid tiers → Standard + Pro + Max.
+ * Models each hosted plan tier is allowed to use (plan = `workspaces.plan`).
+ * Free → Standard only. Paid tiers → Standard + Pro + Max. OSS bypasses this
+ * table and allows every built-in tier because it has no billing plans.
  * The backend silently downgrades unauthorized requests to the best
  * model the plan allows (no error — matches the "downgrade" spec).
  *
@@ -238,10 +240,17 @@ export const PLAN_ALLOWED_MODELS: Record<string, Set<string>> = {
   enterprise: new Set(['standard', 'pro', 'max', 'research']),
 }
 
+const OSS_ALLOWED_MODELS = new Set(['standard', 'pro', 'max', 'research'])
+
+function allowedModelsForPlan(plan: string): Set<string> {
+  if (isOssEdition()) return OSS_ALLOWED_MODELS
+  return PLAN_ALLOWED_MODELS[plan] ?? PLAN_ALLOWED_MODELS.free
+}
+
 /**
- * The default tier alias for a billing plan when no tier is explicitly
- * requested. Paid plans default to **Pro** (per the cost-and-pricing spec —
- * "Default chat is Pro, not Max"); free / unknown plans default to Standard.
+ * The default tier alias when no tier is explicitly requested. Paid plans and
+ * OSS default to **Pro** (per the cost-and-pricing spec — "Default chat is Pro,
+ * not Max"); hosted free / unknown plans default to Standard.
  *
  * Derived from `PLAN_ALLOWED_MODELS` rather than hard-coded so it stays
  * correct if a plan's tier access changes: any plan that may use Pro defaults
@@ -251,7 +260,7 @@ export const PLAN_ALLOWED_MODELS: Record<string, Set<string>> = {
  * → "Model routing".
  */
 export function defaultTierForPlan(plan: string): string {
-  const allowed = PLAN_ALLOWED_MODELS[plan] ?? PLAN_ALLOWED_MODELS.free
+  const allowed = allowedModelsForPlan(plan)
   return allowed.has('pro') ? 'pro' : 'standard'
 }
 
@@ -274,7 +283,7 @@ export function resolveModel(
     return MODEL_MAP.standard
   }
   const alias = requestedModel ?? defaultTierForPlan(plan)
-  const allowed = PLAN_ALLOWED_MODELS[plan] ?? PLAN_ALLOWED_MODELS.free
+  const allowed = allowedModelsForPlan(plan)
   const effectiveAlias = allowed.has(alias) ? alias : 'standard'
   return MODEL_MAP[effectiveAlias] ?? MODEL_MAP.standard
 }

--- a/packages/api/src/routes/__tests__/workspaces.test.ts
+++ b/packages/api/src/routes/__tests__/workspaces.test.ts
@@ -9,7 +9,7 @@
  * on PATCH (admin) and DELETE (owner), and the add-member lookup.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest'
 import request from 'supertest'
 import { createTestApp } from './helpers.js'
 
@@ -83,6 +83,11 @@ beforeEach(() => {
   vi.spyOn(console, 'error').mockImplementation(() => {})
 })
 
+afterEach(() => {
+  delete process.env.USEBRIAN_EDITION
+  delete process.env.NEXT_PUBLIC_USEBRIAN_EDITION
+})
+
 describe('[COMP:api/workspaces-route] POST /', () => {
   it('rejects an unauthenticated request with 401', async () => {
     expect((await request(app()).post('/api/workspaces').send({})).status).toBe(401)
@@ -127,6 +132,20 @@ describe('[COMP:api/workspaces-route] POST /', () => {
       .send({ name: 'New WS', purpose: LONG_PURPOSE })
     expect(res.status).toBe(201)
     expect(res.body.id).toBe('ws-new')
+  })
+
+  it('does not apply the hosted workspace cap in OSS', async () => {
+    process.env.USEBRIAN_EDITION = 'oss'
+    mockFindUser.mockResolvedValueOnce({ id: 'u-1' } as never)
+    workspaceStore.create.mockResolvedValueOnce({ id: 'ws-new', name: 'New WS' })
+
+    const res = await request(app('u-1'))
+      .post('/api/workspaces')
+      .send({ name: 'New WS', purpose: LONG_PURPOSE })
+
+    expect(res.status).toBe(201)
+    expect(mockQuery).not.toHaveBeenCalled()
+    expect(workspaceStore.countFreeOwned).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/api/src/routes/local-session.ts
+++ b/packages/api/src/routes/local-session.ts
@@ -1,6 +1,9 @@
 import { Router } from 'express'
 import { createTokens } from '../auth/jwt.js'
 import { findOrCreateUser, type User } from '../db/users.js'
+import { isOssEdition } from '../edition.js'
+
+export { isOssEdition } from '../edition.js'
 
 /**
  * OSS LOCAL-OWNER SESSION — `GET|POST /auth/local-session`.
@@ -31,19 +34,6 @@ import { findOrCreateUser, type User } from '../db/users.js'
  *
  * Component-map tag: [COMP:api/local-session].
  */
-
-/**
- * True in the open single-player edition. The launcher exports
- * `USEBRIAN_EDITION=oss` (and `NEXT_PUBLIC_USEBRIAN_EDITION=oss` for app-web)
- * into every child's env; either satisfies the server-side gate. Defaults to the
- * hosted edition when unset, so a hosted deploy never opts in by accident.
- */
-export function isOssEdition(): boolean {
-  return (
-    process.env.USEBRIAN_EDITION === 'oss' ||
-    process.env.NEXT_PUBLIC_USEBRIAN_EDITION === 'oss'
-  )
-}
 
 /** OSS single-owner auth is valid in local and production-mode self-hosts. */
 export function isSelfHostedOssEnv(): boolean {

--- a/packages/api/src/routes/workspaces.ts
+++ b/packages/api/src/routes/workspaces.ts
@@ -43,6 +43,7 @@ import {
 import { flushWorkspaceData, WorkspaceFlushNotOwnerError } from '../db/workspace-flush.js'
 import { notifyWorkspaceChange } from '../brain-stream/notify.js'
 import { createConnectionStore } from '../db/connection-store.js'
+import { isOssEdition } from '../edition.js'
 import type { WorkspaceAuditStore, WorkspaceAuditEventType } from '../db/workspace-audit-store.js'
 import type { WorkspaceInvitationStore } from '../db/workspace-invitation-store.js'
 import type { SmtpClient } from '../email/smtp-client.js'
@@ -107,7 +108,7 @@ export function workspaceRoutes({
   //
   // Every user already has a Personal workspace (auto-created at signup;
   // see findOrCreateUser in db/users.ts). This route creates *additional*
-  // workspaces, gated by a free-plan cap: a user may own at most 2
+  // workspaces, gated in hosted by a free-plan cap: a user may own at most 2
   // free-plan workspaces (Personal counts), so a user with no paid
   // workspace gets Personal + 1 more. Owning any paid workspace lifts the
   // cap to unlimited. Only ownership counts — joined workspaces never do.
@@ -140,21 +141,23 @@ export function workspaceRoutes({
       const user = await findUserById(userId)
       if (!user) { res.status(401).json({ error: 'User not found' }); return }
 
-      // Billing is per-workspace (migration 143). A user who owns no paid
+      // Hosted billing is per-workspace (migration 143). A user who owns no paid
       // workspace is capped at 2 free-plan workspaces (the Personal one
       // counts). Owning any paid workspace lifts the cap.
-      const ownsPaid = await query<{ ok: number }>(
-        `SELECT 1 AS ok FROM workspaces WHERE owner_user_id = $1 AND plan <> 'free' LIMIT 1`,
-        [userId],
-      )
-      if (ownsPaid.rows.length === 0) {
-        const freeOwned = await workspaceStore.countFreeOwned(userId)
-        if (freeOwned >= 2) {
-          res.status(403).json({
-            error: 'plan_required',
-            message: 'Free accounts can own up to 2 workspaces. Upgrade a workspace to a paid plan to create more.',
-          })
-          return
+      if (!isOssEdition()) {
+        const ownsPaid = await query<{ ok: number }>(
+          `SELECT 1 AS ok FROM workspaces WHERE owner_user_id = $1 AND plan <> 'free' LIMIT 1`,
+          [userId],
+        )
+        if (ownsPaid.rows.length === 0) {
+          const freeOwned = await workspaceStore.countFreeOwned(userId)
+          if (freeOwned >= 2) {
+            res.status(403).json({
+              error: 'plan_required',
+              message: 'Free accounts can own up to 2 workspaces. Upgrade a workspace to a paid plan to create more.',
+            })
+            return
+          }
         }
       }
 
@@ -1076,23 +1079,24 @@ export function workspaceRoutes({
       const { workspaceId } = req.params as { workspaceId: string }
       const workspacePlan = await getWorkspacePlan(workspaceId)
 
-      const countResult = await query<{ count: string }>(
-        `SELECT COUNT(*) AS count FROM assistant_members WHERE user_id = $1 AND role = 'owner'`,
-        [userId],
-      )
-      const currentCount = Number(countResult.rows[0].count)
-
-      const maxAssistants = workspacePlan === 'free' ? 1 : 10
-      if (currentCount >= maxAssistants) {
-        res.status(403).json({
-          error: 'assistant_limit',
-          plan: workspacePlan,
-          limit: maxAssistants,
-          message: workspacePlan === 'free'
-            ? 'Free plan is limited to 1 assistant. Upgrade to Pro to create more.'
-            : `You've reached the ${maxAssistants}-assistant limit. Contact us for higher limits.`,
-        })
-        return
+      if (!isOssEdition()) {
+        const countResult = await query<{ count: string }>(
+          `SELECT COUNT(*) AS count FROM assistant_members WHERE user_id = $1 AND role = 'owner'`,
+          [userId],
+        )
+        const currentCount = Number(countResult.rows[0].count)
+        const maxAssistants = workspacePlan === 'free' ? 1 : 10
+        if (currentCount >= maxAssistants) {
+          res.status(403).json({
+            error: 'assistant_limit',
+            plan: workspacePlan,
+            limit: maxAssistants,
+            message: workspacePlan === 'free'
+              ? 'Free plan is limited to 1 assistant. Upgrade to Pro to create more.'
+              : `You've reached the ${maxAssistants}-assistant limit. Contact us for higher limits.`,
+          })
+          return
+        }
       }
 
       // Post-089: team-owned assistants satisfy the ownership XOR by


### PR DESCRIPTION
## Summary
- bypass hosted workspace and assistant caps in the OSS edition
- allow OSS requests to use every built-in model tier and default to Pro
- expose Pro, Max, and metered model choices throughout the OSS web app

## Verification
- `pnpm exec vitest run src/routes/__tests__/workspaces.test.ts src/__tests__/model-resolution.test.ts`
- `pnpm exec vitest run src/lib/__tests__/plan-gate.test.ts`
- API and app-web typechecks
- `pnpm smoke`

The full monorepo test run reached 21/23 packages before the runner timed out while API tests retained PostgreSQL listener handles without a local database.