### PR TITLE
feat(browser): support Firefox My Browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules/
 
 # Build outputs
 dist/
+dist-firefox/
 .next/
 .turbo/
 *.tsbuildinfo

--- a/apps/app-desktop/build/installer.nsh
+++ b/apps/app-desktop/build/installer.nsh
@@ -1,0 +1,3 @@
+!macro customUnInstall
+  DeleteRegKey HKCU "Software\Mozilla\NativeMessagingHosts\ai.usebrian.browser"
+!macroend

--- a/apps/app-desktop/electron-builder.yml
+++ b/apps/app-desktop/electron-builder.yml
@@ -97,6 +97,15 @@ nsis:
   oneClick: false
   perMachine: false
   allowToChangeInstallationDirectory: true
+  include: build/installer.nsh
+# ── Linux ───────────────────────────────────────────────────────────────────
+# AppImage is the portable upstream artifact. Distribution-native packages may
+# instead build the same app from source and run it with their Electron runtime.
+linux:
+  target:
+    - AppImage
+  category: Office
+  executableName: use-brian
 # Where `electron-builder --publish always` uploads artifacts. The marketing CTA
 # links the "latest" GitHub Release asset, which must be public-readable for an
 # unauthenticated download. The desktop source is open (this app lives in the

--- a/apps/app-desktop/package.json
+++ b/apps/app-desktop/package.json
@@ -6,19 +6,21 @@
   "author": "SIDAN Lab",
   "private": true,
   "type": "module",
-  "main": "dist/main.js",
+  "main": "dist/bootstrap.js",
   "scripts": {
     "copy:assets": "node scripts/copy-static.mjs",
     "build": "tsc && pnpm run copy:assets",
-    "dev": "tsc && pnpm run copy:assets && electron dist/main.js",
-    "start": "electron dist/main.js",
+    "dev": "tsc && pnpm run copy:assets && electron dist/bootstrap.js",
+    "start": "electron dist/bootstrap.js",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "package": "pnpm run build && electron-builder --mac",
-    "package:win": "pnpm run build && electron-builder --win --x64 --publish never"
+    "package:win": "pnpm run build && electron-builder --win --x64 --publish never",
+    "package:linux": "pnpm run build && electron-builder --linux AppImage --publish never"
   },
   "devDependencies": {
     "@types/node": "^20.19.39",
+    "@types/ws": "^8.5.13",
     "electron": "^43.2.0",
     "electron-builder": "^25.0.0",
     "typescript": "^5.7",
@@ -26,6 +28,7 @@
   },
   "dependencies": {
     "electron-updater": "^6.8.9",
+    "ws": "^8.18.0",
     "zod": "^3.24"
   }
 }

--- a/apps/app-desktop/src/__tests__/firefox-bidi.test.ts
+++ b/apps/app-desktop/src/__tests__/firefox-bidi.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { FirefoxBidiExecutor, FirefoxBidiError, firefoxBidiInternals } from "../firefox-bidi.js";
+
+type Listener = (...args: any[]) => void;
+
+function remote(value: unknown): unknown {
+  if (value === null) return { type: "null" };
+  if (typeof value === "object" && (value as { __node?: unknown }).__node === true) {
+    return { type: "node", sharedId: "node-1" };
+  }
+  if (Array.isArray(value)) return { type: "array", value: value.map(remote) };
+  if (typeof value === "object") {
+    return {
+      type: "object",
+      value: Object.entries(value as Record<string, unknown>).map(([key, entry]) => [remote(key), remote(entry)]),
+    };
+  }
+  return { type: typeof value, value };
+}
+
+class FakeSocket {
+  readonly sent: Array<{ id: number; method: string; params: Record<string, unknown> }> = [];
+  private listeners = new Map<string, Listener[]>();
+
+  constructor() {
+    queueMicrotask(() => this.emit("open"));
+  }
+
+  addEventListener(type: string, listener: Listener): void {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
+  }
+
+  send(data: string): void {
+    const message = JSON.parse(data) as { id: number; method: string; params: Record<string, unknown> };
+    this.sent.push(message);
+    let result: unknown = {};
+    if (message.method === "browsingContext.getTree") {
+      result = { contexts: [{ context: "tab-1", url: "https://example.com", children: [] }] };
+    } else if (message.method === "script.evaluate") {
+      result = { type: "success", result: remote({ focused: true, title: "Example" }) };
+    } else if (message.method === "script.callFunction") {
+      if (String(message.params.functionDeclaration).includes("document.querySelector(selector)")) {
+        result = { type: "success", result: { type: "node", sharedId: "node-1" } };
+      } else if (message.params.functionDeclaration === "() => document.title") {
+        result = { type: "success", result: remote("Example") };
+      } else {
+        result = {
+          type: "success",
+          result: remote({
+            url: "https://example.com",
+            title: "Example",
+            nodes: [{ role: "button", name: "Continue", element: { __node: true } }],
+          }),
+        };
+      }
+    } else if (message.method === "browsingContext.navigate") {
+      result = { url: message.params.url };
+    }
+    queueMicrotask(() => this.emit("message", { data: JSON.stringify({ id: message.id, result }) }));
+  }
+
+  close(): void {
+    this.emit("close");
+  }
+
+  private emit(type: string, value?: unknown): void {
+    for (const listener of this.listeners.get(type) ?? []) listener(value);
+  }
+}
+
+describe("[COMP:app-desktop/firefox-native-host] Firefox BiDi executor", () => {
+  it("binds the focused tab and executes the fixed operation vocabulary", async () => {
+    const socket = new FakeSocket();
+    const executor = new FirefoxBidiExecutor("ws://127.0.0.1:9222/session", () => socket);
+    await executor.connect();
+    await executor.bindFocusedContext();
+    const snapshot = await executor.execute("snapshot", {});
+    expect(snapshot).toEqual({
+      url: "https://example.com",
+      title: "Example",
+      nodes: [{ ref: "@e1", role: "button", name: "Continue" }],
+    });
+    await executor.execute("click", { ref: "@e1" });
+    await executor.execute("type", { ref: "@e1", text: "ok" });
+    expect(socket.sent.filter((message) => message.method === "input.performActions")).toHaveLength(3);
+    expect(await executor.execute("currentUrl", {})).toEqual({
+      url: "https://example.com",
+      title: "Example",
+    });
+  });
+
+  it("rejects generic protocol access and non-http navigation", async () => {
+    const socket = new FakeSocket();
+    const executor = new FirefoxBidiExecutor("ws://127.0.0.1:9222/session", () => socket);
+    await executor.connect();
+    await executor.bindFocusedContext();
+    await expect(executor.execute("sendCommand", {})).rejects.toMatchObject({ code: "backend_error" });
+    await expect(executor.execute("navigate", { url: "file:///etc/passwd" })).rejects.toMatchObject({
+      code: "backend_error",
+    });
+  });
+
+  it("decodes BiDi remote values without eval", () => {
+    expect(
+      firefoxBidiInternals.decodeRemoteValue(
+        remote({ nodes: [{ role: "link", name: "Docs" }], ready: true }),
+      ),
+    ).toEqual({ nodes: [{ role: "link", name: "Docs" }], ready: true });
+  });
+
+  it("never serializes password values and bounds ordinary form values", () => {
+    expect(firefoxBidiInternals.snapshotFunction).toContain('el.type.toLowerCase() === "password"')
+    expect(firefoxBidiInternals.snapshotFunction).toContain('el.value.slice(0, 500)')
+  });
+
+  it("requires an approved focused context", async () => {
+    const socket = new FakeSocket();
+    const executor = new FirefoxBidiExecutor("ws://127.0.0.1:9222/session", () => socket);
+    await executor.connect();
+    await expect(executor.execute("currentUrl", {})).rejects.toBeInstanceOf(FirefoxBidiError);
+  });
+});

--- a/apps/app-desktop/src/__tests__/firefox-launcher.test.ts
+++ b/apps/app-desktop/src/__tests__/firefox-launcher.test.ts
@@ -1,0 +1,43 @@
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  discoverFirefoxRemoteEndpoint,
+  firefoxExecutableCandidates,
+  firefoxProfilesRoot,
+} from "../firefox-launcher.js";
+
+describe("[COMP:app-desktop/firefox-native-host] Firefox launcher", () => {
+  it("resolves standard executable and profile locations", () => {
+    expect(firefoxExecutableCandidates("darwin", {}, "/Users/a")[0]).toBe(
+      "/Applications/Firefox.app/Contents/MacOS/firefox",
+    );
+    expect(firefoxExecutableCandidates("win32", { ProgramFiles: "C:\\Program Files" }, "C:\\Users\\a")).toEqual([
+      "C:\\Program Files/Mozilla Firefox/firefox.exe",
+    ]);
+    expect(firefoxProfilesRoot("darwin", {}, "/Users/a")).toBe(
+      "/Users/a/Library/Application Support/Firefox/Profiles",
+    );
+  });
+
+  it("discovers only a valid loopback endpoint and picks the newest profile", async () => {
+    const root = await mkdtemp(join(tmpdir(), "usebrian-firefox-"));
+    const older = join(root, "older.default");
+    const newer = join(root, "newer.default");
+    await Promise.all([mkdir(older), mkdir(newer)]);
+    await writeFile(join(older, "WebDriverBiDiServer.json"), JSON.stringify({ ws_host: "127.0.0.1", ws_port: 9222 }));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await writeFile(join(newer, "WebDriverBiDiServer.json"), JSON.stringify({ ws_host: "localhost", ws_port: 9555 }));
+    const endpoint = await discoverFirefoxRemoteEndpoint(root);
+    expect(endpoint).toMatchObject({ wsHost: "localhost", wsPort: 9555, profileDir: newer });
+  });
+
+  it("rejects a non-loopback endpoint", async () => {
+    const root = await mkdtemp(join(tmpdir(), "usebrian-firefox-"));
+    const profile = join(root, "unsafe.default");
+    await mkdir(profile);
+    await writeFile(join(profile, "WebDriverBiDiServer.json"), JSON.stringify({ ws_host: "0.0.0.0", ws_port: 9222 }));
+    expect(await discoverFirefoxRemoteEndpoint(root)).toBeNull();
+  });
+});

--- a/apps/app-desktop/src/__tests__/firefox-launcher.test.ts
+++ b/apps/app-desktop/src/__tests__/firefox-launcher.test.ts
@@ -1,11 +1,13 @@
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { spawn } from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
 import {
   discoverFirefoxRemoteEndpoint,
   firefoxExecutableCandidates,
-  firefoxProfilesRoot,
+  firefoxProfilesRoots,
+  launchFirefoxForControl,
 } from "../firefox-launcher.js";
 
 describe("[COMP:app-desktop/firefox-native-host] Firefox launcher", () => {
@@ -16,8 +18,18 @@ describe("[COMP:app-desktop/firefox-native-host] Firefox launcher", () => {
     expect(firefoxExecutableCandidates("win32", { ProgramFiles: "C:\\Program Files" }, "C:\\Users\\a")).toEqual([
       "C:\\Program Files/Mozilla Firefox/firefox.exe",
     ]);
-    expect(firefoxProfilesRoot("darwin", {}, "/Users/a")).toBe(
+    expect(firefoxProfilesRoots("darwin", {}, "/Users/a")).toEqual([
       "/Users/a/Library/Application Support/Firefox/Profiles",
+    ]);
+    expect(
+      firefoxExecutableCandidates("linux", { PATH: "/run/current-system/sw/bin:/usr/bin" }, "/home/a"),
+    ).toContain("/run/current-system/sw/bin/firefox");
+    expect(firefoxProfilesRoots("linux", {}, "/home/a")).toEqual([
+      "/home/a/.mozilla/firefox",
+      "/home/a/.config/mozilla/firefox",
+    ]);
+    expect(firefoxProfilesRoots("linux", { XDG_CONFIG_HOME: "/xdg" }, "/home/a")).toContain(
+      "/xdg/mozilla/firefox",
     );
   });
 
@@ -29,7 +41,7 @@ describe("[COMP:app-desktop/firefox-native-host] Firefox launcher", () => {
     await writeFile(join(older, "WebDriverBiDiServer.json"), JSON.stringify({ ws_host: "127.0.0.1", ws_port: 9222 }));
     await new Promise((resolve) => setTimeout(resolve, 10));
     await writeFile(join(newer, "WebDriverBiDiServer.json"), JSON.stringify({ ws_host: "localhost", ws_port: 9555 }));
-    const endpoint = await discoverFirefoxRemoteEndpoint(root);
+    const endpoint = await discoverFirefoxRemoteEndpoint([root]);
     expect(endpoint).toMatchObject({ wsHost: "localhost", wsPort: 9555, profileDir: newer });
   });
 
@@ -38,6 +50,60 @@ describe("[COMP:app-desktop/firefox-native-host] Firefox launcher", () => {
     const profile = join(root, "unsafe.default");
     await mkdir(profile);
     await writeFile(join(profile, "WebDriverBiDiServer.json"), JSON.stringify({ ws_host: "0.0.0.0", ws_port: 9222 }));
-    expect(await discoverFirefoxRemoteEndpoint(root)).toBeNull();
+    expect(await discoverFirefoxRemoteEndpoint([root])).toBeNull();
+  });
+
+  it("normalizes Firefox's bracketed IPv6 loopback host", async () => {
+    const root = await mkdtemp(join(tmpdir(), "usebrian-firefox-"));
+    const profile = join(root, "ipv6.default");
+    await mkdir(profile);
+    await writeFile(join(profile, "WebDriverBiDiServer.json"), JSON.stringify({ ws_host: "[::1]", ws_port: 9222 }));
+    expect(await discoverFirefoxRemoteEndpoint([root])).toMatchObject({ wsHost: "::1", wsPort: 9222 });
+  });
+
+  it("discovers an absolute custom profile registered in profiles.ini", async () => {
+    const configRoot = await mkdtemp(join(tmpdir(), "usebrian-firefox-config-"));
+    const profilesRoot = join(configRoot, "Profiles");
+    const externalProfile = await mkdtemp(join(tmpdir(), "usebrian-firefox-external-"));
+    await writeFile(
+      join(configRoot, "profiles.ini"),
+      `[Profile0]\nName=external\nIsRelative=0\nPath=${externalProfile}\nDefault=1\n`,
+    );
+    await writeFile(
+      join(externalProfile, "WebDriverBiDiServer.json"),
+      JSON.stringify({ ws_host: "127.0.0.1", ws_port: 9333 }),
+    );
+    expect(await discoverFirefoxRemoteEndpoint([profilesRoot])).toMatchObject({
+      wsHost: "127.0.0.1",
+      wsPort: 9333,
+      profileDir: externalProfile,
+    });
+  });
+
+  it("discovers an endpoint under Firefox's fresh-install XDG root", async () => {
+    const legacyRoot = await mkdtemp(join(tmpdir(), "usebrian-firefox-legacy-"));
+    const xdgRoot = await mkdtemp(join(tmpdir(), "usebrian-firefox-xdg-"));
+    const profile = join(xdgRoot, "fresh.default");
+    await mkdir(profile);
+    await writeFile(
+      join(profile, "WebDriverBiDiServer.json"),
+      JSON.stringify({ ws_host: "127.0.0.1", ws_port: 9444 }),
+    );
+    expect(await discoverFirefoxRemoteEndpoint([legacyRoot, xdgRoot])).toMatchObject({
+      wsPort: 9444,
+      profileDir: profile,
+    });
+  });
+
+  it("starts a new Firefox instance with Remote Agent enabled", () => {
+    const child = { unref: vi.fn() };
+    const spawnProcess = vi.fn(() => child) as unknown as typeof spawn;
+    launchFirefoxForControl("/usr/bin/firefox", spawnProcess);
+    expect(spawnProcess).toHaveBeenCalledWith(
+      "/usr/bin/firefox",
+      ["--new-instance", "--remote-debugging-port=0"],
+      { detached: true, stdio: "ignore" },
+    );
+    expect(child.unref).toHaveBeenCalled();
   });
 });

--- a/apps/app-desktop/src/__tests__/firefox-native-host.test.ts
+++ b/apps/app-desktop/src/__tests__/firefox-native-host.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_NATIVE_MESSAGE_BYTES,
+  NativeMessageDecoder,
+  encodeNativeMessage,
+} from "../firefox-native-host.js";
+
+describe("[COMP:app-desktop/firefox-native-host] native-message framing", () => {
+  it("decodes fragmented and coalesced little-endian frames", () => {
+    const first = encodeNativeMessage({ id: "1", type: "status" });
+    const second = encodeNativeMessage({ id: "2", type: "stop" });
+    const decoder = new NativeMessageDecoder();
+    expect(decoder.push(first.subarray(0, 3))).toEqual([]);
+    expect(decoder.push(Buffer.concat([first.subarray(3), second]))).toEqual([
+      { id: "1", type: "status" },
+      { id: "2", type: "stop" },
+    ]);
+  });
+
+  it("rejects oversized frames before allocating their body", () => {
+    const header = Buffer.alloc(4);
+    header.writeUInt32LE(MAX_NATIVE_MESSAGE_BYTES + 1);
+    expect(() => new NativeMessageDecoder().push(header)).toThrow("native_message_too_large");
+  });
+});

--- a/apps/app-desktop/src/__tests__/firefox-native-registration.test.ts
+++ b/apps/app-desktop/src/__tests__/firefox-native-registration.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  FIREFOX_EXTENSION_ID,
+  FIREFOX_NATIVE_HOST_NAME,
+  buildFirefoxNativeHostManifest,
+  firefoxNativeHostManifestPath,
+  isFirefoxNativeHostArgv,
+} from "../firefox-native-registration.js";
+
+describe("[COMP:app-desktop/firefox-native-host] native-host registration", () => {
+  it("builds a Firefox-only manifest pointing at the desktop executable", () => {
+    expect(buildFirefoxNativeHostManifest("/Applications/Use Brian.app/Contents/MacOS/Use Brian")).toEqual({
+      name: FIREFOX_NATIVE_HOST_NAME,
+      description: "Use Brian Firefox browser-control companion",
+      path: "/Applications/Use Brian.app/Contents/MacOS/Use Brian",
+      type: "stdio",
+      allowed_extensions: [FIREFOX_EXTENSION_ID],
+    });
+  });
+
+  it("uses each platform's per-user Mozilla registration location", () => {
+    expect(
+      firefoxNativeHostManifestPath({ platform: "darwin", home: "/Users/a", userData: "/unused" }),
+    ).toBe(
+      "/Users/a/Library/Application Support/Mozilla/NativeMessagingHosts/ai.usebrian.browser.json",
+    );
+    expect(
+      firefoxNativeHostManifestPath({ platform: "win32", home: "C:\\Users\\a", userData: "C:\\Data" }),
+    ).toBe("C:\\Data/native-messaging/ai.usebrian.browser.json");
+    expect(
+      firefoxNativeHostManifestPath({ platform: "linux", home: "/home/a", userData: "/unused" }),
+    ).toBe("/home/a/.mozilla/native-messaging-hosts/ai.usebrian.browser.json");
+  });
+
+  it("selects native-host mode only for Firefox's authorized launch arguments", () => {
+    expect(isFirefoxNativeHostArgv(["Use Brian", FIREFOX_EXTENSION_ID])).toBe(true);
+    expect(isFirefoxNativeHostArgv(["Use Brian.exe", "moz-extension://generated-uuid/"])).toBe(true);
+    expect(
+      isFirefoxNativeHostArgv([
+        "Use Brian",
+        "/Users/a/Library/Application Support/Mozilla/NativeMessagingHosts/ai.usebrian.browser.json",
+      ]),
+    ).toBe(true);
+    expect(isFirefoxNativeHostArgv(["Use Brian", "usebrian://capture"])).toBe(false);
+  });
+});

