### PR TITLE
refactor(db): multiplex every LISTEN channel onto one shared connection

### DIFF
--- a/packages/api/src/brain-stream/sse-fanout.ts
+++ b/packages/api/src/brain-stream/sse-fanout.ts
@@ -1,22 +1,23 @@
 /**
  * Postgres LISTEN/NOTIFY fan-out for the brain realtime stream.
  *
- * Mirrors the feed inbox SSE pattern (`../feed/sse-fanout.ts`). One dedicated
- * `pg.Client` per process holds the LISTEN connection (LISTEN binds to a
- * single connection — pool checkouts can't carry it). Subscribers register a
- * callback against a `workspaceId`; whenever a writer calls
+ * Mirrors the feed inbox SSE pattern (`../feed/sse-fanout.ts`). Subscribers
+ * register a callback against a `workspaceId`; whenever a writer calls
  * `notifyBrainChange({ workspaceId, primitive, rowId?, action })`, the
  * Postgres NOTIFY fans out to every interested subscriber across this
  * process — and across every other Cloud Run instance.
  *
- * Reconnect is exponential-backoff (1s → 30s cap). On reconnect we re-issue
- * LISTEN so we resume receiving events.
+ * The LISTEN side rides the process-wide shared connection
+ * (`../db/notify-listener.ts`), which owns connect, reconnect-with-backoff, and
+ * re-subscribe. This module used to hold its own `pg.Client`; three fan-out
+ * modules each doing that put six dedicated connections against a 22-slot
+ * fleet budget. See that module's header for the incident.
  *
  * Spec: docs/architecture/platform/realtime-sync.md.
  *
  * [COMP:api/brain-stream-fanout]
  */
-import pg from 'pg'
+import { registerNotifyChannel, startNotifyListener, unregisterNotifyChannel } from '../db/notify-listener.js'
 
 export const BRAIN_CHANNEL = 'brain_events'
 
@@ -95,77 +96,18 @@ type Subscriber = {
   cb: BrainSubscriber
 }
 
-let listenerClient: pg.Client | null = null
-let listenerStatus: 'idle' | 'connecting' | 'listening' | 'reconnecting' = 'idle'
-let reconnectTimer: NodeJS.Timeout | null = null
-let backoffMs = 1_000
 const subscribers = new Set<Subscriber>()
 
