### PR TITLE
fix(mcp): stop the closed-world prompt denying folded connectors

### DIFF
--- a/packages/api/src/evals/fixture.ts
+++ b/packages/api/src/evals/fixture.ts
@@ -226,7 +226,7 @@ export function buildFixtureWorkspace(): FixtureWorkspace {
     LAYER_1_SYSTEM_PROMPT +
     '\n\n' +
     FIXTURE_USER_CONTEXT +
-    buildUnavailableCapabilitiesPrompt(unavailable)
+    buildUnavailableCapabilitiesPrompt(unavailable, tools)
 
   // Frozen-state capability grants: 'tasks' (§3 explicit) + 'crm' (probe
   // expectations require saveContact/listDeals callable). The other declared

--- a/packages/api/src/inter-assistant/executor.ts
+++ b/packages/api/src/inter-assistant/executor.ts
@@ -1089,10 +1089,21 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
     // dependency chain and this file is on the boot path (cf. the boot-time TDZ
     // this repo has hit before). Skipped entirely when nothing is unavailable.
     let unavailableBlock = ''
-    if (unavailableCapabilities.length > 0) {
+    // Also fires with an EMPTY list when the callee holds a search surface:
+    // its connectors are folded behind `mcp_search`, so without the
+    // search-before-denial rule it answers from absence (2026-07-23). The
+    // lazy import still only happens when there is something to emit.
+    //
+    // `finalTools`, NOT `calleeTools` — a pinned `allowedTools` runs through
+    // `filterToolsByAllowList`, which keeps only the named tools and so can
+    // strip `mcp_search`. Gating on the pre-filter map would order the callee
+    // to search with a tool it does not hold (tool-awareness rule), and that
+    // combination is the normal case: pinning an allow-list is exactly what
+    // sets `keepBuiltinsDirect` above. Same map the blueprint gate reads.
+    if (unavailableCapabilities.length > 0 || finalTools.has('mcp_search')) {
       try {
         const { buildUnavailableCapabilitiesPrompt } = await import('../routes/route-helpers.js')
-        unavailableBlock = buildUnavailableCapabilitiesPrompt(unavailableCapabilities)
+        unavailableBlock = buildUnavailableCapabilitiesPrompt(unavailableCapabilities, finalTools)
       } catch (err) {
         console.error('[inter-assistant] unavailable-capabilities prompt failed (skipped):', err)
       }

--- a/packages/api/src/mcp/__tests__/inject.test.ts
+++ b/packages/api/src/mcp/__tests__/inject.test.ts
@@ -60,6 +60,7 @@ import {
   INJECTED_BUILTIN_TOOLS_BY_CONNECTOR,
   _getMcpDiscoveryCacheSize,
 } from '../inject.js'
+import { buildUnavailableCapabilitiesPrompt } from '../../routes/route-helpers.js'
 
 function settingsStoreStub() {
   // Generous stub — the no-connector path touches few of these, but
@@ -1137,5 +1138,48 @@ describe('[COMP:api/mcp-inject] built-in fold vs direct (keepBuiltinsDirect)', (
     expect(tools.has('githubListPullRequests')).toBe(false)
     expect(tools.has('mcp_search')).toBe(true)
     expect(tools.has('mcp_call')).toBe(true)
+  })
+
+  // ── The prod failure this fold caused (2026-07-23) ────────────────
+  // Composed against the REAL injector, because the bug lives in the gap
+  // between two individually-correct halves: the pluck (above) and the
+  // closed-world prompt. TaskMaster held a live github grant, saw
+  // ["mcp_search","mcp_call"] as its whole tool map, read a system prompt
+  // asserting that map plus the unavailable list was the complete
+  // integration surface, and denied a GitHub write it was authorized for.
+  describe('closed-world prompt vs the folded surface', () => {
+    it('never leaves a connected connector in neither the tool map nor the unavailable list without a search order', async () => {
+      // ONE injector run supplies BOTH halves — the map and the unavailable
+      // list have to come from the same turn or the composition proves nothing.
+      const tools = new Map()
+      const result = await injectMcpTools({
+        userId: 'u-1',
+        assistantId: 'a-1',
+        tools,
+        connectorStore: githubConnector() as never,
+        settingsStore: settingsStoreStub() as never,
+        keepBuiltinsDirect: false,
+      })
+
+      // Guard the guard: an empty list would make the github assertion below
+      // vacuous, and this turn genuinely adverts other disconnected providers.
+      expect(result.unavailable.length).toBeGreaterThan(0)
+      // github is connected, so it is correctly absent from `unavailable`...
+      expect(result.unavailable.some((u) => /github/i.test(u))).toBe(false)
+      // ...and plucked, so it is absent from the visible tool map too.
+      expect([...tools.keys()].some((n) => /^github/i.test(n))).toBe(false)
+      expect(tools.has('mcp_search')).toBe(true)
+
+      // Which means the prompt must NOT treat those two sets as exhaustive.
+      const prompt = buildUnavailableCapabilitiesPrompt(result.unavailable, tools)
+      expect(prompt).not.toContain('This list plus your tools is the complete integration surface')
+      expect(prompt).toContain('mcp_search')
+    })
+
+    it('still emits the search order when every connector is healthy (empty unavailable list)', async () => {
+      const tools = await injectWith(false)
+      const prompt = buildUnavailableCapabilitiesPrompt([], tools)
+      expect(prompt).toContain('mcp_search')
+    })
   })
 })

--- a/packages/api/src/routes/__tests__/route-helpers.test.ts
+++ b/packages/api/src/routes/__tests__/route-helpers.test.ts
@@ -76,25 +76,68 @@ describe('[COMP:api/route-helpers] Route helpers', () => {
   })
 
   describe('buildUnavailableCapabilitiesPrompt', () => {
+    // No search surface: `injectMcpTools` skips the mcp_search pair when no
+    // source exists, and these three pin the original strict behaviour.
+    const noSearch = new Map()
+
     it('returns empty string for empty array', () => {
-      expect(buildUnavailableCapabilitiesPrompt([])).toBe('')
+      expect(buildUnavailableCapabilitiesPrompt([], noSearch)).toBe('')
     })
 
     it('includes capability names and NOT available text', () => {
-      const result = buildUnavailableCapabilitiesPrompt(['Gmail', 'Google Calendar'])
+      const result = buildUnavailableCapabilitiesPrompt(['Gmail', 'Google Calendar'], noSearch)
       expect(result).toContain('Gmail')
       expect(result).toContain('Google Calendar')
       expect(result).toContain('NOT available')
     })
 
     it('scopes the Settings suggestion to the listed services (closed world)', () => {
-      const result = buildUnavailableCapabilitiesPrompt(['Gmail'])
+      const result = buildUnavailableCapabilitiesPrompt(['Gmail'], noSearch)
       // The template must be scoped to the list, not a general habit the
       // model extends to arbitrary services (the invented-Jira-connector
       // class caught by the WS2 probe battery).
       expect(result).toContain('listed above')
       expect(result).toContain('Never point the user to a Settings toggle or connector for a service that is not listed here')
       expect(result).not.toContain('an unavailable service')
+    })
+
+    // ── Deferred-surface carve-out (prod incident 2026-07-23) ──────
+    // `injectMcpTools` DELETES every built-in connector tool from the map and
+    // folds it behind `mcp_search`. A granted+connected connector is therefore
+    // in NEITHER `capabilities` (it is connected) NOR the tool map (plucked),
+    // so the bare closed-world sentence told the model to deny it. TaskMaster
+    // refused a GitHub write it held a live grant for, then found 8 GitHub
+    // tools the moment it was pushed into running `mcp_search`.
+    const withSearch = new Map([['mcp_search', {}], ['mcp_call', {}]])
+
+    it('does NOT claim the visible tools are the whole surface when mcp_search is present', () => {
+      const result = buildUnavailableCapabilitiesPrompt(['Gmail'], withSearch)
+      expect(result).not.toContain('This list plus your tools is the complete integration surface')
+    })
+
+    it('orders a search before any denial when mcp_search is present', () => {
+      const result = buildUnavailableCapabilitiesPrompt(['Gmail'], withSearch)
+      expect(result).toContain('mcp_search')
+      expect(result).toMatch(/before .{0,60}unavailable/i)
+      // The listed services stay closed-world — searching for them is still banned.
+      expect(result).toContain('Never point the user to a Settings toggle or connector for a service that is not listed here')
+    })
+
+    it('emits the search guidance even when nothing is unavailable', () => {
+      // The old builder returned '' at length 0, so an assistant with every
+      // connector healthy got NO guidance at all and still denied from absence.
+      const result = buildUnavailableCapabilitiesPrompt([], withSearch)
+      expect(result).toContain('mcp_search')
+      expect(result).not.toContain('# Unavailable capabilities')
+    })
+
+    it('keeps the strict closed world when there is no search surface', () => {
+      // Tool-awareness rule: never name mcp_search when it is not in the map.
+      // `injectMcpTools` skips the search pair entirely when no source exists.
+      expect(buildUnavailableCapabilitiesPrompt([], new Map())).toBe('')
+      const result = buildUnavailableCapabilitiesPrompt(['Gmail'], new Map())
+      expect(result).not.toContain('mcp_search')
+      expect(result).toContain('This list plus your tools is the complete integration surface')
     })
   })
 

--- a/packages/api/src/routes/channel-pipeline.ts
+++ b/packages/api/src/routes/channel-pipeline.ts
@@ -1161,7 +1161,7 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
     })
     fullSystemPrompt += skillResult.promptFragment
   }
