### PR TITLE
fix(skills): make a proposed skill say when it fires, and keep the trigger visible

### DIFF
--- a/packages/api/src/agent-surface/write-tools.ts
+++ b/packages/api/src/agent-surface/write-tools.ts
@@ -98,11 +98,20 @@ export function createAgentWriteTools(deps: AgentWriteToolDeps): Tool[] {
       'Propose a new workspace skill (a reusable procedure the brain can follow). The ' +
       'proposal is STAGED for human review — it never becomes an active skill directly; a ' +
       'workspace member approves it in the web app, and the skill is then born under the ' +
-      'standard governance gate. Provide a clear name, a one-line description of when to ' +
-      'use it, and the full procedure content in markdown.',
+      'standard governance gate. Provide a clear name, a one-line description of what it ' +
+      'does, the trigger condition that should make it fire, and the full procedure ' +
+      'content in markdown.',
     inputSchema: z.object({
       name: z.string().min(3).max(100).describe('Human-readable skill name'),
-      description: z.string().min(3).max(250).describe('One line: what this skill does / when to use it'),
+      description: z.string().min(3).max(250).describe('One line: what this skill does'),
+      // Required for the same reason as `skill_manage`'s create_umbrella: the
+      // trigger is the only thing the skill listing offers the model to select
+      // on, so a proposal without one produces a skill nothing can ever reach.
+      whenToUse: z
+        .string()
+        .min(3)
+        .max(300)
+        .describe('The trigger: what the user says or does that should make this skill fire'),
       content: z.string().min(10).max(5000).describe('The full procedure, markdown'),
     }),
     requiresCapability: CONFIGURE_CAPABILITY,
@@ -118,6 +127,7 @@ export function createAgentWriteTools(deps: AgentWriteToolDeps): Tool[] {
           slug,
           name: input.name,
           description: input.description,
+          whenToUse: input.whenToUse,
           content: input.content,
         },
         approverUserId,

--- a/packages/api/src/db/pending-approvals-store.ts
+++ b/packages/api/src/db/pending-approvals-store.ts
@@ -237,6 +237,11 @@ export type CreateStagedSkillCreationParams = {
     slug: string
     name: string
     description: string
+    /** The skill's trigger condition. Required by `skill_manage`'s own input
+     *  schema (an assistant may not propose a skill it cannot say when to
+     *  use), optional here so approvals staged before the field existed
+     *  still materialise at approve time. */
+    whenToUse?: string
     content: string
     supportFiles?: Array<{
       kind: 'reference' | 'template' | 'script'

--- a/packages/api/src/routes/skill-approvals.ts
+++ b/packages/api/src/routes/skill-approvals.ts
@@ -406,6 +406,9 @@ type StagedCreationArgs = {
     slug: string
     name: string
     description: string
+    /** Optional: approvals staged before `skill_manage` required a trigger
+     *  carry none. Newly proposed umbrellas always have one. */
+    whenToUse?: string
     content: string
     supportFiles?: Array<{
       kind: 'reference' | 'template' | 'script'
@@ -575,6 +578,11 @@ async function applyStagedSkillCreation(
       slug: parsed.umbrella.slug,
       name: parsed.umbrella.name,
       description: parsed.umbrella.description,
+      // Carries the proposal's trigger onto the live row. Without this the
+      // field is dropped at approve time and the skill lands in the listing
+      // with nothing to select on — the shape that left 67 of 72 prod skills
+      // triggerless. `undefined` only for approvals staged before the field.
+      whenToUse: parsed.umbrella.whenToUse,
       content: parsed.umbrella.content,
       category: 'custom',
       source: 'user',

--- a/packages/api/src/workers/skill-review-worker.ts
+++ b/packages/api/src/workers/skill-review-worker.ts
@@ -1230,6 +1230,9 @@ function approvalsPort(approvals: PendingApprovalsStore, approverUserId: string)
         slug: string
         name: string
         description: string
+        /** Forwarded verbatim to the store. Optional here only so approvals
+         *  staged before the field existed still typecheck. */
+        whenToUse?: string
         content: string
         supportFiles?: Array<{ kind: SkillFileKind; name: string; content: string; description?: string }>
       }

--- a/packages/core/src/skills/__tests__/listing.test.ts
+++ b/packages/core/src/skills/__tests__/listing.test.ts
@@ -37,11 +37,36 @@ describe('[COMP:skills/listing] formatSkillListing', () => {
     expect(formatSkillListing([skill({ id: 'a', description: 'Does A.' })])).toBe('- a: Does A.')
   })
 
-  it('joins description and whenToUse with an em-dash', () => {
+  it('leads with whenToUse, then the description', () => {
     const out = formatSkillListing([
       skill({ id: 'a', description: 'Does A.', whenToUse: 'when you need A' }),
     ])
-    expect(out).toBe('- a: Does A. — when you need A')
+    expect(out).toBe('- a: when you need A — Does A.')
+  })
+
+  // The trigger is what the model SELECTS on; the description only
+  // elaborates. Truncation eats the tail, so a description-first join threw
+  // the trigger away exactly when the workspace got big enough to need it:
+  // in prod, an assistant with 41 enabled skills truncated every entry to 60
+  // chars and never once reached the concatenated whenToUse.
+  it('keeps the trigger and sacrifices the description when over budget', () => {
+    const many = Array.from({ length: 40 }, (_, i) =>
+      skill({
+        id: `skill-${String(i).padStart(2, '0')}`,
+        description: 'D'.repeat(300) + 'DESCRIPTION_TAIL',
+        whenToUse: `fires on topic ${i}`,
+      }),
+    )
+    const out = formatSkillListing(many)
+    expect(out.length).toBeLessThanOrEqual(SKILL_LISTING_BUDGET_CHARS)
+    // Truncation definitely engaged.
+    expect(out.split('\n').every((line) => line.endsWith('…'))).toBe(true)
+    // Every row still carries its own trigger, intact.
+    for (let i = 0; i < 40; i++) {
+      expect(out).toContain(`fires on topic ${i}`)
+    }
+    // The description tail is what got cut, not the trigger.
+    expect(out).not.toContain('DESCRIPTION_TAIL')
   })
 
   it('newline-joins multiple skills', () => {

--- a/packages/core/src/skills/__tests__/manage-tool.test.ts
+++ b/packages/core/src/skills/__tests__/manage-tool.test.ts
@@ -495,6 +495,7 @@ describe('[COMP:skills/manage-tool] create_umbrella routing', () => {
         umbrella: {
           name: 'fix-stripe-webhook',
           description: 'desc',
+          whenToUse: 'when the user starts onboarding a new customer',
           content: 'body',
         },
       } as never,
@@ -514,6 +515,7 @@ describe('[COMP:skills/manage-tool] create_umbrella routing', () => {
         umbrella: {
           name: 'customer-onboarding',
           description: 'desc',
+          whenToUse: 'when the user starts onboarding a new customer',
           content: 'See {{reference:nope}}.',
           // No supportFiles provided.
         },
@@ -522,6 +524,56 @@ describe('[COMP:skills/manage-tool] create_umbrella routing', () => {
     )
     expect(out.isError).toBe(true)
     expect((out.data as { error: string }).error).toMatch(/not in the proposal/i)
+  })
+
+  // An assistant may not propose a skill it cannot say when to use. The
+  // trigger is the only field the skill listing offers the model to select
+  // on, and `create_umbrella` had no field for it at all — which is how 67
+  // of 72 prod skills ended up triggerless and 2 of 72 ever ran. A human
+  // authoring in the UI may still omit it; they can see their own library.
+  it('REQUIRES whenToUse on the input schema', () => {
+    const tool = createSkillManageTool(makeDeps())
+    const missing = tool.inputSchema.safeParse({
+      action: 'create_umbrella',
+      umbrella: { name: 'customer-onboarding', description: 'desc', content: 'body' },
+    })
+    expect(missing.success).toBe(false)
+    expect(JSON.stringify(missing.error)).toMatch(/whenToUse/)
+
+    const present = tool.inputSchema.safeParse({
+      action: 'create_umbrella',
+      umbrella: {
+        name: 'customer-onboarding',
+        description: 'desc',
+        whenToUse: 'when the user starts onboarding a new customer',
+        content: 'body',
+      },
+    })
+    expect(present.success).toBe(true)
+  })
+
+  it('carries whenToUse into the staged proposal', async () => {
+    const deps = makeDeps()
+    const tool = createSkillManageTool(deps)
+    await tool.execute(
+      {
+        action: 'create_umbrella',
+        umbrella: {
+          name: 'customer-onboarding',
+          description: 'desc',
+          whenToUse: 'when the user starts onboarding a new customer',
+          content: 'body',
+        },
+      } as never,
+      CTX_STUB,
+    )
+    expect(deps.createStagedSkillCreation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proposedUmbrella: expect.objectContaining({
+          whenToUse: 'when the user starts onboarding a new customer',
+        }),
+      }),
+    )
   })
 
   it('accepts a body whose pointers all resolve to proposed support files', async () => {
@@ -533,6 +585,7 @@ describe('[COMP:skills/manage-tool] create_umbrella routing', () => {
         umbrella: {
           name: 'customer-onboarding',
           description: 'desc',
+          whenToUse: 'when the user starts onboarding a new customer',
           content: 'See {{reference:flow}}.',
           supportFiles: [{ kind: 'reference', name: 'flow', content: 'FLOW' }],
         },
@@ -553,6 +606,7 @@ describe('[COMP:skills/manage-tool] create_umbrella routing', () => {
         umbrella: {
           name: 'customer-onboarding',
           description: 'desc',
+          whenToUse: 'when the user starts onboarding a new customer',
           content: 'plain body',
         },
       } as never,
@@ -598,6 +652,7 @@ describe('[COMP:skills/manage-tool] create_umbrella routing', () => {
         umbrella: {
           name: 'Customer Onboarding',
           description: 'desc',
+          whenToUse: 'when the user starts onboarding a new customer',
           content: 'plain body',
         },
       } as never,

--- a/packages/core/src/skills/listing.ts
+++ b/packages/core/src/skills/listing.ts
@@ -1,8 +1,9 @@
 /**
  * Budget-aware skill listing formatter.
  *
- * Produces a compact "- id: description" listing for injection into the
- * system prompt. Entries are capped at 250 chars, total listing at ~1000 tokens.
+ * Produces a compact "- id: trigger — description" listing for injection into
+ * the system prompt. Entries are capped at 250 chars, total listing at ~1000
+ * tokens.
  *
  * [COMP:skills/listing]
  */
@@ -16,39 +17,43 @@ export const SKILL_LISTING_BUDGET_CHARS = 4000
 export const MAX_ENTRY_CHARS = 250
 
 /**
+ * One entry body: the trigger first, the description after.
+ *
+ * The order is load-bearing, because truncation always eats the tail.
+ * `whenToUse` is what the model SELECTS on; `description` only elaborates.
+ * With the previous description-first join the trigger was discarded exactly
+ * when the workspace grew big enough to need it: in prod, an assistant with
+ * 41 enabled skills re-truncated every entry to 60 chars, so the concatenated
+ * `whenToUse` was never reached and the listing collapsed into 41 rows that
+ * all opened "Standard procedure for...". Skills with no trigger render
+ * exactly as before.
+ */
+function entryBody(s: SkillMeta): string {
+  return s.whenToUse ? `${s.whenToUse} — ${s.description}` : s.description
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? text.slice(0, max - 1) + '…' : text
+}
+
+/**
  * Format a compact skill listing for system prompt injection.
  * Returns empty string if no skills are available.
  */
 export function formatSkillListing(skills: SkillMeta[]): string {
   if (skills.length === 0) return ''
 
-  const entries = skills.map((s) => {
-    const desc = s.whenToUse
-      ? `${s.description} — ${s.whenToUse}`
-      : s.description
-    const truncated = desc.length > MAX_ENTRY_CHARS
-      ? desc.slice(0, MAX_ENTRY_CHARS - 1) + '\u2026'
-      : desc
-    return `- ${s.id}: ${truncated}`
-  })
+  const entries = skills.map((s) => `- ${s.id}: ${truncate(entryBody(s), MAX_ENTRY_CHARS)}`)
 
   // Check total budget
   const full = entries.join('\n')
   if (full.length <= SKILL_LISTING_BUDGET_CHARS) return full
 
-  // Over budget — truncate descriptions further to fit
+  // Over budget — squeeze every entry body to an equal share of what's left.
   const nameOverhead = skills.reduce((sum, s) => sum + s.id.length + 4, 0)
   const newlines = skills.length - 1
   const availableForDescs = SKILL_LISTING_BUDGET_CHARS - nameOverhead - newlines
   const maxDescLen = Math.max(20, Math.floor(availableForDescs / skills.length))
 
-  return skills.map((s) => {
-    const desc = s.whenToUse
-      ? `${s.description} — ${s.whenToUse}`
-      : s.description
-    const truncated = desc.length > maxDescLen
-      ? desc.slice(0, maxDescLen - 1) + '\u2026'
-      : desc
-    return `- ${s.id}: ${truncated}`
-  }).join('\n')
+  return skills.map((s) => `- ${s.id}: ${truncate(entryBody(s), maxDescLen)}`).join('\n')
 }

--- a/packages/core/src/skills/manage-tool.ts
+++ b/packages/core/src/skills/manage-tool.ts
@@ -124,6 +124,10 @@ export type SkillManageApprovalsStore = {
       slug: string
       name: string
       description: string
+      /** Optional on the PORT, required on the tool's own input schema:
+       *  approvals staged before the field existed carry no trigger, and
+       *  approve-time must still be able to materialise them. */
+      whenToUse?: string
       content: string
       supportFiles?: Array<{ kind: SkillFilePointerKind; name: string; content: string; description?: string }>
     }
@@ -221,6 +225,19 @@ const FILE_SCHEMA = z.object({
 const UMBRELLA_SCHEMA = z.object({
   name: z.string().min(1).max(100),
   description: z.string().min(1).max(500),
+  // REQUIRED on this path, deliberately. `when_to_use` is the only field the
+  // skill listing gives the model to select on, and a skill without one is
+  // effectively unreachable: in prod, 67 of 72 workspace skills had no
+  // trigger and 2 had ever been invoked. Every one of those was born here,
+  // through a schema that had no field for it. A human authoring a skill in
+  // the UI may still omit it (`CreateSkillInput.whenToUse` stays optional) —
+  // they can see and fix their own library. An assistant proposing one
+  // cannot, so it must say when the skill fires before it may create it.
+  whenToUse: z
+    .string()
+    .min(1)
+    .max(300)
+    .describe('The trigger condition: what the user says or does that should make this skill fire.'),
   content: z.string().min(1).max(50_000),
   supportFiles: z.array(FILE_SCHEMA).max(20).optional(),
 })
@@ -285,6 +302,8 @@ Choose the action in this order — try each one and only fall through when it d
 3. add_support_file — Add a reference, template, or script under an existing skill. Use when the lesson is concrete enough to be a standalone artefact (a template the user reused, a transcript worth quoting, a checklist the user followed). Body pointers use {{reference:name}} / {{template:name}} / {{script:name}}.
 
 4. create_umbrella — Create a new class-level umbrella. ONLY when nothing above fits. The name must describe a class of task — not a session-specific bug, error, date, or PR number. Names like "fix-...", "debug-...", "audit-...", "today-...", "2026-...", "pr-...", or anything containing a literal error message will be rejected.
+
+whenToUse is required on create and is the single most important field you write. It is the only part of the skill anyone sees when deciding whether to open it, so state the TRIGGER, not the topic: what the user says or does that should make this skill fire. Write "when the user asks to log a diary entry, add a task, or sync the vault", not "diary and task management". A skill whose whenToUse merely restates its name will never be selected.
 
 Routing is automatic — you do not need to consider it. Auto-generated skills are patched directly; user-authored and community skills are queued for the workspace owner's approval; new umbrella creations are always queued. If an equivalent proposal is already waiting for the owner's decision, the tool skips staging a duplicate and reports skipped_pending_approval. The tool result tells you which path was taken.`
 
@@ -536,6 +555,7 @@ async function runCreateUmbrella(
   umbrella: {
     name: string
     description: string
+    whenToUse: string
     content: string
     supportFiles?: Array<{ kind: SkillFilePointerKind; name: string; content: string; description?: string }>
   },
@@ -592,6 +612,7 @@ async function runCreateUmbrella(
       slug,
       name: umbrella.name,
       description: umbrella.description,
+      whenToUse: umbrella.whenToUse,
       content: umbrella.content,
       supportFiles: umbrella.supportFiles,
     },


### PR DESCRIPTION
Two independent defects left the skill library unreachable. Measured in production on 2026-07-29: **72 active workspace skills, 2 ever invoked, 67 with no `when_to_use` at all.**

### 1. `create_umbrella` had no field for a trigger

Every skill an assistant proposed was born without one, and `when_to_use` is the only thing the listing gives the model to select on. It is now required on both assistant-facing creation paths (`skill_manage` → `create_umbrella`, and the agent-surface `proposeSkill`) and threaded proposal → approval → live row, where approve-time was silently dropping it.

It stays **optional** on `CreateSkillInput` and on the store/port types: a human authoring in the UI may skip it (they can see and fix their own library), and approvals staged before the field existed must still materialise.

### 2. The listing joined description-first, so truncation ate the trigger

The over-budget path gives every entry an equal share of 4000 chars, so at 41 enabled skills each row is cut to 60 characters and the concatenated `when_to_use` was never reached. One production assistant's entire listing had collapsed into 41 rows that all opened "Standard procedure for...", cut mid-word.

Entries now render `- <slug>: <trigger> — <description>`, so the description is what gets sacrificed.

### Tests

`@use-brian/core` 4278 passed. `@use-brian/api` 4118 passed, 2 failed (both verified pre-existing/environmental: `knowledge-proposals` fails identically with these changes stashed, `shopify-domain-resolve` is a 5s network timeout). `tsc --noEmit` clean, `pnpm smoke` OK.

New regression tests: `[COMP:skills/manage-tool] REQUIRES whenToUse on the input schema`, `carries whenToUse into the staged proposal`, `[COMP:skills/listing] keeps the trigger and sacrifices the description when over budget`.

### Not in this PR

Backfilling triggers onto the existing 67 skills, raising the listing budget, and the decay-sweep gap (documented as deliberately deferred). Spec: `docs/architecture/engine/skill-system.md` in brian-platform.