### PR TITLE
fix(browser): improve Firefox session recovery

### DIFF
--- a/apps/app-desktop/src/main.ts
+++ b/apps/app-desktop/src/main.ts
@@ -420,7 +420,9 @@ function createWindow(): BrowserWindow {
     // deferred — see docs/architecture/features/app-desktop.md → "Windows (v1 frame)".
     ...(process.platform === "darwin" ? { titleBarStyle: "hiddenInset" as const } : {}),
     backgroundColor: "#ffffff",
-    show: false,
+    // A remote page can stall before ready-to-show, which otherwise leaves the
+    // tray process alive with no window for the user to recover.
+    show: true,
     webPreferences: {
       preload: PRELOAD_PATH,
       contextIsolation: true,

--- a/apps/app-web/src/app/w/[workspaceId]/computer/page.tsx
+++ b/apps/app-web/src/app/w/[workspaceId]/computer/page.tsx
@@ -2,18 +2,44 @@
 
 /**
  * Browsers surface index (`/w/[id]/computer`) — the full-width prompt shown
- * when no session is selected. The live-session list (owned by the left
- * sidebar's `BrowsersSidebarPanel`) picks a session; a row routes to
- * `/computer/<sessionId>`, which fills this pane with the Take-Over view.
+ * when no session is selected and no task is live. If a task is available,
+ * opening the Browsers app routes directly to the most recently active live
+ * session; the sidebar still lets the user switch between multiple sessions.
  *
  * [COMP:app-web/browsers-surface]
  */
 
+import { use as usePromise, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { MonitorPlay } from "lucide-react";
 import { useT } from "@/lib/i18n/client";
+import {
+  listActiveComputerTasks,
+  mostRecentComputerTask,
+} from "@/lib/api/computer";
 
-export default function BrowsersIndexPage() {
+export default function BrowsersIndexPage(props: {
+  params: Promise<{ workspaceId: string }>;
+}) {
+  const { workspaceId } = usePromise(props.params);
+  const router = useRouter();
   const t = useT().computer.sessions;
+
+  useEffect(() => {
+    let cancelled = false;
+    void listActiveComputerTasks(workspaceId).then((tasks) => {
+      const task = mostRecentComputerTask(tasks);
+      if (!cancelled && task) {
+        router.replace(
+          `/w/${workspaceId}/computer/${encodeURIComponent(task.sessionId)}`,
+        );
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [router, workspaceId]);
+
   return (
     <div className="flex h-full flex-col items-center justify-center gap-3 p-8 text-center">
       <MonitorPlay className="size-8 text-muted-foreground/50" aria-hidden />

--- a/apps/app-web/src/app/w/[workspaceId]/computer/page.tsx
+++ b/apps/app-web/src/app/w/[workspaceId]/computer/page.tsx
@@ -18,6 +18,8 @@ import {
   mostRecentComputerTask,
 } from "@/lib/api/computer";
 
+const POLL_MS = 2_000;
+
 export default function BrowsersIndexPage(props: {
   params: Promise<{ workspaceId: string }>;
 }) {
@@ -27,16 +29,22 @@ export default function BrowsersIndexPage(props: {
 
   useEffect(() => {
     let cancelled = false;
-    void listActiveComputerTasks(workspaceId).then((tasks) => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const probe = async () => {
+      const tasks = await listActiveComputerTasks(workspaceId);
       const task = mostRecentComputerTask(tasks);
       if (!cancelled && task) {
         router.replace(
           `/w/${workspaceId}/computer/${encodeURIComponent(task.sessionId)}`,
         );
+        return;
       }
-    });
+      if (!cancelled) timer = setTimeout(() => void probe(), POLL_MS);
+    };
+    void probe();
     return () => {
       cancelled = true;
+      if (timer) clearTimeout(timer);
     };
   }, [router, workspaceId]);
 

--- a/apps/app-web/src/lib/api/__tests__/computer.test.ts
+++ b/apps/app-web/src/lib/api/__tests__/computer.test.ts
@@ -17,6 +17,7 @@ import {
   getComputerFrame,
   getComputerTask,
   listBrowserProfiles,
+  mostRecentComputerTask,
   markComputerSessionCaptured,
   resumeComputerTask,
   revokeProfileSession,
@@ -38,6 +39,23 @@ function respond(status: number, body?: unknown) {
 beforeEach(() => {
   vi.clearAllMocks()
   mockFetch.mockResolvedValue(respond(200, {}))
+})
+
+describe('[COMP:app-web/browsers-surface] Browsers index task selection', () => {
+  it('opens the most recently active running or paused task', () => {
+    const base = {
+      profileId: null,
+      injectedSite: null,
+      createdAt: 1,
+    }
+    expect(
+      mostRecentComputerTask([
+        { ...base, taskId: 't1', sessionId: 's1', status: 'running', lastActivityAt: 10 },
+        { ...base, taskId: 't2', sessionId: 's2', status: 'paused', lastActivityAt: 20 },
+      ])?.sessionId,
+    ).toBe('s2')
+    expect(mostRecentComputerTask([])).toBeNull()
+  })
 })
 
 describe('[COMP:app-web/sandbox-takeover] Take-Over live view SDK', () => {

--- a/apps/app-web/src/lib/api/computer.ts
+++ b/apps/app-web/src/lib/api/computer.ts
@@ -96,6 +96,17 @@ export type ComputerTaskSummary = {
   lastActivityAt: number;
 };
 
+/** Task the Browsers index should open when no session was selected explicitly. */
+export function mostRecentComputerTask(
+  tasks: ComputerTaskSummary[],
+): ComputerTaskSummary | null {
+  return tasks.reduce<ComputerTaskSummary | null>(
+    (latest, task) =>
+      !latest || task.lastActivityAt > latest.lastActivityAt ? task : latest,
+    null,
+  );
+}
+
 /**
  * The caller's live browser tasks in a workspace — the discovery surface the
  * shell pill polls. Empty array on any failure: discovery chrome must never

--- a/apps/browser-extension/CLAUDE.md
+++ b/apps/browser-extension/CLAUDE.md
@@ -13,7 +13,7 @@ browser-relay (`apps/browser-relay`); the app-web connect surface is
 - `relay-client.ts` — the one WebSocket to the relay (`hello` / command / result / event).
 - `executor.ts` — the discrete browser ops against the one allowed tab, via `chrome.debugger` (CDP) only.
 - `task-gate.ts` — per-task consent + single-tab scope + persistent Stop (`[COMP:ext/agent]`).
-- `tab-eligibility.ts` — which tabs CDP can attach to; consent selects the active tab from the last-focused normal browser window (never an extension popup), and an unattachable page raises `no_eligible_tab`, never `consent_denied`.
+- `tab-eligibility.ts` — which tabs can be controlled; consent selects the active tab from the last-focused normal browser window (never an extension popup), Firefox alone may use `about:blank`/`about:home`/`about:newtab` as a navigation launch surface, and an unattachable page raises `no_eligible_tab`, never `consent_denied`.
 - `pairing.ts` — the credential transition behind every Connect, plus the `externally_connectable` sender check (`[COMP:ext/pairing]`).
 - `snapshot.ts` — CDP accessibility tree into the shared snapshot shape.
 - `popup.ts` / `popup-status.ts` / `allow.ts` — the pairing popup, its status wording, and the per-task allow prompt.

--- a/apps/browser-extension/src/__tests__/tab-eligibility.test.ts
+++ b/apps/browser-extension/src/__tests__/tab-eligibility.test.ts
@@ -49,6 +49,17 @@ describe('[COMP:ext/agent] Controllable-tab eligibility', () => {
     }
   })
 
+  it('allows only Firefox empty/new-tab launch pages when explicitly requested', () => {
+    for (const url of ['about:blank', 'about:home', 'about:newtab']) {
+      expect(eligibilityOf(url, { allowFirefoxNewTab: true }), url).toEqual({ eligible: true })
+      expect(eligibilityOf(url), url).toEqual({ eligible: false, reason: 'restricted_url' })
+    }
+    expect(eligibilityOf('about:config', { allowFirefoxNewTab: true })).toEqual({
+      eligible: false,
+      reason: 'restricted_url',
+    })
+  })
+
   it('rejects extension pages, including our own popup and allow window', () => {
     // Prod logged 10x "Cannot access a chrome-extension:// URL" AFTER consent:
     // these passed the old chrome://-only check, then died inside CDP with an

--- a/apps/browser-extension/src/firefox-background.ts
+++ b/apps/browser-extension/src/firefox-background.ts
@@ -21,7 +21,7 @@ function hostOf(url: string): string {
 
 async function promptForConsent(): Promise<ConsentOutcome> {
   const activeTab = await activeTabForConsent((options) => ext.windows.getLastFocused(options))
-  const eligibility = eligibilityOf(activeTab?.url)
+  const eligibility = eligibilityOf(activeTab?.url, { allowFirefoxNewTab: true })
   if (!eligibility.eligible) return { allowed: false, reason: eligibility.reason }
   if (activeTab?.id == null) return { allowed: false, reason: 'no_active_tab' }
   const targetTabId = activeTab.id

--- a/apps/browser-extension/src/tab-eligibility.ts
+++ b/apps/browser-extension/src/tab-eligibility.ts
@@ -18,6 +18,9 @@
 type TabIneligibility = 'restricted_url' | 'no_active_tab'
 
 export type TabEligibility = { eligible: true } | { eligible: false; reason: TabIneligibility }
+export type TabEligibilityOptions = { allowFirefoxNewTab?: boolean }
+
+const FIREFOX_NEW_TAB_URLS = new Set(['about:blank', 'about:home', 'about:newtab'])
 
 /**
  * Resolve consent against a normal browser window, never an extension popup.
@@ -54,11 +57,20 @@ const RESTRICTED_SCHEMES = [
 /** Chrome protects the Web Store from extensions, the debugger included. */
 const RESTRICTED_HOSTS = new Set(['chromewebstore.google.com', 'chrome.google.com'])
 
-export function eligibilityOf(url: string | null | undefined): TabEligibility {
+export function eligibilityOf(
+  url: string | null | undefined,
+  options: TabEligibilityOptions = {},
+): TabEligibility {
   const trimmed = (url ?? '').trim()
   if (!trimmed) return { eligible: false, reason: 'no_active_tab' }
 
   const lower = trimmed.toLowerCase()
+  // Firefox's native BiDi companion can navigate an empty/new-tab context to
+  // an ordinary website. Chromium still uses its stricter debugger posture,
+  // and every other privileged Firefox about: page remains blocked.
+  if (options.allowFirefoxNewTab && FIREFOX_NEW_TAB_URLS.has(lower)) {
+    return { eligible: true }
+  }
   // Prefix-match the raw string rather than parsing: a scheme is only blocked
   // when the page IS one, never when a query parameter merely mentions one.
   if (RESTRICTED_SCHEMES.some((scheme) => lower.startsWith(scheme))) {


### PR DESCRIPTION
## Summary
- allow Firefox new-tab navigation and keep stalled remote windows recoverable
- reopen the most recent active browser session from the Browsers surface
- discover browser sessions that become active after the page mounts