### PR TITLE
feat(knowledge): support local source editing and navigation

### DIFF
--- a/apps/app-web/src/app/w/[workspaceId]/brain/entry/[kind]/[id]/page.tsx
+++ b/apps/app-web/src/app/w/[workspaceId]/brain/entry/[kind]/[id]/page.tsx
@@ -37,9 +37,14 @@ import { useWorkspaces } from "@/contexts/workspace-context";
 import { getActiveAssistantId } from "@/lib/sidebar-cache";
 import {
   getBrainGraph,
+  canOpenLocalKnowledgeSource,
   getKnowledgeEditCapability,
   getKnowledgeEntry,
+  getKnowledgeEntryNavigationUrl,
+  getKnowledgeSourceUrl,
+  openLocalKnowledgeSource,
   proposeKnowledgeEdit,
+  updateLocalKnowledgeEntry,
   type BrainGraph,
   type BrainGraphNode,
   type KnowledgeEditCapability,
@@ -48,6 +53,7 @@ import {
 import { fetchBrainRow, type BrainInboxRowDetail } from "@/lib/api/brain-inbox";
 import {
   KB_WIKILINK_SCHEME,
+  knowledgeEntryHref,
   resolveWikilinkTarget,
   rewriteWikilinks,
 } from "@/lib/kb-wikilinks";
@@ -231,9 +237,13 @@ function KnowledgeReader({
   }
   const stale = view.forId !== entryId;
 
-  const isGithubSynced = entry.sourceId !== null;
-  const canPropose = capability?.canPropose === true;
-  const readOnly = isGithubSynced && capability !== null && !canPropose;
+  const isGithubSynced = entry.source?.sourceType === "github";
+  const isLocalSynced = entry.source?.sourceType === "local";
+  const canEdit = capability?.canEdit === true;
+  const readOnly = !!entry.source && capability !== null && !canEdit;
+  const sourceUrl = entry.source ? getKnowledgeSourceUrl(entry.source) : null;
+  const entryNavigationUrl = getKnowledgeEntryNavigationUrl(entry.navigationUrl);
+  const canOpenLocalSource = isLocalSynced && !sourceUrl && canOpenLocalKnowledgeSource();
 
   const startEditing = () => {
     setDraft(entry.content);
@@ -250,16 +260,26 @@ function KnowledgeReader({
     }
     setSubmitting(true);
     setSubmitError(null);
-    const result = await proposeKnowledgeEdit(activeId, entry.id, {
-      content: draft,
-      comment: comment.trim().length > 0 ? comment.trim() : undefined,
-    });
+    const result = isLocalSynced
+      ? await updateLocalKnowledgeEntry(activeId, entry.id, draft)
+      : await proposeKnowledgeEdit(activeId, entry.id, {
+          content: draft,
+          comment: comment.trim().length > 0 ? comment.trim() : undefined,
+        });
     setSubmitting(false);
     if (!result.ok) {
-      setSubmitError(format(copy.proposalFailed, { message: result.error }));
+      setSubmitError(format(
+        isLocalSynced ? copy.localSaveFailed : copy.proposalFailed,
+        { message: result.error },
+      ));
       return;
     }
-    setPrUrl(result.prUrl);
+    if (isLocalSynced) {
+      const refreshed = await getKnowledgeEntry(entry.id, activeId, getActiveAssistantId());
+      setView({ forId: entryId, entry: refreshed ?? { ...entry, content: draft } });
+    } else if ("prUrl" in result) {
+      setPrUrl(result.prUrl);
+    }
     setEditing(false);
   };
 
@@ -300,17 +320,17 @@ function KnowledgeReader({
             </section>
           )}
 
-          {isGithubSynced && !editing && (
+          {(isGithubSynced || isLocalSynced) && !editing && (
             <ReaderRailCard title={copy.actionsHeading}>
               <Button
                 className="w-full"
                 variant="outline"
-                disabled={!canPropose}
+                disabled={!canEdit}
                 onClick={startEditing}
                 title={readOnly ? copy.readOnlyHint : undefined}
               >
                 <Pencil className="mr-1.5 size-3.5" aria-hidden />
-                {copy.suggestEdit}
+                {isLocalSynced ? copy.editEntry : copy.suggestEdit}
               </Button>
               {capability === null ? (
                 <p className="pt-1.5 text-[11px] text-muted-foreground">
@@ -318,7 +338,7 @@ function KnowledgeReader({
                 </p>
               ) : readOnly ? (
                 <p className="pt-1.5 text-[11px] text-muted-foreground">
-                  {copy.readOnlyHint}
+                  {isLocalSynced ? copy.localReadOnlyHint : copy.readOnlyHint}
                 </p>
               ) : null}
             </ReaderRailCard>
@@ -359,22 +379,55 @@ function KnowledgeReader({
           {entry.source && (
             <ReaderRailCard title={copy.sourceHeading}>
               <dl className="divide-y divide-border/60">
-                <ReaderPropRow label={copy.sourceRepoLabel}>
-                  <a
-                    href={`https://github.com/${entry.source.repo}`}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="inline-flex items-center gap-1 underline-offset-4 hover:underline"
-                  >
+                <ReaderPropRow
+                  label={isLocalSynced ? copy.sourceDirectoryLabel : copy.sourceRepoLabel}
+                >
+                  {sourceUrl ? (
+                    <a
+                      href={sourceUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center gap-1 underline-offset-4 hover:underline"
+                    >
+                      <span className="break-all font-mono text-[11px]">
+                        {entry.source.repo}
+                      </span>
+                      <ExternalLink className="size-3 shrink-0" aria-hidden />
+                    </a>
+                  ) : canOpenLocalSource ? (
+                    <button
+                      type="button"
+                      onClick={() => void openLocalKnowledgeSource(activeId, entry.source!.id)}
+                      className="break-all text-right font-mono text-[11px] underline-offset-4 hover:underline"
+                    >
+                      {entry.source.repo}
+                    </button>
+                  ) : (
                     <span className="break-all font-mono text-[11px]">
                       {entry.source.repo}
                     </span>
-                    <ExternalLink className="size-3 shrink-0" aria-hidden />
-                  </a>
+                  )}
                 </ReaderPropRow>
-                <ReaderPropRow label={copy.sourceBranchLabel}>
-                  <span className="font-mono text-[11px]">{entry.source.branch}</span>
-                </ReaderPropRow>
+                {entryNavigationUrl && (
+                  <ReaderPropRow label={copy.sourceUrlLabel}>
+                    <a
+                      href={entryNavigationUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center gap-1 underline-offset-4 hover:underline"
+                    >
+                      <span className="break-all font-mono text-[11px]">
+                        {entryNavigationUrl}
+                      </span>
+                      <ExternalLink className="size-3 shrink-0" aria-hidden />
+                    </a>
+                  </ReaderPropRow>
+                )}
+                {isGithubSynced && (
+                  <ReaderPropRow label={copy.sourceBranchLabel}>
+                    <span className="font-mono text-[11px]">{entry.source.branch}</span>
+                  </ReaderPropRow>
+                )}
                 <ReaderPropRow label={copy.sourceSyncedLabel}>
                   {entry.source.lastSyncedAt
                     ? new Date(entry.source.lastSyncedAt).toLocaleString()
@@ -420,7 +473,9 @@ function KnowledgeReader({
         {editing ? (
           <div className="mt-2 flex flex-col gap-3 animate-in fade-in-0 duration-200">
             <div className="rounded-lg bg-muted/40 px-3 py-2.5 text-xs text-muted-foreground">
-              {format(copy.editingHint, { repo: capability?.repo ?? "" })}
+              {isLocalSynced
+                ? copy.localEditingHint
+                : format(copy.editingHint, { repo: capability?.repo ?? "" })}
             </div>
             <textarea
               value={draft}
@@ -428,7 +483,7 @@ function KnowledgeReader({
               spellCheck={false}
               className="min-h-[50vh] w-full resize-y rounded-md border border-border bg-background p-3 font-mono text-[13px] leading-relaxed text-foreground focus:outline-none focus-visible:border-ring"
             />
-            <label className="flex flex-col gap-1">
+            {!isLocalSynced && <label className="flex flex-col gap-1">
               <span className="text-xs font-medium text-muted-foreground">
                 {copy.commentLabel}
               </span>
@@ -439,14 +494,20 @@ function KnowledgeReader({
                 rows={3}
                 className="w-full resize-y rounded-md border border-border bg-background p-2.5 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus-visible:border-ring"
               />
-            </label>
+            </label>}
             {submitError && (
               <p className="text-xs text-destructive">{submitError}</p>
             )}
             <div className="flex items-center gap-2">
               <Button onClick={submit} disabled={submitting}>
-                <GitPullRequestArrow className="mr-1.5 size-3.5" aria-hidden />
-                {submitting ? copy.submitting : copy.submitProposal}
+                {isLocalSynced ? (
+                  <Pencil className="mr-1.5 size-3.5" aria-hidden />
+                ) : (
+                  <GitPullRequestArrow className="mr-1.5 size-3.5" aria-hidden />
+                )}
+                {submitting
+                  ? isLocalSynced ? copy.saving : copy.submitting
+                  : isLocalSynced ? copy.saveChanges : copy.submitProposal}
               </Button>
               <Button
                 variant="ghost"
@@ -469,7 +530,10 @@ function KnowledgeReader({
                     currentPath={entry.path}
                     related={related}
                     onNavigate={(refId) =>
-                      router.push(`/w/${activeId}/brain/entry/knowledge/${refId}`)
+                      router.push(knowledgeEntryHref(activeId, refId))
+                    }
+                    hrefForTarget={(refId) =>
+                      knowledgeEntryHref(activeId, refId)
                     }
                   />
                 ),
@@ -498,20 +562,24 @@ function KbLink({
   currentPath,
   related,
   onNavigate,
+  hrefForTarget,
 }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
   currentPath: string;
   related: { id: string; title: string; path: string }[];
   onNavigate: (refId: string) => void;
+  hrefForTarget: (refId: string) => string;
 }) {
   const target = href ? resolveWikilinkTarget(href, currentPath, related) : null;
   if (target) {
     return (
       <a
-        href={`#${target.path}`}
+        href={hrefForTarget(target.id)}
         className="text-primary underline-offset-4 hover:underline"
         onClick={(e) => {
-          e.preventDefault();
-          onNavigate(target.id);
+          if (e.button === 0 && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
+            e.preventDefault();
+            onNavigate(target.id);
+          }
         }}
       >
         {children}

--- a/apps/app-web/src/lib/__tests__/kb-wikilinks.test.ts
+++ b/apps/app-web/src/lib/__tests__/kb-wikilinks.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect } from "vitest";
 import {
   KB_WIKILINK_SCHEME,
+  knowledgeEntryHref,
   resolveWikilinkTarget,
   rewriteWikilinks,
 } from "../kb-wikilinks";
@@ -62,5 +63,13 @@ describe("[COMP:app-web/kb-wikilinks] resolveWikilinkTarget", () => {
   it("ignores external and unresolvable targets", () => {
     expect(resolveWikilinkTarget("https://example.com/doc.md", "x", RELATED)).toBeNull();
     expect(resolveWikilinkTarget(`${KB_WIKILINK_SCHEME}ghost`, "x", RELATED)).toBeNull();
+  });
+});
+
+describe("[COMP:app-web/kb-wikilinks] knowledgeEntryHref", () => {
+  it("points resolved links at the canonical entry route, not a hash fragment", () => {
+    expect(knowledgeEntryHref("workspace-1", "entry-2")).toBe(
+      "/w/workspace-1/brain/entry/knowledge/entry-2",
+    );
   });
 });

--- a/apps/app-web/src/lib/__tests__/knowledge-source.test.ts
+++ b/apps/app-web/src/lib/__tests__/knowledge-source.test.ts
@@ -1,0 +1,60 @@
+/**
+ * [COMP:app-web/entry-reader] Source provenance URL regression.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  canOpenLocalKnowledgeSource,
+  getKnowledgeEntryNavigationUrl,
+  getKnowledgeSourceUrl,
+  type KnowledgeEntrySource,
+} from "@/lib/api/brain";
+
+function source(
+  sourceType: KnowledgeEntrySource["sourceType"],
+  repo: string,
+): KnowledgeEntrySource {
+  return {
+    id: "source-1",
+    sourceType,
+    repo,
+    branch: sourceType === "github" ? "main" : "local",
+    rootPath: "",
+    lastSyncedAt: null,
+  };
+}
+
+describe("[COMP:app-web/entry-reader] knowledge source URL", () => {
+  it("links GitHub repositories", () => {
+    expect(getKnowledgeSourceUrl(source("github", "acme/knowledge"))).toBe(
+      "https://github.com/acme/knowledge",
+    );
+  });
+
+  it("does not turn a local directory into a GitHub URL", () => {
+    expect(getKnowledgeSourceUrl(source("local", "/srv/knowledge"))).toBeNull();
+  });
+
+  it("uses the entry Markdown navigation URL", () => {
+    expect(getKnowledgeEntryNavigationUrl("https://docs.example.com/knowledge"))
+      .toBe("https://docs.example.com/knowledge");
+    expect(getKnowledgeEntryNavigationUrl("joplin://x-callback-url/openNote?id=note-1"))
+      .toBe("joplin://x-callback-url/openNote?id=note-1");
+    expect(getKnowledgeEntryNavigationUrl("obsidian://open?vault=kb&file=note-1"))
+      .toBe("obsidian://open?vault=kb&file=note-1");
+    expect(getKnowledgeEntryNavigationUrl("notes-app://open/note-1"))
+      .toBe("notes-app://open/note-1");
+  });
+
+  it("rejects an unsafe entry Markdown navigation URL", () => {
+    expect(getKnowledgeEntryNavigationUrl("file:///etc/passwd")).toBeNull();
+    expect(getKnowledgeEntryNavigationUrl("javascript:alert(1)")).toBeNull();
+    expect(getKnowledgeEntryNavigationUrl("chrome://settings")).toBeNull();
+  });
+
+  it("offers native folder opening only for loopback APIs", () => {
+    expect(canOpenLocalKnowledgeSource("http://localhost:4000")).toBe(true);
+    expect(canOpenLocalKnowledgeSource("http://127.0.0.1:4000")).toBe(true);
+    expect(canOpenLocalKnowledgeSource("https://brain.example.com")).toBe(false);
+  });
+});

--- a/apps/app-web/src/lib/api/brain.ts
+++ b/apps/app-web/src/lib/api/brain.ts
@@ -326,9 +326,10 @@ export type KnowledgeRelatedRef = {
   path: string;
 };
 
-/** Provenance of a GitHub-synced entry (null for manual entries). */
-type KnowledgeEntrySource = {
+/** Provenance of a synced entry (null for manual entries). */
+export type KnowledgeEntrySource = {
   id: string;
+  sourceType: "github" | "local";
   repo: string;
   branch: string;
   rootPath: string;
@@ -345,6 +346,8 @@ export type KnowledgeEntryDetail = {
   sensitivity: Sensitivity;
   sourceId: string | null;
   sourceSha: string | null;
+  /** Validated from the Markdown entry's optional `url` frontmatter field. */
+  navigationUrl: string | null;
   createdAt: string;
   updatedAt: string;
   /** Resolved `related_ids` (clearance-scoped). Absent on older servers. */
@@ -352,6 +355,41 @@ export type KnowledgeEntryDetail = {
   /** Owning sync source, null for manual entries. Absent on older servers. */
   source?: KnowledgeEntrySource | null;
 };
+
+/** Only GitHub source identifiers are valid browser destinations. */
+export function getKnowledgeSourceUrl(
+  source: KnowledgeEntrySource,
+): string | null {
+  return source.sourceType === "github"
+    ? `https://github.com/${source.repo}`
+    : null;
+}
+
+const BLOCKED_KNOWLEDGE_URL_PROTOCOLS = new Set([
+  "about:", "blob:", "chrome:", "chrome-extension:", "data:", "devtools:",
+  "file:", "javascript:", "vbscript:",
+]);
+
+export function getKnowledgeEntryNavigationUrl(
+  navigationUrl?: string | null,
+): string | null {
+  if (navigationUrl) {
+    try {
+      const url = new URL(navigationUrl);
+      if (
+        /^[a-z][a-z0-9+.-]*:$/.test(url.protocol)
+        && !BLOCKED_KNOWLEDGE_URL_PROTOCOLS.has(url.protocol)
+        && !url.username
+        && !url.password
+      ) {
+        return url.toString();
+      }
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
 
 /**
  * Single knowledge-entry read for the brain detail drawer. Backed by
@@ -379,9 +417,10 @@ export async function getKnowledgeEntry(
 // the DB row updates via the normal sync after merge.
 
 export type KnowledgeEditCapability = {
-  mode: "github" | "manual";
+  mode: "github" | "local" | "manual";
+  canEdit: boolean;
   canPropose: boolean;
-  reason: "no_write_access" | "no_credentials" | "source_missing" | null;
+  reason: "no_write_access" | "no_credentials" | "source_missing" | "not_configured" | null;
   repo: string | null;
   branch: string | null;
   repoUrl: string | null;
@@ -402,6 +441,55 @@ export async function getKnowledgeEditCapability(
   );
   if (!res.ok) return null;
   return (await res.json()) as KnowledgeEditCapability;
+}
+
+export type KnowledgeDirectUpdateResult =
+  | { ok: true; entryId: string; path: string }
+  | { ok: false; error: string };
+
+export async function updateLocalKnowledgeEntry(
+  workspaceId: string,
+  entryId: string,
+  content: string,
+): Promise<KnowledgeDirectUpdateResult> {
+  const res = await authFetch(
+    `${API_URL}/api/workspaces/${encodeURIComponent(workspaceId)}/knowledge/entries/${encodeURIComponent(entryId)}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content }),
+    },
+  );
+  const data = (await res.json().catch(() => ({}))) as {
+    entryId?: string;
+    path?: string;
+    error?: string;
+  };
+  if (!res.ok || !data.entryId) {
+    return { ok: false, error: data.error ?? `Request failed (${res.status})` };
+  }
+  return { ok: true, entryId: data.entryId, path: data.path ?? "" };
+}
+
+export async function openLocalKnowledgeSource(
+  workspaceId: string,
+  sourceId: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const res = await authFetch(
+    `${API_URL}/api/workspaces/${encodeURIComponent(workspaceId)}/knowledge/sources/${encodeURIComponent(sourceId)}/open`,
+    { method: "POST" },
+  );
+  const data = (await res.json().catch(() => ({}))) as { error?: string };
+  return res.ok ? { ok: true } : { ok: false, error: data.error ?? `Request failed (${res.status})` };
+}
+
+export function canOpenLocalKnowledgeSource(apiUrl = API_URL): boolean {
+  try {
+    const hostname = new URL(apiUrl).hostname;
+    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+  } catch {
+    return false;
+  }
 }
 
 export type KnowledgeProposalResult =

--- a/apps/app-web/src/lib/i18n/dictionaries/en.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/en.ts
@@ -3753,6 +3753,11 @@ export const en = {
       readOnlyBadge: "Read-only",
       actionsHeading: "Actions",
       suggestEdit: "Suggest an edit",
+      editEntry: "Edit entry",
+      saveChanges: "Save changes",
+      saving: "Saving…",
+      localEditingHint: "Changes are saved directly to the local knowledge file.",
+      localReadOnlyHint: "Local knowledge editing is not configured on this server.",
       capabilityLoading: "Checking edit access…",
       readOnlyHint:
         "The connected GitHub credential is read-only, so this knowledge base can't be edited from here.",
@@ -3771,6 +3776,8 @@ export const en = {
       kindMemory: "Memory",
       sourceHeading: "Source",
       sourceRepoLabel: "Repository",
+      sourceDirectoryLabel: "Directory",
+      sourceUrlLabel: "URL",
       sourceBranchLabel: "Branch",
       sourceSyncedLabel: "Last synced",
       sourceNever: "Not yet",
@@ -3788,6 +3795,7 @@ export const en = {
         "Your suggested edit is now a pull request. This entry updates after it's merged and synced.",
       viewPr: "View pull request",
       proposalFailed: "Couldn't create the pull request. {message}",
+      localSaveFailed: "Couldn't save the local knowledge file. {message}",
       noContent: "No content to show.",
     },
     // (The former `chatPanel` block is retired: the non-doc surface dock now

--- a/apps/app-web/src/lib/i18n/dictionaries/ja.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/ja.ts
@@ -3554,6 +3554,11 @@ export const ja: Dictionary = {
       readOnlyBadge: "読み取り専用",
       actionsHeading: "アクション",
       suggestEdit: "編集を提案",
+      editEntry: "エントリを編集",
+      saveChanges: "変更を保存",
+      saving: "保存中…",
+      localEditingHint: "変更はローカルのナレッジファイルに直接保存されます。",
+      localReadOnlyHint: "このサーバーではローカルナレッジの編集が設定されていません。",
       capabilityLoading: "編集権限を確認しています…",
       readOnlyHint:
         "接続中の GitHub 認証情報は読み取り専用のため、ここからナレッジベースを編集できません。",
@@ -3572,6 +3577,8 @@ export const ja: Dictionary = {
       kindMemory: "メモリー",
       sourceHeading: "ソース",
       sourceRepoLabel: "リポジトリ",
+      sourceDirectoryLabel: "ディレクトリ",
+      sourceUrlLabel: "URL",
       sourceBranchLabel: "ブランチ",
       sourceSyncedLabel: "最終同期",
       sourceNever: "未同期",
@@ -3589,6 +3596,7 @@ export const ja: Dictionary = {
         "提案した編集はプルリクエストになりました。マージと同期が完了するとこのエントリに反映されます。",
       viewPr: "プルリクエストを見る",
       proposalFailed: "プルリクエストを作成できませんでした。{message}",
+      localSaveFailed: "ローカルナレッジファイルを保存できませんでした。{message}",
       noContent: "表示する内容がありません。",
     },
     // （旧 chatPanel ブロックは廃止：非ドックサーフェスも doc の FloatingChat を

--- a/apps/app-web/src/lib/i18n/dictionaries/zh.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh.ts
@@ -3517,6 +3517,11 @@ export const zh: Dictionary = {
       readOnlyBadge: "唯讀",
       actionsHeading: "操作",
       suggestEdit: "建議編輯",
+      editEntry: "編輯項目",
+      saveChanges: "儲存變更",
+      saving: "儲存中…",
+      localEditingHint: "變更會直接儲存到本機知識檔案。",
+      localReadOnlyHint: "此伺服器尚未設定本機知識編輯。",
       capabilityLoading: "正在確認編輯權限…",
       readOnlyHint:
         "連接的 GitHub 憑證僅有讀取權限，因此無法在這裡編輯知識庫。",
@@ -3534,6 +3539,8 @@ export const zh: Dictionary = {
       kindMemory: "記憶",
       sourceHeading: "來源",
       sourceRepoLabel: "儲存庫",
+      sourceDirectoryLabel: "目錄",
+      sourceUrlLabel: "URL",
       sourceBranchLabel: "分支",
       sourceSyncedLabel: "上次同步",
       sourceNever: "尚未同步",
@@ -3551,6 +3558,7 @@ export const zh: Dictionary = {
         "你建議的修改已成為 Pull Request。合併並同步後，這則項目就會更新。",
       viewPr: "查看 Pull Request",
       proposalFailed: "無法建立 Pull Request。{message}",
+      localSaveFailed: "無法儲存本機知識檔案。{message}",
       noContent: "沒有可顯示的內容。",
     },
     // （舊 chatPanel 區塊已淘汰：非文件介面同樣掛載 doc 的 FloatingChat，

--- a/apps/app-web/src/lib/kb-wikilinks.ts
+++ b/apps/app-web/src/lib/kb-wikilinks.ts
@@ -28,6 +28,10 @@ import type { KnowledgeRelatedRef } from "@/lib/api/brain";
 
 export const KB_WIKILINK_SCHEME = "kbwiki:";
 
+export function knowledgeEntryHref(workspaceId: string, entryId: string): string {
+  return `/w/${encodeURIComponent(workspaceId)}/brain/entry/knowledge/${encodeURIComponent(entryId)}`;
+}
+
 const WIKILINK_RE = /\[\[([^\]]+)\]\]/g;
 const FENCE_RE = /^(```|~~~)/;
 

--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -4241,6 +4241,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     connectorInstanceStore,
     connectorGrantStore,
     syncCredentials,
+    knowledgeRepoWriter,
     triggerSync: async () => { if (syncWorkerRef) await syncWorkerRef.tick() },
   }))
 

--- a/packages/api/src/routes/__tests__/brain.test.ts
+++ b/packages/api/src/routes/__tests__/brain.test.ts
@@ -768,12 +768,22 @@ describe('[COMP:brain/knowledge-detail-http] GET /api/brain/knowledge/:id', () =
       content: '# Identity healing\n\nLong-form body…',
       tags: ['identity', 'merge'],
       sensitivity: 'confidential',
+      metadata: { url: 'notes-app://open/note-1' },
       sourceId: 's-1',
       sourceSha: 'abc123',
       createdAt: new Date('2026-05-01T00:00:00Z'),
       updatedAt: new Date('2026-05-20T00:00:00Z'),
     }
     const knowledge = makeKnowledgeStore([], entry)
+    knowledge.getSource.mockResolvedValue({
+      id: 's-1',
+      workspaceId: 'ws-1',
+      sourceType: 'local',
+      repo: '/srv/knowledge',
+      branch: 'local',
+      rootPath: '',
+      lastSyncedAt: new Date('2026-05-19T00:00:00Z'),
+    })
     const res = await request(
       makeApp(makeEntityStore(null), makeRetrievalStore(), undefined, knowledge),
     )
@@ -787,8 +797,17 @@ describe('[COMP:brain/knowledge-detail-http] GET /api/brain/knowledge/:id', () =
       content: '# Identity healing\n\nLong-form body…',
       tags: ['identity', 'merge'],
       sensitivity: 'confidential',
+      navigationUrl: 'notes-app://open/note-1',
+      source: {
+        id: 's-1',
+        sourceType: 'local',
+        repo: '/srv/knowledge',
+        branch: 'local',
+        rootPath: '',
+      },
     })
     expect(knowledge.getById).toHaveBeenCalledTimes(1)
+    expect(knowledge.getSource).toHaveBeenCalledWith('s-1')
   })
 
   it('404s when the entry belongs to a different workspace', async () => {

--- a/packages/api/src/routes/__tests__/knowledge-proposals.test.ts
+++ b/packages/api/src/routes/__tests__/knowledge-proposals.test.ts
@@ -16,6 +16,9 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import request from 'supertest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { createTestApp } from './helpers.js'
 
 vi.mock('../../db/client.js', () => ({
@@ -51,6 +54,11 @@ const githubOps = {
 }
 
 const syncCredentials = { getPat: vi.fn() }
+const knowledgeRepoWriter = {
+  commitEntryUpdate: vi.fn(),
+  commitEntryCreate: vi.fn(),
+}
+const openLocalPath = vi.fn()
 
 const ENTRY = {
   id: 'e-1',
@@ -79,6 +87,9 @@ function app(userId?: string) {
       knowledgeStore: knowledgeStore as never,
       syncCredentials,
       githubOps: githubOps as never,
+      knowledgeRepoWriter: knowledgeRepoWriter as never,
+      allowLocalSources: true,
+      openLocalPath,
     }),
     userId ? { userId } : undefined,
   )
@@ -116,6 +127,15 @@ beforeEach(() => {
   githubOps.createBranchRef.mockResolvedValue(undefined)
   githubOps.createOrUpdateFile.mockResolvedValue({})
   githubOps.createPullRequest.mockResolvedValue({ number: 7, html_url: 'https://github.com/acme/kb/pull/7' })
+  knowledgeRepoWriter.commitEntryUpdate.mockResolvedValue({
+    ok: true,
+    entryId: 'e-1',
+    path: 'products/vault',
+    sourceType: 'local',
+    commitSha: null,
+    commitUrl: null,
+  })
+  openLocalPath.mockResolvedValue(undefined)
   vi.spyOn(console, 'error').mockImplementation(() => {})
 })
 
@@ -160,6 +180,29 @@ describe('[COMP:api/knowledge-proposals] GET /entries/:id/edit-capability', () =
     expect(res.body).toMatchObject({ mode: 'manual', canPropose: false, reason: null })
   })
 
+  it('reports local mode without resolving credentials or calling GitHub', async () => {
+    knowledgeStore.getSource.mockResolvedValue({
+      ...SOURCE,
+      sourceType: 'local',
+      repo: '/srv/knowledge',
+      branch: 'local',
+      connectorInstanceId: null,
+    })
+    const res = await request(app('u-1')).get('/api/workspaces/ws-1/knowledge/entries/e-1/edit-capability')
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({
+      mode: 'local',
+      canEdit: true,
+      canPropose: false,
+      reason: null,
+      repo: null,
+      branch: null,
+      repoUrl: null,
+    })
+    expect(syncCredentials.getPat).not.toHaveBeenCalled()
+    expect(githubOps.getRepoPermissions).not.toHaveBeenCalled()
+  })
+
   it('reports no_credentials when the PAT cannot resolve', async () => {
     syncCredentials.getPat.mockRejectedValue(new Error('no creds'))
     const res = await request(app('u-1')).get('/api/workspaces/ws-1/knowledge/entries/e-1/edit-capability')
@@ -172,6 +215,78 @@ describe('[COMP:api/knowledge-proposals] GET /entries/:id/edit-capability', () =
     const res = await request(app('u-1')).get('/api/workspaces/ws-1/knowledge/entries/e-1/edit-capability')
     expect(res.status).toBe(200)
     expect(res.body).toMatchObject({ mode: 'github', canPropose: false, reason: 'source_missing' })
+  })
+})
+
+describe('[COMP:api/knowledge-proposals] PATCH /entries/:id local edit', () => {
+  it('updates through the local writer without calling GitHub', async () => {
+    knowledgeStore.getSource.mockResolvedValue({
+      ...SOURCE,
+      sourceType: 'local',
+      repo: '/srv/knowledge',
+      branch: 'local',
+      connectorInstanceId: null,
+    })
+    const res = await request(app('u-1'))
+      .patch('/api/workspaces/ws-1/knowledge/entries/e-1')
+      .send({ content: 'new local body' })
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({ ok: true, mode: 'local', entryId: 'e-1' })
+    expect(knowledgeRepoWriter.commitEntryUpdate).toHaveBeenCalledWith({
+      workspaceId: 'ws-1',
+      entry: {
+        id: 'e-1', path: 'products/vault', content: 'old body', sourceId: 'src-1',
+      },
+      newBody: 'new local body',
+      changeSummary: 'update products/vault from knowledge reader',
+      requestedBy: { userId: 'u-1' },
+    })
+    expect(syncCredentials.getPat).not.toHaveBeenCalled()
+    expect(githubOps.getRepoPermissions).not.toHaveBeenCalled()
+    expect(githubOps.createOrUpdateFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects GitHub entries before invoking the local writer', async () => {
+    const res = await request(app('u-1'))
+      .patch('/api/workspaces/ws-1/knowledge/entries/e-1')
+      .send({ content: 'new body' })
+    expect(res.status).toBe(400)
+    expect(knowledgeRepoWriter.commitEntryUpdate).not.toHaveBeenCalled()
+  })
+
+  it('maps a stale local file to 409', async () => {
+    knowledgeStore.getSource.mockResolvedValue({ ...SOURCE, sourceType: 'local' })
+    knowledgeRepoWriter.commitEntryUpdate.mockResolvedValue({
+      ok: false,
+      reason: 'stale_entry',
+      message: 'The local file moved ahead.',
+    })
+    const res = await request(app('u-1'))
+      .patch('/api/workspaces/ws-1/knowledge/entries/e-1')
+      .send({ content: 'new body' })
+    expect(res.status).toBe(409)
+    expect(res.body).toMatchObject({ reason: 'stale_entry' })
+  })
+})
+
+describe('[COMP:api/knowledge-proposals] local source navigation', () => {
+  it('opens the configured local root without accepting a client path', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'brian-kb-open-'))
+    try {
+      knowledgeStore.getSource.mockResolvedValue({
+        ...SOURCE,
+        sourceType: 'local',
+        repo: dir,
+        rootPath: '',
+      })
+      const res = await request(app('u-1'))
+        .post('/api/workspaces/ws-1/knowledge/sources/src-1/open')
+        .send({ path: '/etc' })
+      expect(res.status).toBe(200)
+      expect(openLocalPath).toHaveBeenCalledWith(dir)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/packages/api/src/routes/brain.ts
+++ b/packages/api/src/routes/brain.ts
@@ -33,12 +33,37 @@ import type {
   SearchResultRow,
   Sensitivity,
 } from '@use-brian/core'
+
 import { TASK_STATUSES as TASK_RECORD_STATUSES } from '@use-brian/core'
 import { query } from '../db/client.js'
 import { listCompanies, listContacts, listDeals } from '../db/crm.js'
 import { listTasks as listWorkspaceTasks } from '../db/tasks.js'
 import { resolveWorkspaceViewpoint } from '../db/workspace-viewpoint.js'
 import type { KnowledgeStore } from '../db/knowledge-store.js'
+
+const BLOCKED_KNOWLEDGE_URL_PROTOCOLS = new Set([
+  'about:', 'blob:', 'chrome:', 'chrome-extension:', 'data:', 'devtools:',
+  'file:', 'javascript:', 'vbscript:',
+])
+
+function knowledgeNavigationUrl(metadata: unknown): string | null {
+  const value = metadata && typeof metadata === 'object'
+    ? (metadata as Record<string, unknown>).url
+    : null
+  if (typeof value !== 'string' || value.length > 2048) return null
+  try {
+    const url = new URL(value)
+    if (
+      !/^[a-z][a-z0-9+.-]*:$/.test(url.protocol)
+      || BLOCKED_KNOWLEDGE_URL_PROTOCOLS.has(url.protocol)
+      || url.username
+      || url.password
+    ) return null
+    return url.toString()
+  } catch {
+    return null
+  }
+}
 
 /** Format a pg-parsed DATE (local-midnight Date) back to its YYYY-MM-DD. */
 function formatDateOnly(d: Date): string {
@@ -1246,12 +1271,14 @@ export function brainRoutes(deps: {
         sensitivity: entry.sensitivity,
         sourceId: entry.sourceId,
         sourceSha: entry.sourceSha,
+        navigationUrl: knowledgeNavigationUrl(entry.metadata),
         createdAt: entry.createdAt,
         updatedAt: entry.updatedAt,
         related: related.map((r) => ({ id: r.id, title: r.title, path: r.path })),
         source: source && source.workspaceId === ctx.workspaceId
           ? {
               id: source.id,
+              sourceType: source.sourceType,
               repo: source.repo,
               branch: source.branch,
               rootPath: source.rootPath,

--- a/packages/api/src/routes/knowledge.ts
+++ b/packages/api/src/routes/knowledge.ts
@@ -29,6 +29,8 @@ import type { AccessContext, Sensitivity } from '@use-brian/core'
 import { splitFrontmatterBlock, resolveRepoFilePath } from '../knowledge/repo-files.js'
 import { promises as fs } from 'node:fs'
 import * as nodePath from 'node:path'
+import { execFile } from 'node:child_process'
+import type { KnowledgeRepoWriter } from '@use-brian/core'
 
 // Re-exported for existing consumers/tests; the implementations moved to
 // `../knowledge/repo-files.ts` so the assistant repo writer shares them.
@@ -101,6 +103,21 @@ type KnowledgeRouteOptions = {
   syncCredentials?: { getPat(workspaceId: string, connectorInstanceId: string | null): Promise<string> }
   /** Test seam for the proposal flow's GitHub calls. Defaults to the real client. */
   githubOps?: KnowledgeGithubOps
+  /** Shared source writer used for direct local reader edits. */
+  knowledgeRepoWriter?: KnowledgeRepoWriter
+  /** Test seam for the loopback-only local folder action. */
+  openLocalPath?: (path: string) => Promise<void>
+}
+
+function isLoopbackAddress(address: string | undefined): boolean {
+  return address === '127.0.0.1' || address === '::1' || address === '::ffff:127.0.0.1'
+}
+
+function openPathWithSystem(path: string): Promise<void> {
+  const command = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'explorer.exe' : 'xdg-open'
+  return new Promise((resolve, reject) => {
+    execFile(command, [path], (error) => error ? reject(error) : resolve())
+  })
 }
 
 /**
@@ -1048,6 +1065,8 @@ export function workspaceKnowledgeRoutes({
   triggerSync,
   syncCredentials,
   githubOps = DEFAULT_GITHUB_OPS,
+  knowledgeRepoWriter,
+  openLocalPath = openPathWithSystem,
 }: KnowledgeRouteOptions): Router {
   const router = Router({ mergeParams: true })
 
@@ -1154,8 +1173,11 @@ export function workspaceKnowledgeRoutes({
         }
         res.json({
           mode: target.failure === 'manual_entry' ? 'manual' : target.failure === 'local_source' ? 'local' : 'github',
+          canEdit: target.failure === 'local_source' && !!knowledgeRepoWriter,
           canPropose: false,
-          reason: target.failure === 'manual_entry' || target.failure === 'local_source' ? null : target.failure,
+          reason: target.failure === 'local_source' && !knowledgeRepoWriter
+            ? 'not_configured'
+            : target.failure === 'manual_entry' || target.failure === 'local_source' ? null : target.failure,
           repo: null,
           branch: null,
           repoUrl: null,
@@ -1170,7 +1192,7 @@ export function workspaceKnowledgeRoutes({
       } catch (err) {
         console.error('[knowledge:workspace] permission probe failed:', err)
         res.json({
-          mode: 'github', canPropose: false, reason: 'no_credentials',
+          mode: 'github', canEdit: false, canPropose: false, reason: 'no_credentials',
           repo: target.source.repo, branch: target.source.branch,
           repoUrl: `https://github.com/${target.source.repo}`,
         })
@@ -1179,6 +1201,7 @@ export function workspaceKnowledgeRoutes({
 
       res.json({
         mode: 'github',
+        canEdit: push,
         canPropose: push,
         reason: push ? null : 'no_write_access',
         repo: target.source.repo,
@@ -1188,6 +1211,59 @@ export function workspaceKnowledgeRoutes({
     } catch (err) {
       console.error('[knowledge:workspace] edit-capability failed:', err)
       res.status(500).json({ error: 'Failed to check edit capability' })
+    }
+  })
+
+  // ── PATCH /entries/:id — direct local-source body update ──
+  router.patch('/entries/:id', async (req, res) => {
+    const auth = await verifyWorkspaceMember(req as any, res)
+    if (!auth) return
+    const content = (req.body as { content?: unknown }).content
+    if (typeof content !== 'string' || content.trim().length === 0) {
+      res.status(400).json({ error: 'content (non-empty string) is required' })
+      return
+    }
+    if (content.length > 200_000) {
+      res.status(400).json({ error: 'content is too large' })
+      return
+    }
+    if (!knowledgeRepoWriter) {
+      res.status(503).json({ error: 'Local knowledge editing is not configured on this server.' })
+      return
+    }
+    try {
+      const entry = await knowledgeStore.getById(memberCtx(auth), (req.params as { id: string }).id)
+      if (!entry || entry.workspaceId !== auth.workspaceId) {
+        res.status(404).json({ error: 'Entry not found' })
+        return
+      }
+      if (!entry.sourceId) {
+        res.status(400).json({ error: 'This entry is not backed by a local source.' })
+        return
+      }
+      const source = await knowledgeStore.getSource(entry.sourceId)
+      if (!source || source.workspaceId !== auth.workspaceId || source.sourceType !== 'local') {
+        res.status(400).json({ error: 'This endpoint only edits local knowledge sources.' })
+        return
+      }
+      const result = await knowledgeRepoWriter.commitEntryUpdate({
+        workspaceId: auth.workspaceId,
+        entry: { id: entry.id, path: entry.path, content: entry.content, sourceId: entry.sourceId },
+        newBody: content,
+        changeSummary: `update ${entry.path} from knowledge reader`,
+        requestedBy: { userId: auth.userId },
+      })
+      if (!result.ok) {
+        const status = result.reason === 'stale_entry' || result.reason === 'file_missing' || result.reason === 'source_missing'
+          ? 409
+          : result.reason === 'not_writable' ? 403 : 500
+        res.status(status).json({ error: result.message, reason: result.reason })
+        return
+      }
+      res.json({ ok: true, mode: 'local', entryId: result.entryId, path: result.path })
+    } catch (err) {
+      console.error('[knowledge:workspace] local entry update failed:', err)
+      res.status(500).json({ error: 'Failed to update the local knowledge entry.' })
     }
   })
 
@@ -1307,6 +1383,34 @@ export function workspaceKnowledgeRoutes({
     } catch (err) {
       console.error('[knowledge:workspace] list sources failed:', err)
       res.status(500).json({ error: 'Failed to list sources' })
+    }
+  })
+
+  router.post('/sources/:id/open', async (req, res) => {
+    const auth = await verifyWorkspaceMember(req as any, res)
+    if (!auth) return
+    if (!allowLocalSources || !isLoopbackAddress(req.socket.remoteAddress)) {
+      res.status(403).json({ error: 'Local folders can only be opened from the localhost deployment.' })
+      return
+    }
+    const source = await knowledgeStore.getSource((req.params as { id: string }).id)
+    if (!source || source.workspaceId !== auth.workspaceId || source.sourceType !== 'local') {
+      res.status(404).json({ error: 'Local source not found' })
+      return
+    }
+    try {
+      const base = await fs.realpath(source.repo)
+      const root = await fs.realpath(nodePath.resolve(base, source.rootPath || '.'))
+      const relative = nodePath.relative(base, root)
+      if (relative === '..' || relative.startsWith(`..${nodePath.sep}`) || nodePath.isAbsolute(relative)) {
+        res.status(400).json({ error: 'Local source root escapes its configured directory.' })
+        return
+      }
+      await openLocalPath(root)
+      res.json({ ok: true })
+    } catch (err) {
+      console.error('[knowledge:workspace] open local source failed:', err)
+      res.status(500).json({ error: 'Failed to open the local knowledge directory.' })
     }
   })
 


### PR DESCRIPTION
## Summary
- distinguish local and GitHub knowledge provenance without constructing GitHub URLs for filesystem paths
- save local entry edits through the existing atomic filesystem writer and refresh the reader immediately
- expose generic frontmatter navigation URLs, localhost folder opening, and canonical related-entry links

## Testing
- `pnpm --filter @use-brian/api exec vitest run src/routes/__tests__/brain.test.ts src/routes/__tests__/knowledge-proposals.test.ts`
- `pnpm --filter @use-brian/api typecheck`
- `pnpm --filter app-web exec vitest run src/lib/__tests__/knowledge-source.test.ts src/lib/__tests__/kb-wikilinks.test.ts`
- `pnpm --filter @use-brian/core smoke`