--- a/apps/app-desktop/src/__tests__/menu-template.test.ts
+++ b/apps/app-desktop/src/__tests__/menu-template.test.ts
@@ -14,6 +14,7 @@ const handlers: MenuTemplateHandlers = {
   onUpdate: () => {},
   onSwitchTarget: () => {},
   onUninstall: () => {},
+  onStartFirefoxControl: () => {},
 };
 
 /** Default options; spread + override per test. */
@@ -72,6 +73,19 @@ describe("[COMP:app-desktop/menu-template] buildMenuTemplate", () => {
       const record = allItems(t).find((i) => i.label === "Start Recording");
       expect(record?.accelerator).toBe("CommandOrControl+Shift+R");
     }
+  });
+
+  it("starts Firefox browser control from both platform menus", () => {
+    const onStartFirefoxControl = vi.fn();
+    for (const isMac of [true, false]) {
+      const items = allItems(
+        buildMenuTemplate(opts({ isMac }), { ...handlers, onStartFirefoxControl }),
+      );
+      const item = items.find((candidate) => candidate.label === "Start Firefox for My Browser…");
+      expect(item).toBeDefined();
+      (item?.click as () => void)();
+    }
+    expect(onStartFirefoxControl).toHaveBeenCalledTimes(2);
   });
 
   it("offers View-menu zoom on both platforms, with a hidden Cmd/Ctrl+= zoom-in alias", () => {

--- a/apps/app-desktop/src/__tests__/uninstall.test.ts
+++ b/apps/app-desktop/src/__tests__/uninstall.test.ts
@@ -21,6 +21,9 @@ describe("[COMP:app-desktop/uninstall] uninstall planning", () => {
     expect(paths).toContain(
       "/Users/alice/Library/Saved Application State/ai.sidan.desktop.savedState",
     );
+    expect(paths).toContain(
+      "/Users/alice/Library/Application Support/Mozilla/NativeMessagingHosts/ai.usebrian.browser.json",
+    );
     for (const p of paths) expect(p.startsWith(`${HOME}/Library/`)).toBe(true);
   });
 

--- a/apps/app-desktop/src/bootstrap.ts
+++ b/apps/app-desktop/src/bootstrap.ts
@@ -1,0 +1,20 @@
+/** Select Firefox native-host mode before Electron GUI code is imported. */
+import { homedir } from "node:os";
+import { isFirefoxNativeHostArgv } from "./firefox-native-registration.js";
+import { runFirefoxNativeHost } from "./firefox-native-host.js";
+
+if (isFirefoxNativeHostArgv(process.argv)) {
+  void runFirefoxNativeHost({
+    input: process.stdin,
+    output: process.stdout,
+    error: process.stderr,
+    platform: process.platform,
+    env: process.env,
+    home: homedir(),
+  }).catch((error) => {
+    process.stderr.write(`Use Brian Firefox companion failed: ${String(error)}\n`);
+    process.exitCode = 1;
+  });
+} else {
+  void import("./main.js");
+}

--- a/apps/app-desktop/src/firefox-bidi.ts
+++ b/apps/app-desktop/src/firefox-bidi.ts
@@ -1,0 +1,439 @@
+/**
+ * Fixed-vocabulary WebDriver BiDi executor for Firefox My Browser.
+ * It is deliberately not a generic protocol proxy.
+ * [COMP:app-desktop/firefox-native-host]
+ */
+import WebSocket from "ws";
+
+export class FirefoxBidiError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+  ) {
+    super(message);
+    this.name = "FirefoxBidiError";
+  }
+}
+
+type BidiSocket = {
+  send(data: string): void;
+  close(): void;
+  addEventListener(type: "open", listener: () => void, opts?: { once?: boolean }): void;
+  addEventListener(type: "message", listener: (event: { data: unknown }) => void): void;
+  addEventListener(type: "close", listener: () => void): void;
+  addEventListener(type: "error", listener: () => void, opts?: { once?: boolean }): void;
+};
+
+type BidiSocketFactory = (url: string) => BidiSocket;
+type BidiResponse = { id?: number; result?: unknown; error?: string; message?: string };
+type BrowsingContextInfo = { context: string; url?: string; children?: BrowsingContextInfo[] | null };
+type SnapshotNode = {
+  ref: string;
+  role: string;
+  name: string;
+  value?: string;
+  disabled?: boolean;
+};
+
+type StoredRef = { context: string; sharedId: string };
+const BIDI_COMMAND_TIMEOUT_MS = 30_000;
+
+const SNAPSHOT_FUNCTION = String.raw`() => {
+  const roles = new Set([
+    "button", "link", "textbox", "searchbox", "combobox", "checkbox", "radio",
+    "menuitem", "menuitemcheckbox", "menuitemradio", "tab", "switch", "slider",
+    "spinbutton", "option", "listbox"
+  ]);
+  const implicitRole = (el) => {
+    const tag = el.tagName.toLowerCase();
+    if (tag === "a" && el.hasAttribute("href")) return "link";
+    if (tag === "button") return "button";
+    if (tag === "textarea") return "textbox";
+    if (tag === "select") return el.multiple ? "listbox" : "combobox";
+    if (tag !== "input") return "";
+    const type = (el.getAttribute("type") || "text").toLowerCase();
+    if (["button", "submit", "reset", "image"].includes(type)) return "button";
+    if (type === "checkbox") return "checkbox";
+    if (type === "radio") return "radio";
+    if (type === "range") return "slider";
+    if (type === "number") return "spinbutton";
+    if (type === "search") return "searchbox";
+    if (["hidden", "file"].includes(type)) return "";
+    return "textbox";
+  };
+  const nameOf = (el) => {
+    const aria = (el.getAttribute("aria-label") || "").trim();
+    if (aria) return aria;
+    const labelled = (el.getAttribute("aria-labelledby") || "").trim();
+    if (labelled) {
+      const text = labelled.split(/\s+/).map((id) => document.getElementById(id)?.textContent || "").join(" ").trim();
+      if (text) return text;
+    }
+    if (el.labels?.length) {
+      const text = Array.from(el.labels).map((label) => label.textContent || "").join(" ").trim();
+      if (text) return text;
+    }
+    return (el.getAttribute("alt") || el.getAttribute("title") || el.getAttribute("placeholder") || el.textContent || "")
+      .replace(/\s+/g, " ").trim().slice(0, 500);
+  };
+  const visible = (el) => {
+    const style = getComputedStyle(el);
+    const rect = el.getBoundingClientRect();
+    return style.display !== "none" && style.visibility !== "hidden" && rect.width > 0 && rect.height > 0;
+  };
+  const nodes = [];
+  for (const el of document.querySelectorAll("a,button,input,textarea,select,[role],[tabindex],[contenteditable='true']")) {
+    if (nodes.length >= 1000) break;
+    if (!visible(el)) continue;
+    const role = (el.getAttribute("role") || implicitRole(el) || (el.isContentEditable ? "textbox" : "")).toLowerCase();
+    const focusable = el.tabIndex >= 0 || el.isContentEditable;
+    if (!roles.has(role) && !focusable) continue;
+    const name = nameOf(el);
+    if (!name && !roles.has(role)) continue;
+    const isPassword = el instanceof HTMLInputElement && el.type.toLowerCase() === "password";
+    const value = !isPassword && "value" in el && typeof el.value === "string" ? el.value.slice(0, 500) : "";
+    nodes.push({
+      role: role || "node",
+      name,
+      ...(value ? { value } : {}),
+      ...(el.matches(":disabled,[aria-disabled='true']") ? { disabled: true } : {}),
+      element: el
+    });
+  }
+  return { url: location.href, title: document.title, nodes };
+}`;
+
+function decodeRemoteValue(value: unknown): unknown {
+  if (!value || typeof value !== "object") return value;
+  const remote = value as { type?: string; value?: unknown };
+  if (remote.type === "undefined") return undefined;
+  if (remote.type === "null") return null;
+  if (remote.type === "node") {
+    const sharedId = (remote as { sharedId?: unknown }).sharedId;
+    return typeof sharedId === "string" ? { $sharedId: sharedId } : null;
+  }
+  if (["string", "boolean", "number", "bigint"].includes(remote.type ?? "")) return remote.value;
+  if (remote.type === "array" && Array.isArray(remote.value)) {
+    return remote.value.map((entry) => decodeRemoteValue(entry));
+  }
+  if (remote.type === "object" && Array.isArray(remote.value)) {
+    return Object.fromEntries(
+      remote.value
+        .filter((entry): entry is [unknown, unknown] => Array.isArray(entry) && entry.length === 2)
+        .map(([key, entry]) => [String(decodeRemoteValue(key)), decodeRemoteValue(entry)]),
+    );
+  }
+  return remote.value;
+}
+
+function flattenContexts(contexts: readonly BrowsingContextInfo[]): BrowsingContextInfo[] {
+  const flattened: BrowsingContextInfo[] = [];
+  for (const context of contexts) {
+    flattened.push(context);
+    if (context.children) flattened.push(...flattenContexts(context.children));
+  }
+  return flattened;
+}
+
+function topLevelContexts(result: unknown): BrowsingContextInfo[] {
+  const contexts = (result as { contexts?: unknown } | null)?.contexts;
+  return Array.isArray(contexts)
+    ? contexts.filter(
+        (context): context is BrowsingContextInfo =>
+          Boolean(context) && typeof context === "object" && typeof (context as BrowsingContextInfo).context === "string",
+      )
+    : [];
+}
+
+export class FirefoxBidiExecutor {
+  private socket: BidiSocket | null = null;
+  private nextId = 0;
+  private pending = new Map<
+    number,
+    { resolve: (value: unknown) => void; reject: (error: Error) => void; timer: ReturnType<typeof setTimeout> }
+  >();
+  private contextId: string | null = null;
+  private refs = new Map<string, StoredRef>();
+
+  constructor(
+    private readonly url: string,
+    private readonly createSocket: BidiSocketFactory = (url) => new WebSocket(url) as unknown as BidiSocket,
+  ) {}
+
+  async connect(): Promise<void> {
+    if (this.socket) return;
+    const socket = this.createSocket(this.url);
+    this.socket = socket;
+    socket.addEventListener("message", (event) => this.onMessage(event.data));
+    socket.addEventListener("close", () => this.onClosed());
+    await new Promise<void>((resolve, reject) => {
+      socket.addEventListener("open", resolve, { once: true });
+      socket.addEventListener("error", () => reject(new FirefoxBidiError("Could not connect to Firefox.", "detached")), {
+        once: true,
+      });
+    });
+    await this.command("session.new", { capabilities: { alwaysMatch: {} } });
+  }
+
+  private onMessage(raw: unknown): void {
+    if (typeof raw !== "string") return;
+    let response: BidiResponse;
+    try {
+      response = JSON.parse(raw) as BidiResponse;
+    } catch {
+      return;
+    }
+    if (typeof response.id !== "number") return;
+    const pending = this.pending.get(response.id);
+    if (!pending) return;
+    this.pending.delete(response.id);
+    clearTimeout(pending.timer);
+    if (response.error) {
+      pending.reject(new FirefoxBidiError(response.message ?? response.error, "backend_error"));
+    } else {
+      pending.resolve(response.result);
+    }
+  }
+
+  private onClosed(): void {
+    this.socket = null;
+    this.contextId = null;
+    this.refs.clear();
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new FirefoxBidiError("Firefox ended the browser-control session.", "detached"));
+    }
+    this.pending.clear();
+  }
+
+  private command(method: string, params: Record<string, unknown>): Promise<unknown> {
+    if (!this.socket) return Promise.reject(new FirefoxBidiError("Firefox is not connected.", "detached"));
+    const id = ++this.nextId;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new FirefoxBidiError(`Firefox timed out while running ${method}.`, "backend_error"));
+      }, BIDI_COMMAND_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, timer });
+      this.socket?.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  private async getTree(): Promise<BrowsingContextInfo[]> {
+    return topLevelContexts(await this.command("browsingContext.getTree", { maxDepth: 8 }));
+  }
+
+  async bindFocusedContext(expected?: { url?: string; title?: string }): Promise<{ bound: true }> {
+    const contexts = await this.getTree();
+    const candidates = contexts.filter((context) => !expected?.url || context.url === expected.url);
+    const focusedMatches: Array<{ context: BrowsingContextInfo; title: string }> = [];
+    for (const context of candidates) {
+      const evaluated = (await this.command("script.evaluate", {
+        expression: "({ focused: document.hasFocus(), title: document.title })",
+        target: { context: context.context },
+        awaitPromise: false,
+        resultOwnership: "none",
+        serializationOptions: { maxObjectDepth: 1 },
+      })) as { type?: string; result?: unknown };
+      if (evaluated.type !== "success") continue;
+      const state = decodeRemoteValue(evaluated.result) as { focused?: unknown; title?: unknown };
+      const title = typeof state?.title === "string" ? state.title : "";
+      if (state?.focused === true) {
+        focusedMatches.push({ context, title });
+      }
+    }
+    if (focusedMatches.length === 1) {
+      this.contextId = focusedMatches[0].context.context;
+      this.refs.clear();
+      return { bound: true };
+    }
+    throw new FirefoxBidiError(
+      "The approved Firefox tab could not be matched. Focus the tab you want Use Brian to control and allow it again.",
+      "no_eligible_tab",
+    );
+  }
+
+  private mustContext(): string {
+    if (!this.contextId) {
+      throw new FirefoxBidiError("No Firefox tab has been approved for this task.", "consent_denied");
+    }
+    return this.contextId;
+  }
+
+  private async callFunction(
+    functionDeclaration: string,
+    args: unknown[] = [],
+    resultOwnership: "none" | "root" = "none",
+  ): Promise<{ type?: string; result?: unknown }> {
+    return (await this.command("script.callFunction", {
+      functionDeclaration,
+      target: { context: this.mustContext() },
+      arguments: args.map((value) => ({ type: "string", value: String(value) })),
+      awaitPromise: true,
+      resultOwnership,
+      serializationOptions: { maxObjectDepth: 8, maxDomDepth: 0 },
+    })) as { type?: string; result?: unknown };
+  }
+
+  async execute(op: string, args: Record<string, unknown>): Promise<unknown> {
+    switch (op) {
+      case "navigate":
+        return this.navigate(String(args.url ?? ""));
+      case "snapshot":
+        return this.snapshot();
+      case "click":
+        await this.click(String(args.ref ?? ""));
+        return { clicked: true };
+      case "type":
+        await this.type(String(args.ref ?? ""), String(args.text ?? ""));
+        return { typed: true };
+      case "currentUrl":
+        return this.currentUrl();
+      default:
+        throw new FirefoxBidiError(`Unknown browser operation ${op}.`, "backend_error");
+    }
+  }
+
+  private async navigate(url: string): Promise<{ url: string }> {
+    if (!/^https?:\/\//i.test(url)) {
+      throw new FirefoxBidiError("My Browser navigation accepts only http(s) URLs.", "backend_error");
+    }
+    this.refs.clear();
+    const result = (await this.command("browsingContext.navigate", {
+      context: this.mustContext(),
+      url,
+      wait: "complete",
+    })) as { url?: unknown };
+    return { url: typeof result.url === "string" ? result.url : url };
+  }
+
+  private async snapshot(): Promise<{ url: string; title: string; nodes: SnapshotNode[] }> {
+    const context = this.mustContext();
+    const response = await this.callFunction(SNAPSHOT_FUNCTION);
+    if (response.type !== "success") {
+      throw new FirefoxBidiError("Firefox could not read this page.", "backend_error");
+    }
+    const decoded = decodeRemoteValue(response.result) as {
+      url?: unknown;
+      title?: unknown;
+      nodes?: Array<Record<string, unknown>>;
+    };
+    this.refs.clear();
+    const nodes: SnapshotNode[] = [];
+    for (const raw of Array.isArray(decoded?.nodes) ? decoded.nodes : []) {
+      const sharedId = (raw.element as { $sharedId?: unknown } | undefined)?.$sharedId;
+      if (typeof sharedId !== "string" || typeof raw.role !== "string" || typeof raw.name !== "string") continue;
+      const ref = `@e${nodes.length + 1}`;
+      this.refs.set(ref, { context, sharedId });
+      nodes.push({
+        ref,
+        role: raw.role,
+        name: raw.name,
+        ...(typeof raw.value === "string" && raw.value ? { value: raw.value } : {}),
+        ...(raw.disabled === true ? { disabled: true } : {}),
+      });
+    }
+    return {
+      url: typeof decoded?.url === "string" ? decoded.url : "",
+      title: typeof decoded?.title === "string" ? decoded.title : "",
+      nodes,
+    };
+  }
+
+  private resolveRef(ref: string): StoredRef {
+    const stored = this.refs.get(ref);
+    if (!stored || stored.context !== this.mustContext()) {
+      throw new FirefoxBidiError(
+        `Unknown ref ${ref}; refs are valid for the latest snapshot only. Take a fresh browserSnapshot.`,
+        "stale_ref",
+      );
+    }
+    return stored;
+  }
+
+  private sharedNode(ref: string): { sharedId: string } {
+    const stored = this.resolveRef(ref);
+    return { sharedId: stored.sharedId };
+  }
+
+  private async click(ref: string): Promise<void> {
+    const element = this.sharedNode(ref);
+    try {
+      await this.command("input.performActions", {
+        context: this.mustContext(),
+        actions: [
+          {
+            type: "pointer",
+            id: "use-brian-mouse",
+            parameters: { pointerType: "mouse" },
+            actions: [
+              { type: "pointerMove", x: 0, y: 0, duration: 0, origin: { type: "element", element } },
+              { type: "pointerDown", button: 0 },
+              { type: "pointerUp", button: 0 },
+            ],
+          },
+        ],
+      });
+    } catch (error) {
+      if (error instanceof FirefoxBidiError && /node|element|reference|stale/i.test(error.message)) {
+        throw new FirefoxBidiError(`Ref ${ref} is no longer on the page. Take a fresh browserSnapshot.`, "stale_ref");
+      }
+      throw error;
+    }
+  }
+
+  private async type(ref: string, text: string): Promise<void> {
+    await this.click(ref);
+    await this.command("input.performActions", {
+      context: this.mustContext(),
+      actions: [
+        {
+          type: "key",
+          id: "use-brian-keyboard",
+          actions: Array.from(text).flatMap((value) => [
+            { type: "keyDown", value },
+            { type: "keyUp", value },
+          ]),
+        },
+      ],
+    });
+  }
+
+  private async currentUrl(): Promise<{ url: string; title: string }> {
+    const contextId = this.mustContext();
+    const context = flattenContexts(await this.getTree()).find((candidate) => candidate.context === contextId);
+    if (!context) {
+      this.contextId = null;
+      this.refs.clear();
+      throw new FirefoxBidiError("The approved Firefox tab was closed.", "tab_closed");
+    }
+    const titleResponse = await this.callFunction("() => document.title");
+    return {
+      url: context.url ?? "",
+      title: typeof decodeRemoteValue(titleResponse.result) === "string" ? String(decodeRemoteValue(titleResponse.result)) : "",
+    };
+  }
+
+  async stop(): Promise<void> {
+    if (!this.socket) return;
+    try {
+      if (this.contextId) {
+        await this.command("input.releaseActions", { context: this.contextId });
+      }
+      await this.command("session.end", {});
+    } catch {
+      // Firefox may already have exited.
+    }
+    this.contextId = null;
+    this.refs.clear();
+    this.socket?.close();
+    this.socket = null;
+  }
+}
+
+export const firefoxBidiInternals = {
+  decodeRemoteValue,
+  flattenContexts,
+  topLevelContexts,
+  snapshotFunction: SNAPSHOT_FUNCTION,
+};

