### PR TITLE
feat(skills): suggest groups for a library that grew faster than anyone filed it

### DIFF
--- a/apps/app-web/src/app/w/[workspaceId]/brain/page.tsx
+++ b/apps/app-web/src/app/w/[workspaceId]/brain/page.tsx
@@ -63,7 +63,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { ArrowDownToLine, Plus } from "lucide-react";
+import { ArrowDownToLine, Plus, Sparkles } from "lucide-react";
 import { useWorkspaces } from "@/contexts/workspace-context";
 import { useT, format } from "@/lib/i18n/client";
 import { cn } from "@/lib/utils";
@@ -126,6 +126,7 @@ import {
   type SkillImportPrefill,
 } from "@/components/brain/skill-creator";
 import { SkillImportDialog } from "@/components/brain/skill-import-dialog";
+import { SkillGroupsDialog } from "@/components/brain/skill-groups-dialog";
 import { BlueprintsLibrary } from "@/components/brain/blueprints-library";
 import { ProvenanceProvider, useProvenanceState } from "@/components/provenance/provenance-context";
 import { ProvenanceSheet } from "@/components/provenance/provenance-sheet";
@@ -238,6 +239,8 @@ function BrainPageInner() {
   // draft is held here and handed to the creator via `initialImport`; the
   // seq keys the creator so a fresh import re-seeds its mount state.
   const [importOpen, setImportOpen] = useState(false);
+  // Bulk group suggestion (skill-system.md → "Suggesting groups").
+  const [groupsOpen, setGroupsOpen] = useState(false);
   const [importPrefill, setImportPrefill] = useState<SkillImportPrefill | null>(null);
   const [importSeq, setImportSeq] = useState(0);
   const [selectedSkill, setSelectedSkill] = useState<WorkspaceSkillSummary | null>(
@@ -689,6 +692,14 @@ function BrainPageInner() {
         )}
         <button
           type="button"
+          onClick={() => setGroupsOpen(true)}
+          className="inline-flex h-7 items-center gap-1 rounded-md border border-border px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <Sparkles className="size-3.5" aria-hidden />
+          {t.brainPage.skillGroups.cta}
+        </button>
+        <button
+          type="button"
           onClick={() => setImportOpen(true)}
           className="inline-flex h-7 items-center gap-1 rounded-md border border-border px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
         >
@@ -735,6 +746,14 @@ function BrainPageInner() {
       />
 
       {activeId && (
+        <>
+        <SkillGroupsDialog
+          workspaceId={activeId}
+          open={groupsOpen}
+          onClose={() => setGroupsOpen(false)}
+          skills={skills ?? []}
+          onApplied={() => requestBrainRefresh(activeId)}
+        />
         <SkillImportDialog
           workspaceId={activeId}
           open={importOpen}
@@ -746,6 +765,7 @@ function BrainPageInner() {
             openSkillCreator();
           }}
         />
+        </>
       )}
 
       {/* Mobile-only inline controls — the section switch + entry filters

--- a/apps/app-web/src/components/brain/skill-groups-dialog.tsx
+++ b/apps/app-web/src/components/brain/skill-groups-dialog.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+/**
+ * Suggest groups — the bulk review pass over a library that accumulated
+ * skills faster than anyone filed them.
+ *
+ * A workspace that has been running a while has dozens of skills, its own
+ * plus everything the background curator induced, and every one of them sits
+ * in the `custom` sink because nothing set `category` before the editor
+ * picker existed. Re-filing them one editor visit at a time is the friction
+ * this removes.
+ *
+ * Three stages, and the middle one is the point:
+ *
+ *   intent  — states how many skills are unsorted and asks before spending
+ *             anything. The count is a free client-side read of the list the
+ *             page already has, so the cost is named before it is incurred
+ *             (the pre-flight-confirm invariant).
+ *   review  — every proposed move as a checked row, grouped by target, each
+ *             with a per-row override. The model is guessing a bucket from a
+ *             name and a description; nothing here is applied unchecked.
+ *   done    — how many moved, and anything that did not.
+ *
+ * Applying sends ONLY `category` per skill, which is metadata — so a bulk
+ * re-file does not carry the D2 edit-is-confirm stamp and cannot silently
+ * verify and activate every Suggested skill it touches.
+ *
+ * Spec: docs/architecture/engine/skill-system.md → "Suggesting groups".
+ *
+ * [COMP:app-web/brain-skill-groups]
+ */
+
+import * as React from "react";
+import { Dialog } from "@base-ui/react/dialog";
+import { Check, Loader2, Sparkles } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useT, format } from "@/lib/i18n/client";
+import { Button } from "@/components/ui/button";
+import { SearchableSelect } from "@/components/ui/searchable-select";
+import {
+  applySkillGroups,
+  suggestSkillGroups,
+  type SkillGroupSuggestion,
+  type WorkspaceSkillSummary,
+} from "@/lib/api/skills";
+import {
+  skillCategoryOf,
+  SKILL_CATEGORIES,
+  type SkillCategory,
+} from "@/lib/skills-view";
+
+type Props = {
+  workspaceId: string;
+  open: boolean;
+  onClose: () => void;
+  /** The library's current rows — the unsorted count comes from these, so the
+   *  intent stage costs nothing. */
+  skills: WorkspaceSkillSummary[];
+  /** Fired after a successful apply so the page refetches. */
+  onApplied: () => void;
+};
+
+type Row = SkillGroupSuggestion & { chosen: SkillCategory; checked: boolean };
+
+export function SkillGroupsDialog({
+  workspaceId,
+  open,
+  onClose,
+  skills,
+  onApplied,
+}: Props) {
+  const t = useT();
+  const copy = t.brainPage.skillGroups;
+  const categoryCopy = t.brainPage.skillsLibrary.categories;
+
+  const [busy, setBusy] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [rows, setRows] = React.useState<Row[] | null>(null);
+  const [applied, setApplied] = React.useState<{ updated: number; failed: number } | null>(null);
+
+  const unsorted = React.useMemo(
+    () => skills.filter((s) => skillCategoryOf(s) === "custom").length,
+    [skills],
+  );
+
+  // Reopening starts clean — a stale review list would apply decisions the
+  // user made against a library that has since moved.
+  React.useEffect(() => {
+    if (!open) {
+      setBusy(false);
+      setError(null);
+      setRows(null);
+      setApplied(null);
+    }
+  }, [open]);
+
+  async function runSuggest() {
+    setBusy(true);
+    setError(null);
+    const res = await suggestSkillGroups(workspaceId);
+    setBusy(false);
+    if (!res.ok) {
+      setError(res.error);
+      return;
+    }
+    setRows(
+      res.suggestions.map((s) => ({
+        ...s,
+        chosen: (s.suggested as SkillCategory) ?? "custom",
+        checked: true,
+      })),
+    );
+  }
+
+  async function apply() {
+    if (!rows) return;
+    const assignments = rows
+      .filter((r) => r.checked)
+      .map((r) => ({ skillRowId: r.skillRowId, category: r.chosen }));
+    if (assignments.length === 0) return;
+
+    setBusy(true);
+    setError(null);
+    const res = await applySkillGroups(workspaceId, assignments);
+    setBusy(false);
+    if (!res.ok) {
+      setError(res.error);
+      return;
+    }
+    setApplied({ updated: res.updated, failed: res.failed.length });
+    onApplied();
+  }
+
+  const checkedCount = rows?.filter((r) => r.checked).length ?? 0;
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(next) => !next && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/40 backdrop-blur-[1px]" />
+        <Dialog.Popup className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[min(46rem,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-xl border border-border bg-background p-5 shadow-xl">
+          <Dialog.Title className="text-sm font-semibold text-foreground">
+            {copy.title}
+          </Dialog.Title>
+
+          {/* ── Done ── */}
+          {applied ? (
+            <div className="mt-4">
+              <p className="text-sm text-foreground">
+                {format(copy.appliedBody, { count: applied.updated })}
+              </p>
+              {applied.failed > 0 && (
+                <p className="mt-1.5 text-xs text-muted-foreground">
+                  {format(copy.appliedFailed, { count: applied.failed })}
+                </p>
+              )}
+              <div className="mt-6 flex justify-end">
+                <Button variant="default" size="sm" onClick={onClose}>
+                  {copy.done}
+                </Button>
+              </div>
+            </div>
+          ) : rows === null ? (
+            /* ── Intent: name the scope before spending anything ── */
+            <div className="mt-4">
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                {unsorted === 0
+                  ? copy.nothingToGroup
+                  : format(copy.intentBody, { count: unsorted })}
+              </p>
+              {unsorted > 0 && (
+                <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                  {copy.intentHint}
+                </p>
+              )}
+              {error && (
+                <p role="alert" className="mt-3 text-xs leading-relaxed text-red-500">
+                  {error}
+                </p>
+              )}
+              <div className="mt-6 flex justify-end gap-2">
+                <Button variant="outline" size="sm" onClick={onClose}>
+                  {copy.cancel}
+                </Button>
+                {unsorted > 0 && (
+                  <Button variant="default" size="sm" disabled={busy} onClick={() => void runSuggest()}>
+                    {busy ? (
+                      <>
+                        <Loader2 className="size-3.5 animate-spin" aria-hidden />
+                        {copy.suggesting}
+                      </>
+                    ) : (
+                      <>
+                        <Sparkles className="size-3.5" aria-hidden />
+                        {copy.suggestCta}
+                      </>
+                    )}
+                  </Button>
+                )}
+              </div>
+            </div>
+          ) : rows.length === 0 ? (
+            /* The model looked and left everything where it was — a real
+               answer, not an error. */
+            <div className="mt-4">
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                {copy.noSuggestions}
+              </p>
+              <div className="mt-6 flex justify-end">
+                <Button variant="outline" size="sm" onClick={onClose}>
+                  {copy.close}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            /* ── Review ── */
+            <>
+              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                {format(copy.reviewBody, { count: rows.length })}
+              </p>
+
+              <ul className="mt-4 min-h-0 flex-1 overflow-y-auto">
+                {rows.map((row, i) => (
+                  <li
+                    key={row.skillRowId}
+                    className="flex items-center gap-3 border-b border-border py-2.5 last:border-b-0"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={row.checked}
+                      aria-label={format(copy.includeAria, { name: row.name })}
+                      onChange={(e) => {
+                        const next = [...rows];
+                        next[i] = { ...row, checked: e.target.checked };
+                        setRows(next);
+                      }}
+                      className="size-4 shrink-0 accent-primary"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p
+                        className={cn(
+                          "truncate text-sm",
+                          row.checked ? "text-foreground" : "text-muted-foreground line-through",
+                        )}
+                      >
+                        {row.name}
+                      </p>
+                      {row.rationale && (
+                        <p className="truncate text-xs text-muted-foreground">{row.rationale}</p>
+                      )}
+                    </div>
+                    <div className="w-40 shrink-0">
+                      <SearchableSelect
+                        value={row.chosen}
+                        onValueChange={(next) => {
+                          const updated = [...rows];
+                          updated[i] = {
+                            ...row,
+                            chosen: (next || "custom") as SkillCategory,
+                          };
+                          setRows(updated);
+                        }}
+                        items={SKILL_CATEGORIES.map((value) => ({
+                          value,
+                          label: categoryCopy[value],
+                        }))}
+                        placeholder={copy.groupLabel}
+                        aria-label={format(copy.groupAria, { name: row.name })}
+                      />
+                    </div>
+                  </li>
+                ))}
+              </ul>
+
+              {error && (
+                <p role="alert" className="mt-3 text-xs leading-relaxed text-red-500">
+                  {error}
+                </p>
+              )}
+
+              <div className="mt-4 flex items-center justify-between gap-3 border-t border-border pt-4">
+                <button
+                  type="button"
+                  onClick={() => {
+                    const allOn = checkedCount === rows.length;
+                    setRows(rows.map((r) => ({ ...r, checked: !allOn })));
+                  }}
+                  className="text-xs text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline"
+                >
+                  {checkedCount === rows.length ? copy.deselectAll : copy.selectAll}
+                </button>
+                <div className="flex gap-2">
+                  <Button variant="outline" size="sm" onClick={onClose}>
+                    {copy.cancel}
+                  </Button>
+                  <Button
+                    variant="default"
+                    size="sm"
+                    disabled={busy || checkedCount === 0}
+                    onClick={() => void apply()}
+                  >
+                    {busy ? (
+                      <>
+                        <Loader2 className="size-3.5 animate-spin" aria-hidden />
+                        {copy.applying}
+                      </>
+                    ) : (
+                      <>
+                        <Check className="size-3.5" aria-hidden />
+                        {format(copy.applyCta, { count: checkedCount })}
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/app-web/src/lib/api/skills.ts
+++ b/apps/app-web/src/lib/api/skills.ts
@@ -682,3 +682,83 @@ export async function deleteSkillFile(
   }
   return { ok: true };
 }
+
+// ── Bulk group suggestion ────────────────────────────────────────
+//
+// Propose → review → apply, never one shot: `suggestSkillGroups` writes
+// nothing and `applySkillGroups` takes only the assignments the user has
+// seen. Backed by `POST /api/skills/categorize` + `/categorize/apply`; spec:
+// docs/architecture/engine/skill-system.md → "Suggesting groups".
+
+export type SkillGroupSuggestion = {
+  skillRowId: string;
+  name: string;
+  current: string;
+  suggested: string;
+  /** Short model rationale; absent when it returned none. */
+  rationale?: string;
+};
+
+/**
+ * Ask for a group per unsorted skill. `considered` is how many were in the
+ * batch, which is NOT `suggestions.length` — a skill the model left where it
+ * was produces no row. `501`/`503` (no workspace store / no provider) map to
+ * an unavailable result so the caller can hide the affordance rather than
+ * show an error for a feature this deployment simply lacks.
+ */
+export async function suggestSkillGroups(
+  workspaceId: string,
+): Promise<
+  | { ok: true; suggestions: SkillGroupSuggestion[]; considered: number }
+  | { ok: false; unavailable: boolean; error: string }
+> {
+  const res = await authFetch(`${API_URL}/api/skills/categorize`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ workspaceId }),
+  });
+  if (!res.ok) {
+    const data = (await res.json().catch(() => ({}))) as { error?: string };
+    return {
+      ok: false,
+      unavailable: res.status === 501 || res.status === 503,
+      error: data.error ?? "Failed to suggest groups",
+    };
+  }
+  const data = (await res.json().catch(() => ({}))) as {
+    suggestions?: SkillGroupSuggestion[];
+    considered?: number;
+  };
+  return {
+    ok: true,
+    suggestions: Array.isArray(data.suggestions) ? data.suggestions : [],
+    considered: typeof data.considered === "number" ? data.considered : 0,
+  };
+}
+
+/** Apply the reviewed assignments. `failed` names rows that matched nothing. */
+export async function applySkillGroups(
+  workspaceId: string,
+  assignments: { skillRowId: string; category: string }[],
+): Promise<
+  { ok: true; updated: number; failed: string[] } | { ok: false; error: string }
+> {
+  const res = await authFetch(`${API_URL}/api/skills/categorize/apply`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ workspaceId, assignments }),
+  });
+  if (!res.ok) {
+    const data = (await res.json().catch(() => ({}))) as { error?: string };
+    return { ok: false, error: data.error ?? "Failed to apply groups" };
+  }
+  const data = (await res.json().catch(() => ({}))) as {
+    updated?: number;
+    failed?: string[];
+  };
+  return {
+    ok: true,
+    updated: typeof data.updated === "number" ? data.updated : 0,
+    failed: Array.isArray(data.failed) ? data.failed : [],
+  };
+}

--- a/apps/app-web/src/lib/i18n/dictionaries/en.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/en.ts
@@ -3424,6 +3424,33 @@ export const en = {
       send: "Send",
       attach: "Attach files",
     },
+    skillGroups: {
+      title: "Suggest groups",
+      cta: "Suggest groups",
+      intentBody:
+        "{count} skills are not in a group yet. Brian can read their names and descriptions and propose one for each.",
+      intentHint:
+        "Nothing is saved until you review the list. Skills you already put in a group are left alone.",
+      nothingToGroup: "Every skill is already in a group.",
+      suggestCta: "Suggest",
+      suggesting: "Reading your skills…",
+      noSuggestions:
+        "Brian read them and left everything where it was. Nothing to change.",
+      reviewBody:
+        "{count} proposed moves. Uncheck anything you disagree with, or pick a different group.",
+      groupLabel: "Group",
+      groupAria: "Group for {name}",
+      includeAria: "Include {name}",
+      selectAll: "Select all",
+      deselectAll: "Clear all",
+      applyCta: "Group {count} skills",
+      applying: "Grouping…",
+      appliedBody: "{count} skills grouped.",
+      appliedFailed: "{count} could not be updated. They were left as they were.",
+      done: "Done",
+      close: "Close",
+      cancel: "Cancel",
+    },
     skillFiles: {
       heading: "Files",
       explainer:

--- a/apps/app-web/src/lib/i18n/dictionaries/ja.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/ja.ts
@@ -3226,6 +3226,33 @@ export const ja: Dictionary = {
       send: "送信",
       attach: "ファイルを添付",
     },
+    skillGroups: {
+      title: "グループを提案",
+      cta: "グループを提案",
+      intentBody:
+        "{count} 件のスキルがまだグループに入っていません。Brian が名前と説明を読んで、それぞれに提案できます。",
+      intentHint:
+        "リストを確認するまで保存されません。すでにグループに入れたスキルはそのままです。",
+      nothingToGroup: "すべてのスキルがすでにグループに入っています。",
+      suggestCta: "提案する",
+      suggesting: "スキルを読み込み中…",
+      noSuggestions:
+        "Brian が確認しましたが、変更の必要はありませんでした。",
+      reviewBody:
+        "{count} 件の変更案です。同意できないものはチェックを外すか、別のグループを選んでください。",
+      groupLabel: "グループ",
+      groupAria: "{name} のグループ",
+      includeAria: "{name} を含める",
+      selectAll: "すべて選択",
+      deselectAll: "選択を解除",
+      applyCta: "{count} 件をグループ分け",
+      applying: "適用中…",
+      appliedBody: "{count} 件のスキルをグループ分けしました。",
+      appliedFailed: "{count} 件は更新できず、そのままになっています。",
+      done: "完了",
+      close: "閉じる",
+      cancel: "キャンセル",
+    },
     skillFiles: {
       heading: "ファイル",
       explainer:

--- a/apps/app-web/src/lib/i18n/dictionaries/zh.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh.ts
@@ -3190,6 +3190,32 @@ export const zh: Dictionary = {
       send: "傳送",
       attach: "附加檔案",
     },
+    skillGroups: {
+      title: "建議分組",
+      cta: "建議分組",
+      intentBody:
+        "有 {count} 個技能尚未分組。Brian 可以讀取它們的名稱與說明，為每一個提出建議。",
+      intentHint:
+        "在你檢視清單之前都不會儲存。你已經分好組的技能不會被動到。",
+      nothingToGroup: "所有技能都已分組。",
+      suggestCta: "建議",
+      suggesting: "正在讀取你的技能…",
+      noSuggestions: "Brian 看過了，維持原樣即可，沒有需要變更的項目。",
+      reviewBody:
+        "共 {count} 項建議調整。不同意的可取消勾選，或改選其他分組。",
+      groupLabel: "分組",
+      groupAria: "{name} 的分組",
+      includeAria: "包含 {name}",
+      selectAll: "全選",
+      deselectAll: "全部取消",
+      applyCta: "分組 {count} 個技能",
+      applying: "套用中…",
+      appliedBody: "已將 {count} 個技能分組。",
+      appliedFailed: "有 {count} 項無法更新，維持原狀。",
+      done: "完成",
+      close: "關閉",
+      cancel: "取消",
+    },
     skillFiles: {
       heading: "檔案",
       explainer:

--- a/packages/api/src/routes/__tests__/skills-categorize.test.ts
+++ b/packages/api/src/routes/__tests__/skills-categorize.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Route tests for bulk group suggestion
+ * (`POST /api/skills/categorize` + `/categorize/apply`).
+ *
+ * The split is the design: suggest PROPOSES and writes nothing, apply takes
+ * the explicit assignments the user reviewed. These tests pin that split, and
+ * pin that apply sends only `category` — a metadata-only update, so a bulk
+ * re-file cannot carry the D2 trust stamp and silently activate every
+ * Suggested skill it touches.
+ *
+ * Component tag: [COMP:api/skill-categorize]; spec:
+ * docs/architecture/engine/skill-system.md → "Suggesting groups".
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import request from 'supertest'
+import { createTestApp } from './helpers.js'
+import { skillRoutes } from '../skills.js'
+
+const skillStore = {
+  listPublished: vi.fn(),
+  listStarred: vi.fn(),
+  listOwned: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  publish: vi.fn(),
+  unpublish: vi.fn(),
+  star: vi.fn(),
+  unstar: vi.fn(),
+  getBySlug: vi.fn(),
+}
+
+const workspaceStore = { getRole: vi.fn() }
+const workspaceSkillStore = { listForWorkspace: vi.fn(), update: vi.fn(), getByIdSystem: vi.fn() }
+
+/** The slice of the stream options these tests read back. */
+type StreamOpts = { messages: Array<{ role: string; content: string }> }
+
+/** Stream stub in the provider's shape — one text block, then done. */
+function providerReturning(text: string) {
+  return {
+    name: 'stub',
+    models: ['standard'],
+    createSession: vi.fn(),
+    stream: vi.fn(async function* (_opts: StreamOpts) {
+      yield { type: 'text_delta', text }
+      yield {
+        type: 'turn_complete',
+        response: {
+          content: [{ type: 'text', text }],
+          stopReason: 'end_turn',
+          usage: { inputTokens: 1, outputTokens: 1 },
+          model: 'standard',
+        },
+      }
+    }),
+  }
+}
+
+function categorizeApp(extra: Record<string, unknown> = {}) {
+  return createTestApp(
+    '/api/skills',
+    skillRoutes({
+      skillStore: skillStore as never,
+      workspaceStore: workspaceStore as never,
+      workspaceSkillStore: workspaceSkillStore as never,
+      getWorkspacePlan: async () => 'pro',
+      checkUsageBudget: async () => ({ status: 'ok' as const }),
+      ...extra,
+    } as never),
+    { userId: 'u-1' },
+  )
+}
+
+function wsSkill(over: Record<string, unknown> = {}) {
+  return {
+    rowId: 'a',
+    name: 'Weekly status',
+    description: 'How we write the weekly update',
+    whenToUse: 'On Fridays',
+    category: 'custom',
+    state: 'active',
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  workspaceStore.getRole.mockResolvedValue('member')
+  workspaceSkillStore.listForWorkspace.mockResolvedValue([wsSkill()])
+  workspaceSkillStore.update.mockImplementation(async () => ({ rowId: 'a' }))
+})
+
+describe('[COMP:api/skill-categorize] POST /api/skills/categorize', () => {
+  it('suggests a group per unsorted skill and writes nothing', async () => {
+    const draftProvider = providerReturning('[{"i":1,"category":"communication","why":"writes an update"}]')
+
+    const res = await request(categorizeApp({ draftProvider }))
+      .post('/api/skills/categorize')
+      .send({ workspaceId: 'w-1' })
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({
+      considered: 1,
+      suggestions: [
+        {
+          skillRowId: 'a',
+          name: 'Weekly status',
+          current: 'custom',
+          suggested: 'communication',
+          rationale: 'writes an update',
+        },
+      ],
+    })
+    expect(workspaceSkillStore.update).not.toHaveBeenCalled()
+  })
+
+  // Only the `custom` sink is in scope — a deliberate category is not
+  // re-decided in bulk.
+  it('leaves already-grouped and archived skills out of the batch', async () => {
+    const draftProvider = providerReturning('[]')
+    workspaceSkillStore.listForWorkspace.mockResolvedValue([
+      wsSkill({ rowId: 'a', name: 'Already grouped', category: 'research' }),
+      wsSkill({ rowId: 'b', name: 'Archived one', category: 'custom', state: 'archived' }),
+      wsSkill({ rowId: 'c', name: 'Still unsorted', category: 'custom' }),
+    ])
+
+    const res = await request(categorizeApp({ draftProvider })).post('/api/skills/categorize').send({
+      workspaceId: 'w-1',
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.body.considered).toBe(1)
+    const prompt = draftProvider.stream.mock.calls[0]![0].messages[0]!.content
+    expect(prompt).toContain('Still unsorted')
+    expect(prompt).not.toContain('Already grouped')
+    expect(prompt).not.toContain('Archived one')
+  })
+
+  it('short-circuits with no model call when nothing is unsorted', async () => {
+    const draftProvider = providerReturning('[]')
+    workspaceSkillStore.listForWorkspace.mockResolvedValue([wsSkill({ category: 'productivity' })])
+
+    const res = await request(categorizeApp({ draftProvider })).post('/api/skills/categorize').send({
+      workspaceId: 'w-1',
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ suggestions: [], considered: 0 })
+    expect(draftProvider.stream).not.toHaveBeenCalled()
+  })
+
+  it('drops model output that names an unknown category or a bad index', async () => {
+    const draftProvider = providerReturning(
+      '[{"i":1,"category":"sales"},{"i":9,"category":"research"}]',
+    )
+    const res = await request(categorizeApp({ draftProvider })).post('/api/skills/categorize').send({
+      workspaceId: 'w-1',
+    })
+    expect(res.status).toBe(200)
+    expect(res.body.suggestions).toEqual([])
+  })
+
+  it('503s without a provider and 404s a non-member', async () => {
+    const noProvider = await request(categorizeApp()).post('/api/skills/categorize').send({
+      workspaceId: 'w-1',
+    })
+    expect(noProvider.status).toBe(503)
+
+    workspaceStore.getRole.mockResolvedValue(null)
+    const nonMember = await request(categorizeApp({ draftProvider: providerReturning('[]') }))
+      .post('/api/skills/categorize')
+      .send({ workspaceId: 'w-9' })
+    expect(nonMember.status).toBe(404)
+  })
+})
+
+describe('[COMP:api/skill-categorize] POST /api/skills/categorize/apply', () => {
+  it('applies each assignment as a metadata-only update', async () => {
+    const res = await request(categorizeApp())
+      .post('/api/skills/categorize/apply')
+      .send({
+        workspaceId: 'w-1',
+        assignments: [
+          { skillRowId: 'a', category: 'communication' },
+          { skillRowId: 'b', category: 'research' },
+        ],
+      })
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ updated: 2, failed: [] })
+    // ONLY `category` — anything else in this patch would trip the D2 stamp
+    // and activate every Suggested skill in the batch.
+    expect(workspaceSkillStore.update).toHaveBeenNthCalledWith(1, 'u-1', 'w-1', 'a', {
+      category: 'communication',
+    })
+    expect(workspaceSkillStore.update).toHaveBeenNthCalledWith(2, 'u-1', 'w-1', 'b', {
+      category: 'research',
+    })
+  })
+
+  it('reports rows that matched nothing instead of failing the batch', async () => {
+    workspaceSkillStore.update.mockImplementation(async (_u: string, _w: string, id: string) =>
+      id === 'a' ? { rowId: 'a' } : null,
+    )
+
+    const res = await request(categorizeApp())
+      .post('/api/skills/categorize/apply')
+      .send({
+        workspaceId: 'w-1',
+        assignments: [
+          { skillRowId: 'a', category: 'research' },
+          { skillRowId: 'gone', category: 'research' },
+        ],
+      })
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ updated: 1, failed: ['gone'] })
+  })
+
+  it('keeps going when one update throws', async () => {
+    workspaceSkillStore.update.mockImplementation(async (_u: string, _w: string, id: string) => {
+      if (id === 'boom') throw new Error('db said no')
+      return { rowId: id }
+    })
+
+    const res = await request(categorizeApp())
+      .post('/api/skills/categorize/apply')
+      .send({
+        workspaceId: 'w-1',
+        assignments: [
+          { skillRowId: 'boom', category: 'research' },
+          { skillRowId: 'b', category: 'research' },
+        ],
+      })
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ updated: 1, failed: ['boom'] })
+  })
+
+  it('400s an unknown category or an empty batch, and 404s a non-member', async () => {
+    const app = categorizeApp()
+    const badCategory = await request(app)
+      .post('/api/skills/categorize/apply')
+      .send({ workspaceId: 'w-1', assignments: [{ skillRowId: 'a', category: 'sales' }] })
+    expect(badCategory.status).toBe(400)
+
+    const empty = await request(app)
+      .post('/api/skills/categorize/apply')
+      .send({ workspaceId: 'w-1', assignments: [] })
+    expect(empty.status).toBe(400)
+
+    workspaceStore.getRole.mockResolvedValue(null)
+    const nonMember = await request(categorizeApp())
+      .post('/api/skills/categorize/apply')
+      .send({ workspaceId: 'w-9', assignments: [{ skillRowId: 'a', category: 'research' }] })
+    expect(nonMember.status).toBe(404)
+    expect(workspaceSkillStore.update).not.toHaveBeenCalled()
+  })
+})