-  fullSystemPrompt += buildUnavailableCapabilitiesPrompt(unavailableCapabilities)
+  fullSystemPrompt += buildUnavailableCapabilitiesPrompt(unavailableCapabilities, allTools)
   fullSystemPrompt += buildBrowserEscalationPrompt(allTools)
 
   // ── Pre-flight-confirm reply correlation (channel-recording-preflight-confirm §6) ──

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -3475,7 +3475,7 @@ export function chatRoutes(options: WebChatOptions): Router {
 
       // Inject unavailable capabilities so the model doesn't waste turns
       // searching for tools that don't exist.
-      fullSystemPrompt += buildUnavailableCapabilitiesPrompt(unavailableCapabilities)
+      fullSystemPrompt += buildUnavailableCapabilitiesPrompt(unavailableCapabilities, allTools)
 
       // Browser-escalation guidance — dynamic injection gated on the acting
       // browser tools being in the map (tool-awareness carve-out): search

--- a/packages/api/src/routes/public-turn.ts
+++ b/packages/api/src/routes/public-turn.ts
@@ -458,7 +458,7 @@ export async function executePublicTurn(
   // Append the unavailable-capabilities block so the model doesn't
   // burn turns hunting for tools that aren't connected. Same pattern
   // as chat.ts (line 1124).
-  const fullSystemPrompt = promptWithMemory + buildUnavailableCapabilitiesPrompt(mcpInjection.unavailable)
+  const fullSystemPrompt = promptWithMemory + buildUnavailableCapabilitiesPrompt(mcpInjection.unavailable, baseTools)
 
   // ── 10. Load history + proactive compaction ──────────────
   // Mirrors web chat (chat.ts:797–816). `runProactiveCompaction`

--- a/packages/api/src/routes/route-helpers.ts
+++ b/packages/api/src/routes/route-helpers.ts
@@ -205,10 +205,63 @@ export function isValidDateString(date: string): boolean {
  * arbitrary services ("enable the Jira connector in Settings") and invent
  * integrations that do not exist (caught by the WS2 probe battery,
  * conn-jira-post / wf-crm-deal-won).
+ *
+ * The closed world has to account for the DEFERRED surface (prod incident
+ * 2026-07-23). `injectMcpTools` deletes every built-in connector tool from
+ * the map and folds it behind `mcp_search`, so a connected + granted
+ * connector sits in NEITHER `capabilities` (it is connected, so it is never
+ * adverted unavailable) NOR the visible tool map (it was plucked). The old
+ * wording — "this list plus your tools is the complete integration surface:
+ * for a service in neither, Use Brian has no integration" — therefore told
+ * the model to deny a capability it held a live grant for. TaskMaster
+ * refused a GitHub write, then listed 8 GitHub tools the moment the user
+ * pushed it into running `mcp_search`.
+ *
+ * So when the search surface exists, the closed world is widened to include
+ * it and a search is ordered before any denial. `tools` gates that wording
+ * the same way `buildBrowserEscalationPrompt` gates its own: `injectMcpTools`
+ * skips the search pair entirely when no source is present, and naming a
+ * tool that is not in the map is exactly what the tool-awareness rule bans.
+ * It is REQUIRED, not optional, so a new call site cannot silently restore
+ * the pre-incident wording — the compiler is the enforcement.
+ *
+ * Pass the map the QUERY LOOP receives, not an earlier one. Anything that
+ * narrows the map afterwards (the inter-assistant allow-list filter) can
+ * drop `mcp_search`, and ordering a search for a tool the callee does not
+ * hold is the same tool-awareness violation in the opposite direction.
  */
-export function buildUnavailableCapabilitiesPrompt(capabilities: string[]): string {
-  if (capabilities.length === 0) return ''
-  return `\n\n# Unavailable capabilities\n\nThe following services are NOT available. Do not attempt to use them or search for them:\n${capabilities.map((c) => `- ${c}`).join('\n')}\n\nIf the user asks for something that requires one of the services listed above, say it is not connected and suggest enabling it in Settings (when an entry includes its own connect phrase, use that instead). This list plus your tools is the complete integration surface: for a service in neither, Use Brian has no integration to enable. Say so plainly and offer the nearest supported alternative. Never point the user to a Settings toggle or connector for a service that is not listed here.`
+const SEARCH_BEFORE_DENIAL =
+  'Before you tell the user a capability is unavailable, run `mcp_search` for it.'
+
+/**
+ * Deliberately "may be folded", not "is folded": the workflow path runs with
+ * `keepBuiltinsDirect`, which leaves built-ins in the map by name while a
+ * custom remote source can still put `mcp_search` there. "Every connector is
+ * hidden" would be a falsehood on that path.
+ */
+const FOLDED_SURFACE =
+  'Your visible tools are not the whole integration surface: connector tools may be folded behind `mcp_search` and not appear by name until you search for them.'
+
+export function buildUnavailableCapabilitiesPrompt(
+  capabilities: string[],
+  tools: { has(name: string): boolean },
+): string {
+  const searchable = tools.has('mcp_search')
+
+  // Nothing unavailable, but connectors may still be folded out of sight:
+  // the model needs the search-before-denial rule or it answers from absence.
+  if (capabilities.length === 0) {
+    if (!searchable) return ''
+    return `\n\n# Connector tools\n\n${FOLDED_SURFACE} ${SEARCH_BEFORE_DENIAL}`
+  }
+
+  const head = `\n\n# Unavailable capabilities\n\nThe following services are NOT available. Do not attempt to use them or search for them:\n${capabilities.map((c) => `- ${c}`).join('\n')}\n\nIf the user asks for something that requires one of the services listed above, say it is not connected and suggest enabling it in Settings (when an entry includes its own connect phrase, use that instead).`
+
+  const closedWorld = searchable
+    ? ` This list, your visible tools, and every tool reachable through \`mcp_search\` together are the complete integration surface. ${FOLDED_SURFACE} ${SEARCH_BEFORE_DENIAL} Only a service listed above, or one \`mcp_search\` cannot find, has no integration to enable: say so plainly then and offer the nearest supported alternative.`
+    : ` This list plus your tools is the complete integration surface: for a service in neither, Use Brian has no integration to enable. Say so plainly and offer the nearest supported alternative.`
+
+  return `${head}${closedWorld} Never point the user to a Settings toggle or connector for a service that is not listed here.`
 }
 
 /**


### PR DESCRIPTION
`injectMcpTools` deletes every built-in connector tool from the turn's map and folds it behind `mcp_search`, so a connected + granted connector is in **neither** `unavailable[]` (it works, so it is never adverted) **nor** the visible tool map (it was plucked). `buildUnavailableCapabilitiesPrompt` nonetheless declared those two sets "the complete integration surface" and told the model to say no integration exists for anything outside them.

The prompt was not merely failing to help. It was ordering the denial.

### Production incident, 2026-07-23

Assistant "TaskMaster" held a live `github` grant (`read_allowed`, plus three write actions). Asked "did you update the git repo?", it replied "GitHub is not connected to this Assistant, so I have no permission" with **no tool call**, and pointed the user at Studio → Connectors.

Its entire tool map that turn was `["mcp_search","mcp_call"]`. Pushed to look, it ran `mcp_search("github")`, got 8 tools back, and reversed itself.

### The fix

| `mcp_search` in map | Completeness claim | Denial rule |
|---|---|---|
| yes | `unavailable[]` + visible tools + everything reachable through `mcp_search` | run `mcp_search` **before** saying a capability is unavailable |
| no | original strict wording, unchanged | deny directly |

Naming `mcp_search` is gated on it being in the map, the same dynamic-injection carve-out `buildBrowserEscalationPrompt` uses. The block also emits with an empty `unavailable[]` when a search surface exists; it previously returned `''`, so an assistant whose connectors were all healthy got no guidance and still answered from absence.

The tool-map parameter is **required**, not optional, so a new call site cannot silently restore the pre-incident wording. Callers pass the map the query loop actually receives: `executor.ts` gates on `finalTools`, never the pre-filter `calleeTools`, because a pinned `allowedTools` runs through `filterToolsByAllowList` and can strip `mcp_search`.

### Tests

Full `@use-brian/api` suite: zero new failures against a stashed-changes baseline. `tsc --noEmit` clean, `pnpm smoke` OK.

Regression tests: `[COMP:api/route-helpers] buildUnavailableCapabilitiesPrompt` (both branches) and `[COMP:api/mcp-inject] closed-world prompt vs the folded surface`, composed against the real injector because the defect lives in the gap between two individually-correct halves.

### Deliberately not included

A positive "Connected services" roster. It would over-claim at action granularity, since ungranted write tools stay in the map and throw at execute time. Documented as a known gap in `docs/architecture/integrations/mcp.md`.

Branched from `195a3b5e`; `develop` has moved since, so rebase or merge as you prefer.