### PR TITLE
fix(browser-relay): restore brian-kb install links in the Docker build

### DIFF
--- a/apps/browser-relay/Dockerfile
+++ b/apps/browser-relay/Dockerfile
@@ -13,7 +13,7 @@ COPY packages/channels/package.json packages/channels/tsconfig.json ./packages/c
 COPY packages/doc-model/package.json packages/doc-model/tsconfig.json ./packages/doc-model/
 COPY packages/core/package.json packages/core/tsconfig.json ./packages/core/
 COPY packages/api/package.json packages/api/tsconfig.json ./packages/api/
-COPY packages/brian-kb/package.json ./packages/brian-kb/
+COPY packages/brian-kb/package.json packages/brian-kb/tsconfig.json ./packages/brian-kb/
 COPY apps/browser-relay/package.json apps/browser-relay/tsconfig.json ./apps/browser-relay/
 
 RUN pnpm install --frozen-lockfile
@@ -28,7 +28,9 @@ COPY packages/core/src ./packages/core/src
 COPY packages/core/scripts ./packages/core/scripts
 COPY packages/api/src ./packages/api/src
 COPY packages/api/migrations ./packages/api/migrations
-COPY packages/brian-kb ./packages/brian-kb
+# Source only: copying the whole package dir would clobber the node_modules
+# symlinks pnpm created in the deps stage, breaking a clean build.
+COPY packages/brian-kb/src ./packages/brian-kb/src
 COPY apps/browser-relay/src ./apps/browser-relay/src
 
 # pnpm topological build (deps-first), not turbo — see discord-connector.
@@ -57,7 +59,7 @@ COPY --from=build /app/packages/channels/dist ./packages/channels/dist
 COPY --from=build /app/packages/doc-model/dist ./packages/doc-model/dist
 COPY --from=build /app/packages/core/dist ./packages/core/dist
 COPY --from=build /app/packages/api/dist ./packages/api/dist
-COPY --from=build /app/packages/brian-kb ./packages/brian-kb
+COPY --from=build /app/packages/brian-kb/dist ./packages/brian-kb/dist
 COPY --from=build /app/apps/browser-relay/dist ./apps/browser-relay/dist
 
 ENV NODE_ENV=production


### PR DESCRIPTION
## What

Ports `37e9214a` ("repair clean deployment builds") to this Dockerfile. It fixed exactly these three `COPY` lines in the platform tree's copy of this same app, and this copy never received it.

```diff
-COPY packages/brian-kb/package.json ./packages/brian-kb/
+COPY packages/brian-kb/package.json packages/brian-kb/tsconfig.json ./packages/brian-kb/

-COPY packages/brian-kb ./packages/brian-kb
+COPY packages/brian-kb/src ./packages/brian-kb/src

-COPY --from=build /app/packages/brian-kb ./packages/brian-kb
+COPY --from=build /app/packages/brian-kb/dist ./packages/brian-kb/dist
```

Copying the whole `packages/brian-kb` directory overwrites the `node_modules` links pnpm created in the deps stage; the runner variant additionally drags build-stage dev dependencies into the production image.

(`packages/brian-kb` here is the TypeScript package `@use-brian/brian-kb` — the KB parser/linter — not the markdown `brian-kb` content submodule.)

## Why now

The platform tree also had a copy of this app at `apps/browser-relay`, so `@use-brian/browser-relay` was declared by two workspace projects once the platform root absorbed both trees. pnpm tolerates duplicate names; turbo does not, and aborted at workspace load:

```
x Failed to add workspace "@use-brian/browser-relay" from "use-brian/apps/browser-relay/package.json",
| it already exists at "apps/browser-relay/package.json"
```

Root `package.json` routes `build`/`typecheck`/`test` through `turbo run`, so all three were down repo-wide, while `check` and `smoke` (`pnpm --filter`) kept reporting green.

The platform copy is being deleted (it is a strict subset in `src` — 0 unique lines). But its Dockerfile was **not** a subset: it carried this fix. Deleting it without this port would have reintroduced the outage `37e9214a` fixed, since `scripts/deploy-browser-relay.sh` now builds this file with `use-brian/` as the context.

## Verification

- `docker build -f apps/browser-relay/Dockerfile <submodule-root>` succeeds
- image boots: `browser-relay listening on port 8080`
- `GET /health` → `{"status":"ok","connections":0}`
- workspace links intact in the image (`@use-brian/api -> ../../../../packages/api`)
- relay tests 19/19

A `workspace-name-collision` graded invariant lands in the platform PR so this class fails mechanically instead of silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)