--- a/packages/api/src/routes/skills.ts
+++ b/packages/api/src/routes/skills.ts
@@ -68,6 +68,11 @@ import {
   type GithubContentsReader,
 } from '../skills/import-service.js'
 import {
+  selectCategorizableSkills,
+  suggestSkillCategories,
+  SKILL_CATEGORIES,
+} from '../skills/categorize.js'
+import {
   validateSupportFile,
   validateSupportFileSet,
   SUPPORT_FILE_KINDS,
@@ -1212,6 +1217,130 @@ export function skillRoutes({
       console.error('[skills] access update failed:', err)
       res.status(500).json({ error: 'Failed to update skill access' })
     }
+  })
+
+  // ── /categorize — suggest a library group for the unsorted skills ──
+  //
+  // A workspace that has been running a while accumulates dozens of skills —
+  // its own plus everything the background curator induced — and every one of
+  // them lands in the `custom` sink, because nothing set `category` until the
+  // editor picker existed. Re-filing them one editor visit at a time is the
+  // friction this removes.
+  //
+  // Two routes, deliberately split: `/categorize` PROPOSES and writes nothing,
+  // `/categorize/apply` takes the explicit per-skill assignments the user
+  // reviewed. The model is guessing a bucket from a name and a description, so
+  // a bulk write nobody looked at is the failure mode to design out.
+  //
+  // Spec: docs/architecture/engine/skill-system.md → "Suggesting groups".
+
+  const categorizeBodySchema = z.object({ workspaceId: z.string().trim().min(1) })
+
+  const categorizeApplySchema = z.object({
+    workspaceId: z.string().trim().min(1),
+    assignments: z
+      .array(
+        z.object({
+          skillRowId: z.string().trim().min(1),
+          category: z.enum(SKILL_CATEGORIES),
+        }),
+      )
+      .min(1)
+      .max(500),
+  })
+
+  router.post('/categorize', async (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+    if (!workspaceSkillStore || !workspaceStore) {
+      res.status(501).json({ error: 'Skill grouping is not available' }); return
+    }
+    if (!draftProvider) {
+      res.status(503).json({ error: 'Skill grouping is not available' }); return
+    }
+
+    const parsed = categorizeBodySchema.safeParse(req.body)
+    if (!parsed.success) { res.status(400).json({ error: 'workspaceId is required' }); return }
+    const { workspaceId } = parsed.data
+
+    const role = await workspaceStore.getRole(userId, workspaceId)
+    if (!role) { res.status(404).json({ error: 'Not found' }); return }
+
+    // Shares the draft limiter: both are user-triggered model calls from the
+    // same surface, and one budget is easier to reason about than two.
+    if (!draftLimiter.check(`u:${userId}`)) {
+      res.status(429).json({ error: 'Too many requests — try again later' }); return
+    }
+
+    const plan = await getWorkspacePlan(workspaceId)
+    const budget = await checkUsageBudget(workspaceId, plan)
+    if (budget.status === 'blocked') {
+      res.status(429).json({ error: 'This workspace has no active plan. Pick a plan to keep going, or self-host the open-source version.' }); return
+    }
+
+    try {
+      const all = await workspaceSkillStore.listForWorkspace(workspaceId, { actingUserId: userId })
+      const candidates = selectCategorizableSkills(
+        all.filter((s) => s.state !== 'archived'),
+      ).map((s) => ({
+        rowId: s.rowId,
+        name: s.name,
+        description: s.description,
+        whenToUse: s.whenToUse ?? null,
+        category: s.category,
+      }))
+
+      if (candidates.length === 0) {
+        res.json({ suggestions: [], considered: 0 })
+        return
+      }
+
+      const suggestions = await suggestSkillCategories({
+        provider: draftProvider,
+        // Bucketing a name + description is the cheapest kind of judgement;
+        // it never needs more than the plan's floor tier.
+        model: resolveModel('standard', plan, budget.status),
+        skills: candidates,
+      })
+      res.json({ suggestions, considered: candidates.length })
+    } catch (err) {
+      console.error('[skills] categorize failed:', err)
+      res.status(500).json({ error: 'Failed to suggest groups' })
+    }
+  })
+
+  router.post('/categorize/apply', async (req, res) => {
+    const userId = req.userId
+    if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
+    if (!workspaceSkillStore || !workspaceStore) {
+      res.status(501).json({ error: 'Skill grouping is not available' }); return
+    }
+
+    const parsed = categorizeApplySchema.safeParse(req.body)
+    if (!parsed.success) { res.status(400).json({ error: 'Invalid assignments' }); return }
+    const { workspaceId, assignments } = parsed.data
+
+    const role = await workspaceStore.getRole(userId, workspaceId)
+    if (!role) { res.status(404).json({ error: 'Not found' }); return }
+
+    // `update` scopes by (id, workspace_id), so a row from another workspace
+    // simply matches nothing — it is counted as skipped, never applied.
+    // Category is metadata, so this does NOT carry the D2 trust stamp: a bulk
+    // re-file must not silently verify and activate every Suggested skill it
+    // touches (`skill-store.ts` → "Metadata-only edits ... don't qualify").
+    let updated = 0
+    const failed: string[] = []
+    for (const { skillRowId, category } of assignments) {
+      try {
+        const row = await workspaceSkillStore.update(userId, workspaceId, skillRowId, { category })
+        if (row) updated += 1
+        else failed.push(skillRowId)
+      } catch (err) {
+        console.error('[skills] categorize apply failed for', skillRowId, err)
+        failed.push(skillRowId)
+      }
+    }
+    res.json({ updated, failed })
   })
 
   // ── /:id/files — the skill's support-file bundle ────────────

