### PR TITLE
Promote develop to main: browser-relay Docker fix + app-desktop v0.0.9

### DIFF
--- a/apps/app-desktop/package.json
+++ b/apps/app-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@use-brian/app-desktop",
   "productName": "Use Brian",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Use Brian — saved table + board views over your tasks, CRM, and workflow runs.",
   "author": "SIDAN Lab",
   "private": true,

--- a/apps/browser-relay/Dockerfile
+++ b/apps/browser-relay/Dockerfile
@@ -13,7 +13,7 @@ COPY packages/channels/package.json packages/channels/tsconfig.json ./packages/c
 COPY packages/doc-model/package.json packages/doc-model/tsconfig.json ./packages/doc-model/
 COPY packages/core/package.json packages/core/tsconfig.json ./packages/core/
 COPY packages/api/package.json packages/api/tsconfig.json ./packages/api/
-COPY packages/brian-kb/package.json ./packages/brian-kb/
+COPY packages/brian-kb/package.json packages/brian-kb/tsconfig.json ./packages/brian-kb/
 COPY apps/browser-relay/package.json apps/browser-relay/tsconfig.json ./apps/browser-relay/
 
 RUN pnpm install --frozen-lockfile
@@ -28,7 +28,9 @@ COPY packages/core/src ./packages/core/src
 COPY packages/core/scripts ./packages/core/scripts
 COPY packages/api/src ./packages/api/src
 COPY packages/api/migrations ./packages/api/migrations
-COPY packages/brian-kb ./packages/brian-kb
+# Source only: copying the whole package dir would clobber the node_modules
+# symlinks pnpm created in the deps stage, breaking a clean build.
+COPY packages/brian-kb/src ./packages/brian-kb/src
 COPY apps/browser-relay/src ./apps/browser-relay/src
 
 # pnpm topological build (deps-first), not turbo — see discord-connector.
@@ -57,7 +59,7 @@ COPY --from=build /app/packages/channels/dist ./packages/channels/dist
 COPY --from=build /app/packages/doc-model/dist ./packages/doc-model/dist
 COPY --from=build /app/packages/core/dist ./packages/core/dist
 COPY --from=build /app/packages/api/dist ./packages/api/dist
-COPY --from=build /app/packages/brian-kb ./packages/brian-kb
+COPY --from=build /app/packages/brian-kb/dist ./packages/brian-kb/dist
 COPY --from=build /app/apps/browser-relay/dist ./apps/browser-relay/dist
 
 ENV NODE_ENV=production


### PR DESCRIPTION
Routine develop → main promotion, two commits:

- `687ec956` **fix(browser-relay): restore brian-kb install links in the Docker build** (#124) — ports `37e9214a` to this Dockerfile. Copying the whole `packages/brian-kb` directory overwrites the `node_modules` links pnpm created in the deps stage, and the runner variant drags build-stage dev dependencies into the production image.
- `dfa36ada` chore(app-desktop): release v0.0.9 (version bump only)

Tree delta vs `main` is exactly two files: `apps/browser-relay/Dockerfile` and `apps/app-desktop/package.json`.

## Why now

The platform tree is deleting its duplicate copy of `apps/browser-relay` (two projects declaring `@use-brian/browser-relay` stopped turbo loading the workspace at all), which makes this Dockerfile the only remaining one — and `scripts/deploy-browser-relay.sh` now builds it with `use-brian/` as the Docker context. The platform gitlink tracks `main`, so the fix has to be here before that lands, or the deploy reintroduces the outage `37e9214a` fixed.

Verified on the fix: image builds from the submodule context, boots, and serves `/health`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)