-function buildClient(): pg.Client {
-  return new pg.Client({ connectionString: process.env.DATABASE_URL })
-}
-
-async function startListener(): Promise<void> {
-  if (listenerStatus === 'connecting' || listenerStatus === 'listening') return
-  listenerStatus = 'connecting'
-
-  const client = buildClient()
-  listenerClient = client
-
-  client.on('notification', (msg) => {
-    if (msg.channel !== BRAIN_CHANNEL || !msg.payload) return
-    let parsed: BrainChangePayload
-    try {
-      parsed = JSON.parse(msg.payload) as BrainChangePayload
-    } catch {
-      return
-    }
-    if (!parsed.workspaceId) return
-    dispatchBrainChangeLocal(parsed)
-  })
-
-  client.on('error', (err) => {
-    console.warn('[brain-stream] listener error, will reconnect:', err.message)
-    scheduleReconnect()
-  })
-  client.on('end', () => {
-    if (listenerStatus !== 'reconnecting') {
-      console.warn('[brain-stream] listener ended unexpectedly')
-      scheduleReconnect()
-    }
-  })
-
+/** Shared-connection handler for `brain_events`. Parses, then dispatches locally. */
+function handleBrainNotification(payload: string): void {
+  let parsed: BrainChangePayload
   try {
-    await client.connect()
-    await client.query(`LISTEN ${BRAIN_CHANNEL}`)
-    listenerStatus = 'listening'
-    backoffMs = 1_000
-    console.log(`[brain-stream] LISTEN ${BRAIN_CHANNEL} active`)
-  } catch (err) {
-    console.warn('[brain-stream] failed to start listener:', err)
-    scheduleReconnect()
+    parsed = JSON.parse(payload) as BrainChangePayload
+  } catch {
+    return
   }
-}
-
-function scheduleReconnect(): void {
-  if (listenerStatus === 'reconnecting') return
-  listenerStatus = 'reconnecting'
-
-  if (listenerClient) {
-    listenerClient.removeAllListeners()
-    listenerClient.end().catch(() => {})
-    listenerClient = null
-  }
-
-  const delay = backoffMs
-  backoffMs = Math.min(backoffMs * 2, 30_000)
-
-  if (reconnectTimer) clearTimeout(reconnectTimer)
-  reconnectTimer = setTimeout(() => {
-    reconnectTimer = null
-    listenerStatus = 'idle'
-    void startListener()
-  }, delay)
+  if (!parsed.workspaceId) return
+  dispatchBrainChangeLocal(parsed)
 }
 
 /**
@@ -176,9 +118,9 @@ function scheduleReconnect(): void {
 export function startBrainStreamFanout(): void {
   // Single-process boot skips the LISTEN connection entirely — writes reach
   // local subscribers directly via dispatchBrainChangeLocal (see notify.ts).
-  if (!SINGLE_PROCESS && listenerStatus === 'idle') {
-    void startListener()
-  }
+  if (SINGLE_PROCESS) return
+  registerNotifyChannel(BRAIN_CHANNEL, handleBrainNotification)
+  startNotifyListener()
 }
 
 /**
@@ -210,15 +152,12 @@ export function _dispatchLocalForTests(payload: BrainChangePayload): void {
   dispatchBrainChangeLocal(payload)
 }
 
-/** Test helper — graceful shutdown for vitest cleanup. */
+/**
+ * Test helper — graceful shutdown for vitest cleanup. Deregisters only THIS
+ * module's channel; the shared connection closes itself once the last channel
+ * goes, so tearing this fan-out down never silences the others.
+ */
 export async function _shutdownBrainStreamFanout(): Promise<void> {
-  if (reconnectTimer) clearTimeout(reconnectTimer)
-  reconnectTimer = null
-  if (listenerClient) {
-    listenerClient.removeAllListeners()
-    await listenerClient.end().catch(() => {})
-    listenerClient = null
-  }
-  listenerStatus = 'idle'
+  await unregisterNotifyChannel(BRAIN_CHANNEL)
   subscribers.clear()
 }

--- a/packages/api/src/db/__tests__/notify-listener.test.ts
+++ b/packages/api/src/db/__tests__/notify-listener.test.ts
@@ -27,6 +27,8 @@ type FakeClient = {
 const clients: FakeClient[] = []
 /** Make the next `connect()` reject, simulating a refused connection. */
 let failNextConnect = false
+/** Make every `LISTEN` reject while the TCP connect still succeeds. */
+let failListen = false
 
 function buildFakeClient(): FakeClient {
   const handlers = new Map<string, ((...args: unknown[]) => void)[]>()
@@ -40,6 +42,7 @@ function buildFakeClient(): FakeClient {
     }),
     query: vi.fn(async (text: string) => {
       statements.push(text)
+      if (failListen && text.startsWith('LISTEN')) throw new Error('LISTEN refused')
       return { rows: [], rowCount: 0 }
     }),
     end: vi.fn(async () => {}),
@@ -85,6 +88,7 @@ function listens(): string[] {
 beforeEach(() => {
   clients.length = 0
   failNextConnect = false
+  failListen = false
 })
 
 afterEach(async () => {
@@ -233,6 +237,30 @@ describe('[COMP:platform/notify-listener] shared LISTEN connection', () => {
 
     expect(_getNotifyChannels()).toEqual([])
     expect(clients[0]!.end).toHaveBeenCalled()
+  })
+
+  // Regression: `status = 'listening'` and the backoff reset used to happen
+  // BEFORE the LISTEN queries. A server that accepts connections but rejects
+  // LISTEN therefore looked like a success on every attempt, so the backoff
+  // reset to 1s each time and the module retried at a flat 1s forever instead
+  // of climbing to the 30s cap — a tight reconnect loop against a database that
+  // is, by construction, already struggling.
+  it('backs off exponentially when the connection succeeds but LISTEN fails', async () => {
+    vi.useFakeTimers()
+    failListen = true
+    registerNotifyChannel('brain_events', () => {})
+    startNotifyListener()
+    await vi.waitFor(() => expect(clients).toHaveLength(1))
+
+    // 1st retry after 1s.
+    await vi.advanceTimersByTimeAsync(1_000)
+    await vi.waitFor(() => expect(clients).toHaveLength(2))
+
+    // 2nd retry must wait 2s, not 1s — proof the backoff climbed.
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(clients).toHaveLength(2)
+    await vi.advanceTimersByTimeAsync(1_000)
+    await vi.waitFor(() => expect(clients).toHaveLength(3))
   })
 
   it('rejects a channel name that is not a bare identifier', () => {

--- a/packages/api/src/db/__tests__/notify-listener.test.ts
+++ b/packages/api/src/db/__tests__/notify-listener.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Unit tests for the shared LISTEN/NOTIFY connection.
+ * Component tag: [COMP:platform/notify-listener].
+ *
+ * The point of this module is a connection-budget invariant: however many
+ * channels the process subscribes to, it must hold exactly ONE dedicated
+ * `pg.Client` outside the pools. These tests mock `pg` so the client count,
+ * the LISTEN statements, and the reconnect re-subscribe are all directly
+ * observable without a live Postgres.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type FakeClient = {
+  connect: ReturnType<typeof vi.fn>
+  query: ReturnType<typeof vi.fn>
+  end: ReturnType<typeof vi.fn>
+  on: (event: string, cb: (...args: unknown[]) => void) => void
+  removeAllListeners: ReturnType<typeof vi.fn>
+  /** Statements this client ran, in order. */
+  statements: string[]
+  /** Fire a handler the module registered on the client. */
+  fire: (event: string, ...args: unknown[]) => void
+}
+
+/** Every client the module has constructed, in order. */
+const clients: FakeClient[] = []
+/** Make the next `connect()` reject, simulating a refused connection. */
+let failNextConnect = false
+
+function buildFakeClient(): FakeClient {
+  const handlers = new Map<string, ((...args: unknown[]) => void)[]>()
+  const statements: string[] = []
+  const client: FakeClient = {
+    connect: vi.fn(async () => {
+      if (failNextConnect) {
+        failNextConnect = false
+        throw new Error('remaining connection slots are reserved')
+      }
+    }),
+    query: vi.fn(async (text: string) => {
+      statements.push(text)
+      return { rows: [], rowCount: 0 }
+    }),
+    end: vi.fn(async () => {}),
+    on: (event, cb) => {
+      const list = handlers.get(event) ?? []
+      list.push(cb)
+      handlers.set(event, list)
+    },
+    removeAllListeners: vi.fn(() => handlers.clear()),
+    statements,
+    fire: (event, ...args) => {
+      for (const cb of handlers.get(event) ?? []) cb(...args)
+    },
+  }
+  return client
+}
+
+vi.mock('pg', () => ({
+  default: {
+    Client: class {
+      constructor() {
+        const fake = buildFakeClient()
+        clients.push(fake)
+        return fake as unknown as object
+      }
+    },
+  },
+}))
+
+import {
+  _getNotifyChannels,
+  _shutdownNotifyListener,
+  registerNotifyChannel,
+  startNotifyListener,
+  unregisterNotifyChannel,
+} from '../notify-listener.js'
+
+/** All LISTEN statements issued across every client built so far. */
+function listens(): string[] {
+  return clients.flatMap((c) => c.statements).filter((s) => s.startsWith('LISTEN'))
+}
+
+beforeEach(() => {
+  clients.length = 0
+  failNextConnect = false
+})
+
+afterEach(async () => {
+  await _shutdownNotifyListener()
+  vi.useRealTimers()
+})
+
+describe('[COMP:platform/notify-listener] shared LISTEN connection', () => {
+  it('holds ONE client no matter how many channels register', async () => {
+    registerNotifyChannel('brain_events', () => {})
+    registerNotifyChannel('feed_events', () => {})
+    registerNotifyChannel('session_event', () => {})
+    startNotifyListener()
+    await vi.waitFor(() => expect(listens()).toHaveLength(3))
+
+    expect(clients).toHaveLength(1)
+    expect(listens().sort()).toEqual([
+      'LISTEN brain_events',
+      'LISTEN feed_events',
+      'LISTEN session_event',
+    ])
+  })
+
+  it('subscribes a channel registered after the connection is already live, on the same client', async () => {
+    registerNotifyChannel('brain_events', () => {})
+    startNotifyListener()
+    await vi.waitFor(() => expect(listens()).toHaveLength(1))
+
+    registerNotifyChannel('feed_events', () => {})
+    await vi.waitFor(() => expect(listens()).toHaveLength(2))
+
+    expect(clients).toHaveLength(1)
+    expect(listens()).toContain('LISTEN feed_events')
+  })
+
+  it('startNotifyListener is idempotent', async () => {
+    registerNotifyChannel('brain_events', () => {})
+    startNotifyListener()
+    startNotifyListener()
+    await vi.waitFor(() => expect(listens()).toHaveLength(1))
+    startNotifyListener()
+
+    expect(clients).toHaveLength(1)
+  })
+
+  it('routes a notification only to the handler for its channel', async () => {
+    const brain: string[] = []
+    const feed: string[] = []
+    registerNotifyChannel('brain_events', (p) => brain.push(p))
+    registerNotifyChannel('feed_events', (p) => feed.push(p))
+    startNotifyListener()
+    await vi.waitFor(() => expect(listens()).toHaveLength(2))
+
+    clients[0]!.fire('notification', { channel: 'feed_events', payload: '{"a":1}' })
+
+    expect(feed).toEqual(['{"a":1}'])
+    expect(brain).toEqual([])
+  })
+
+  it('ignores notifications for unregistered channels and empty payloads', async () => {
+    const brain: string[] = []
+    registerNotifyChannel('brain_events', (p) => brain.push(p))
+    startNotifyListener()
+    await vi.waitFor(() => expect(listens()).toHaveLength(1))
+
+    clients[0]!.fire('notification', { channel: 'nobody_listening', payload: 'x' })
+    clients[0]!.fire('notification', { channel: 'brain_events', payload: undefined })
+
+    expect(brain).toEqual([])
+  })
+
+  it('a throwing handler does not stop the other channels', async () => {
+    const feed: string[] = []
+    registerNotifyChannel('brain_events', () => {
+      throw new Error('subscriber exploded')
+    })
+    registerNotifyChannel('feed_events', (p) => feed.push(p))
+    startNotifyListener()
+    await vi.waitFor(() => expect(listens()).toHaveLength(2))
+
+    expect(() =>
+      clients[0]!.fire('notification', { channel: 'brain_events', payload: 'boom' }),
+    ).not.toThrow()
+    clients[0]!.fire('notification', { channel: 'feed_events', payload: 'ok' })
+
+    expect(feed).toEqual(['ok'])
+  })
+
+  it('re-issues LISTEN for every channel after a reconnect', async () => {
+    vi.useFakeTimers()
+    registerNotifyChannel('brain_events', () => {})
+    registerNotifyChannel('feed_events', () => {})
+    startNotifyListener()
+    await vi.waitFor(() => expect(listens()).toHaveLength(2))
+
+    clients[0]!.fire('error', new Error('connection terminated'))
+    await vi.advanceTimersByTimeAsync(1_000)
+    await vi.waitFor(() => expect(clients).toHaveLength(2))
+
+    expect(clients[1]!.statements.filter((s) => s.startsWith('LISTEN')).sort()).toEqual([
+      'LISTEN brain_events',
+      'LISTEN feed_events',
+    ])
+  })
+
+  it('retries with backoff when the connection is refused', async () => {
+    vi.useFakeTimers()
+    failNextConnect = true
+    registerNotifyChannel('brain_events', () => {})
+    startNotifyListener()
+    await vi.waitFor(() => expect(clients).toHaveLength(1))
+    expect(listens()).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    await vi.waitFor(() => expect(clients).toHaveLength(2))
+    await vi.waitFor(() => expect(listens()).toEqual(['LISTEN brain_events']))
+  })
+
+  it('deregistering one channel leaves the others listening on the same client', async () => {
+    const brain: string[] = []
+    const feed: string[] = []
+    registerNotifyChannel('brain_events', (p) => brain.push(p))
+    registerNotifyChannel('feed_events', (p) => feed.push(p))
+    startNotifyListener()
+    await vi.waitFor(() => expect(listens()).toHaveLength(2))
+
+    await unregisterNotifyChannel('brain_events')
+
+    // One module tearing itself down must not silence the others.
+    expect(_getNotifyChannels()).toEqual(['feed_events'])
+    expect(clients[0]!.end).not.toHaveBeenCalled()
+    clients[0]!.fire('notification', { channel: 'feed_events', payload: 'still here' })
+    clients[0]!.fire('notification', { channel: 'brain_events', payload: 'gone' })
+    expect(feed).toEqual(['still here'])
+    expect(brain).toEqual([])
+  })
+
+  it('closes the shared connection when the LAST channel deregisters', async () => {
+    registerNotifyChannel('brain_events', () => {})
+    registerNotifyChannel('feed_events', () => {})
+    startNotifyListener()
+    await vi.waitFor(() => expect(listens()).toHaveLength(2))
+
+    await unregisterNotifyChannel('brain_events')
+    await unregisterNotifyChannel('feed_events')
+
+    expect(_getNotifyChannels()).toEqual([])
+    expect(clients[0]!.end).toHaveBeenCalled()
+  })
+
+  it('rejects a channel name that is not a bare identifier', () => {
+    // The channel is interpolated into `LISTEN <channel>` — it cannot be a
+    // bind parameter, so the identifier shape is the only guard.
+    expect(() => registerNotifyChannel('brain_events; DROP TABLE users', () => {})).toThrow(
+      /identifier/i,
+    )
+    expect(() => registerNotifyChannel('Brain-Events', () => {})).toThrow(/identifier/i)
+    expect(_getNotifyChannels()).toEqual([])
+  })
+})

--- a/packages/api/src/db/notify-listener.ts
+++ b/packages/api/src/db/notify-listener.ts
@@ -1,0 +1,200 @@
+/**
+ * The process's single dedicated LISTEN/NOTIFY connection.
+ *
+ * `LISTEN` binds to one Postgres session, so a pool checkout cannot carry it —
+ * every channel needs a client held open for the lifetime of the instance.
+ * Historically each fan-out module opened its own: `brain_events`
+ * (`../brain-stream/sse-fanout.ts`), `session_event` (`../session-event-bus.ts`)
+ * and `feed_events` (`@use-brian/api-platform/feed/sse-fanout.ts`), so a single
+ * api process held THREE connections outside the pools and the fleet held six.
+ *
+ * That is a connection-budget problem, not a style one. Prod Cloud SQL is a
+ * `db-f1-micro`: `max_connections = 25` minus `superuser_reserved_connections = 3`
+ * leaves 22 slots for the whole fleet, and the pools already claim 16. The
+ * graded budget assumed 4 LISTEN clients while reality was 6, which put the
+ * true worst case at exactly 22 with zero headroom — one `prod-db.sh` session or
+ * migration run over the line, and Postgres refuses connections with 53300
+ * ("remaining connection slots are reserved…"), which surfaces to users as a
+ * failed chat turn. One session can `LISTEN` on any number of channels, so
+ * multiplexing here takes the fleet from 6 dedicated clients to 2.
+ *
+ * Ownership split: this module owns the connection, the reconnect, and the
+ * channel→handler routing. It does NOT parse payloads or know about
+ * subscribers — each fan-out module registers a handler that receives the raw
+ * NOTIFY payload string and does its own parsing and dispatch. Registration is
+ * order-independent: register before or after `startNotifyListener()`, and a
+ * channel registered while the connection is already live is subscribed on that
+ * same client.
+ *
+ * Spec: docs/architecture/platform/deployment.md → "fleet-wide connection budget".
+ *
+ * [COMP:platform/notify-listener]
+ */
+
+import pg from 'pg'
+
+/** Receives the raw NOTIFY payload; the caller parses it. */
+export type NotifyHandler = (payload: string) => void
+
+/**
+ * `LISTEN <channel>` takes an identifier, not a bind parameter, so the channel
+ * name is interpolated into the statement. Every caller passes a module-level
+ * constant today, but the shape check is the only thing standing between this
+ * function and SQL injection if that ever stops being true.
+ */
+const CHANNEL_IDENTIFIER = /^[a-z_][a-z0-9_]*$/
+
+const handlers = new Map<string, NotifyHandler>()
+
+let client: pg.Client | null = null
+let status: 'idle' | 'connecting' | 'listening' | 'reconnecting' = 'idle'
+let reconnectTimer: NodeJS.Timeout | null = null
+let backoffMs = 1_000
+
+function buildClient(): pg.Client {
+  return new pg.Client({ connectionString: process.env.DATABASE_URL })
+}
+
+/**
+ * Register a channel and its handler. Idempotent per channel — re-registering
+ * replaces the handler. Safe to call before or after `startNotifyListener()`;
+ * when the connection is already live the `LISTEN` is issued immediately.
+ */
+export function registerNotifyChannel(channel: string, handler: NotifyHandler): void {
+  if (!CHANNEL_IDENTIFIER.test(channel)) {
+    throw new Error(
+      `[notify-listener] "${channel}" is not a bare lowercase SQL identifier — ` +
+        'LISTEN cannot bind the channel as a parameter, so it must match /^[a-z_][a-z0-9_]*$/',
+    )
+  }
+  const alreadyRegistered = handlers.has(channel)
+  handlers.set(channel, handler)
+  // Only the first registration needs a LISTEN; a replacement handler rides the
+  // subscription that is already open.
+  if (!alreadyRegistered && status === 'listening' && client) {
+    void subscribe(client, channel)
+  }
+}
+
+/** Issue one `LISTEN`. Returns false if it failed and a reconnect was scheduled. */
+async function subscribe(target: pg.Client, channel: string): Promise<boolean> {
+  try {
+    await target.query(`LISTEN ${channel}`)
+    console.log(`[notify-listener] LISTEN ${channel} active`)
+    return true
+  } catch (err) {
+    console.warn(`[notify-listener] failed to LISTEN ${channel}, will reconnect:`, err)
+    scheduleReconnect()
+    return false
+  }
+}
+
+async function connect(): Promise<void> {
+  if (status === 'connecting' || status === 'listening') return
+  status = 'connecting'
+
+  const next = buildClient()
+  client = next
+
+  next.on('notification', (msg) => {
+    if (!msg.payload) return
+    const handler = handlers.get(msg.channel)
+    if (!handler) return
+    try {
+      handler(msg.payload)
+    } catch (err) {
+      // One module's bad payload must not take down the shared connection —
+      // that would silently kill realtime for every other channel.
+      console.warn(`[notify-listener] handler for ${msg.channel} threw:`, err)
+    }
+  })
+
+  next.on('error', (err) => {
+    console.warn('[notify-listener] connection error, will reconnect:', err.message)
+    scheduleReconnect()
+  })
+  next.on('end', () => {
+    if (status !== 'reconnecting') {
+      console.warn('[notify-listener] connection ended unexpectedly')
+      scheduleReconnect()
+    }
+  })
+
+  try {
+    await next.connect()
+    status = 'listening'
+    backoffMs = 1_000
+    for (const channel of handlers.keys()) {
+      // Stop at the first failure: `subscribe` has already scheduled the
+      // reconnect and ended this client, so the remaining channels would each
+      // throw against a dead client and log a duplicate warning. The reconnect
+      // re-subscribes all of them.
+      if (!(await subscribe(next, channel))) break
+    }
+  } catch (err) {
+    console.warn('[notify-listener] failed to connect:', err)
+    scheduleReconnect()
+  }
+}
+
+function scheduleReconnect(): void {
+  if (status === 'reconnecting') return
+  status = 'reconnecting'
+
+  if (client) {
+    client.removeAllListeners()
+    client.end().catch(() => {})
+    client = null
+  }
+
+  const delay = backoffMs
+  backoffMs = Math.min(backoffMs * 2, 30_000)
+
+  if (reconnectTimer) clearTimeout(reconnectTimer)
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null
+    status = 'idle'
+    // Every registered channel is re-subscribed by `connect()`.
+    void connect()
+  }, delay)
+}
+
+/**
+ * Open the shared connection. Idempotent — safe to call from every fan-out
+ * module's own boot entry point and from their lazy first-subscriber paths.
+ */
+export function startNotifyListener(): void {
+  if (status === 'idle') void connect()
+}
+
+/**
+ * Drop one channel's registration and, once the last one goes, close the shared
+ * connection. Scoped per channel on purpose: each fan-out module owns its own
+ * channel and nothing else, so a module tearing itself down must not silence
+ * the other two — which is what a blanket `handlers.clear()` here would do.
+ * `UNLISTEN` is skipped: the handler lookup already drops the notification, and
+ * on the last deregistration the connection closes anyway.
+ */
+export async function unregisterNotifyChannel(channel: string): Promise<void> {
+  handlers.delete(channel)
+  if (handlers.size === 0) await _shutdownNotifyListener()
+}
+
+/** Test helper — the channels currently registered, in registration order. */
+export function _getNotifyChannels(): string[] {
+  return [...handlers.keys()]
+}
+
+/** Close the shared connection and forget every channel. Test-only teardown. */
+export async function _shutdownNotifyListener(): Promise<void> {
+  if (reconnectTimer) clearTimeout(reconnectTimer)
+  reconnectTimer = null
+  if (client) {
+    client.removeAllListeners()
+    await client.end().catch(() => {})
+    client = null
+  }
+  status = 'idle'
+  backoffMs = 1_000
+  handlers.clear()
+}

--- a/packages/api/src/db/notify-listener.ts
+++ b/packages/api/src/db/notify-listener.ts
@@ -46,6 +46,14 @@ const CHANNEL_IDENTIFIER = /^[a-z_][a-z0-9_]*$/
 
 const handlers = new Map<string, NotifyHandler>()
 
+/**
+ * Channels whose `LISTEN` succeeded on the CURRENT connection. Cleared on every
+ * reconnect, because a new session inherits no subscriptions. Keeping this
+ * separate from `handlers` is what lets a channel registered while `connect()`
+ * is mid-loop be picked up exactly once.
+ */
+const subscribed = new Set<string>()
+
 let client: pg.Client | null = null
 let status: 'idle' | 'connecting' | 'listening' | 'reconnecting' = 'idle'
 let reconnectTimer: NodeJS.Timeout | null = null
@@ -67,11 +75,13 @@ export function registerNotifyChannel(channel: string, handler: NotifyHandler): 
         'LISTEN cannot bind the channel as a parameter, so it must match /^[a-z_][a-z0-9_]*$/',
     )
   }
-  const alreadyRegistered = handlers.has(channel)
   handlers.set(channel, handler)
-  // Only the first registration needs a LISTEN; a replacement handler rides the
-  // subscription that is already open.
-  if (!alreadyRegistered && status === 'listening' && client) {
+  // A replacement handler rides the subscription that is already open; only a
+  // channel this connection has not yet subscribed needs a LISTEN. `subscribed`
+  // (not `handlers`) is the right guard: it is per-connection, so this stays
+  // correct across reconnects and cannot double-issue against `connect()`'s
+  // in-flight loop.
+  if (status === 'listening' && client && !subscribed.has(channel)) {
     void subscribe(client, channel)
   }
 }
@@ -80,6 +90,7 @@ export function registerNotifyChannel(channel: string, handler: NotifyHandler): 
 async function subscribe(target: pg.Client, channel: string): Promise<boolean> {
   try {
     await target.query(`LISTEN ${channel}`)
+    subscribed.add(channel)
     console.log(`[notify-listener] LISTEN ${channel} active`)
     return true
   } catch (err) {
@@ -122,14 +133,27 @@ async function connect(): Promise<void> {
 
   try {
     await next.connect()
-    status = 'listening'
-    backoffMs = 1_000
     for (const channel of handlers.keys()) {
       // Stop at the first failure: `subscribe` has already scheduled the
       // reconnect and ended this client, so the remaining channels would each
       // throw against a dead client and log a duplicate warning. The reconnect
       // re-subscribes all of them.
-      if (!(await subscribe(next, channel))) break
+      if (!(await subscribe(next, channel))) return
+    }
+    // Only now is the connection actually useful, so only now does it count as
+    // a success. Declaring 'listening' (and resetting the backoff) before the
+    // LISTENs land would make a server that ACCEPTS connections but fails
+    // LISTEN retry at a flat 1s forever instead of climbing to the 30s cap —
+    // a tight reconnect loop against a database that is already struggling,
+    // which is the exact condition this module exists to stay clear of.
+    status = 'listening'
+    backoffMs = 1_000
+    // A channel registered while the loop above was in flight saw
+    // `status !== 'listening'` and skipped its immediate LISTEN. The live Map
+    // iteration usually catches it; this sweep covers the case where it was
+    // added behind the cursor.
+    for (const channel of handlers.keys()) {
+      if (!subscribed.has(channel)) void subscribe(next, channel)
     }
   } catch (err) {
     console.warn('[notify-listener] failed to connect:', err)
@@ -146,6 +170,9 @@ function scheduleReconnect(): void {
     client.end().catch(() => {})
     client = null
   }
+  // A new session inherits no subscriptions, so nothing is subscribed until
+  // the next connect re-issues every LISTEN.
+  subscribed.clear()
 
   const delay = backoffMs
   backoffMs = Math.min(backoffMs * 2, 30_000)
@@ -197,4 +224,5 @@ export async function _shutdownNotifyListener(): Promise<void> {
   status = 'idle'
   backoffMs = 1_000
   handlers.clear()
+  subscribed.clear()
 }

--- a/packages/api/src/session-event-bus.ts
+++ b/packages/api/src/session-event-bus.ts
@@ -7,11 +7,11 @@
  *
  * Wires three jobs into one module:
  *
- *   1. **Cross-instance fan-out.** A dedicated `pg.Client` (outside the
- *      pool) holds `LISTEN session_event` for the lifetime of the
- *      Cloud Run instance. Whenever a route emits an event for a session,
- *      every instance with a subscriber for that sessionId receives the
- *      NOTIFY and pushes the SSE frame.
+ *   1. **Cross-instance fan-out.** `LISTEN session_event` rides the
+ *      process-wide shared connection (`./db/notify-listener.ts`), which
+ *      owns connect, reconnect-with-backoff, and re-subscribe. Whenever a
+ *      route emits an event for a session, every instance with a subscriber
+ *      for that sessionId receives the NOTIFY and pushes the SSE frame.
  *
  *   2. **Local in-process fan-out.** The producer instance does not wait
  *      for the NOTIFY round-trip — `emit()` dispatches to local
@@ -32,8 +32,12 @@
  * See docs/architecture/features/doc-comments.md → "Live turn reconnect".
  */
 
-import pg from 'pg'
 import { getPool, query } from './db/client.js'
+import {
+  registerNotifyChannel,
+  startNotifyListener,
+  unregisterNotifyChannel,
+} from './db/notify-listener.js'
 import { getSessionMessages } from './db/sessions.js'
 // The event TYPES live in the port (so route builders can reference them as an
 // injected dependency). Re-exported below for consumers that import them here.
@@ -80,88 +84,29 @@ type PresenceEntry = {
   connections: number
 }
 
-let listenerClient: pg.Client | null = null
-let listenerStatus: 'idle' | 'connecting' | 'listening' | 'reconnecting' = 'idle'
-let reconnectTimer: NodeJS.Timeout | null = null
 let sweepTimer: NodeJS.Timeout | null = null
-let backoffMs = 1_000
 
 const subscribers = new Set<Subscriber>()
 /** Per-session presence: sessionId → userId → entry. */
 const presence = new Map<string, Map<string, PresenceEntry>>()
 
-function buildClient(): pg.Client {
-  return new pg.Client({ connectionString: process.env.DATABASE_URL })
-}
-
-async function startListener(): Promise<void> {
-  if (listenerStatus === 'connecting' || listenerStatus === 'listening') return
-  listenerStatus = 'connecting'
-
-  const client = buildClient()
-  listenerClient = client
-
-  client.on('notification', (msg) => {
-    if (msg.channel !== CHANNEL || !msg.payload) return
-    let parsed: { kind: SessionEvent['kind']; sessionId: string; payload?: unknown; pointer?: { sequenceNum: number } }
-    try {
-      parsed = JSON.parse(msg.payload)
-    } catch {
-      return
-    }
-    if (!parsed.sessionId || !parsed.kind) return
-
-    if (parsed.pointer) {
-      // Large payload — fetch before fanout.
-      void hydrateAndDispatch(parsed.sessionId, parsed.kind, parsed.pointer.sequenceNum)
-      return
-    }
-
-    dispatchToLocal({ kind: parsed.kind, sessionId: parsed.sessionId, payload: parsed.payload } as SessionEvent)
-  })
-
-  client.on('error', (err) => {
-    console.warn('[session-event-bus] listener error, will reconnect:', err.message)
-    scheduleReconnect()
-  })
-  client.on('end', () => {
-    if (listenerStatus !== 'reconnecting') {
-      console.warn('[session-event-bus] listener ended unexpectedly')
-      scheduleReconnect()
-    }
-  })
-
+/** Shared-connection handler for `session_event`. */
+function handleSessionNotification(payload: string): void {
+  let parsed: { kind: SessionEvent['kind']; sessionId: string; payload?: unknown; pointer?: { sequenceNum: number } }
   try {
-    await client.connect()
-    await client.query(`LISTEN ${CHANNEL}`)
-    listenerStatus = 'listening'
-    backoffMs = 1_000
-    console.log(`[session-event-bus] LISTEN ${CHANNEL} active`)
-  } catch (err) {
-    console.warn('[session-event-bus] failed to start listener:', err)
-    scheduleReconnect()
+    parsed = JSON.parse(payload)
+  } catch {
+    return
   }
-}
+  if (!parsed.sessionId || !parsed.kind) return
 
-function scheduleReconnect(): void {
-  if (listenerStatus === 'reconnecting') return
-  listenerStatus = 'reconnecting'
-
-  if (listenerClient) {
-    listenerClient.removeAllListeners()
-    listenerClient.end().catch(() => {})
-    listenerClient = null
+  if (parsed.pointer) {
+    // Large payload — fetch before fanout.
+    void hydrateAndDispatch(parsed.sessionId, parsed.kind, parsed.pointer.sequenceNum)
+    return
   }
 
-  const delay = backoffMs
-  backoffMs = Math.min(backoffMs * 2, 30_000)
-
-  if (reconnectTimer) clearTimeout(reconnectTimer)
-  reconnectTimer = setTimeout(() => {
-    reconnectTimer = null
-    listenerStatus = 'idle'
-    void startListener()
-  }, delay)
+  dispatchToLocal({ kind: parsed.kind, sessionId: parsed.sessionId, payload: parsed.payload } as SessionEvent)
 }
 
 function dispatchToLocal(event: SessionEvent): void {
@@ -310,11 +255,12 @@ function startSweep(): void {
  * before the first SSE subscriber connects.
  */
 export function startSessionEventBus(): void {
-  // Single-process boot skips the dedicated LISTEN connection entirely (no
+  // Single-process boot skips the LISTEN subscription entirely (no
   // cross-instance fan-out to receive). The local-dispatch + presence sweep
   // below is the whole bus in that mode.
-  if (!SINGLE_PROCESS && listenerStatus === 'idle') {
-    void startListener()
+  if (!SINGLE_PROCESS) {
+    registerNotifyChannel(CHANNEL, handleSessionNotification)
+    startNotifyListener()
   }
   startSweep()
 }
@@ -435,18 +381,15 @@ export function _getSessionSubscriberCount(): number {
   return subscribers.size
 }
 
-/** Test helper — graceful shutdown for vitest cleanup. */
+/**
+ * Test helper — graceful shutdown for vitest cleanup. Deregisters only THIS
+ * module's channel; the shared connection closes itself once the last channel
+ * goes, so tearing this bus down never silences the others.
+ */
 export async function _shutdownSessionEventBus(): Promise<void> {
-  if (reconnectTimer) clearTimeout(reconnectTimer)
-  reconnectTimer = null
   if (sweepTimer) clearInterval(sweepTimer)
   sweepTimer = null
-  if (listenerClient) {
-    listenerClient.removeAllListeners()
-    await listenerClient.end().catch(() => {})
-    listenerClient = null
-  }
-  listenerStatus = 'idle'
+  await unregisterNotifyChannel(CHANNEL)
   subscribers.clear()
   presence.clear()
   void getPool


### PR DESCRIPTION
`LISTEN` binds to a single Postgres session, so each fan-out module opened its own dedicated `pg.Client` outside the pools: `brain_events`, `session_event`, and `feed_events`. None of the three starts is gated on `--no-workers`, so both `brian-api` and `brian-api-workers` ran all three — six dedicated connections fleet-wide, not the four the graded budget assumed.

Prod Cloud SQL is a `db-f1-micro`: `max_connections = 25` minus `superuser_reserved_connections = 3` leaves 22 for every non-superuser connection (`cloudsqladmin` is the only superuser; `postgres` and `app_user` are not). The pools already claim 16, so 16 + 6 = 22 is exactly the ceiling with zero headroom — one `prod-db.sh` session or migration run over the line and Postgres refuses with 53300, which reaches users as a failed chat turn.

One session can `LISTEN` on any number of channels. `db/notify-listener.ts` is now the process's single dedicated connection: it owns connect, reconnect-with-backoff, re-subscribe, and channel to handler routing. Payload parsing and subscriber dispatch stay in the fan-out modules.

This migrates the two open channels; `feed_events` lives in the platform tree and moves in the paired platform commit. Fleet LISTEN clients then go from 6 to 2, taking the worst case to 18 of 22.

Details worth reviewing:
- Registration is order-independent, and a channel registered while the connection is already live is subscribed on that same client.
- A throwing handler cannot take down the connection the other channels share.
- `unregisterNotifyChannel` is per channel, so one module's teardown never silences the others; the connection closes when the last channel goes.
- Channel names are validated as bare identifiers, because `LISTEN` cannot bind them as parameters.

11 tests in `packages/api/src/db/__tests__/notify-listener.test.ts`. Full `@use-brian/api` suite: 4130 passed, 1 pre-existing failure (`knowledge-proposals`, fails identically on `develop`).