--- a/packages/api/src/skills/__tests__/categorize.test.ts
+++ b/packages/api/src/skills/__tests__/categorize.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildCategorizePrompt,
+  parseCategorySuggestions,
+  selectCategorizableSkills,
+  type CategorizableSkill,
+} from '../categorize.js'
+
+function skill(over: Partial<CategorizableSkill> = {}): CategorizableSkill {
+  return {
+    rowId: 'row-1',
+    name: 'Weekly status',
+    description: 'How we write the weekly update',
+    whenToUse: 'On Fridays',
+    category: 'custom',
+    ...over,
+  }
+}
+
+describe('[COMP:api/skill-categorize] Candidate selection', () => {
+  // `custom` is the sink the server writes when nobody said otherwise, so it
+  // is the only bucket a bulk action may touch. A skill sitting in
+  // `research` was put there by an import declaration or a human, and
+  // second-guessing that in bulk is exactly the presumption to avoid.
+  it('takes only skills currently in the custom sink', () => {
+    const picked = selectCategorizableSkills([
+      skill({ rowId: 'a', category: 'custom' }),
+      skill({ rowId: 'b', category: 'research' }),
+      skill({ rowId: 'c', category: 'productivity' }),
+    ])
+    expect(picked.map((s) => s.rowId)).toEqual(['a'])
+  })
+
+  it('treats an unknown or missing category as the custom sink', () => {
+    const picked = selectCategorizableSkills([
+      skill({ rowId: 'a', category: 'sales-enablement' }),
+      skill({ rowId: 'b', category: undefined as unknown as string }),
+    ])
+    expect(picked.map((s) => s.rowId)).toEqual(['a', 'b'])
+  })
+})
+
+describe('[COMP:api/skill-categorize] Prompt', () => {
+  it('numbers the skills and carries name, description, and when-to-use', () => {
+    const prompt = buildCategorizePrompt([
+      skill({ rowId: 'a', name: 'Weekly status' }),
+      skill({ rowId: 'b', name: 'Lead research', description: 'Digs into a company', whenToUse: null }),
+    ])
+    expect(prompt).toContain('1.')
+    expect(prompt).toContain('2.')
+    expect(prompt).toContain('Weekly status')
+    expect(prompt).toContain('Digs into a company')
+    expect(prompt).toContain('On Fridays')
+    // The row ids are internal — never worth the tokens, and never something
+    // the model should be able to echo back as a target.
+    expect(prompt).not.toContain('row-1')
+  })
+
+  it('names every allowed category so the model cannot invent one', () => {
+    const prompt = buildCategorizePrompt([skill()])
+    for (const c of ['productivity', 'communication', 'research', 'custom']) {
+      expect(prompt).toContain(c)
+    }
+  })
+})
+
+describe('[COMP:api/skill-categorize] Response parsing', () => {
+  const skills = [
+    skill({ rowId: 'a', name: 'Weekly status' }),
+    skill({ rowId: 'b', name: 'Lead research' }),
+  ]
+
+  it('maps 1-based indexes back onto row ids', () => {
+    const out = parseCategorySuggestions(
+      JSON.stringify([
+        { i: 1, category: 'communication', why: 'It writes an update.' },
+        { i: 2, category: 'research', why: 'It digs into a company.' },
+      ]),
+      skills,
+    )
+    expect(out).toEqual([
+      {
+        skillRowId: 'a',
+        name: 'Weekly status',
+        current: 'custom',
+        suggested: 'communication',
+        rationale: 'It writes an update.',
+      },
+      {
+        skillRowId: 'b',
+        name: 'Lead research',
+        current: 'custom',
+        suggested: 'research',
+        rationale: 'It digs into a company.',
+      },
+    ])
+  })
+
+  it('reads a fenced JSON block', () => {
+    const out = parseCategorySuggestions(
+      '```json\n[{"i":1,"category":"research"}]\n```',
+      skills,
+    )
+    expect(out).toHaveLength(1)
+    expect(out[0]!.suggested).toBe('research')
+  })
+
+  // A suggestion that changes nothing is noise in a review list the user has
+  // to read row by row.
+  it('drops a suggestion equal to the current category', () => {
+    expect(parseCategorySuggestions('[{"i":1,"category":"custom"}]', skills)).toEqual([])
+  })
+
+  it('drops an out-of-range index and an invented category', () => {
+    const out = parseCategorySuggestions(
+      JSON.stringify([
+        { i: 0, category: 'research' },
+        { i: 3, category: 'research' },
+        { i: 1, category: 'sales' },
+        { i: 2, category: 'research' },
+      ]),
+      skills,
+    )
+    expect(out.map((s) => s.skillRowId)).toEqual(['b'])
+  })
+
+  it('keeps the first suggestion when the model repeats an index', () => {
+    const out = parseCategorySuggestions(
+      JSON.stringify([
+        { i: 1, category: 'research' },
+        { i: 1, category: 'communication' },
+      ]),
+      skills,
+    )
+    expect(out).toHaveLength(1)
+    expect(out[0]!.suggested).toBe('research')
+  })
+
+  it('returns nothing for unparseable, non-array, or empty output', () => {
+    for (const raw of ['', 'I could not classify these.', '{"i":1}', '[]']) {
+      expect(parseCategorySuggestions(raw, skills)).toEqual([])
+    }
+  })
+
+  it('drops a non-string rationale rather than failing the row', () => {
+    const out = parseCategorySuggestions('[{"i":1,"category":"research","why":42}]', skills)
+    expect(out).toEqual([
+      { skillRowId: 'a', name: 'Weekly status', current: 'custom', suggested: 'research' },
+    ])
+  })
+})