--- a/apps/app-desktop/src/firefox-launcher.ts
+++ b/apps/app-desktop/src/firefox-launcher.ts
@@ -1,0 +1,117 @@
+/** Firefox Remote Agent launch/discovery planning. [COMP:app-desktop/firefox-native-host] */
+import { access, readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { spawn, type ChildProcess } from "node:child_process";
+
+export type FirefoxRemoteEndpoint = {
+  wsHost: string;
+  wsPort: number;
+  profileDir: string;
+  modifiedAtMs: number;
+};
+
+export function firefoxExecutableCandidates(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+  home: string,
+): string[] {
+  if (platform === "darwin") {
+    return [
+      "/Applications/Firefox.app/Contents/MacOS/firefox",
+      join(home, "Applications", "Firefox.app", "Contents", "MacOS", "firefox"),
+    ];
+  }
+  if (platform === "win32") {
+    return [env.ProgramFiles, env["ProgramFiles(x86)"], env.LOCALAPPDATA]
+      .filter((root): root is string => Boolean(root))
+      .map((root) => join(root, "Mozilla Firefox", "firefox.exe"));
+  }
+  if (platform === "linux") return ["/usr/bin/firefox", "/usr/local/bin/firefox"];
+  return [];
+}
+
+export function firefoxProfilesRoot(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+  home: string,
+): string | null {
+  if (platform === "darwin") return join(home, "Library", "Application Support", "Firefox", "Profiles");
+  if (platform === "win32" && env.APPDATA) return join(env.APPDATA, "Mozilla", "Firefox", "Profiles");
+  if (platform === "linux") return join(home, ".mozilla", "firefox");
+  return null;
+}
+
+export async function findFirefoxExecutable(candidates: readonly string[]): Promise<string | null> {
+  for (const candidate of candidates) {
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {
+      // Try the next standard install location.
+    }
+  }
+  return null;
+}
+
+function parseEndpoint(raw: string, profileDir: string, modifiedAtMs: number): FirefoxRemoteEndpoint | null {
+  try {
+    const value = JSON.parse(raw) as { ws_host?: unknown; ws_port?: unknown };
+    if (typeof value.ws_host !== "string" || typeof value.ws_port !== "number") return null;
+    if (!Number.isInteger(value.ws_port) || value.ws_port < 1 || value.ws_port > 65_535) return null;
+    if (!["127.0.0.1", "localhost", "::1"].includes(value.ws_host)) return null;
+    return { wsHost: value.ws_host, wsPort: value.ws_port, profileDir, modifiedAtMs };
+  } catch {
+    return null;
+  }
+}
+
+export async function discoverFirefoxRemoteEndpoint(profilesRoot: string): Promise<FirefoxRemoteEndpoint | null> {
+  let entries: string[];
+  try {
+    entries = await readdir(profilesRoot);
+  } catch {
+    return null;
+  }
+  const candidates = await Promise.all(
+    entries.map(async (entry) => {
+      const profileDir = join(profilesRoot, entry);
+      const endpointFile = join(profileDir, "WebDriverBiDiServer.json");
+      try {
+        const [raw, info] = await Promise.all([readFile(endpointFile, "utf8"), stat(endpointFile)]);
+        return parseEndpoint(raw, profileDir, info.mtimeMs);
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return candidates
+    .filter((candidate): candidate is FirefoxRemoteEndpoint => candidate !== null)
+    .sort((a, b) => b.modifiedAtMs - a.modifiedAtMs)[0] ?? null;
+}
+
+export function launchFirefoxForControl(
+  executablePath: string,
+  spawnProcess: typeof spawn = spawn,
+): ChildProcess {
+  const child = spawnProcess(executablePath, ["--remote-debugging-port=0"], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+  return child;
+}
+
+export async function waitForFirefoxRemoteEndpoint(
+  profilesRoot: string,
+  opts: { afterMs: number; timeoutMs?: number; pollMs?: number } = { afterMs: 0 },
+): Promise<FirefoxRemoteEndpoint | null> {
+  const timeoutMs = opts.timeoutMs ?? 15_000;
+  const pollMs = opts.pollMs ?? 250;
+  const deadline = Date.now() + timeoutMs;
+  do {
+    const endpoint = await discoverFirefoxRemoteEndpoint(profilesRoot);
+    if (endpoint && endpoint.modifiedAtMs >= opts.afterMs) return endpoint;
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  } while (Date.now() < deadline);
+  return null;
+}

--- a/apps/app-desktop/src/firefox-launcher.ts
+++ b/apps/app-desktop/src/firefox-launcher.ts
@@ -1,6 +1,6 @@
 /** Firefox Remote Agent launch/discovery planning. [COMP:app-desktop/firefox-native-host] */
 import { access, readdir, readFile, stat } from "node:fs/promises";
-import { join } from "node:path";
+import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
 
 export type FirefoxRemoteEndpoint = {
@@ -26,19 +26,39 @@ export function firefoxExecutableCandidates(
       .filter((root): root is string => Boolean(root))
       .map((root) => join(root, "Mozilla Firefox", "firefox.exe"));
   }
-  if (platform === "linux") return ["/usr/bin/firefox", "/usr/local/bin/firefox"];
+  if (platform === "linux") {
+    return [
+      ...(env.PATH ?? "")
+        .split(delimiter)
+        .filter(Boolean)
+        .map((directory) => join(directory, "firefox")),
+      "/run/current-system/sw/bin/firefox",
+      join(home, ".nix-profile", "bin", "firefox"),
+      "/usr/bin/firefox",
+      "/usr/local/bin/firefox",
+    ].filter((candidate, index, all) => all.indexOf(candidate) === index);
+  }
   return [];
 }
 
-export function firefoxProfilesRoot(
+export function firefoxProfilesRoots(
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv,
   home: string,
-): string | null {
-  if (platform === "darwin") return join(home, "Library", "Application Support", "Firefox", "Profiles");
-  if (platform === "win32" && env.APPDATA) return join(env.APPDATA, "Mozilla", "Firefox", "Profiles");
-  if (platform === "linux") return join(home, ".mozilla", "firefox");
-  return null;
+): string[] {
+  if (platform === "darwin") return [join(home, "Library", "Application Support", "Firefox", "Profiles")];
+  if (platform === "win32" && env.APPDATA) return [join(env.APPDATA, "Mozilla", "Firefox", "Profiles")];
+  if (platform === "linux") {
+    const xdgConfigHome = env.XDG_CONFIG_HOME && isAbsolute(env.XDG_CONFIG_HOME)
+      ? env.XDG_CONFIG_HOME
+      : join(home, ".config");
+    return [
+      ...(env.MOZ_APP_DATA && isAbsolute(env.MOZ_APP_DATA) ? [env.MOZ_APP_DATA] : []),
+      join(home, ".mozilla", "firefox"),
+      join(xdgConfigHome, "mozilla", "firefox"),
+    ].filter((root, index, all) => all.indexOf(root) === index);
+  }
+  return [];
 }
 
 export async function findFirefoxExecutable(candidates: readonly string[]): Promise<string | null> {
@@ -58,23 +78,49 @@ function parseEndpoint(raw: string, profileDir: string, modifiedAtMs: number): F
     const value = JSON.parse(raw) as { ws_host?: unknown; ws_port?: unknown };
     if (typeof value.ws_host !== "string" || typeof value.ws_port !== "number") return null;
     if (!Number.isInteger(value.ws_port) || value.ws_port < 1 || value.ws_port > 65_535) return null;
-    if (!["127.0.0.1", "localhost", "::1"].includes(value.ws_host)) return null;
-    return { wsHost: value.ws_host, wsPort: value.ws_port, profileDir, modifiedAtMs };
+    const wsHost = value.ws_host === "[::1]" ? "::1" : value.ws_host;
+    if (!["127.0.0.1", "localhost", "::1"].includes(wsHost)) return null;
+    return { wsHost, wsPort: value.ws_port, profileDir, modifiedAtMs };
   } catch {
     return null;
   }
 }
 
-export async function discoverFirefoxRemoteEndpoint(profilesRoot: string): Promise<FirefoxRemoteEndpoint | null> {
-  let entries: string[];
+async function firefoxProfileDirectories(profilesRoot: string): Promise<string[]> {
+  const directories: string[] = [];
   try {
-    entries = await readdir(profilesRoot);
+    directories.push(...(await readdir(profilesRoot)).map((entry) => join(profilesRoot, entry)));
   } catch {
-    return null;
+    // profiles.ini can still point entirely outside the conventional root.
   }
+
+  for (const iniPath of [join(profilesRoot, "profiles.ini"), join(profilesRoot, "..", "profiles.ini")]) {
+    let raw: string;
+    try {
+      raw = await readFile(iniPath, "utf8");
+    } catch {
+      continue;
+    }
+    for (const section of raw.split(/^\s*\[/m).slice(1)) {
+      if (!/^Profile\d+\]/.test(section)) continue;
+      const path = /^Path=(.+)$/m.exec(section)?.[1]?.trim();
+      if (!path) continue;
+      const isRelative = /^IsRelative=1\s*$/m.test(section);
+      directories.push(isRelative && !isAbsolute(path) ? resolve(dirname(iniPath), path) : path);
+    }
+  }
+
+  return directories.filter((directory, index, all) => all.indexOf(directory) === index);
+}
+
+export async function discoverFirefoxRemoteEndpoint(
+  profilesRoots: readonly string[],
+): Promise<FirefoxRemoteEndpoint | null> {
+  const profileDirectories = (
+    await Promise.all(profilesRoots.map((profilesRoot) => firefoxProfileDirectories(profilesRoot)))
+  ).flat();
   const candidates = await Promise.all(
-    entries.map(async (entry) => {
-      const profileDir = join(profilesRoot, entry);
+    profileDirectories.map(async (profileDir) => {
       const endpointFile = join(profileDir, "WebDriverBiDiServer.json");
       try {
         const [raw, info] = await Promise.all([readFile(endpointFile, "utf8"), stat(endpointFile)]);
@@ -93,7 +139,7 @@ export function launchFirefoxForControl(
   executablePath: string,
   spawnProcess: typeof spawn = spawn,
 ): ChildProcess {
-  const child = spawnProcess(executablePath, ["--remote-debugging-port=0"], {
+  const child = spawnProcess(executablePath, ["--new-instance", "--remote-debugging-port=0"], {
     detached: true,
     stdio: "ignore",
   });
@@ -102,14 +148,14 @@ export function launchFirefoxForControl(
 }
 
 export async function waitForFirefoxRemoteEndpoint(
-  profilesRoot: string,
+  profilesRoots: readonly string[],
   opts: { afterMs: number; timeoutMs?: number; pollMs?: number } = { afterMs: 0 },
 ): Promise<FirefoxRemoteEndpoint | null> {
   const timeoutMs = opts.timeoutMs ?? 15_000;
   const pollMs = opts.pollMs ?? 250;
   const deadline = Date.now() + timeoutMs;
   do {
-    const endpoint = await discoverFirefoxRemoteEndpoint(profilesRoot);
+    const endpoint = await discoverFirefoxRemoteEndpoint(profilesRoots);
     if (endpoint && endpoint.modifiedAtMs >= opts.afterMs) return endpoint;
     await new Promise((resolve) => setTimeout(resolve, pollMs));
   } while (Date.now() < deadline);

--- a/apps/app-desktop/src/firefox-native-host.ts
+++ b/apps/app-desktop/src/firefox-native-host.ts
@@ -1,0 +1,185 @@
+/** Firefox native-messaging stdio host. [COMP:app-desktop/firefox-native-host] */
+import type { Readable, Writable } from "node:stream";
+import { spawn } from "node:child_process";
+import { FirefoxBidiExecutor, FirefoxBidiError } from "./firefox-bidi.js";
+import { discoverFirefoxRemoteEndpoint, firefoxProfilesRoot } from "./firefox-launcher.js";
+
+// Firefox caps native-host -> extension frames at 1 MiB. Leave framing headroom.
+export const MAX_NATIVE_MESSAGE_BYTES = 900 * 1024;
+
+export function encodeNativeMessage(value: unknown): Buffer {
+  const body = Buffer.from(JSON.stringify(value), "utf8");
+  if (body.length > MAX_NATIVE_MESSAGE_BYTES) throw new Error("native_message_too_large");
+  const frame = Buffer.allocUnsafe(4 + body.length);
+  frame.writeUInt32LE(body.length, 0);
+  body.copy(frame, 4);
+  return frame;
+}
+
+export class NativeMessageDecoder {
+  private buffered = Buffer.alloc(0);
+
+  push(chunk: Buffer): unknown[] {
+    this.buffered = Buffer.concat([this.buffered, chunk]);
+    const messages: unknown[] = [];
+    while (this.buffered.length >= 4) {
+      const length = this.buffered.readUInt32LE(0);
+      if (length > MAX_NATIVE_MESSAGE_BYTES) throw new Error("native_message_too_large");
+      if (this.buffered.length < 4 + length) break;
+      const body = this.buffered.subarray(4, 4 + length);
+      this.buffered = this.buffered.subarray(4 + length);
+      messages.push(JSON.parse(body.toString("utf8")) as unknown);
+    }
+    return messages;
+  }
+}
+
+type NativeRequest = {
+  id: string;
+  type: "status" | "bind" | "execute" | "stop" | "openDesktop";
+  op?: string;
+  args?: Record<string, unknown>;
+};
+
+function parseRequest(value: unknown): NativeRequest | null {
+  if (!value || typeof value !== "object") return null;
+  const req = value as Partial<NativeRequest>;
+  if (typeof req.id !== "string") return null;
+  if (!(["status", "bind", "execute", "stop", "openDesktop"] as const).includes(req.type as NativeRequest["type"])) {
+    return null;
+  }
+  return {
+    id: req.id,
+    type: req.type as NativeRequest["type"],
+    ...(typeof req.op === "string" ? { op: req.op } : {}),
+    ...(req.args && typeof req.args === "object" ? { args: req.args } : {}),
+  };
+}
+
+export type FirefoxNativeHostDeps = {
+  input: Readable;
+  output: Writable;
+  error: Writable;
+  platform: NodeJS.Platform;
+  env: NodeJS.ProcessEnv;
+  home: string;
+  createExecutor?: (url: string) => FirefoxBidiExecutor;
+};
+
+export async function runFirefoxNativeHost(deps: FirefoxNativeHostDeps): Promise<void> {
+  const decoder = new NativeMessageDecoder();
+  let executor: FirefoxBidiExecutor | null = null;
+  const profilesRoot = firefoxProfilesRoot(deps.platform, deps.env, deps.home);
+
+  const ensureExecutor = async (): Promise<FirefoxBidiExecutor> => {
+    if (executor) return executor;
+    if (!profilesRoot) throw new FirefoxBidiError("Firefox is not supported on this platform.", "unsupported_browser");
+    const endpoint = await discoverFirefoxRemoteEndpoint(profilesRoot);
+    if (!endpoint) {
+      throw new FirefoxBidiError(
+        "Firefox was not started for My Browser. Quit Firefox, then choose Start Firefox for My Browser in the Use Brian desktop app.",
+        "firefox_restart_required",
+      );
+    }
+    const host = endpoint.wsHost.includes(":") ? `[${endpoint.wsHost}]` : endpoint.wsHost;
+    const candidate = (deps.createExecutor ?? ((url) => new FirefoxBidiExecutor(url)))(
+      `ws://${host}:${endpoint.wsPort}/session`,
+    );
+    try {
+      await candidate.connect();
+      executor = candidate;
+      return candidate;
+    } catch (error) {
+      executor = null;
+      throw error;
+    }
+  };
+
+  const reply = (value: unknown): void => {
+    deps.output.write(encodeNativeMessage(value));
+  };
+
+  const handle = async (value: unknown): Promise<void> => {
+    const req = parseRequest(value);
+    if (!req) {
+      reply({ id: null, ok: false, error: "Invalid native-host request.", code: "backend_error" });
+      return;
+    }
+    try {
+      if (req.type === "status") {
+        try {
+          await ensureExecutor();
+          reply({ id: req.id, ok: true, data: { ready: true } });
+        } catch (error) {
+          reply({
+            id: req.id,
+            ok: true,
+            data: {
+              ready: false,
+              reason: error instanceof FirefoxBidiError ? error.code : "firefox_restart_required",
+            },
+          });
+        }
+        return;
+      }
+      if (req.type === "bind") {
+        const active = await ensureExecutor();
+        reply({
+          id: req.id,
+          ok: true,
+          data: await active.bindFocusedContext({
+            ...(typeof req.args?.url === "string" ? { url: req.args.url } : {}),
+            ...(typeof req.args?.title === "string" ? { title: req.args.title } : {}),
+          }),
+        });
+        return;
+      }
+      if (req.type === "openDesktop") {
+        const child = spawn(process.execPath, ["usebrian://firefox-control"], {
+          detached: true,
+          stdio: "ignore",
+        });
+        child.unref();
+        reply({ id: req.id, ok: true, data: { opened: true } });
+        return;
+      }
+      if (req.type === "stop") {
+        await executor?.stop();
+        executor = null;
+        reply({ id: req.id, ok: true, data: { stopped: true } });
+        return;
+      }
+      if (!req.op) throw new FirefoxBidiError("Missing browser operation.", "backend_error");
+      const active = await ensureExecutor();
+      reply({ id: req.id, ok: true, data: await active.execute(req.op, req.args ?? {}) });
+    } catch (error) {
+      const code = error instanceof FirefoxBidiError ? error.code : "backend_error";
+      if (code === "detached") executor = null;
+      reply({
+        id: req.id,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+        code,
+      });
+    }
+  };
+
+  await new Promise<void>((resolve, reject) => {
+    let queue = Promise.resolve();
+    deps.input.on("data", (chunk: Buffer | string) => {
+      try {
+        for (const message of decoder.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))) {
+          if ((message as { type?: unknown } | null)?.type === "stop") void handle(message);
+          else queue = queue.then(() => handle(message));
+        }
+        queue.catch(reject);
+      } catch (error) {
+        reject(error);
+      }
+    });
+    deps.input.on("end", () => queue.finally(resolve));
+    deps.input.on("error", reject);
+  }).finally(async () => {
+    await executor?.stop();
+  });
+}

--- a/apps/app-desktop/src/firefox-native-host.ts
+++ b/apps/app-desktop/src/firefox-native-host.ts
@@ -2,7 +2,7 @@
 import type { Readable, Writable } from "node:stream";
 import { spawn } from "node:child_process";
 import { FirefoxBidiExecutor, FirefoxBidiError } from "./firefox-bidi.js";
-import { discoverFirefoxRemoteEndpoint, firefoxProfilesRoot } from "./firefox-launcher.js";
+import { discoverFirefoxRemoteEndpoint, firefoxProfilesRoots } from "./firefox-launcher.js";
 
 // Firefox caps native-host -> extension frames at 1 MiB. Leave framing headroom.
 export const MAX_NATIVE_MESSAGE_BYTES = 900 * 1024;
@@ -69,12 +69,14 @@ export type FirefoxNativeHostDeps = {
 export async function runFirefoxNativeHost(deps: FirefoxNativeHostDeps): Promise<void> {
   const decoder = new NativeMessageDecoder();
   let executor: FirefoxBidiExecutor | null = null;
-  const profilesRoot = firefoxProfilesRoot(deps.platform, deps.env, deps.home);
+  const profilesRoots = firefoxProfilesRoots(deps.platform, deps.env, deps.home);
 
   const ensureExecutor = async (): Promise<FirefoxBidiExecutor> => {
     if (executor) return executor;
-    if (!profilesRoot) throw new FirefoxBidiError("Firefox is not supported on this platform.", "unsupported_browser");
-    const endpoint = await discoverFirefoxRemoteEndpoint(profilesRoot);
+    if (profilesRoots.length === 0) {
+      throw new FirefoxBidiError("Firefox is not supported on this platform.", "unsupported_browser");
+    }
+    const endpoint = await discoverFirefoxRemoteEndpoint(profilesRoots);
     if (!endpoint) {
       throw new FirefoxBidiError(
         "Firefox was not started for My Browser. Quit Firefox, then choose Start Firefox for My Browser in the Use Brian desktop app.",

--- a/apps/app-desktop/src/firefox-native-registration.ts
+++ b/apps/app-desktop/src/firefox-native-registration.ts
@@ -1,0 +1,94 @@
+/**
+ * Firefox native-host registration for the packaged desktop executable.
+ * [COMP:app-desktop/firefox-native-host]
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { execFile } from "node:child_process";
+
+export const FIREFOX_NATIVE_HOST_NAME = "ai.usebrian.browser";
+export const FIREFOX_EXTENSION_ID = "browser@usebrian.ai";
+export const FIREFOX_NATIVE_HOST_REGISTRY_KEY =
+  `HKCU\\Software\\Mozilla\\NativeMessagingHosts\\${FIREFOX_NATIVE_HOST_NAME}`;
+
+export type FirefoxNativeHostManifest = {
+  name: string;
+  description: string;
+  path: string;
+  type: "stdio";
+  allowed_extensions: string[];
+};
+
+export function buildFirefoxNativeHostManifest(executablePath: string): FirefoxNativeHostManifest {
+  return {
+    name: FIREFOX_NATIVE_HOST_NAME,
+    description: "Use Brian Firefox browser-control companion",
+    path: executablePath,
+    type: "stdio",
+    allowed_extensions: [FIREFOX_EXTENSION_ID],
+  };
+}
+
+export function firefoxNativeHostManifestPath(opts: {
+  platform: NodeJS.Platform;
+  home: string;
+  userData: string;
+}): string | null {
+  if (opts.platform === "darwin") {
+    return join(
+      opts.home,
+      "Library",
+      "Application Support",
+      "Mozilla",
+      "NativeMessagingHosts",
+      `${FIREFOX_NATIVE_HOST_NAME}.json`,
+    );
+  }
+  if (opts.platform === "win32") {
+    return join(opts.userData, "native-messaging", `${FIREFOX_NATIVE_HOST_NAME}.json`);
+  }
+  if (opts.platform === "linux") {
+    return join(opts.home, ".mozilla", "native-messaging-hosts", `${FIREFOX_NATIVE_HOST_NAME}.json`);
+  }
+  return null;
+}
+
+export function isFirefoxNativeHostArgv(argv: readonly string[]): boolean {
+  return argv.some(
+    (arg) =>
+      arg === FIREFOX_EXTENSION_ID ||
+      arg.startsWith("moz-extension://") ||
+      arg.endsWith(`/${FIREFOX_NATIVE_HOST_NAME}.json`) ||
+      arg.endsWith(`\\${FIREFOX_NATIVE_HOST_NAME}.json`),
+  );
+}
+
+type RegisterOptions = {
+  platform: NodeJS.Platform;
+  home: string;
+  userData: string;
+  executablePath: string;
+  execFile?: typeof execFile;
+};
+
+export async function registerFirefoxNativeHost(opts: RegisterOptions): Promise<string | null> {
+  const manifestPath = firefoxNativeHostManifestPath(opts);
+  if (!manifestPath) return null;
+  await mkdir(dirname(manifestPath), { recursive: true });
+  await writeFile(
+    manifestPath,
+    `${JSON.stringify(buildFirefoxNativeHostManifest(opts.executablePath), null, 2)}\n`,
+    { mode: 0o600 },
+  );
+  if (opts.platform === "win32") {
+    const run = opts.execFile ?? execFile;
+    await new Promise<void>((resolve, reject) => {
+      run(
+        "reg.exe",
+        ["ADD", FIREFOX_NATIVE_HOST_REGISTRY_KEY, "/ve", "/t", "REG_SZ", "/d", manifestPath, "/f"],
+        (error) => (error ? reject(error) : resolve()),
+      );
+    });
+  }
+  return manifestPath;
+}

--- a/apps/app-desktop/src/main.ts
+++ b/apps/app-desktop/src/main.ts
@@ -167,6 +167,14 @@ import {
   serializeAccessGrant,
   type CloudflareAccessGrant,
 } from "./cloudflare-access-oauth.js";
+import { registerFirefoxNativeHost } from "./firefox-native-registration.js";
+import {
+  findFirefoxExecutable,
+  firefoxExecutableCandidates,
+  firefoxProfilesRoot,
+  launchFirefoxForControl,
+  waitForFirefoxRemoteEndpoint,
+} from "./firefox-launcher.js";
 
 const { autoUpdater } = electronUpdater;
 
@@ -2189,6 +2197,10 @@ function startAutoUpdate(): void {
 // ── Deep links + auth callback ─────────────────────────────────
 
 function handleIncomingUrl(rawUrl: string): void {
+  if (rawUrl === `${cfg.protocolScheme}://firefox-control`) {
+    void startFirefoxForControl();
+    return;
+  }
   const auth = parseAuthCallback(rawUrl, cfg.protocolScheme);
   if (auth) {
     if (auth.kind === "code") void completeSignIn(auth.code);
@@ -2252,6 +2264,43 @@ async function confirmAndUninstall(): Promise<void> {
   app.quit();
 }
 
+async function startFirefoxForControl(): Promise<void> {
+  const candidates = firefoxExecutableCandidates(process.platform, process.env, homedir());
+  const executable = await findFirefoxExecutable(candidates);
+  const profilesRoot = firefoxProfilesRoot(process.platform, process.env, homedir());
+  if (!executable || !profilesRoot) {
+    await dialog.showMessageBox({
+      type: "error",
+      message: "Firefox was not found",
+      detail: "Install Firefox in its standard location, then try again.",
+      buttons: ["OK"],
+    });
+    return;
+  }
+  const { response } = await dialog.showMessageBox({
+    type: "info",
+    message: "Start Firefox for My Browser?",
+    detail:
+      "Quit Firefox completely before continuing. Use Brian will reopen your normal Firefox profile with a loopback-only browser-control endpoint for this launch.",
+    buttons: ["Start Firefox", "Cancel"],
+    defaultId: 0,
+    cancelId: 1,
+  });
+  if (response !== 0) return;
+  const startedAt = Date.now() - 1_000;
+  launchFirefoxForControl(executable);
+  const endpoint = await waitForFirefoxRemoteEndpoint(profilesRoot, { afterMs: startedAt });
+  if (!endpoint) {
+    await dialog.showMessageBox({
+      type: "warning",
+      message: "Firefox browser control did not start",
+      detail:
+        "Firefox may still have been running. Quit every Firefox window, wait a moment, then choose Start Firefox for My Browser again.",
+      buttons: ["OK"],
+    });
+  }
+}
+
 /**
  * (Re)build + install the application menu. Called at startup and again on
  * every update-state change, so the update item's label tracks the state
@@ -2267,6 +2316,7 @@ function refreshAppMenu(): void {
       onUpdate: handleUpdateMenuClick,
       onSwitchTarget: () => void switchTargetFromMenu(),
       onUninstall: () => void confirmAndUninstall(),
+      onStartFirefoxControl: () => void startFirefoxForControl(),
       isDev,
       update: updateMenuItem(),
       target: { kind: cfg.target, label: cfg.targetLabel },
@@ -2288,6 +2338,7 @@ function buildTrayMenu(): Menu {
     { label: "Open Use Brian", click: () => focusWindow(ensureWindow()) },
     { label: "Quick Capture", click: () => summonAndCapture() },
     { label: "Start Recording", click: () => summonAndRecord() },
+    { label: "Start Firefox for My Browser…", click: () => void startFirefoxForControl() },
   ];
   // A local target has no login — the tray mirrors the app menu (§2.3).
   if (cfg.target !== "local") {
@@ -2351,6 +2402,7 @@ const gotLock = app.requestSingleInstanceLock();
 if (!gotLock) {
   app.quit();
 } else {
+  pendingUrl = appUrlFromArgv(process.argv);
   app.on("second-instance", (_event, argv) => {
     focusWindow(ensureWindow());
     const url = appUrlFromArgv(argv);
@@ -2503,6 +2555,17 @@ if (!gotLock) {
   }
 
   app.whenReady().then(async () => {
+    if (app.isPackaged) {
+      void registerFirefoxNativeHost({
+        platform: process.platform,
+        home: homedir(),
+        userData: app.getPath("userData"),
+        executablePath:
+          process.platform === "linux" && process.env.APPIMAGE
+            ? process.env.APPIMAGE
+            : app.getPath("exe"),
+      }).catch((error) => console.warn("Failed to register Firefox native host", error));
+    }
     // macOS resolves `usebrian://` through the bundle Info.plist (the `protocols:`
     // block in electron-builder.yml). Windows/Linux register the running executable
     // with the OS; an UNPACKAGED Windows dev run must pass execPath + the script

--- a/apps/app-desktop/src/main.ts
+++ b/apps/app-desktop/src/main.ts
@@ -171,7 +171,7 @@ import { registerFirefoxNativeHost } from "./firefox-native-registration.js";
 import {
   findFirefoxExecutable,
   firefoxExecutableCandidates,
-  firefoxProfilesRoot,
+  firefoxProfilesRoots,
   launchFirefoxForControl,
   waitForFirefoxRemoteEndpoint,
 } from "./firefox-launcher.js";
@@ -2267,8 +2267,8 @@ async function confirmAndUninstall(): Promise<void> {
 async function startFirefoxForControl(): Promise<void> {
   const candidates = firefoxExecutableCandidates(process.platform, process.env, homedir());
   const executable = await findFirefoxExecutable(candidates);
-  const profilesRoot = firefoxProfilesRoot(process.platform, process.env, homedir());
-  if (!executable || !profilesRoot) {
+  const profilesRoots = firefoxProfilesRoots(process.platform, process.env, homedir());
+  if (!executable || profilesRoots.length === 0) {
     await dialog.showMessageBox({
       type: "error",
       message: "Firefox was not found",
@@ -2289,7 +2289,7 @@ async function startFirefoxForControl(): Promise<void> {
   if (response !== 0) return;
   const startedAt = Date.now() - 1_000;
   launchFirefoxForControl(executable);
-  const endpoint = await waitForFirefoxRemoteEndpoint(profilesRoot, { afterMs: startedAt });
+  const endpoint = await waitForFirefoxRemoteEndpoint(profilesRoots, { afterMs: startedAt });
   if (!endpoint) {
     await dialog.showMessageBox({
       type: "warning",

--- a/apps/app-desktop/src/menu-template.ts
+++ b/apps/app-desktop/src/menu-template.ts
@@ -64,6 +64,8 @@ export interface MenuTemplateHandlers {
   onSwitchTarget: () => void;
   /** Confirm, tear down local traces, trash the bundle, quit (uninstall.ts). */
   onUninstall: () => void;
+  /** Start Firefox with its loopback Remote Agent enabled for My Browser. */
+  onStartFirefoxControl: () => void;
 }
 
 /** Build the platform-appropriate menu template (pure). */
@@ -106,6 +108,10 @@ export function buildMenuTemplate(
       label: "Start Recording",
       accelerator: "CommandOrControl+Shift+R",
       click: () => handlers.onRecord(),
+    },
+    {
+      label: "Start Firefox for My Browser…",
+      click: () => handlers.onStartFirefoxControl(),
     },
   ];
   // A local target has no login (the shell mints the local-owner session), so

--- a/apps/app-desktop/src/menu.ts
+++ b/apps/app-desktop/src/menu.ts
@@ -30,6 +30,8 @@ export interface MenuHandlers {
   onSwitchTarget: () => void;
   /** Confirm, tear down local traces, trash the bundle, quit (uninstall.ts). */
   onUninstall: () => void;
+  /** Start Firefox with its loopback Remote Agent enabled for My Browser. */
+  onStartFirefoxControl: () => void;
   /** Whether DevTools / reload affordances should be shown (dev only). */
   isDev: boolean;
   /** Show "Uninstall …" in the macOS app menu (packaged macOS builds only). */

--- a/apps/app-desktop/src/uninstall.ts
+++ b/apps/app-desktop/src/uninstall.ts
@@ -46,6 +46,9 @@ export function collectUninstallPaths(home: string): string[] {
       `${home}/Library/Saved Application State/${appId}.savedState`,
     );
   }
+  paths.push(
+    `${home}/Library/Application Support/Mozilla/NativeMessagingHosts/ai.usebrian.browser.json`,
+  );
   return paths;
 }
 

--- a/apps/app-web/src/components/settings-modal/__tests__/settings-modal.test.ts
+++ b/apps/app-web/src/components/settings-modal/__tests__/settings-modal.test.ts
@@ -1,9 +1,28 @@
-import { describe, expect, it } from "vitest";
-import { workspaceSettingsSections } from "../settings-modal";
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/edition", () => ({
+  isOssEdition: () => true,
+  HOSTED_UPGRADE_URL: "https://usebrian.ai",
+}));
+vi.mock("../sections/browser-profiles-section", () => ({
+  BrowserProfilesSection: () => "my-browser-settings",
+}));
+
+import { SectionBody, workspaceSettingsSections } from "../settings-modal";
 
 describe("[COMP:app-web/connect-browser] OSS settings navigation", () => {
   it("shows Browser profiles so OSS users can pair My Browser", () => {
     expect(workspaceSettingsSections(true)).toContain("ws-browser-profiles");
+  });
+
+  it("renders My Browser settings instead of the hosted upgrade in OSS", () => {
+    const html = renderToString(
+      createElement(SectionBody, { section: "ws-browser-profiles", onClose: () => undefined }),
+    );
+    expect(html).toContain("my-browser-settings");
+    expect(html).not.toContain("Upgrade to hosted");
   });
 
   it("keeps hosted-only billing and model sections out of OSS", () => {

--- a/apps/app-web/src/components/settings-modal/__tests__/settings-modal.test.ts
+++ b/apps/app-web/src/components/settings-modal/__tests__/settings-modal.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { workspaceSettingsSections } from "../settings-modal";
+
+describe("[COMP:app-web/connect-browser] OSS settings navigation", () => {
+  it("shows Browser profiles so OSS users can pair My Browser", () => {
+    expect(workspaceSettingsSections(true)).toContain("ws-browser-profiles");
+  });
+
+  it("keeps hosted-only billing and model sections out of OSS", () => {
+    expect(workspaceSettingsSections(true)).not.toContain("ws-plan");
+    expect(workspaceSettingsSections(true)).not.toContain("ws-models");
+  });
+});

--- a/apps/app-web/src/components/settings-modal/sections/connect-browser-panel.tsx
+++ b/apps/app-web/src/components/settings-modal/sections/connect-browser-panel.tsx
@@ -4,10 +4,10 @@
  * "My Browser" connect surface (my-browser.md P1): pair the user's own Chrome
  * (via the browser extension + relay) so the assistant can browse as them, with
  * their logins and home network, for hardened/authenticated sites the cloud
- * browser cannot reach. Paid-gated on the hosted edition (D3); OSS never gates
- * (and never shows this section). Renders at the top of the Browser profiles
- * section - setting a profile's backend to "My Browser" routes browsing to the
- * paired Chrome.
+ * browser cannot reach. Paid-gated on the hosted edition (D3); OSS exposes the
+ * same section without a plan gate for a configured self-hosted relay. Renders
+ * at the top of the Browser profiles section - setting a profile's backend to
+ * "My Browser" routes browsing to the paired Chrome.
  *
  * [COMP:app-web/connect-browser]
  */

--- a/apps/app-web/src/components/settings-modal/settings-modal.tsx
+++ b/apps/app-web/src/components/settings-modal/settings-modal.tsx
@@ -101,8 +101,9 @@ const WORKSPACE_SECTIONS: SettingsSection[] = [
   // Metered model profiles (model-registry.md L15). Hosted-only: the lane
   // bills credits; the OSS list below omits it.
   "ws-models",
-  // Computer-use Profile-Management (hosted-only: profiles + the vault are
-  // closed platform halves, so the OSS list below omits it).
+  // Computer-use Profile-Management. OSS keeps this navigation entry for the
+  // open My Browser pairing panel; without the optional closed profile/vault
+  // ports, the remaining profile controls report unconfigured.
   "ws-browser-profiles",
   // ws-usage is absent on purpose: the Usage block renders inside ws-plan
   // ("Plan & usage") — the alias case below still routes old deep links.
@@ -111,18 +112,24 @@ const WORKSPACE_SECTIONS: SettingsSection[] = [
 ];
 // The OSS single-player edition has no billing: drop the Plan + Usage sections
 // entirely. Members stays (relabeled "Teammates"), routed to the hosted-upgrade
-// pitch instead of the live members manager. Hosted keeps the full list above.
+// pitch instead of the live members manager. Browser profiles stays so OSS can
+// pair its self-hosted My Browser relay. Hosted keeps the full list above.
 const OSS_WORKSPACE_SECTIONS: SettingsSection[] = [
   "ws-general",
   "ws-members",
   "ws-llm-key",
   "ws-domains",
+  "ws-browser-profiles",
 ];
+
+export function workspaceSettingsSections(oss: boolean): SettingsSection[] {
+  return oss ? OSS_WORKSPACE_SECTIONS : WORKSPACE_SECTIONS;
+}
 
 export function SettingsModal({ open, initialSection = "profile", onClose }: Props) {
   const t = useT();
   const oss = isOssEdition();
-  const workspaceSections = oss ? OSS_WORKSPACE_SECTIONS : WORKSPACE_SECTIONS;
+  const workspaceSections = workspaceSettingsSections(oss);
   const [section, setSection] = useState<SettingsSection>(initialSection);
   // Which pane shows below the `sm` breakpoint (no effect from `sm:` up,
   // where both panes render side by side): the modal opens on the section

--- a/apps/app-web/src/components/settings-modal/settings-modal.tsx
+++ b/apps/app-web/src/components/settings-modal/settings-modal.tsx
@@ -323,7 +323,7 @@ function SectionGroup({
   );
 }
 
-function SectionBody({
+export function SectionBody({
   section,
   onClose,
 }: {
@@ -367,10 +367,9 @@ function SectionBody({
       // hosted billing construct; OSS nav hides the section, this is defensive.
       return isOssEdition() ? <HostedUpgradeSection /> : <ModelsSection />;
     case "ws-browser-profiles":
-      // Computer-use Profile-Management (computer-use.md §7, R2-4). Profiles
-      // + the vault are closed platform halves; OSS nav hides the section,
-      // this is defensive.
-      return isOssEdition() ? <HostedUpgradeSection /> : <BrowserProfilesSection />;
+      // My Browser pairing is open and available in OSS. Optional persistent
+      // profile/vault ports report unconfigured inside the section when absent.
+      return <BrowserProfilesSection />;
   }
 }
 

--- a/apps/browser-extension/CLAUDE.md
+++ b/apps/browser-extension/CLAUDE.md
@@ -13,7 +13,7 @@ browser-relay (`apps/browser-relay`); the app-web connect surface is
 - `relay-client.ts` — the one WebSocket to the relay (`hello` / command / result / event).
 - `executor.ts` — the discrete browser ops against the one allowed tab, via `chrome.debugger` (CDP) only.
 - `task-gate.ts` — per-task consent + single-tab scope + persistent Stop (`[COMP:ext/agent]`).
-- `tab-eligibility.ts` — which tabs CDP can attach to; an unattachable page raises `no_eligible_tab`, never `consent_denied`.
+- `tab-eligibility.ts` — which tabs CDP can attach to; consent selects the active tab from the last-focused normal browser window (never an extension popup), and an unattachable page raises `no_eligible_tab`, never `consent_denied`.
 - `pairing.ts` — the credential transition behind every Connect, plus the `externally_connectable` sender check (`[COMP:ext/pairing]`).
 - `snapshot.ts` — CDP accessibility tree into the shared snapshot shape.
 - `popup.ts` / `popup-status.ts` / `allow.ts` — the pairing popup, its status wording, and the per-task allow prompt.

--- a/apps/browser-extension/CLAUDE.md
+++ b/apps/browser-extension/CLAUDE.md
@@ -1,7 +1,7 @@
 # apps/browser-extension — "My Browser" local backend
 
-The Chrome/Edge extension that lets a Use Brian assistant drive the user's own
-browser (the local backend, surfaced in-product as **My Browser**). Spec:
+The Chrome/Edge and Firefox extensions that let a Use Brian assistant drive the
+user's own browser (the local backend, surfaced in-product as **My Browser**). Spec:
 [`docs/architecture/engine/computer-use.md`](../../docs/architecture/engine/computer-use.md) §1/§5 + plan
 [`docs/plans/my-browser.md`](../../docs/plans/my-browser.md). Pairs to the account via the
 browser-relay (`apps/browser-relay`); the app-web connect surface is
@@ -17,14 +17,24 @@ browser-relay (`apps/browser-relay`); the app-web connect surface is
 - `pairing.ts` — the credential transition behind every Connect, plus the `externally_connectable` sender check (`[COMP:ext/pairing]`).
 - `snapshot.ts` — CDP accessibility tree into the shared snapshot shape.
 - `popup.ts` / `popup-status.ts` / `allow.ts` — the pairing popup, its status wording, and the per-task allow prompt.
+- `firefox-background.ts` / `firefox-native-client.ts` — Firefox relay/consent wiring and the fixed-operation native-messaging bridge to the installed Electron companion (`[COMP:ext/firefox-agent]`).
+- `firefox-popup.ts` / `firefox-allow.ts` — the Firefox pages, visually matched to the Chromium popup/allow pages.
 
 ## Governance guardrail (my-browser.md §4 D4 / §6) — DO NOT WIDEN
 
 The narrow surface **is** the feature. The extension:
 
 - drives ONLY via `chrome.debugger` (CDP) against one user-approved tab — no content scripts, no `cookies` / `scripting` / `webRequest`;
-- requests NO `host_permissions` (`permissions` stays `["debugger","tabs","storage"]` — `chrome.debugger` needs no host grant);
+- requests NO `host_permissions` (Chromium requires `tabs`/`storage` and offers `debugger` as the only optional permission);
 - gates every task on explicit per-tab consent (`task-gate.ts`), scopes to that tab, and honors a persistent Stop + close-to-kill.
+
+Firefox has no WebExtension debugger API. Its build therefore requests only
+`nativeMessaging`, `tabs`, and `storage`, and delegates the same fixed operation
+vocabulary to the Use Brian Electron executable over the registered
+`ai.usebrian.browser` host. The companion connects to Firefox's loopback-only
+WebDriver BiDi endpoint; Firefox must have been started through the desktop app.
+This is not permission to add content scripts or host access. The Firefox manifest
+test locks the same no-host/no-content-script boundary.
 
 A broad `<all_urls>` / cookies / content-script grant is the **Manus Browser Operator anti-pattern** (Mindgard "Rubra" credential-exfil + Aurascape "SilentBridge" CVSS 9.8 zero-click takeover). Never add it. `src/__tests__/manifest.test.ts` locks the narrow permission set as a regression guard.
 

--- a/apps/browser-extension/package.json
+++ b/apps/browser-extension/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc && node scripts/assemble.mjs",
+    "build:firefox": "tsc && node scripts/assemble-firefox.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/apps/browser-extension/scripts/assemble-firefox.mjs
+++ b/apps/browser-extension/scripts/assemble-firefox.mjs
@@ -1,0 +1,28 @@
+/** Assemble the unpacked Firefox extension beside the Chromium build. */
+import { cpSync, mkdirSync, readdirSync, rmSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const compiled = join(root, 'dist')
+const output = join(root, 'dist-firefox')
+rmSync(output, { recursive: true, force: true })
+mkdirSync(output, { recursive: true })
+
+const runtimeFiles = [
+  'firefox-allow.js',
+  'firefox-background.js',
+  'firefox-native-client.js',
+  'firefox-popup.js',
+  'pairing.js',
+  'protocol.js',
+  'relay-client.js',
+  'tab-eligibility.js',
+  'task-gate.js',
+]
+for (const file of runtimeFiles) cpSync(join(compiled, file), join(output, file))
+for (const file of readdirSync(join(root, 'static-firefox'))) {
+  cpSync(join(root, 'static-firefox', file), join(output, file), { recursive: true })
+}
+
+console.log('firefox extension assembled at apps/browser-extension/dist-firefox')

--- a/apps/browser-extension/src/__tests__/firefox-manifest.test.ts
+++ b/apps/browser-extension/src/__tests__/firefox-manifest.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const manifest = JSON.parse(
+  readFileSync(fileURLToPath(new URL('../../static-firefox/manifest.json', import.meta.url)), 'utf8'),
+) as {
+  manifest_version?: number
+  permissions?: string[]
+  optional_permissions?: string[]
+  host_permissions?: string[]
+  optional_host_permissions?: string[]
+  content_scripts?: unknown[]
+  background?: { page?: string; persistent?: boolean; service_worker?: string }
+  browser_specific_settings?: {
+    gecko?: { id?: string; data_collection_permissions?: { required?: string[] } }
+  }
+}
+
+describe('[COMP:ext/firefox-agent] Firefox manifest parity and guardrails', () => {
+  it('authorizes only the desktop native host transport and portable tab storage APIs', () => {
+    expect(new Set(manifest.permissions)).toEqual(new Set(['tabs', 'storage', 'nativeMessaging']))
+    expect(manifest.optional_permissions ?? []).toEqual([])
+  })
+
+  it('keeps the no-host-access and no-content-script security boundary', () => {
+    expect(manifest.host_permissions ?? []).toEqual([])
+    expect(manifest.optional_host_permissions ?? []).toEqual([])
+    expect(manifest.content_scripts ?? []).toEqual([])
+    expect(manifest.permissions).not.toContain('<all_urls>')
+  })
+
+  it('uses the stable id authorized by the desktop host manifest', () => {
+    expect(manifest.browser_specific_settings?.gecko?.id).toBe('browser@usebrian.ai')
+  })
+
+  it('truthfully declares the functional data sent to the paired assistant', () => {
+    expect(new Set(manifest.browser_specific_settings?.gecko?.data_collection_permissions?.required)).toEqual(
+      new Set(['authenticationInfo', 'browsingActivity', 'websiteContent']),
+    )
+  })
+
+  it('uses Firefox background-page lifecycle instead of a Chromium service worker', () => {
+    expect(manifest.manifest_version).toBe(2)
+    expect(manifest.background).toEqual({ page: 'background.html', persistent: true })
+    expect(manifest.background?.service_worker).toBeUndefined()
+  })
+})

--- a/apps/browser-extension/src/__tests__/tab-eligibility.test.ts
+++ b/apps/browser-extension/src/__tests__/tab-eligibility.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { eligibilityOf } from '../tab-eligibility.js'
+import { activeTabForConsent, eligibilityOf } from '../tab-eligibility.js'
 
 /**
  * Which tabs the extension can actually drive.
@@ -14,6 +14,22 @@ import { eligibilityOf } from '../tab-eligibility.js'
  * borrow its error code.
  */
 describe('[COMP:ext/agent] Controllable-tab eligibility', () => {
+  it('selects the active tab from a normal window instead of an extension popup', async () => {
+    const getLastFocused = async (options: { populate: true; windowTypes: ['normal'] }) => {
+      expect(options).toEqual({ populate: true, windowTypes: ['normal'] })
+      return {
+        tabs: [
+          { id: 1, active: false, url: 'https://example.com/' },
+          { id: 2, active: true, url: 'https://google.com/' },
+        ],
+      }
+    }
+    await expect(activeTabForConsent(getLastFocused)).resolves.toMatchObject({
+      id: 2,
+      url: 'https://google.com/',
+    })
+  })
+
   it('accepts ordinary web pages', () => {
     expect(eligibilityOf('https://example.com/dashboard')).toEqual({ eligible: true })
     expect(eligibilityOf('http://localhost:3003/w/abc')).toEqual({ eligible: true })

--- a/apps/browser-extension/src/background.ts
+++ b/apps/browser-extension/src/background.ts
@@ -7,7 +7,7 @@
 import { RelayClient } from './relay-client.js'
 import { TabExecutor, ExecutorError, isDetachedError, retryableAfterReattach } from './executor.js'
 import { TaskGate, CONSENT_PROMPT_TIMEOUT_MS, type ConsentOutcome } from './task-gate.js'
-import { eligibilityOf } from './tab-eligibility.js'
+import { activeTabForConsent, eligibilityOf } from './tab-eligibility.js'
 import { credentialsForConfigure, isTrustedPairingOrigin, type PairRequest } from './pairing.js'
 import { hasBrowserControl } from './browser-control-permission.js'
 
@@ -34,7 +34,7 @@ async function openGrantWindow(): Promise<void> {
 let pendingConsent: ((res: { allowed: boolean }) => void) | null = null
 
 async function promptForConsent(): Promise<ConsentOutcome> {
-  const [activeTab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true })
+  const activeTab = await activeTabForConsent((options) => chrome.windows.getLastFocused(options))
   // An unattachable page is NOT a refusal. Reporting it as one told users they
   // had declined a prompt never shown, and sent the assistant chasing a consent
   // problem instead of saying "switch to the page you want me to work on".

--- a/apps/browser-extension/src/firefox-allow.ts
+++ b/apps/browser-extension/src/firefox-allow.ts
@@ -1,0 +1,15 @@
+/** Firefox per-task Allow/Deny prompt. */
+export {}
+
+const ext = (globalThis as unknown as { browser: typeof chrome }).browser
+const params = new URLSearchParams(location.search)
+const host = params.get('host') ?? 'this page'
+const detail = document.getElementById('detail')
+if (detail) detail.textContent = `Use Brian wants to work in the tab on ${host}. You can watch it and stop at any time.`
+
+document.getElementById('allow')?.addEventListener('click', () => {
+  void ext.runtime.sendMessage({ type: 'consent-response', allowed: true }).then(() => window.close())
+})
+document.getElementById('deny')?.addEventListener('click', () => {
+  void ext.runtime.sendMessage({ type: 'consent-response', allowed: false }).then(() => window.close())
+})

--- a/apps/browser-extension/src/firefox-background.ts
+++ b/apps/browser-extension/src/firefox-background.ts
@@ -1,7 +1,7 @@
 /** Firefox My Browser background page: relay + consent + desktop companion. */
 import { RelayClient } from './relay-client.js'
 import { TaskGate, CONSENT_PROMPT_TIMEOUT_MS, type ConsentOutcome } from './task-gate.js'
-import { eligibilityOf } from './tab-eligibility.js'
+import { activeTabForConsent, eligibilityOf } from './tab-eligibility.js'
 import { credentialsForConfigure, type PairRequest } from './pairing.js'
 import { FirefoxNativeClient, FirefoxNativeError } from './firefox-native-client.js'
 
@@ -20,7 +20,7 @@ function hostOf(url: string): string {
 }
 
 async function promptForConsent(): Promise<ConsentOutcome> {
-  const [activeTab] = await ext.tabs.query({ active: true, lastFocusedWindow: true })
+  const activeTab = await activeTabForConsent((options) => ext.windows.getLastFocused(options))
   const eligibility = eligibilityOf(activeTab?.url)
   if (!eligibility.eligible) return { allowed: false, reason: eligibility.reason }
   if (activeTab?.id == null) return { allowed: false, reason: 'no_active_tab' }

--- a/apps/browser-extension/src/firefox-background.ts
+++ b/apps/browser-extension/src/firefox-background.ts
@@ -1,0 +1,169 @@
+/** Firefox My Browser background page: relay + consent + desktop companion. */
+import { RelayClient } from './relay-client.js'
+import { TaskGate, CONSENT_PROMPT_TIMEOUT_MS, type ConsentOutcome } from './task-gate.js'
+import { eligibilityOf } from './tab-eligibility.js'
+import { credentialsForConfigure, type PairRequest } from './pairing.js'
+import { FirefoxNativeClient, FirefoxNativeError } from './firefox-native-client.js'
+
+const ext = (globalThis as unknown as { browser: typeof chrome }).browser
+const native = new FirefoxNativeClient()
+let boundTabId: number | null = null
+let boundGeneration = 0
+let pendingConsent: ((res: { allowed: boolean }) => void) | null = null
+
+function hostOf(url: string): string {
+  try {
+    return new URL(url).hostname
+  } catch {
+    return ''
+  }
+}
+
+async function promptForConsent(): Promise<ConsentOutcome> {
+  const [activeTab] = await ext.tabs.query({ active: true, lastFocusedWindow: true })
+  const eligibility = eligibilityOf(activeTab?.url)
+  if (!eligibility.eligible) return { allowed: false, reason: eligibility.reason }
+  if (activeTab?.id == null) return { allowed: false, reason: 'no_active_tab' }
+  const targetTabId = activeTab.id
+  await ext.windows.create({
+    url: ext.runtime.getURL(`allow.html?host=${encodeURIComponent(hostOf(activeTab.url ?? ''))}`),
+    type: 'popup',
+    width: 380,
+    height: 220,
+    focused: true,
+  })
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      pendingConsent = null
+      resolve({ allowed: false, reason: 'denied' })
+    }, CONSENT_PROMPT_TIMEOUT_MS)
+    pendingConsent = (res) => {
+      clearTimeout(timer)
+      pendingConsent = null
+      resolve(res.allowed ? { allowed: true, tabId: targetTabId } : { allowed: false, reason: 'denied' })
+    }
+  })
+}
+
+const gate = new TaskGate({ prompt: promptForConsent })
+
+async function getStored<T = string>(key: string): Promise<T | null> {
+  const obj = await ext.storage.local.get(key)
+  return (obj[key] as T | undefined) ?? null
+}
+
+const client = new RelayClient({
+  getUrl: () => getStored('relayUrl'),
+  connect: (url) => new WebSocket(url) as unknown as import('./relay-client.js').WebSocketLike,
+  getToken: async () => (await getStored('sessionToken')) ?? (await getStored('pairingToken')),
+  onSessionToken: async (token) => {
+    await ext.storage.local.set({ sessionToken: token })
+    await ext.storage.local.remove('pairingToken')
+  },
+  onCommand: (cmd) => void handleCommand(cmd),
+  onStateChange: (state) => {
+    void ext.browserAction.setBadgeText({ text: state === 'ready' ? 'ON' : '' })
+    void ext.browserAction.setBadgeBackgroundColor({ color: '#16a34a' })
+  },
+})
+
+async function applyPairing(req: PairRequest): Promise<void> {
+  const { set, remove } = credentialsForConfigure(req)
+  if (Object.keys(set).length > 0) await ext.storage.local.set(set)
+  if (remove.length > 0) await ext.storage.local.remove(remove)
+  client.stop()
+  client.start()
+}
+
+async function handleCommand(cmd: { id: string; op: string; args: Record<string, unknown> }): Promise<void> {
+  try {
+    const data = await executeOp(cmd.op, cmd.args)
+    client.sendResult({ id: cmd.id, ok: true, data })
+  } catch (error) {
+    client.sendResult({
+      id: cmd.id,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+      code: error instanceof FirefoxNativeError ? error.code : ((error as { code?: string })?.code ?? 'backend_error'),
+    })
+  }
+}
+
+async function executeOp(op: string, args: Record<string, unknown>): Promise<unknown> {
+  if (op === 'stop') {
+    gate.stop()
+    boundTabId = null
+    return native.request('stop')
+  }
+  const status = await native.status()
+  if (!status.ready) {
+    throw new FirefoxNativeError(
+      status.reason === 'firefox_companion_missing'
+        ? 'Install or open the Use Brian desktop app to use My Browser in Firefox.'
+        : 'Quit Firefox, then choose Start Firefox for My Browser in the Use Brian desktop app.',
+      status.reason ?? 'firefox_restart_required',
+    )
+  }
+  const tabId = await gate.requireTab()
+  const generation = native.connectionGeneration()
+  if (boundTabId !== tabId || boundGeneration !== generation) {
+    const tab = await ext.tabs.get(tabId)
+    await ext.tabs.update(tabId, { active: true })
+    if (tab.windowId != null) await ext.windows.update(tab.windowId, { focused: true })
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    await native.request('bind', { args: { url: tab.url ?? '', title: tab.title ?? '' } })
+    boundTabId = tabId
+    boundGeneration = generation
+  }
+  return native.request('execute', { op, args })
+}
+
+ext.tabs.onRemoved.addListener((tabId) => {
+  if (!gate.onTabRemoved(tabId)) return
+  boundTabId = null
+  void native.request('stop')
+  client.sendEvent('tab_closed')
+})
+
+ext.runtime.onMessage.addListener((message: unknown) => {
+  const msg = message as { type?: string; allowed?: boolean; relayUrl?: string; pairingToken?: string }
+  if (msg.type === 'consent-response') {
+    pendingConsent?.({ allowed: msg.allowed === true })
+    return Promise.resolve({ ok: true })
+  }
+  if (msg.type === 'stop-task') {
+    gate.stop()
+    boundTabId = null
+    void native.request('stop')
+    client.sendEvent('stopped')
+    return Promise.resolve({ ok: true })
+  }
+  if (msg.type === 'configure') {
+    return applyPairing({ relayUrl: msg.relayUrl, pairingToken: msg.pairingToken }).then(() => ({ ok: true }))
+  }
+  if (msg.type === 'disconnect') {
+    gate.stop()
+    boundTabId = null
+    void native.request('stop')
+    return ext.storage.local.remove(['sessionToken', 'pairingToken']).then(() => {
+      client.stop()
+      return { ok: true }
+    })
+  }
+  if (msg.type === 'open-firefox-control') {
+    return native.request('openDesktop').then(() => ({ ok: true }))
+  }
+  if (msg.type === 'status') {
+    return native.status().then((control) => ({
+      state: client.getState(),
+      controlledTab: gate.currentTab(),
+      stopped: gate.isStopped(),
+      hasControl: control.ready,
+      controlReason: control.reason,
+      extensionId: ext.runtime.id,
+    }))
+  }
+  return undefined
+})
+
+client.start()

--- a/apps/browser-extension/src/firefox-native-client.ts
+++ b/apps/browser-extension/src/firefox-native-client.ts
@@ -1,0 +1,82 @@
+/** Request/response transport to the Use Brian desktop native host. */
+const HOST_NAME = 'ai.usebrian.browser'
+
+type NativeResponse = {
+  id: string | null
+  ok: boolean
+  data?: unknown
+  error?: string
+  code?: string
+}
+
+type Pending = { resolve: (value: unknown) => void; reject: (error: Error) => void }
+
+export class FirefoxNativeError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+  ) {
+    super(message)
+    this.name = 'FirefoxNativeError'
+  }
+}
+
+export class FirefoxNativeClient {
+  private port: chrome.runtime.Port | null = null
+  private counter = 0
+  private pending = new Map<string, Pending>()
+  private generation = 0
+
+  connectionGeneration(): number {
+    return this.generation
+  }
+
+  private connect(): chrome.runtime.Port {
+    if (this.port) return this.port
+    const port = chrome.runtime.connectNative(HOST_NAME)
+    this.port = port
+    this.generation += 1
+    port.onMessage.addListener((message: unknown) => {
+      const response = message as Partial<NativeResponse>
+      if (typeof response.id !== 'string') return
+      const pending = this.pending.get(response.id)
+      if (!pending) return
+      this.pending.delete(response.id)
+      if (response.ok) pending.resolve(response.data)
+      else pending.reject(new FirefoxNativeError(response.error ?? 'Firefox companion failed.', response.code ?? 'backend_error'))
+    })
+    port.onDisconnect.addListener(() => {
+      const message = chrome.runtime.lastError?.message ?? 'Use Brian desktop companion disconnected.'
+      this.port = null
+      for (const pending of this.pending.values()) {
+        pending.reject(new FirefoxNativeError(message, 'firefox_companion_missing'))
+      }
+      this.pending.clear()
+    })
+    return port
+  }
+
+  request(type: 'status' | 'bind' | 'execute' | 'stop' | 'openDesktop', payload: Record<string, unknown> = {}): Promise<unknown> {
+    const id = `fx-${Date.now()}-${++this.counter}`
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject })
+      try {
+        this.connect().postMessage({ id, type, ...payload })
+      } catch (error) {
+        this.pending.delete(id)
+        reject(new FirefoxNativeError(error instanceof Error ? error.message : String(error), 'firefox_companion_missing'))
+      }
+    })
+  }
+
+  async status(): Promise<{ ready: boolean; reason?: string }> {
+    try {
+      return (await this.request('status')) as { ready: boolean; reason?: string }
+    } catch (error) {
+      return {
+        ready: false,
+        reason: error instanceof FirefoxNativeError ? error.code : 'firefox_companion_missing',
+      }
+    }
+  }
+}

--- a/apps/browser-extension/src/firefox-popup.ts
+++ b/apps/browser-extension/src/firefox-popup.ts
@@ -1,0 +1,88 @@
+/** Firefox popup with the same layout/actions as the Chromium popup. */
+export {}
+
+const ext = (globalThis as unknown as { browser: typeof chrome }).browser
+
+function el<T extends HTMLElement>(id: string): T {
+  const node = document.getElementById(id)
+  if (!node) throw new Error(`missing #${id}`)
+  return node as T
+}
+
+type Status = {
+  state?: string
+  controlledTab?: number | null
+  stopped?: boolean
+  hasControl?: boolean
+  controlReason?: string
+}
+
+const STATE_LABELS: Record<string, string> = {
+  ready: 'Connected. The assistant can request browser tasks.',
+  connecting: 'Connecting to the relay...',
+  disconnected: 'Disconnected. Reconnecting automatically.',
+  unpaired: 'Not paired. Paste a pairing token from Use Brian settings.',
+  replaced: 'Another browser took over this pairing. Press Connect to take it back.',
+}
+
+const statusBox = el<HTMLDivElement>('status')
+const statusText = el<HTMLSpanElement>('status-text')
+const relayUrlInput = el<HTMLInputElement>('relay-url')
+const tokenInput = el<HTMLInputElement>('pairing-token')
+const grantRow = el<HTMLDivElement>('grant-row')
+
+function statusLine(status: Status): string {
+  if (status.hasControl === false) {
+    return status.controlReason === 'firefox_companion_missing'
+      ? 'Use Brian desktop is required. Open it below to finish Firefox setup.'
+      : 'Firefox must be started for My Browser. Open Use Brian below, then restart Firefox.'
+  }
+  if (status.stopped) return 'Task stopped. The next request will ask your permission again.'
+  return `${STATE_LABELS[status.state ?? 'unpaired'] ?? status.state ?? 'unpaired'}${
+    status.controlledTab != null ? ' Controlling one allowed tab.' : ''
+  }`
+}
+
+async function refreshStatus(): Promise<void> {
+  const status = ((await ext.runtime.sendMessage({ type: 'status' })) ?? {}) as Status
+  const ready = status.hasControl !== false
+  statusBox.classList.toggle('ready', status.state === 'ready' && !status.stopped && ready)
+  statusText.textContent = statusLine(status)
+  grantRow.hidden = ready
+}
+
+async function loadStored(): Promise<void> {
+  const stored = await ext.storage.local.get(['relayUrl'])
+  if (typeof stored.relayUrl === 'string') relayUrlInput.value = stored.relayUrl
+}
+
+el<HTMLButtonElement>('grant').addEventListener('click', () => {
+  void ext.runtime
+    .sendMessage({ type: 'open-firefox-control' })
+    .then(() => window.close())
+    .catch(() => {
+      statusText.textContent = 'Open the Use Brian desktop app, then choose Start Firefox for My Browser.'
+    })
+})
+el<HTMLButtonElement>('connect').addEventListener('click', () => {
+  void ext.runtime
+    .sendMessage({
+      type: 'configure',
+      relayUrl: relayUrlInput.value.trim(),
+      pairingToken: tokenInput.value.trim() || undefined,
+    })
+    .then(() => {
+      tokenInput.value = ''
+      setTimeout(() => void refreshStatus(), 400)
+    })
+})
+el<HTMLButtonElement>('disconnect').addEventListener('click', () => {
+  void ext.runtime.sendMessage({ type: 'disconnect' }).then(() => refreshStatus())
+})
+el<HTMLButtonElement>('stop').addEventListener('click', () => {
+  void ext.runtime.sendMessage({ type: 'stop-task' }).then(() => refreshStatus())
+})
+
+void loadStored()
+void refreshStatus()
+setInterval(() => void refreshStatus(), 2_000)

--- a/apps/browser-extension/src/tab-eligibility.ts
+++ b/apps/browser-extension/src/tab-eligibility.ts
@@ -20,6 +20,18 @@ type TabIneligibility = 'restricted_url' | 'no_active_tab'
 export type TabEligibility = { eligible: true } | { eligible: false; reason: TabIneligibility }
 
 /**
+ * Resolve consent against a normal browser window, never an extension popup.
+ * Firefox can keep an allow/browser-action popup as `lastFocusedWindow` after
+ * the user returns to a website, which made an eligible page look restricted.
+ */
+export async function activeTabForConsent<T extends { active?: boolean }>(
+  getLastFocused: (options: { populate: true; windowTypes: ['normal'] }) => Promise<{ tabs?: T[] }>,
+): Promise<T | undefined> {
+  const window = await getLastFocused({ populate: true, windowTypes: ['normal'] })
+  return window.tabs?.find((tab) => tab.active === true)
+}
+
+/**
  * Schemes the debugger cannot attach to. `chrome-extension:` covers our own
  * popup and allow window: prod logged 10x "Cannot access a chrome-extension://
  * URL" AFTER consent, because those passed the old `chrome://`-only check and

--- a/apps/browser-extension/static-firefox/allow.html
+++ b/apps/browser-extension/static-firefox/allow.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body { font: 13px/1.5 -apple-system, system-ui, sans-serif; margin: 0; padding: 18px; color: #111; }
+      h1 { font-size: 16px; margin: 0 0 8px; }
+      p { color: #475569; margin: 0 0 16px; }
+      .actions { display: flex; gap: 8px; }
+      button { padding: 7px 14px; border-radius: 6px; border: 1px solid #cbd5e1; background: #fff; cursor: pointer; }
+      button.primary { background: #111; color: #fff; border-color: #111; }
+    </style>
+  </head>
+  <body>
+    <h1>Allow Use Brian in this tab?</h1>
+    <p id="detail">Use Brian wants to work in this tab. You can watch it and stop at any time.</p>
+    <div class="actions">
+      <button id="allow" class="primary">Allow</button>
+      <button id="deny">Deny</button>
+    </div>
+    <script type="module" src="firefox-allow.js"></script>
+  </body>
+</html>

--- a/apps/browser-extension/static-firefox/background.html
+++ b/apps/browser-extension/static-firefox/background.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html>
+  <head><meta charset="utf-8" /></head>
+  <body><script type="module" src="firefox-background.js"></script></body>
+</html>

--- a/apps/browser-extension/static-firefox/manifest.json
+++ b/apps/browser-extension/static-firefox/manifest.json
@@ -1,0 +1,24 @@
+{
+  "manifest_version": 2,
+  "name": "Use Brian Browser Agent",
+  "version": "0.1.0",
+  "description": "Lets your Use Brian assistant act in your own browser: consent-gated, approval-gated sends, always stoppable.",
+  "permissions": ["tabs", "storage", "nativeMessaging"],
+  "background": {
+    "page": "background.html",
+    "persistent": true
+  },
+  "browser_action": {
+    "default_popup": "popup.html",
+    "default_title": "Use Brian"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "browser@usebrian.ai",
+      "strict_min_version": "142.0",
+      "data_collection_permissions": {
+        "required": ["authenticationInfo", "browsingActivity", "websiteContent"]
+      }
+    }
+  }
+}

--- a/apps/browser-extension/static-firefox/popup.html
+++ b/apps/browser-extension/static-firefox/popup.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body { font: 13px/1.45 -apple-system, system-ui, sans-serif; width: 320px; margin: 0; padding: 14px; color: #111; }
+      h1 { font-size: 14px; margin: 0 0 10px; }
+      .row { margin-bottom: 8px; }
+      label { display: block; font-weight: 600; margin-bottom: 3px; }
+      input { width: 100%; box-sizing: border-box; padding: 6px 8px; border: 1px solid #cbd5e1; border-radius: 6px; font-size: 12px; }
+      button { padding: 6px 12px; border-radius: 6px; border: 1px solid #cbd5e1; background: #fff; cursor: pointer; font-size: 12px; }
+      button.primary { background: #111; color: #fff; border-color: #111; }
+      button.danger { background: #dc2626; color: #fff; border-color: #dc2626; }
+      .status { padding: 6px 8px; border-radius: 6px; background: #f1f5f9; margin-bottom: 10px; }
+      .status .dot { display: inline-block; width: 8px; height: 8px; border-radius: 4px; margin-right: 6px; background: #94a3b8; }
+      .status.ready .dot { background: #16a34a; }
+      .actions { display: flex; gap: 6px; margin-top: 10px; }
+      .hint { color: #64748b; font-size: 11px; margin-top: 8px; }
+    </style>
+  </head>
+  <body>
+    <h1>Use Brian Browser Agent</h1>
+    <div id="status" class="status"><span class="dot"></span><span id="status-text">Checking...</span></div>
+    <div class="row" id="grant-row" hidden>
+      <button id="grant" class="primary" style="width: 100%">Open Use Brian desktop setup</button>
+    </div>
+    <div class="row">
+      <label for="relay-url">Relay URL</label>
+      <input id="relay-url" placeholder="wss://relay.usebrian.ai/ext" />
+    </div>
+    <div class="row">
+      <label for="pairing-token">Pairing token</label>
+      <input id="pairing-token" placeholder="Paste from Settings > Browser extension" />
+    </div>
+    <div class="actions">
+      <button id="connect" class="primary">Connect</button>
+      <button id="disconnect">Disconnect</button>
+      <button id="stop" class="danger">Stop task</button>
+    </div>
+    <p class="hint">The assistant only acts in a tab you allow, one task at a time. Stop ends the current task immediately.</p>
+    <script type="module" src="firefox-popup.js"></script>
+  </body>
+</html>

--- a/apps/browser-relay/Dockerfile
+++ b/apps/browser-relay/Dockerfile
@@ -1,0 +1,66 @@
+# ── Stage 1: Install dependencies ──────────────────────────────
+FROM node:22-slim AS deps
+
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+
+WORKDIR /app
+
+# Workspace config + the package.json/tsconfig of every package in the build
+# graph (browser-relay → @use-brian/api → @use-brian/core/channels/shared/…).
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json turbo.json tsconfig.base.json ./
+COPY packages/shared/package.json packages/shared/tsconfig.json ./packages/shared/
+COPY packages/channels/package.json packages/channels/tsconfig.json ./packages/channels/
+COPY packages/doc-model/package.json packages/doc-model/tsconfig.json ./packages/doc-model/
+COPY packages/core/package.json packages/core/tsconfig.json ./packages/core/
+COPY packages/api/package.json packages/api/tsconfig.json ./packages/api/
+COPY packages/brian-kb/package.json ./packages/brian-kb/
+COPY apps/browser-relay/package.json apps/browser-relay/tsconfig.json ./apps/browser-relay/
+
+RUN pnpm install --frozen-lockfile
+
+# ── Stage 2: Build ─────────────────────────────────────────────
+FROM deps AS build
+
+COPY packages/shared/src ./packages/shared/src
+COPY packages/channels/src ./packages/channels/src
+COPY packages/doc-model/src ./packages/doc-model/src
+COPY packages/core/src ./packages/core/src
+COPY packages/core/scripts ./packages/core/scripts
+COPY packages/api/src ./packages/api/src
+COPY packages/api/migrations ./packages/api/migrations
+COPY packages/brian-kb ./packages/brian-kb
+COPY apps/browser-relay/src ./apps/browser-relay/src
+
+# pnpm topological build (deps-first), not turbo — see discord-connector.
+RUN pnpm --filter "@use-brian/browser-relay..." run build
+
+# ── Stage 3: Production image ─────────────────────────────────
+FROM node:22-slim AS runner
+
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+
+WORKDIR /app
+
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/shared/package.json ./packages/shared/
+COPY packages/channels/package.json ./packages/channels/
+COPY packages/doc-model/package.json ./packages/doc-model/
+COPY packages/core/package.json ./packages/core/
+COPY packages/api/package.json ./packages/api/
+COPY packages/brian-kb/package.json ./packages/brian-kb/
+COPY apps/browser-relay/package.json ./apps/browser-relay/
+
+RUN pnpm install --frozen-lockfile --prod
+
+COPY --from=build /app/packages/shared/dist ./packages/shared/dist
+COPY --from=build /app/packages/channels/dist ./packages/channels/dist
+COPY --from=build /app/packages/doc-model/dist ./packages/doc-model/dist
+COPY --from=build /app/packages/core/dist ./packages/core/dist
+COPY --from=build /app/packages/api/dist ./packages/api/dist
+COPY --from=build /app/packages/brian-kb ./packages/brian-kb
+COPY --from=build /app/apps/browser-relay/dist ./apps/browser-relay/dist
+
+ENV NODE_ENV=production
+EXPOSE 8080
+
+CMD ["node", "apps/browser-relay/dist/index.js"]

--- a/apps/browser-relay/package.json
+++ b/apps/browser-relay/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@use-brian/browser-relay",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@use-brian/api": "workspace:*",
+    "express": "^5",
+    "ws": "^8.18.0",
+    "zod": "^3.24"
+  },
+  "devDependencies": {
+    "@types/express": "^5",
+    "@types/node": "^20.19.39",
+    "@types/ws": "^8.5.13",
+    "tsx": "^4",
+    "typescript": "^5.7",
+    "vitest": "^3"
+  }
+}

--- a/apps/browser-relay/src/__tests__/relay.test.ts
+++ b/apps/browser-relay/src/__tests__/relay.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { BrowserRelay, LIVENESS_WINDOW_MS, type RelaySocket } from '../relay.js'
+import { relaySecretMatches } from '../auth.js'
+import {
+  signBrowserExtPairToken,
+  signBrowserExtSessionToken,
+  verifyBrowserExtHelloToken,
+  verifyBrowserExtPairToken,
+  verifyBrowserExtSessionToken,
+} from '@use-brian/api/auth/browser-ext-pair-token.js'
+
+const SECRET = 'test-jwt-secret'
+
+type FakeSocket = RelaySocket & {
+  sent: Array<Record<string, unknown>>
+  closed: { code?: number; reason?: string } | null
+}
+
+function fakeSocket(): FakeSocket {
+  const socket: FakeSocket = {
+    sent: [],
+    closed: null,
+    send(data: unknown) {
+      socket.sent.push(JSON.parse(String(data)) as Record<string, unknown>)
+    },
+    close(code?: number, reason?: string) {
+      socket.closed = { code, reason }
+    },
+  } as FakeSocket
+  return socket
+}
+
+function relayWithVerifier(commandTimeoutMs?: number): BrowserRelay {
+  return new BrowserRelay({
+    verifyPairingToken: (token) => {
+      const payload = verifyBrowserExtPairToken(token, SECRET)
+      return payload ? { userId: payload.userId, workspaceId: payload.workspaceId } : null
+    },
+    commandTimeoutMs,
+  })
+}
+
+function pair(relay: BrowserRelay, userId = 'user-1'): FakeSocket {
+  const socket = fakeSocket()
+  const token = signBrowserExtPairToken({ userId, workspaceId: 'ws-1' }, SECRET)
+  relay.handleMessage(socket, JSON.stringify({ type: 'hello', pairingToken: token }))
+  return socket
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('[COMP:ext/relay] Browser extension relay', () => {
+  it('verifies a P1.3 pairing token on hello and answers ready', () => {
+    const relay = relayWithVerifier()
+    const socket = pair(relay)
+    expect(socket.sent).toEqual([{ type: 'ready' }])
+    expect(relay.isConnected('user-1')).toBe(true)
+  })
+
+  it('rejects a bad pairing token with error + close 4401', () => {
+    const relay = relayWithVerifier()
+    const socket = fakeSocket()
+    relay.handleMessage(socket, JSON.stringify({ type: 'hello', pairingToken: 'garbage' }))
+    expect(socket.sent[0]).toMatchObject({ type: 'error' })
+    expect(socket.closed?.code).toBe(4401)
+    expect(relay.isConnected('user-1')).toBe(false)
+  })
+
+  it('rejects a token signed with the wrong secret', () => {
+    const relay = relayWithVerifier()
+    const socket = fakeSocket()
+    const token = signBrowserExtPairToken({ userId: 'user-1', workspaceId: 'ws-1' }, 'other-secret')
+    relay.handleMessage(socket, JSON.stringify({ type: 'hello', pairingToken: token }))
+    expect(socket.closed?.code).toBe(4401)
+  })
+
+  it('routes a command to the paired extension and resolves on its result (P1.4)', async () => {
+    const relay = relayWithVerifier()
+    const socket = pair(relay)
+
+    const resultPromise = relay.dispatchCommand({ userId: 'user-1', op: 'snapshot' })
+    const command = socket.sent.find((m) => m.type === 'command') as { id: string; op: string }
+    expect(command.op).toBe('snapshot')
+
+    relay.handleMessage(
+      socket,
+      JSON.stringify({ type: 'result', id: command.id, ok: true, data: { url: 'https://x.test/', title: '', nodes: [] } }),
+    )
+    await expect(resultPromise).resolves.toEqual({
+      ok: true,
+      data: { url: 'https://x.test/', title: '', nodes: [] },
+    })
+  })
+
+  it('returns the clear no-extension error immediately when the user has no connection — never a hang', async () => {
+    const relay = relayWithVerifier()
+    const res = await relay.dispatchCommand({ userId: 'nobody', op: 'navigate', args: { url: 'https://x.test/' } })
+    expect(res).toMatchObject({ ok: false, code: 'no_extension' })
+  })
+
+  it('times out an unanswered command with code timeout', async () => {
+    vi.useFakeTimers()
+    const relay = relayWithVerifier(1_000)
+    pair(relay)
+    const resultPromise = relay.dispatchCommand({ userId: 'user-1', op: 'click', args: { ref: '@e1' } })
+    await vi.advanceTimersByTimeAsync(1_001)
+    await expect(resultPromise).resolves.toMatchObject({ ok: false, code: 'timeout' })
+  })
+
+  it('rejects in-flight commands when the extension emits event{stopped} (close-to-stop)', async () => {
+    const relay = relayWithVerifier()
+    const socket = pair(relay)
+    const resultPromise = relay.dispatchCommand({ userId: 'user-1', op: 'type', args: { ref: '@e1', text: 'hi' } })
+    relay.handleMessage(socket, JSON.stringify({ type: 'event', kind: 'stopped' }))
+    await expect(resultPromise).resolves.toMatchObject({ ok: false, code: 'stopped' })
+  })
+
+  it('rejects in-flight commands when the extension emits event{detached}', async () => {
+    // Chrome's debugging banner has its own Cancel, which ends the CDP session
+    // without closing the tab. The waiting command must fail as `detached`
+    // with its own message — reporting "the tab was closed" sends the model
+    // hunting for a problem that is not there.
+    const relay = relayWithVerifier()
+    const socket = pair(relay)
+    const resultPromise = relay.dispatchCommand({ userId: 'user-1', op: 'snapshot' })
+    relay.handleMessage(socket, JSON.stringify({ type: 'event', kind: 'detached' }))
+    const res = await resultPromise
+    expect(res.ok).toBe(false)
+    if (res.ok) throw new Error('unreachable')
+    expect(res.code).toBe('detached')
+    expect(res.error).not.toMatch(/closed/i)
+    expect(res.error).toMatch(/debugging session/i)
+  })
+
+  it('rejects in-flight commands with no_extension when the socket disconnects', async () => {
+    const relay = relayWithVerifier()
+    const socket = pair(relay)
+    const resultPromise = relay.dispatchCommand({ userId: 'user-1', op: 'snapshot' })
+    relay.handleDisconnect(socket)
+    await expect(resultPromise).resolves.toMatchObject({ ok: false, code: 'no_extension' })
+    expect(relay.isConnected('user-1')).toBe(false)
+  })
+
+  it('replaces an existing connection on re-pairing (latest wins) without dropping the new one', () => {
+    const relay = relayWithVerifier()
+    const first = pair(relay)
+    const second = pair(relay)
+    expect(first.closed?.code).toBe(4000)
+    // The old socket's close event must not unregister the fresh connection.
+    relay.handleDisconnect(first)
+    expect(relay.isConnected('user-1')).toBe(true)
+    expect(second.sent).toEqual([{ type: 'ready' }])
+  })
+
+  it('answers ping with pong and refuses non-hello frames from unpaired sockets', () => {
+    const relay = relayWithVerifier()
+    const socket = pair(relay)
+    relay.handleMessage(socket, JSON.stringify({ type: 'ping' }))
+    expect(socket.sent).toContainEqual({ type: 'pong' })
+
+    const stranger = fakeSocket()
+    relay.handleMessage(stranger, JSON.stringify({ type: 'ping' }))
+    expect(stranger.closed?.code).toBe(4401)
+  })
+
+  it('closes connections that go silent past the liveness window', () => {
+    vi.useFakeTimers()
+    const relay = relayWithVerifier()
+    const socket = pair(relay)
+    vi.setSystemTime(Date.now() + LIVENESS_WINDOW_MS + 1_000)
+    const closed = relay.sweepDead()
+    expect(closed).toBe(1)
+    expect(socket.closed?.code).toBe(4002)
+    expect(relay.isConnected('user-1')).toBe(false)
+  })
+
+  it('drops malformed frames with error + close 4400', () => {
+    const relay = relayWithVerifier()
+    const socket = fakeSocket()
+    relay.handleMessage(socket, 'not json')
+    expect(socket.closed?.code).toBe(4400)
+
+    const socket2 = fakeSocket()
+    relay.handleMessage(socket2, JSON.stringify({ type: 'launch_missiles' }))
+    expect(socket2.closed?.code).toBe(4400)
+  })
+})
+
+describe('[COMP:ext/relay] Session-token exchange', () => {
+  function relayWithMinter(): BrowserRelay {
+    return new BrowserRelay({
+      verifyPairingToken: (token) => verifyBrowserExtHelloToken(token, SECRET),
+      mintSessionToken: (identity) => signBrowserExtSessionToken(identity, SECRET),
+    })
+  }
+
+  it('returns a session token in ready after a first-time pair-token hello', () => {
+    const relay = relayWithMinter()
+    const socket = fakeSocket()
+    const token = signBrowserExtPairToken({ userId: 'user-1', workspaceId: 'ws-1' }, SECRET)
+    relay.handleMessage(socket, JSON.stringify({ type: 'hello', pairingToken: token }))
+    const ready = socket.sent[0] as { type: string; sessionToken?: string }
+    expect(ready.type).toBe('ready')
+    expect(typeof ready.sessionToken).toBe('string')
+    const session = verifyBrowserExtSessionToken(ready.sessionToken as string, SECRET)
+    expect(session).toMatchObject({ kind: 'browser-ext-session', userId: 'user-1', workspaceId: 'ws-1' })
+  })
+
+  it('accepts a session-token hello on reconnect without minting another token', () => {
+    const relay = relayWithMinter()
+    const socket = fakeSocket()
+    const session = signBrowserExtSessionToken({ userId: 'user-1', workspaceId: 'ws-1' }, SECRET)
+    relay.handleMessage(socket, JSON.stringify({ type: 'hello', pairingToken: session }))
+    expect(socket.sent[0]).toEqual({ type: 'ready' })
+    expect(relay.isConnected('user-1')).toBe(true)
+  })
+
+  it('keeps the token kinds distinct: a pair token is not a session token and vice versa', () => {
+    const pairTok = signBrowserExtPairToken({ userId: 'u', workspaceId: 'w' }, SECRET)
+    const sessTok = signBrowserExtSessionToken({ userId: 'u', workspaceId: 'w' }, SECRET)
+    expect(verifyBrowserExtSessionToken(pairTok, SECRET)).toBeNull()
+    expect(verifyBrowserExtPairToken(sessTok, SECRET)).toBeNull()
+    expect(verifyBrowserExtHelloToken(pairTok, SECRET)?.kind).toBe('browser-ext-pair')
+    expect(verifyBrowserExtHelloToken(sessTok, SECRET)?.kind).toBe('browser-ext-session')
+  })
+})
+
+describe('[COMP:ext/relay] Relay internal auth', () => {
+  it('matches only the exact shared secret, constant-time, fail-closed', () => {
+    expect(relaySecretMatches('s3cret', 's3cret')).toBe(true)
+    expect(relaySecretMatches('nope', 's3cret')).toBe(false)
+    expect(relaySecretMatches(undefined, 's3cret')).toBe(false)
+    expect(relaySecretMatches('anything', '')).toBe(false)
+  })
+})

--- a/apps/browser-relay/src/auth.ts
+++ b/apps/browser-relay/src/auth.ts
@@ -1,0 +1,13 @@
+import { timingSafeEqual } from 'node:crypto'
+
+/**
+ * Constant-time X-Relay-Secret check for the internal command API.
+ * Fails closed: an empty/unset expected secret matches nothing (the
+ * discord-connector pattern).
+ */
+export function relaySecretMatches(provided: unknown, expected: string): boolean {
+  if (typeof provided !== 'string' || expected.length === 0) return false
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  return a.length === b.length && timingSafeEqual(a, b)
+}

--- a/apps/browser-relay/src/env.ts
+++ b/apps/browser-relay/src/env.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+
+const envSchema = z.object({
+  PORT: z.coerce.number().default(8080),
+  /**
+   * Shared secret the api presents on `/internal/browser/*` calls
+   * (X-Relay-Secret, constant-time checked — the connector-app pattern).
+   */
+  BROWSER_RELAY_SECRET: z.string().min(1, 'BROWSER_RELAY_SECRET is required'),
+  /**
+   * The SAME JWT secret the api signs with (P1.3): pairing tokens minted by
+   * `POST /api/browser-extension/pair` verify here.
+   */
+  JWT_SECRET: z.string().min(1, 'JWT_SECRET is required'),
+  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+})
+
+export type Env = z.infer<typeof envSchema>
+
+let _env: Env | null = null
+
+export function getEnv(): Env {
+  if (!_env) {
+    _env = envSchema.parse(process.env)
+  }
+  return _env
+}

--- a/apps/browser-relay/src/index.ts
+++ b/apps/browser-relay/src/index.ts
@@ -1,0 +1,88 @@
+/**
+ * browser-relay — the computer-use local-mode bridge (spec:
+ * docs/architecture/engine/computer-use.md §4).
+ *
+ * Terminates the browser extension's WebSocket (`/ext`), verifies P1.3
+ * pairing tokens, holds the in-memory `userId → connection` registry, and
+ * exposes `POST /internal/browser/command` for the api's relay transport.
+ * **Single-instance** on Cloud Run (min=max=1) — the registry is process
+ * memory, the wa/discord-connector deployment shape.
+ */
+
+import { createServer } from 'node:http'
+import express from 'express'
+import { WebSocketServer, type WebSocket } from 'ws'
+import {
+  signBrowserExtSessionToken,
+  verifyBrowserExtHelloToken,
+} from '@use-brian/api/auth/browser-ext-pair-token.js'
+import { relaySecretMatches } from './auth.js'
+import { getEnv } from './env.js'
+import { BrowserRelay } from './relay.js'
+import { InternalCommandRequestSchema } from './protocol.js'
+
+const env = getEnv()
+const app = express()
+app.use(express.json({ limit: '1mb' }))
+
+const relay = new BrowserRelay({
+  verifyPairingToken: (token) => verifyBrowserExtHelloToken(token, env.JWT_SECRET),
+  mintSessionToken: (identity) => signBrowserExtSessionToken(identity, env.JWT_SECRET),
+})
+
+// ── Health check (no auth) ────────────────────────────────────
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok', connections: relay.connectionCount() })
+})
+
+// ── Auth: shared secret on every /internal route ──────────────
+app.use('/internal', (req, res, next) => {
+  if (!relaySecretMatches(req.headers['x-relay-secret'], env.BROWSER_RELAY_SECRET)) {
+    res.status(401).json({ error: 'Invalid or missing X-Relay-Secret' })
+    return
+  }
+  next()
+})
+
+// ── Command routing (P1.4) ────────────────────────────────────
+app.post('/internal/browser/command', async (req, res) => {
+  const parsed = InternalCommandRequestSchema.safeParse(req.body)
+  if (!parsed.success) {
+    res.status(400).json({ error: 'userId and op are required' })
+    return
+  }
+  const result = await relay.dispatchCommand(parsed.data)
+  res.json(result)
+})
+
+app.get('/internal/browser/status/:userId', (req, res) => {
+  res.json({ connected: relay.isConnected(req.params.userId) })
+})
+
+// ── WebSocket endpoint for extensions ─────────────────────────
+const server = createServer(app)
+const wss = new WebSocketServer({ server, path: '/ext', maxPayload: 8 * 1024 * 1024 })
+
+wss.on('connection', (socket: WebSocket) => {
+  socket.on('message', (raw) => relay.handleMessage(socket, raw as Buffer))
+  socket.on('close', () => relay.handleDisconnect(socket))
+  socket.on('error', () => relay.handleDisconnect(socket))
+})
+
+const sweep = setInterval(() => relay.sweepDead(), 30_000)
+
+server.listen(env.PORT, () => {
+  console.log(`browser-relay listening on port ${env.PORT}`)
+})
+
+// ── Graceful shutdown ─────────────────────────────────────────
+function shutdown(): void {
+  console.log('Shutting down browser-relay...')
+  clearInterval(sweep)
+  wss.close()
+  server.close()
+  process.exit(0)
+}
+
+process.on('SIGTERM', shutdown)
+process.on('SIGINT', shutdown)

--- a/apps/browser-relay/src/protocol.ts
+++ b/apps/browser-relay/src/protocol.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod'
+
+/**
+ * Extension ↔ relay wire protocol (P1.2 / computer-use.md §4): JSON envelopes
+ * over one WebSocket per extension. The extension is the executor; the relay
+ * only routes. Mirror image lives in apps/browser-extension/src/protocol.ts —
+ * keep the two in sync (the relay zod-validates every inbound frame, so drift
+ * fails loud, not silent).
+ *
+ *   ext → relay : hello{pairingToken} · result{id,ok,data|error,code?} ·
+ *                 event{kind} · ping
+ *   relay → ext : ready · command{id,op,args} · pong · error{message}
+ */
+
+// ── Extension → relay ──────────────────────────────────────────
+
+const HelloMessageSchema = z.object({
+  type: z.literal('hello'),
+  pairingToken: z.string().min(1),
+})
+
+const ResultMessageSchema = z.object({
+  type: z.literal('result'),
+  id: z.string().min(1),
+  ok: z.boolean(),
+  data: z.unknown().optional(),
+  error: z.string().optional(),
+  /** BrowserBackendErrorCode-compatible short code (stopped, tab_closed, stale_ref …). */
+  code: z.string().optional(),
+})
+
+const EVENT_KINDS = ['stopped', 'tab_closed', 'detached'] as const
+
+const EventMessageSchema = z.object({
+  type: z.literal('event'),
+  kind: z.enum(EVENT_KINDS),
+})
+
+const PingMessageSchema = z.object({ type: z.literal('ping') })
+
+export const ExtensionMessageSchema = z.discriminatedUnion('type', [
+  HelloMessageSchema,
+  ResultMessageSchema,
+  EventMessageSchema,
+  PingMessageSchema,
+])
+type ExtensionMessage = z.infer<typeof ExtensionMessageSchema>
+
+// ── Relay → extension ──────────────────────────────────────────
+
+type ReadyMessage = { type: 'ready'; sessionToken?: string }
+type CommandMessage = { type: 'command'; id: string; op: string; args: Record<string, unknown> }
+type PongMessage = { type: 'pong' }
+type ErrorMessage = { type: 'error'; message: string }
+export type RelayToExtensionMessage = ReadyMessage | CommandMessage | PongMessage | ErrorMessage
+
+// ── Internal command API (api → relay) ─────────────────────────
+
+export const InternalCommandRequestSchema = z.object({
+  userId: z.string().min(1),
+  op: z.string().min(1),
+  args: z.record(z.unknown()).optional(),
+})
+type InternalCommandRequest = z.infer<typeof InternalCommandRequestSchema>
+
+/** The RelayCommandResult shape the api's transport port expects. */
+export type InternalCommandResponse =
+  | { ok: true; data?: unknown }
+  | { ok: false; error: string; code?: string }

--- a/apps/browser-relay/src/relay.ts
+++ b/apps/browser-relay/src/relay.ts
@@ -1,0 +1,274 @@
+import { randomUUID } from 'node:crypto'
+import type { WebSocket } from 'ws'
+import {
+  ExtensionMessageSchema,
+  type InternalCommandResponse,
+  type RelayToExtensionMessage,
+} from './protocol.js'
+
+/**
+ * The relay core (P1.3 verify + P1.4 registry/routing), transport-agnostic so
+ * tests can drive it with fake sockets. One process holds the whole
+ * `userId → connection` registry — the reason the Cloud Run service is
+ * single-instance (min=max=1), like the other connector apps.
+ */
+
+export type PairingVerifier = (
+  token: string,
+) => { kind?: 'browser-ext-pair' | 'browser-ext-session'; userId: string; workspaceId: string } | null
+
+/**
+ * Mints the longer-lived `browser-ext-session` token returned in
+ * `ready{sessionToken}` after a first-time pair-token hello, so reconnects
+ * never need a fresh pairing. Optional — absent, `ready` carries no token.
+ */
+export type SessionTokenMinter = (identity: { userId: string; workspaceId: string }) => string
+
+export type RelaySocket = Pick<WebSocket, 'send' | 'close'>
+
+type Pending = {
+  resolve: (res: InternalCommandResponse) => void
+  timer: NodeJS.Timeout
+}
+
+type Connection = {
+  socket: RelaySocket
+  userId: string
+  workspaceId: string
+  pending: Map<string, Pending>
+  lastSeenAt: number
+}
+
+const DEFAULT_COMMAND_TIMEOUT_MS = 30_000
+
+/** Connections silent past this are presumed dead and closed by the sweep. */
+export const LIVENESS_WINDOW_MS = 90_000
+
+/** Why the in-flight commands died, in the model's terms. */
+const EVENT_MESSAGES = {
+  stopped: 'The user stopped the task.',
+  tab_closed: 'The controlled tab was closed.',
+  detached:
+    'Chrome ended the debugging session for the tab, so the browser is no longer under control. ' +
+    'Retry the step: the user will be asked to allow the tab again. The website did not block this.',
+} as const
+
+const NO_EXTENSION_RESPONSE: InternalCommandResponse = {
+  ok: false,
+  error: 'No connected browser extension for this user.',
+  code: 'no_extension',
+}
+
+export class BrowserRelay {
+  private readonly byUser = new Map<string, Connection>()
+  private readonly bySocket = new Map<RelaySocket, Connection>()
+  private readonly verify: PairingVerifier
+  private readonly mintSessionToken: SessionTokenMinter | null
+  private readonly commandTimeoutMs: number
+
+  constructor(opts: {
+    verifyPairingToken: PairingVerifier
+    mintSessionToken?: SessionTokenMinter
+    commandTimeoutMs?: number
+  }) {
+    this.verify = opts.verifyPairingToken
+    this.mintSessionToken = opts.mintSessionToken ?? null
+    this.commandTimeoutMs = opts.commandTimeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS
+  }
+
+  private sendTo(socket: RelaySocket, message: RelayToExtensionMessage): void {
+    try {
+      socket.send(JSON.stringify(message))
+    } catch {
+      // A dying socket's close handler does the cleanup.
+    }
+  }
+
+  /** Number of live extension connections (health/status surface). */
+  connectionCount(): number {
+    return this.byUser.size
+  }
+
+  isConnected(userId: string): boolean {
+    return this.byUser.has(userId)
+  }
+
+  /**
+   * Handle one inbound WebSocket frame. The first frame must be a valid
+   * `hello` — anything else (or a bad token) gets `error` + close (4401).
+   */
+  handleMessage(socket: RelaySocket, raw: string | Buffer): void {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(typeof raw === 'string' ? raw : raw.toString('utf8'))
+    } catch {
+      this.sendTo(socket, { type: 'error', message: 'invalid JSON' })
+      socket.close(4400, 'invalid JSON')
+      return
+    }
+    const msg = ExtensionMessageSchema.safeParse(parsed)
+    if (!msg.success) {
+      this.sendTo(socket, { type: 'error', message: 'invalid envelope' })
+      socket.close(4400, 'invalid envelope')
+      return
+    }
+
+    const conn = this.bySocket.get(socket)
+
+    if (msg.data.type === 'hello') {
+      const identity = this.verify(msg.data.pairingToken)
+      if (!identity) {
+        this.sendTo(socket, { type: 'error', message: 'unauthorized' })
+        socket.close(4401, 'unauthorized')
+        return
+      }
+      // Latest pairing wins: replace any existing connection for this user.
+      const existing = this.byUser.get(identity.userId)
+      if (existing && existing.socket !== socket) {
+        this.rejectPending(existing, {
+          ok: false,
+          error: 'Extension connection was replaced by a newer pairing.',
+          code: 'no_extension',
+        })
+        this.bySocket.delete(existing.socket)
+        try {
+          existing.socket.close(4000, 'replaced')
+        } catch {
+          /* already gone */
+        }
+      }
+      const fresh: Connection = {
+        socket,
+        userId: identity.userId,
+        workspaceId: identity.workspaceId,
+        pending: conn?.pending ?? new Map(),
+        lastSeenAt: Date.now(),
+      }
+      this.byUser.set(identity.userId, fresh)
+      this.bySocket.set(socket, fresh)
+      // First-time pairing (short-lived pair token) → hand back a session
+      // token so reconnect + re-hello works after the pair token expires.
+      const sessionToken =
+        identity.kind !== 'browser-ext-session' && this.mintSessionToken
+          ? this.mintSessionToken({ userId: identity.userId, workspaceId: identity.workspaceId })
+          : undefined
+      this.sendTo(socket, sessionToken ? { type: 'ready', sessionToken } : { type: 'ready' })
+      return
+    }
+
+    // Every non-hello frame requires a bound connection.
+    if (!conn) {
+      this.sendTo(socket, { type: 'error', message: 'hello required' })
+      socket.close(4401, 'hello required')
+      return
+    }
+    conn.lastSeenAt = Date.now()
+
+    if (msg.data.type === 'ping') {
+      this.sendTo(socket, { type: 'pong' })
+      return
+    }
+
+    if (msg.data.type === 'result') {
+      const pending = conn.pending.get(msg.data.id)
+      if (!pending) return // late result after timeout — drop
+      conn.pending.delete(msg.data.id)
+      clearTimeout(pending.timer)
+      if (msg.data.ok) {
+        pending.resolve({ ok: true, data: msg.data.data })
+      } else {
+        pending.resolve({
+          ok: false,
+          error: msg.data.error ?? 'extension error',
+          code: msg.data.code,
+        })
+      }
+      return
+    }
+
+    if (msg.data.type === 'event') {
+      // stopped / tab_closed / detached abort everything in flight for this
+      // user (P1.7 close-to-stop; the extension itself refuses follow-up
+      // commands). Each carries its own message: they are different situations
+      // and a wrong one sends the model chasing the wrong cause.
+      this.rejectPending(conn, {
+        ok: false,
+        error: EVENT_MESSAGES[msg.data.kind],
+        code: msg.data.kind,
+      })
+    }
+  }
+
+  /** WebSocket close/error hook: clear registry + fail anything in flight. */
+  handleDisconnect(socket: RelaySocket): void {
+    const conn = this.bySocket.get(socket)
+    if (!conn) return
+    this.bySocket.delete(socket)
+    // Guard against the replaced-connection race: only unregister the user if
+    // this socket is still the registered one.
+    if (this.byUser.get(conn.userId)?.socket === socket) {
+      this.byUser.delete(conn.userId)
+    }
+    this.rejectPending(conn, {
+      ok: false,
+      error: 'The browser extension disconnected.',
+      code: 'no_extension',
+    })
+  }
+
+  /**
+   * Route one command to the user's extension and await its `result`
+   * (P1.4). Missing connection → the clear no-extension error, immediately —
+   * never a hang. Timeout → `{ok:false, code:'timeout'}`.
+   */
+  async dispatchCommand(params: {
+    userId: string
+    op: string
+    args?: Record<string, unknown>
+    timeoutMs?: number
+  }): Promise<InternalCommandResponse> {
+    const conn = this.byUser.get(params.userId)
+    if (!conn) return NO_EXTENSION_RESPONSE
+
+    const id = randomUUID()
+    const timeoutMs = params.timeoutMs ?? this.commandTimeoutMs
+
+    return new Promise<InternalCommandResponse>((resolve) => {
+      const timer = setTimeout(() => {
+        conn.pending.delete(id)
+        resolve({
+          ok: false,
+          error: `The extension did not answer within ${Math.round(timeoutMs / 1000)}s.`,
+          code: 'timeout',
+        })
+      }, timeoutMs)
+      conn.pending.set(id, { resolve, timer })
+      this.sendTo(conn.socket, { type: 'command', id, op: params.op, args: params.args ?? {} })
+    })
+  }
+
+  /** Close connections that have gone silent past the liveness window. */
+  sweepDead(now = Date.now()): number {
+    let closed = 0
+    for (const conn of [...this.byUser.values()]) {
+      if (now - conn.lastSeenAt > LIVENESS_WINDOW_MS) {
+        closed += 1
+        try {
+          conn.socket.close(4002, 'liveness timeout')
+        } catch {
+          /* already gone */
+        }
+        this.handleDisconnect(conn.socket)
+      }
+    }
+    return closed
+  }
+
+  private rejectPending(conn: Connection, response: InternalCommandResponse): void {
+    for (const [, pending] of conn.pending) {
+      clearTimeout(pending.timer)
+      pending.resolve(response)
+    }
+    conn.pending.clear()
+  }
+}

--- a/apps/browser-relay/tsconfig.json
+++ b/apps/browser-relay/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/core/src/sandbox/__tests__/browser-provider.test.ts
+++ b/packages/core/src/sandbox/__tests__/browser-provider.test.ts
@@ -137,6 +137,19 @@ describe('[COMP:sandbox/local-browser] LocalBrowserProvider', () => {
     }
   })
 
+  it('preserves Firefox setup failures so the user gets the right remedy', async () => {
+    for (const code of [
+      'firefox_companion_missing',
+      'firefox_restart_required',
+      'unsupported_browser',
+    ] as const) {
+      const { transport } = transportRecording(() => ({ ok: false, error: `nope: ${code}`, code }))
+      const provider = createLocalBrowserProvider({ transport })
+      const err = await provider.snapshot(CTX).catch((e: unknown) => e)
+      expect((err as BrowserBackendError).code).toBe(code)
+    }
+  })
+
   it('rejects a malformed snapshot payload at the zod boundary', async () => {
     const { transport } = transportRecording(() => ({ ok: true, data: { nodes: 'nope' } }))
     const provider = createLocalBrowserProvider({ transport })

--- a/packages/core/src/sandbox/__tests__/computer-tools.test.ts
+++ b/packages/core/src/sandbox/__tests__/computer-tools.test.ts
@@ -383,10 +383,11 @@ describe('[COMP:sandbox/browser-tools] Computer tool surface', () => {
   })
 
   describe('safety fuse (P1.8)', () => {
-    it('caps per-session browser calls', async () => {
+    it('caps per-session cloud browser calls', async () => {
       const tools = createComputerTools({
         local: fakeProvider('local'),
         cloud: fakeProvider('cloud'),
+        cloudAvailable: () => true,
         fuse: { maxCallsPerSession: 2 },
       })
       const ctx = toolContext()
@@ -397,11 +398,12 @@ describe('[COMP:sandbox/browser-tools] Computer tool surface', () => {
       expect(String(res.data)).toContain('safety cap')
     })
 
-    it('caps per-session wall clock', async () => {
+    it('caps per-session cloud wall clock', async () => {
       let t = 1_000_000
       const tools = createComputerTools({
         local: fakeProvider('local'),
         cloud: fakeProvider('cloud'),
+        cloudAvailable: () => true,
         fuse: { maxWallMsPerSession: 60_000 },
         now: () => t,
       })
@@ -418,6 +420,7 @@ describe('[COMP:sandbox/browser-tools] Computer tool surface', () => {
       const tools = createComputerTools({
         local: fakeProvider('local'),
         cloud: fakeProvider('cloud'),
+        cloudAvailable: () => true,
         fuse: { maxCallsPerSession: 2, maxWallMsPerSession: 60_000, idleResetMs: 120_000 },
         now: () => t,
       })
@@ -435,6 +438,27 @@ describe('[COMP:sandbox/browser-tools] Computer tool surface', () => {
       t += 59_000
       const withinWall = await run(tools.browserCurrentUrl, {}, ctx)
       expect(withinWall.isError ?? false).toBe(false)
+    })
+
+    it('does not cap the watched local browser even when cloud is available', async () => {
+      let t = 1_000_000
+      const local = fakeProvider('local')
+      const tools = createComputerTools({
+        local,
+        cloud: fakeProvider('cloud'),
+        cloudAvailable: () => true,
+        fuse: { maxCallsPerSession: 1, maxWallMsPerSession: 1 },
+        now: () => t,
+      })
+      const ctx = toolContext()
+      tools.setSessionBackendOverride(ctx.sessionId, 'local')
+      await run(tools.browserSnapshot, {}, ctx)
+      t += 60_000
+      const second = await run(tools.browserCurrentUrl, {}, ctx)
+      const third = await run(tools.browserSnapshot, {}, ctx)
+      expect(second.isError ?? false).toBe(false)
+      expect(third.isError ?? false).toBe(false)
+      expect(local.calls).toEqual(['snapshot', 'currentUrl', 'snapshot'])
     })
   })
 

--- a/packages/core/src/sandbox/local-browser-provider.ts
+++ b/packages/core/src/sandbox/local-browser-provider.ts
@@ -29,6 +29,9 @@ const KNOWN_ERROR_CODES: ReadonlySet<string> = new Set([
   'detached',
   'consent_denied',
   'no_eligible_tab',
+  'firefox_companion_missing',
+  'firefox_restart_required',
+  'unsupported_browser',
   'stale_ref',
   'backend_error',
 ])

--- a/packages/core/src/sandbox/tools.ts
+++ b/packages/core/src/sandbox/tools.ts
@@ -397,7 +397,7 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
     }
   }
 
-  /** Shared pre-execution gates. Returns an error result or the live state. */
+  /** Shared policy gates. Backend-specific resource fusing runs after routing. */
   async function gates(
     toolName: string,
     context: ToolContext,
@@ -406,12 +406,17 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
     if (autonomous) return { error: autonomous }
     const blocked = await policyBlockGate(toolName, context)
     if (blocked) return { error: blocked }
-    const state = sessionState(context)
+    return { state: sessionState(context) }
+  }
+
+  /** The action/wall-clock fuse protects cloud work; watched local browsing is exempt. */
+  function backendFuseGate(state: SessionBrowseState, backend: BrowserBackendKind): ToolResult | null {
+    if (backend === 'local') return null
     const fused = fuseGate(state)
-    if (fused) return { error: fused }
+    if (fused) return fused
     state.calls += 1
     state.lastCallAt = now()
-    return { state }
+    return null
   }
 
   function backendErrorResult(err: unknown, backend?: BrowserBackendKind): ToolResult {
@@ -615,6 +620,8 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
       gate.state.profileName = profile?.name ?? null
       const backend = resolveBackend(gate.state, profile)
       gate.state.backend = backend
+      const fused = backendFuseGate(gate.state, backend)
+      if (fused) return fused
       gate.state.refLabels.clear()
       try {
         const res = await providerFor(backend).navigate(callCtx(context, gate.state), input.url)
@@ -709,6 +716,8 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
       const gate = await gates('browserSnapshot', context)
       if ('error' in gate) return gate.error
       const backend = gate.state.backend
+      const fused = backendFuseGate(gate.state, backend)
+      if (fused) return fused
       try {
         const snapshot = await providerFor(backend).snapshot(callCtx(context, gate.state))
         gate.state.refLabels = new Map(snapshot.nodes.map((n) => [n.ref, n.name]))
@@ -788,6 +797,8 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
       const gate = await gates('browserClick', context)
       if ('error' in gate) return gate.error
       const backend = gate.state.backend
+      const fused = backendFuseGate(gate.state, backend)
+      if (fused) return fused
       try {
         await providerFor(backend).click(callCtx(context, gate.state), input.ref)
         emit({ type: 'browser_action', op: 'click', backend, host: null, ok: true }, context)
@@ -838,6 +849,8 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
       const gate = await gates('browserType', context)
       if ('error' in gate) return gate.error
       const backend = gate.state.backend
+      const fused = backendFuseGate(gate.state, backend)
+      if (fused) return fused
       try {
         await providerFor(backend).type(callCtx(context, gate.state), input.ref, input.text)
         gate.state.lastTyped = input.text
@@ -879,6 +892,8 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
       const gate = await gates('browserCurrentUrl', context)
       if ('error' in gate) return gate.error
       const backend = gate.state.backend
+      const fused = backendFuseGate(gate.state, backend)
+      if (fused) return fused
       try {
         const res = await providerFor(backend).currentUrl(callCtx(context, gate.state))
         const data = `URL: ${res.url}\nTitle: ${res.title || '(untitled)'}`
@@ -992,6 +1007,8 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
       // lets backendErrorResult apply the same connection-block posture (§5) a
       // hard edge reject gets on the interactive tools.
       const backend: BrowserBackendKind = 'cloud'
+      const fused = backendFuseGate(gate.state, backend)
+      if (fused) return fused
       // Identity-less on purpose: no profile resolution, no profileId in the
       // call context — a worker read never initiates a vault injection.
       const ctx: BrowserCallContext = {

--- a/packages/core/src/sandbox/types.ts
+++ b/packages/core/src/sandbox/types.ts
@@ -71,6 +71,9 @@ export type BrowserBackendErrorCode =
   | 'detached'       // Chrome ended the CDP session (banner cancelled, DevTools, crash)
   | 'consent_denied' // the user declined the extension's per-tab Allow prompt
   | 'no_eligible_tab' // the active tab is one Chrome will not attach the debugger to
+  | 'firefox_companion_missing' // Firefox extension cannot reach the installed desktop host
+  | 'firefox_restart_required' // Firefox was not started with its loopback Remote Agent
+  | 'unsupported_browser' // local browser control is unavailable on this platform
   | 'stale_ref'      // ref is not from the latest snapshot
   | 'backend_error'  // anything else the backend reported
 
@@ -91,7 +94,7 @@ export class BrowserBackendError extends Error {
  * never a hang, and that does not require discarding the reason.
  */
 export const NO_EXTENSION_REMEDY =
-  'Ask the user to open Chrome with the Use Brian extension installed and enabled (and signed in), then retry.'
+  'Ask the user to open a supported browser with the Use Brian extension installed and enabled, then retry.'
 
 /** The P1.4 contract: a missing extension is a clear instruction, never a hang. */
 export const NO_EXTENSION_MESSAGE = `No Use Brian browser extension is connected. ${NO_EXTENSION_REMEDY}`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,10 +60,16 @@ importers:
       zod:
         specifier: ^3.24
         version: 3.25.76
+      ws:
+        specifier: ^8.18.0
+        version: 8.21.0
     devDependencies:
       '@types/node':
         specifier: ^20.19.39
         version: 20.19.43
+      '@types/ws':
+        specifier: ^8.5.13
+        version: 8.18.1
       electron:
         specifier: ^43.2.0
         version: 43.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,12 +57,12 @@ importers:
       electron-updater:
         specifier: ^6.8.9
         version: 6.8.9
-      zod:
-        specifier: ^3.24
-        version: 3.25.76
       ws:
         specifier: ^8.18.0
         version: 8.21.0
+      zod:
+        specifier: ^3.24
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^20.19.39
@@ -269,6 +269,40 @@ importers:
       '@types/node':
         specifier: ^20.19.39
         version: 20.19.43
+      typescript:
+        specifier: ^5.7
+        version: 5.9.3
+      vitest:
+        specifier: ^3
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@20.19.43)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(tsx@4.22.4)
+
+  apps/browser-relay:
+    dependencies:
+      '@use-brian/api':
+        specifier: workspace:*
+        version: link:../../packages/api
+      express:
+        specifier: ^5
+        version: 5.2.1
+      ws:
+        specifier: ^8.18.0
+        version: 8.21.0
+      zod:
+        specifier: ^3.24
+        version: 3.25.76
+    devDependencies:
+      '@types/express':
+        specifier: ^5
+        version: 5.0.6
+      '@types/node':
+        specifier: ^20.19.39
+        version: 20.19.43
+      '@types/ws':
+        specifier: ^8.5.13
+        version: 8.18.1
+      tsx:
+        specifier: ^4
+        version: 4.22.4
       typescript:
         specifier: ^5.7
         version: 5.9.3
@@ -5151,10 +5185,6 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
-    engines: {node: '>=0.10.0'}
-
-  iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.3:
@@ -10839,7 +10869,7 @@ snapshots:
       content-type: 2.0.0
       debug: 4.4.3
       http-errors: 2.0.1
-      iconv-lite: 0.7.2
+      iconv-lite: 0.7.3
       on-finished: 2.4.1
       qs: 6.15.2
       raw-body: 3.0.2
@@ -12884,10 +12914,6 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  iconv-lite@0.7.2:
-    dependencies:
-      safer-buffer: 2.1.2
-
   iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -14777,7 +14803,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       http-errors: 2.0.1
-      iconv-lite: 0.7.2
+      iconv-lite: 0.7.3
       unpipe: 1.0.0
 
   react-dom@19.2.4(react@19.2.4):


### PR DESCRIPTION
## Summary
- add Firefox native-messaging and loopback WebDriver BiDi support to the existing desktop companion
- add a Firefox extension build with the same pairing, consent, fixed operations, and narrow permissions as My Browser
- move the browser relay into OSS so self-hosted deployments build and run it from the public workspace
- select consent targets from the last-focused normal browser window, never extension or consent popups
- allow Firefox empty/new tabs as navigation launch surfaces while keeping privileged settings pages blocked
- discover current Linux Firefox profiles across XDG, legacy, Nix, and custom profile locations
- expose My Browser pairing settings in OSS deployments without hosted plan gates
- keep the browser action/wall-clock safety fuse on cloud browsing while exempting watched local Chrome and Firefox

## Testing
- `pnpm --filter @use-brian/app-desktop typecheck`
- `pnpm --filter @use-brian/app-desktop test` (288 tests)
- `pnpm --filter @use-brian/browser-extension test` (79 tests)
- `pnpm --filter @use-brian/browser-extension build:firefox`
- `pnpm --filter @use-brian/browser-relay typecheck`
- `pnpm --filter @use-brian/browser-relay test` (17 tests)
- `pnpm --filter @use-brian/browser-relay build`
- `pnpm --filter @use-brian/core test` (4,191 passed, 20 skipped)
- focused app-web My Browser settings tests (8 tests)

App-web production build succeeds in the self-hosted deployment. The earlier local standalone typecheck was affected only by stale ignored `.next/dev` route declarations.