--- a/packages/api/src/skills/categorize.ts
+++ b/packages/api/src/skills/categorize.ts
@@ -1,0 +1,210 @@
+/**
+ * Bulk category suggestion — proposes a library group for the skills sitting
+ * in the `custom` sink, so a workspace that accumulated dozens of skills (its
+ * own, plus everything the background curator induced) can be organised in
+ * one review pass instead of one editor visit per skill.
+ *
+ * Propose → review → apply. This module only ever PROPOSES: it returns
+ * suggestions, writes nothing, and the route that applies them takes an
+ * explicit per-skill assignment list the user has seen. That split is the
+ * point — a bulk write nobody reviewed is the failure mode here, and
+ * `category` is metadata the model is guessing at from a name and a
+ * description.
+ *
+ * Spec: docs/architecture/engine/skill-system.md → "Suggesting groups".
+ *
+ * [COMP:api/skill-categorize]
+ */
+
+import { collectStream, type LLMProvider } from '@use-brian/core'
+
+/** The library display order, mirrored from `apps/app-web/src/lib/skills-view.ts`. */
+export const SKILL_CATEGORIES = [
+  'productivity',
+  'communication',
+  'research',
+  'custom',
+] as const
+
+export type SkillCategory = (typeof SKILL_CATEGORIES)[number]
+
+const KNOWN = new Set<string>(SKILL_CATEGORIES)
+
+/** Fold any value the TEXT column carries onto the known set. Local: the
+ *  client has its own copy (`skillCategoryOf`) because it cannot import from
+ *  packages/api. */
+function normalizeCategory(value: unknown): SkillCategory {
+  return typeof value === 'string' && KNOWN.has(value) ? (value as SkillCategory) : 'custom'
+}
+
+export type CategorizableSkill = {
+  rowId: string
+  name: string
+  description: string
+  whenToUse?: string | null
+  category: string
+}
+
+export type CategorySuggestion = {
+  skillRowId: string
+  name: string
+  current: SkillCategory
+  suggested: SkillCategory
+  rationale?: string
+}
+
+/**
+ * The skills a bulk suggestion may touch: only those in the `custom` sink.
+ *
+ * `custom` is what the create route writes when nobody said otherwise, so it
+ * means "unclassified". Every other value was set deliberately — by an
+ * imported file's frontmatter or by a human in the editor — and re-deciding
+ * those in bulk would quietly overwrite an intent the user already expressed.
+ * A legacy or third-party value outside the enum reads as `custom` here for
+ * the same reason it does in the UI: it is not a bucket anyone chose.
+ */
+export function selectCategorizableSkills<T extends { category: string }>(skills: T[]): T[] {
+  return skills.filter((s) => normalizeCategory(s.category) === 'custom')
+}
+
+// Keep the per-skill footprint small: this runs over a whole library in one
+// call, and a name + description + trigger is all the signal a bucket needs.
+const DESCRIPTION_CAP = 300
+const WHEN_TO_USE_CAP = 200
+
+function clip(value: string, cap: number): string {
+  const trimmed = value.trim().replace(/\s+/g, ' ')
+  return trimmed.length > cap ? `${trimmed.slice(0, cap)}…` : trimmed
+}
+
+/**
+ * One prompt for the whole batch. Skills are addressed by 1-based INDEX, not
+ * row id: the ids are internal, cost tokens, and would give the model a
+ * writable-looking handle on a specific row. The index round-trips through
+ * `parseCategorySuggestions`, which is the only thing that knows the mapping.
+ */
+export function buildCategorizePrompt(skills: CategorizableSkill[]): string {
+  const lines = skills.map((s, i) => {
+    const parts = [`${i + 1}. ${s.name.trim()}`]
+    if (s.description?.trim()) parts.push(`   what it does: ${clip(s.description, DESCRIPTION_CAP)}`)
+    if (s.whenToUse?.trim()) parts.push(`   when it runs: ${clip(s.whenToUse, WHEN_TO_USE_CAP)}`)
+    return parts.join('\n')
+  })
+
+  return [
+    'Sort each of these workplace assistant skills into exactly one category.',
+    '',
+    'Categories:',
+    '- productivity — planning, scheduling, tasks, documents, internal process',
+    '- communication — writing to or for people: email, messages, updates, posts',
+    '- research — finding out about something: companies, people, markets, sources',
+    '- custom — anything that does not clearly belong to the three above',
+    '',
+    'Skills:',
+    ...lines,
+    '',
+    'Rules:',
+    `- Answer with a JSON array only, no prose: [{"i": <skill number>, "category": "<one of ${SKILL_CATEGORIES.join(' | ')}>", "why": "<max 12 words>"}]`,
+    '- Include every skill number exactly once.',
+    '- Use "custom" when the fit is genuinely unclear. A wrong confident bucket is worse than leaving it unsorted.',
+  ].join('\n')
+}
+
+/** First JSON array in the text, tolerating a ```json fence or stray prose. */
+function extractJsonArray(raw: string): unknown {
+  const fenced = raw.match(/```(?:json)?\s*([\s\S]*?)```/)
+  const candidate = (fenced?.[1] ?? raw).trim()
+  const start = candidate.indexOf('[')
+  const end = candidate.lastIndexOf(']')
+  if (start === -1 || end === -1 || end < start) return null
+  try {
+    return JSON.parse(candidate.slice(start, end + 1))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Map the model's answer back onto row ids, dropping anything it invented.
+ *
+ * Every row is validated rather than trusted: an out-of-range index, a
+ * category outside the enum, or a repeat of an index already seen is
+ * discarded silently. A suggestion equal to the skill's current category is
+ * dropped too — it changes nothing and would only pad a list the user has to
+ * read row by row.
+ */
+export function parseCategorySuggestions(
+  raw: string,
+  skills: CategorizableSkill[],
+): CategorySuggestion[] {
+  const parsed = extractJsonArray(raw)
+  if (!Array.isArray(parsed)) return []
+
+  const out: CategorySuggestion[] = []
+  const seen = new Set<number>()
+
+  for (const entry of parsed) {
+    if (typeof entry !== 'object' || entry === null) continue
+    const row = entry as Record<string, unknown>
+
+    const index = typeof row.i === 'number' ? row.i : Number.NaN
+    if (!Number.isInteger(index) || index < 1 || index > skills.length) continue
+    if (seen.has(index)) continue
+
+    const category = row.category
+    if (typeof category !== 'string' || !KNOWN.has(category)) continue
+
+    const skill = skills[index - 1]!
+    const current = normalizeCategory(skill.category)
+    if (category === current) continue
+
+    seen.add(index)
+    const suggestion: CategorySuggestion = {
+      skillRowId: skill.rowId,
+      name: skill.name,
+      current,
+      suggested: category as SkillCategory,
+    }
+    if (typeof row.why === 'string' && row.why.trim()) {
+      suggestion.rationale = row.why.trim()
+    }
+    out.push(suggestion)
+  }
+
+  return out
+}
+
+/** Ask the model to bucket a batch. Returns `[]` rather than throwing when the
+ *  answer is unusable — an empty review list is a fine outcome, an exception
+ *  on the user's "Suggest" click is not. */
+export async function suggestSkillCategories(params: {
+  provider: LLMProvider
+  model: string
+  skills: CategorizableSkill[]
+}): Promise<CategorySuggestion[]> {
+  const { provider, model, skills } = params
+  if (skills.length === 0) return []
+
+  // One stateless turn — the `draft-generator.ts` plain-turn shape. No tools,
+  // no session: this is a classification, and nothing it produces is applied
+  // without the user checking it first.
+  const response = await collectStream(
+    provider.stream({
+      model,
+      systemPrompt:
+        'You sort workplace assistant skills into a small fixed set of categories. You answer with a JSON array only.',
+      messages: [{ role: 'user', content: buildCategorizePrompt(skills) }],
+      maxTokens: 2000,
+      // Bucketing is a judgement with one defensible answer per skill; the
+      // latitude that helps prose writing only adds variance here.
+      temperature: 0,
+    }),
+  )
+
+  const text = response.content
+    .map((b) => (b.type === 'text' ? (b.text ?? '') : ''))
+    .join('')
+    .trim()
+
+  return parseCategorySuggestions(text, skills)
+}


### PR DESCRIPTION
Follow-up to #119. That PR gave `category` a write surface, which fixes new skills and does nothing for the library a workspace already has: a team that has been running a while holds dozens of skills - its own, plus everything the background curator induced - and **every one of them is in `custom`**, because nothing set the column before the editor picker existed. Grouping was real but empty of signal.

Adds a bulk pass. Brian reads the names and descriptions of the ungrouped skills, proposes a group for each, the user reviews, and only what they checked is applied.

### Propose and apply are two routes on purpose

| Method | Path | |
|---|---|---|
| `POST` | `/api/skills/categorize` | One model call over the unsorted skills. **Writes nothing.** |
| `POST` | `/api/skills/categorize/apply` | Takes only the assignments that came back through the review list. |

The model is guessing a bucket from a name and a description, so a bulk write nobody read is the failure mode being designed out.

### Three things worth review attention

**Only the `custom` sink is in scope.** That is what the create route writes when nobody said otherwise, so it means *unclassified*. Every other value was set deliberately - by an imported file's frontmatter or by a human - and re-deciding those in bulk would overwrite an intent the user already expressed. Archived rows are dropped first.

**Apply sends `category` and nothing else, and that is load-bearing.** `WorkspaceSkillStore.update` carries the D2 edit-is-confirm stamp - verifier recorded, confidence lifted, a Suggested skill *activated* - only when `name` or `content` is in the patch (`skill-store.ts` → "Metadata-only edits ... don't qualify"). A bulk re-file that slipped any other field in would silently verify and activate every Suggested skill it touched, turning a tidy-up into a mass governance decision. The route test pins the exact patch shape for that reason.

**The model is addressed by index, never row id**, and every row it returns is validated rather than trusted: out-of-range index, invented category, repeated index, or a no-op suggestion is dropped. Unusable output degrades to an empty review list, not an exception on the user's click.

### Cost
The dialog's first stage states the unsorted count - a free client-side read off the list the page already holds - and asks before any model call, per the pre-flight-confirm invariant. The call is one stateless turn at the plan's floor tier, temperature 0, on the same rate limiter and plan/budget gate as `POST /draft`. Nothing unsorted means no model call at all.

### Verification
`pnpm test` 4139/4140, app-web 2339/2339, `pnpm smoke` OK, both packages typecheck. The one failure is `knowledge-proposals.test.ts`, a macOS `/var` vs `/private/var` tmpdir assertion, pre-existing on `develop`.

20 new tests across the classifier and the two routes.

Docs + KB + component-map rows: use-brian/brian-platform `docs/skill-group-suggestions`, use-brian/brian-kb `docs/skill-group-suggestions`.