### PR TITLE
fix(mailbox): stop an unhandled IMAP 'error' event from killing the workers process

### DIFF
--- a/packages/api/src/db/__tests__/workflow-run-queue-store.integration.test.ts
+++ b/packages/api/src/db/__tests__/workflow-run-queue-store.integration.test.ts
@@ -463,3 +463,141 @@ describeIf('[COMP:workflow/run-queue] claimNextPendingRunSystem (mig 302)', () =
     }
   })
 })
+
+describeIf('[COMP:workflow/run-queue] failAbandonedInlineRunsSystem', () => {
+  // The inverse gate of everything above: these are the runs the queue does NOT
+  // own. It may only mark them dead. Regression cover for 2026-07-28, when a
+  // crash-looping worker orphaned 216 schedule runs that no sweeper could see.
+  const WINDOW = { abandonedSeconds: 3600 }
+
+  it('fails an abandoned inline run — pending AND running, whatever the inline kind', async () => {
+    const f = await makeFixture()
+    try {
+      // The whole non-event half of the trigger_kind check constraint. Webhook
+      // receivers have no kind of their own — they stamp 'manual'.
+      const kinds = ['schedule', 'manual', 'button']
+      const pendings = await Promise.all(
+        kinds.map((k) =>
+          f.addRun({ workflowId: f.wfA, status: 'pending', lastActiveAgoSeconds: 7200, triggerKind: k }),
+        ),
+      )
+      // 'running' is the mid-step death: the executor wrote a step, then died.
+      const mid = await f.addRun({
+        workflowId: f.wfB,
+        status: 'running',
+        lastActiveAgoSeconds: 7200,
+        triggerKind: 'schedule',
+      })
+
+      const n = await queue.failAbandonedInlineRunsSystem(WINDOW)
+      expect(n).toBeGreaterThanOrEqual(kinds.length + 1)
+
+      for (const id of [...pendings, mid]) {
+        const state = await rowState(id)
+        expect(state.status).toBe('failed')
+        expect(state.reason).toBe('run_abandoned')
+      }
+    } finally {
+      await f.cleanup()
+    }
+  })
+
+  it('never touches an EVENT run — those belong to the claim/requeue path', async () => {
+    const f = await makeFixture()
+    try {
+      // Long-abandoned but queue-owned: the stale-running reaper re-queues this
+      // one (event runs are safe to retry). This sweep must leave it alone, or
+      // a retryable run gets killed instead.
+      const evt = await f.addRun({
+        workflowId: f.wfA,
+        status: 'running',
+        lastActiveAgoSeconds: 99_999,
+        triggerKind: 'event',
+      })
+      const evtPending = await f.addRun({
+        workflowId: f.wfB,
+        status: 'pending',
+        lastActiveAgoSeconds: 99_999,
+        triggerKind: 'event',
+      })
+
+      await queue.failAbandonedInlineRunsSystem(WINDOW)
+      expect((await rowState(evt)).status).toBe('running')
+      expect((await rowState(evtPending)).status).toBe('pending')
+    } finally {
+      await f.cleanup()
+    }
+  })
+
+  it('leaves a still-active inline run alone', async () => {
+    const f = await makeFixture()
+    try {
+      // Every step write bumps last_active_at, so a live multi-step run keeps
+      // proving it is alive. 10s of inactivity is a working run, not a corpse.
+      const live = await f.addRun({
+        workflowId: f.wfA,
+        status: 'running',
+        lastActiveAgoSeconds: 10,
+        triggerKind: 'schedule',
+      })
+      const justStarted = await f.addRun({
+        workflowId: f.wfB,
+        status: 'pending',
+        lastActiveAgoSeconds: 0,
+        triggerKind: 'manual',
+      })
+
+      expect(await queue.failAbandonedInlineRunsSystem(WINDOW)).toBe(0)
+      expect((await rowState(live)).status).toBe('running')
+      expect((await rowState(justStarted)).status).toBe('pending')
+    } finally {
+      await f.cleanup()
+    }
+  })
+
+  it('never touches a run parked on a wait or an approval, however long it waits', async () => {
+    const f = await makeFixture()
+    try {
+      // These are idle BY DESIGN — a wait step until next Monday, or a human
+      // approval nobody has answered yet. Failing them would break the feature.
+      const waiting = await f.addRun({
+        workflowId: f.wfA,
+        status: 'awaiting_wait',
+        lastActiveAgoSeconds: 99_999,
+        triggerKind: 'schedule',
+      })
+      const forInput = await f.addRun({
+        workflowId: f.wfB,
+        status: 'awaiting_input',
+        lastActiveAgoSeconds: 99_999,
+        triggerKind: 'manual',
+      })
+
+      await queue.failAbandonedInlineRunsSystem(WINDOW)
+      expect((await rowState(waiting)).status).toBe('awaiting_wait')
+      expect((await rowState(forInput)).status).toBe('awaiting_input')
+    } finally {
+      await f.cleanup()
+    }
+  })
+
+  it('is idempotent — a second sweep finds nothing and does not re-stamp', async () => {
+    const f = await makeFixture()
+    try {
+      const run = await f.addRun({
+        workflowId: f.wfA,
+        status: 'pending',
+        lastActiveAgoSeconds: 7200,
+        triggerKind: 'schedule',
+      })
+      expect(await queue.failAbandonedInlineRunsSystem(WINDOW)).toBeGreaterThanOrEqual(1)
+      const first = await pool!.query(`SELECT finished_at FROM workflow_runs WHERE id = $1`, [run])
+
+      expect(await queue.failAbandonedInlineRunsSystem(WINDOW)).toBe(0)
+      const second = await pool!.query(`SELECT finished_at FROM workflow_runs WHERE id = $1`, [run])
+      expect(second.rows[0].finished_at).toEqual(first.rows[0].finished_at)
+    } finally {
+      await f.cleanup()
+    }
+  })
+})

--- a/packages/api/src/db/workflow-store.ts
+++ b/packages/api/src/db/workflow-store.ts
@@ -1272,6 +1272,28 @@ export function createWorkflowRunQueueStore(): RunQueueStore {
       )
       return (requeued.rowCount ?? 0) + (failed.rowCount ?? 0)
     },
+
+    async failAbandonedInlineRunsSystem({ abandonedSeconds }) {
+      const result = await query(
+        `UPDATE workflow_runs
+            SET status = 'failed', finished_at = now(),
+                error = jsonb_build_object(
+                  'message', 'Run was abandoned — the process advancing it stopped without recording an outcome.',
+                  'reason', 'run_abandoned')
+          WHERE status IN ('pending', 'running')
+            -- The INVERSE gate of every method above: these are the inline-path
+            -- runs the queue does not own. It may only mark them dead, never
+            -- claim or re-queue them (re-running re-fires delivery — the
+            -- 2026-07-06 reminder storm). Failing fires nothing.
+            AND trigger_kind <> 'event'
+            -- awaiting_wait / awaiting_input are excluded by the status filter
+            -- above: a run parked on a wait step or a human approval is idle on
+            -- purpose and may legitimately sit for days.
+            AND last_active_at < now() - make_interval(secs => $1)`,
+        [abandonedSeconds],
+      )
+      return result.rowCount ?? 0
+    },
   }
 }
 

--- a/packages/api/src/mailbox/__tests__/imap-session.test.ts
+++ b/packages/api/src/mailbox/__tests__/imap-session.test.ts
@@ -1,5 +1,14 @@
+import { EventEmitter } from 'node:events'
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { createMailboxSessionCache, type ImapClientLike } from '../imap-session.js'
+import {
+  attachSessionErrorSink,
+  createImapClient,
+  createMailboxSessionCache,
+  createSocketKeepWarm,
+  MAILBOX_KEEP_WARM_MS,
+  MAILBOX_SOCKET_TIMEOUT_MS,
+  type ImapClientLike,
+} from '../imap-session.js'
 import type { MailboxAccountSettings } from '../types.js'
 
 const SETTINGS: MailboxAccountSettings = {
@@ -111,5 +120,114 @@ describe('[COMP:api/mailbox-imap-client] Per-turn IMAP session reuse (D12 #1)', 
     await expect(cache.withClient('inst-1', SETTINGS, async () => 'ok')).resolves.toBe('ok')
     expect(attempts).toBe(2)
     await cache.closeAll()
+  })
+})
+
+describe("[COMP:api/mailbox-imap-client] Session 'error' event sink", () => {
+  // imapflow IS an EventEmitter and reports every post-connect failure through
+  // `emit('error', err)`. These tests pin the EventEmitter semantics the
+  // 2026-07-28 crash loop turned on, using a bare emitter as the stand-in.
+
+  it('an unlistened error event throws — the crash the sink prevents', () => {
+    const emitter = new EventEmitter()
+    // No listener: Node rethrows rather than dropping the event. In production
+    // this throw arrives on the socket timer's stack, so no `try/catch` around
+    // any of our awaits can catch it — the process dies.
+    expect(() => emitter.emit('error', Object.assign(new Error('Socket timeout'), { code: 'ETIMEOUT' })))
+      .toThrow('Socket timeout')
+  })
+
+  it('reports the error and the account instead of throwing, once the sink is attached', () => {
+    const emitter = new EventEmitter()
+    const logged: string[] = []
+    attachSessionErrorSink(emitter as unknown as ImapClientLike, 'me@corp.example', (m) => logged.push(m))
+
+    expect(() => emitter.emit('error', Object.assign(new Error('Socket timeout'), { code: 'ETIMEOUT' })))
+      .not.toThrow()
+    expect(logged).toHaveLength(1)
+    expect(logged[0]).toContain('me@corp.example')
+    expect(logged[0]).toContain('Socket timeout')
+    // The code travels too — ETIMEOUT vs a reset distinguishes an idle socket
+    // from a server hangup when reading the logs later.
+    expect(logged[0]).toContain('ETIMEOUT')
+  })
+
+  it('survives a non-Error rejection value', () => {
+    const emitter = new EventEmitter()
+    const logged: string[] = []
+    attachSessionErrorSink(emitter as unknown as ImapClientLike, 'me@corp.example', (m) => logged.push(m))
+    expect(() => emitter.emit('error', 'plain string failure')).not.toThrow()
+    expect(logged[0]).toContain('plain string failure')
+  })
+
+  it('createImapClient ships with the sink attached', async () => {
+    // Constructing is enough — no connect, no network. If the sink were
+    // missing, the emit below would throw out of this test.
+    const client = createImapClient(SETTINGS)
+    try {
+      expect(() => (client as unknown as EventEmitter).emit('error', new Error('Socket timeout')))
+        .not.toThrow()
+    } finally {
+      client.close()
+    }
+  })
+})
+
+describe('[COMP:api/mailbox-imap-client] Socket keep-warm', () => {
+  it('stays under the inactivity timeout it guards', () => {
+    // The NOOP itself needs room to complete inside the timeout window.
+    expect(MAILBOX_KEEP_WARM_MS).toBeLessThan(MAILBOX_SOCKET_TIMEOUT_MS / 2)
+  })
+
+  it('costs nothing while the loop is fast', async () => {
+    let noops = 0
+    let clock = 0
+    const client = makeFakeClient({ noop: async () => { noops++; return {} } })
+    const warm = createSocketKeepWarm(client, { everyMs: 30_000, now: () => clock })
+    for (let i = 0; i < 200; i++) {
+      clock += 10 // 200 quick inserts, 2s total
+      await warm.pingIfIdle()
+    }
+    expect(noops).toBe(0)
+  })
+
+  it('never lets the socket go quiet longer than the timeout, however slow the inserts', async () => {
+    // The property that matters: not a NOOP count, but that no gap between
+    // socket activity ever reaches MAILBOX_SOCKET_TIMEOUT_MS.
+    let clock = 0
+    const pingsAt: number[] = []
+    const client = makeFakeClient({ noop: async () => { pingsAt.push(clock); return {} } })
+    const warm = createSocketKeepWarm(client, {
+      everyMs: MAILBOX_KEEP_WARM_MS,
+      now: () => clock,
+    })
+    // 40 inserts at 20s each — 800s of otherwise-silent socket, nine times the
+    // 90s timeout. (20s per insert is not hyperbole: the incident's inserts
+    // were hitting statement timeouts.)
+    for (let i = 0; i < 40; i++) {
+      clock += 20_000
+      await warm.pingIfIdle()
+    }
+    expect(pingsAt.length).toBeGreaterThan(0)
+
+    let previous = 0
+    for (const at of pingsAt) {
+      expect(at - previous).toBeLessThan(MAILBOX_SOCKET_TIMEOUT_MS)
+      previous = at
+    }
+    // And the tail: the final stretch after the last ping is also short enough.
+    expect(clock - previous).toBeLessThan(MAILBOX_SOCKET_TIMEOUT_MS)
+    // Cheap: one ping per idle window, not one per message.
+    expect(pingsAt.length).toBeLessThan(40)
+  })
+
+  it('rethrows when the session is already gone', async () => {
+    const client = makeFakeClient({ noop: async () => { throw new Error('Socket is already closed') } })
+    let clock = 0
+    const warm = createSocketKeepWarm(client, { everyMs: 1_000, now: () => clock })
+    clock += 5_000
+    // The caller's walk must abort rather than keep inserting against a dead
+    // connection; `syncInstance` persists advanced checkpoints on the way out.
+    await expect(warm.pingIfIdle()).rejects.toThrow('Socket is already closed')
   })
 })

--- a/packages/api/src/mailbox/__tests__/sync-worker.test.ts
+++ b/packages/api/src/mailbox/__tests__/sync-worker.test.ts
@@ -63,6 +63,7 @@ function makeFakeImap(
   },
 ) {
   let openFolder = ''
+  let noopCalls = 0
   const client = {
     usable: true,
     async connect() {},
@@ -121,8 +122,17 @@ function makeFakeImap(
     async append() {
       return {}
     },
+    // Counted, because the insert phase's socket keep-warm calls it — a real
+    // client that never gets one loses the session to the inactivity timeout.
+    async noop() {
+      noopCalls++
+      return {}
+    },
+    on() {},
   } as unknown as ImapClientLike
-  return client
+  return Object.defineProperty(client, 'noopCalls', { get: () => noopCalls }) as ImapClientLike & {
+    noopCalls: number
+  }
 }
 
 function makeInstanceStore(instance: ConnectorInstance) {
@@ -174,6 +184,7 @@ function makeWorker(over: Partial<MailboxSyncWorkerDeps> & { client: ImapClientL
     ...('brain' in over ? { brain: over.brain } : {}),
     backfillChunk: over.backfillChunk,
     deltaChunk: over.deltaChunk,
+    ...(over.keepWarm ? { keepWarm: over.keepWarm } : {}),
   })
   return { worker, configs, insertMessage, deleteFolder, instanceId: instance.id }
 }
@@ -309,6 +320,110 @@ describe('[COMP:api/mailbox-sync-worker] backfill', () => {
     // called at construction; route() only fires on delta inserts).
     await worker.tick()
     expect(route).not.toHaveBeenCalled()
+  })
+})
+
+// ── The insert phase must not hold a silent socket ────────────────
+//
+// Regression cover for the 2026-07-28 crash loop: the worker fetches a chunk,
+// releases the mailbox lock, then spends the rest of the walk parsing and
+// inserting with the IMAP session still held and the socket idle. imapflow's
+// `socketTimeout` is inactivity-based, so a slow insert phase looks exactly
+// like a dead server — it killed the session, the unlistened 'error' event
+// killed the process, and every in-flight scheduled workflow run orphaned.
+// These tests pin that BOTH insert loops go through the keep-warm.
+
+describe('[COMP:api/mailbox-sync-worker] insert-phase socket keep-warm', () => {
+  /** A keep-warm whose window has always already elapsed — one ping per call. */
+  function eagerKeepWarm(pings: string[], label: string) {
+    return (client: ImapClientLike) => ({
+      async pingIfIdle() {
+        pings.push(label)
+        await client.noop()
+      },
+    })
+  }
+
+  it('keeps the socket warm through the BACKFILL insert loop', async () => {
+    const pings: string[] = []
+    const sources = Object.fromEntries([1, 2, 3, 4, 5, 6].map((u) => [u, rfc822(u)]))
+    const client = makeFakeImap({ INBOX: { uidvalidity: '7', uids: [1, 2, 3, 4, 5, 6], sources } })
+    const instance = instanceRow({
+      config: {
+        mailboxSync: {
+          folders: { INBOX: { uidvalidity: '7', lastUid: 6 } },
+          backfill: { scope: 'all', requestedAt: '2026-07-22T00:00:00Z', status: 'running', totalEstimate: 6 },
+        },
+      },
+    } as never)
+    const { worker, insertMessage } = makeWorker({
+      client,
+      instance,
+      backfillChunk: 10,
+      keepWarm: eagerKeepWarm(pings, 'backfill'),
+    })
+    await worker.tick()
+
+    expect(insertMessage).toHaveBeenCalledTimes(6)
+    // One guarded step per message — the walk is never unguarded.
+    expect(pings).toHaveLength(6)
+    expect(client.noopCalls).toBe(6)
+  })
+
+  it('keeps the socket warm through the DELTA insert loop (where brain routing runs)', async () => {
+    const pings: string[] = []
+    const sources = Object.fromEntries([1, 2, 3].map((u) => [u, rfc822(u)]))
+    const client = makeFakeImap({ INBOX: { uidvalidity: '7', uids: [1, 2, 3], sources } })
+    const instance = instanceRow({
+      config: { mailboxSync: { folders: { INBOX: { uidvalidity: '7', lastUid: 0 } } } },
+    } as never)
+    const { worker, insertMessage } = makeWorker({
+      client,
+      instance,
+      keepWarm: eagerKeepWarm(pings, 'delta'),
+    })
+    await worker.tick()
+
+    expect(insertMessage).toHaveBeenCalledTimes(3)
+    expect(pings).toEqual(['delta', 'delta', 'delta'])
+  })
+
+  it('a keep-warm failure aborts the walk with progress already persisted', async () => {
+    // A dead session must stop the walk, not have it keep inserting into the
+    // void — but the checkpoints earned before the failure have to survive, or
+    // the next tick re-fetches work that was already archived.
+    const sources = Object.fromEntries([1, 2, 3, 4, 5, 6].map((u) => [u, rfc822(u)]))
+    const client = makeFakeImap({ INBOX: { uidvalidity: '7', uids: [1, 2, 3, 4, 5, 6], sources } })
+    const instance = instanceRow({
+      config: {
+        mailboxSync: {
+          folders: { INBOX: { uidvalidity: '7', lastUid: 6 } },
+          backfill: { scope: 'all', requestedAt: '2026-07-22T00:00:00Z', status: 'running', totalEstimate: 6 },
+        },
+      },
+    } as never)
+    let calls = 0
+    const { worker, insertMessage, configs } = makeWorker({
+      client,
+      instance,
+      backfillChunk: 10,
+      keepWarm: () => ({
+        async pingIfIdle() {
+          if (++calls > 3) throw new Error('Socket is already closed')
+        },
+      }),
+    })
+    // `tick()` swallows per-instance failures (it logs and moves on).
+    await worker.tick()
+
+    // Stopped, did not grind through all six.
+    expect(insertMessage).toHaveBeenCalledTimes(3)
+    // Newest-first walk got 6, 5, 4 in — and the checkpoint says so, so the
+    // next tick resumes below 4 instead of redoing them.
+    const state = readMailboxSyncState(configs.get('inst-1'))
+    expect(state.folders.INBOX.backfillLow).toBe(4)
+    expect(state.lastError).toContain('Socket is already closed')
+    expect(state.folders.INBOX.backfillDone).toBeUndefined()
   })
 })
 

--- a/packages/api/src/mailbox/imap-session.ts
+++ b/packages/api/src/mailbox/imap-session.ts
@@ -54,6 +54,19 @@ export type ImapClientLike = {
     meta?: { contentType?: string; filename?: string; expectedSize?: number }
     content: AsyncIterable<Uint8Array> & { destroy?: (err?: Error) => void }
   }>
+  /**
+   * Keep the socket from going quiet while we hold the session but are not
+   * talking IMAP (the backfill's per-message DB insert phase — sync-worker.ts).
+   * `socketTimeout` is INACTIVITY-based, so a long insert phase reads to the
+   * socket exactly like a dead server.
+   */
+  noop(): Promise<unknown>
+  /**
+   * imapflow surfaces post-connect failures as an `'error'` EVENT, not a
+   * rejection — see `attachSessionErrorSink`. Registering a listener is the
+   * only thing that stops Node rethrowing it as an uncaughtException.
+   */
+  on(event: 'error', listener: (err: unknown) => void): unknown
   usable: boolean
 }
 
@@ -103,9 +116,99 @@ export const MAILBOX_SESSION_MAX_LIFETIME_MS = 10 * 60_000
  */
 export const MAILBOX_SOCKET_TIMEOUT_MS = 90_000
 export const MAILBOX_GREETING_TIMEOUT_MS = 20_000
+/**
+ * How long the socket may sit quiet while we hold the session but are NOT
+ * talking IMAP, before we spend a NOOP to keep it warm. Must stay well under
+ * `MAILBOX_SOCKET_TIMEOUT_MS` — the NOOP itself needs room to complete.
+ */
+export const MAILBOX_KEEP_WARM_MS = 30_000
+
+/** Guards the non-IMAP phase of a sync against the inactivity timeout. */
+export type SocketKeepWarm = {
+  /**
+   * Call once per unit of non-IMAP work. Issues a NOOP only when the socket
+   * has actually been quiet longer than `everyMs`, so a fast loop costs
+   * nothing. Rethrows if the session is gone: the caller's walk must abort
+   * rather than keep inserting against a dead connection.
+   */
+  pingIfIdle(): Promise<void>
+}
+
+/**
+ * `socketTimeout` is INACTIVITY-based, not a command deadline — it fires when
+ * no bytes cross the socket for `MAILBOX_SOCKET_TIMEOUT_MS`, and it cannot
+ * tell a dead server from a busy client. The sync worker fetches a chunk of
+ * messages, releases the mailbox lock, then spends the next stretch on
+ * per-message MIME parsing, archive inserts and (delta path) brain routing —
+ * all of it with the IMAP session still held and the socket silent. When those
+ * inserts are slow (a starved DB pool, statement timeouts) the quiet stretch
+ * passes 90 s and imapflow kills the connection out from under a walk that was
+ * making perfectly good progress.
+ *
+ * Raising or dropping the timeout is the wrong lever: it exists so a server
+ * that stops responding mid-FETCH cannot hang the tick forever, and the
+ * backfill's poison-UID bisection needs that throw. The fix is to stop holding
+ * a silent socket while we work — one cheap NOOP per idle window.
+ */
+export function createSocketKeepWarm(
+  client: ImapClientLike,
+  opts?: { everyMs?: number; now?: () => number },
+): SocketKeepWarm {
+  const everyMs = opts?.everyMs ?? MAILBOX_KEEP_WARM_MS
+  const now = opts?.now ?? (() => Date.now())
+  // Seeded at construction: the caller builds this right after the fetch that
+  // was the socket's last real activity.
+  let lastActivity = now()
+  return {
+    async pingIfIdle() {
+      if (now() - lastActivity < everyMs) return
+      await client.noop()
+      lastActivity = now()
+    },
+  }
+}
+
+/**
+ * Register the `'error'` sink every long-lived IMAP session must carry.
+ *
+ * imapflow is an EventEmitter, and once `connect()` has resolved it reports
+ * every later failure — socket timeout, mid-command disconnect, server reset —
+ * by calling `emitError`, which ends in `this.emit('error', err)`. Node's
+ * EventEmitter treats `'error'` as a special case: with **zero** listeners it
+ * RETHROWS the error instead of dropping it. That throw happens on the timer
+ * stack that fired it (`Socket._onTimeout`), so no `try/catch` around any
+ * `await` of ours is on the stack to catch it — the process dies with
+ * `Unhandled 'error' event`.
+ *
+ * That is not theoretical: from 2026-07-28 the single-instance
+ * `brian-api-workers` container crash-looped every ~100 s for two days on
+ * `Error: Socket timeout` out of a mailbox backfill, taking all 19 background
+ * workers with it. Every scheduled workflow run longer than the crash interval
+ * orphaned mid-flight (216 rows stuck `pending`/`running`), because a SIGKILL
+ * leaves no status behind.
+ *
+ * Attaching the listener is not swallowing the error — `emitError` calls
+ * `closeAfter()` BEFORE emitting, so the connection is already torn down and
+ * `usable` is already false. The listener only stops the process death, which
+ * lets the failure path that already exists run: the in-flight command
+ * rejects, `withClient` drops the dead session, and `syncInstance` records
+ * `lastError` on the instance and logs the failure. One tick degrades instead
+ * of the whole fleet dying.
+ */
+export function attachSessionErrorSink(
+  client: ImapClientLike,
+  label: string,
+  log: (msg: string) => void = (msg) => console.warn(msg),
+): void {
+  client.on('error', (err) => {
+    const text = err instanceof Error ? err.message : String(err)
+    const code = (err as { code?: string } | null)?.code
+    log(`[mailbox] IMAP session error for ${label}: ${text}${code ? ` (${code})` : ''}`)
+  })
+}
 
 export function createImapClient(settings: MailboxAccountSettings): ImapClientLike {
-  return new ImapFlow({
+  const client = new ImapFlow({
     host: settings.imapHost,
     port: settings.imapPort,
     secure: true,
@@ -114,6 +217,8 @@ export function createImapClient(settings: MailboxAccountSettings): ImapClientLi
     greetingTimeout: MAILBOX_GREETING_TIMEOUT_MS,
     socketTimeout: MAILBOX_SOCKET_TIMEOUT_MS,
   }) as unknown as ImapClientLike
+  attachSessionErrorSink(client, settings.email)
+  return client
 }
 
 type SessionEntry = {

--- a/packages/api/src/mailbox/sync-worker.ts
+++ b/packages/api/src/mailbox/sync-worker.ts
@@ -68,9 +68,11 @@ import {
 } from '../db/email-archive-store.js'
 import {
   createMailboxSessionCache,
+  createSocketKeepWarm,
   type ImapClientLike,
   type ImapFetchedMessage,
   type MailboxSessionCache,
+  type SocketKeepWarm,
 } from './imap-session.js'
 import { htmlToText, messageRef, parseReferencesHeader } from './mailbox-api.js'
 import type { MailboxAccountSettings } from './types.js'
@@ -476,6 +478,12 @@ export type MailboxSyncWorkerDeps = {
   deltaChunk?: number
   /** Max backfill messages fetched per folder per tick. */
   backfillChunk?: number
+  /**
+   * Builds the guard that keeps the IMAP socket from idling past its
+   * inactivity timeout during the per-message insert phase. Injectable so
+   * tests can drive the NOOP cadence without real clocks.
+   */
+  keepWarm?: (client: ImapClientLike) => SocketKeepWarm
   now?: () => Date
 }
 
@@ -573,6 +581,7 @@ export function createMailboxSyncWorker(deps: MailboxSyncWorkerDeps): MailboxSyn
   const intervalMs = deps.intervalMs ?? DEFAULT_INTERVAL_MS
   const deltaChunk = deps.deltaChunk ?? DEFAULT_DELTA_CHUNK
   const backfillChunk = deps.backfillChunk ?? DEFAULT_BACKFILL_CHUNK
+  const keepWarm = deps.keepWarm ?? ((client: ImapClientLike) => createSocketKeepWarm(client))
   const now = deps.now ?? (() => new Date())
   const router = deps.brain ? createMailboxBrainRouter(deps.brain) : null
 
@@ -666,7 +675,14 @@ export function createMailboxSyncWorker(deps: MailboxSyncWorkerDeps): MailboxSyn
         lock.release()
       }
       fetched.sort((a, b) => a.uid - b.uid)
+      // The IMAP socket goes silent from here to the end of the loop while we
+      // parse, insert and (below) brain-route each message — brain routing is
+      // an LLM call, so this stretch is the longest quiet window in the sync.
+      // Without the keep-warm the inactivity timeout kills the session
+      // mid-walk. See `createSocketKeepWarm`.
+      const deltaKeepWarm = keepWarm(client)
       for (const msg of fetched) {
+        await deltaKeepWarm.pingIfIdle()
         const parsed = await parseSyncedMessage({ accountEmail: settings.email, folder, msg })
         if (parsed) {
           try {
@@ -747,7 +763,12 @@ export function createMailboxSyncWorker(deps: MailboxSyncWorkerDeps): MailboxSyn
       }
       // Newest-first: recent mail is searchable within minutes of consent.
       fetched.sort((a, b) => b.uid - a.uid)
+      // Up to `backfillChunk` (200) sequential inserts with the session held and
+      // the socket silent — the window that crash-looped the workers container
+      // on 2026-07-28. See `createSocketKeepWarm`.
+      const backfillKeepWarm = keepWarm(client)
       for (const msg of fetched) {
+        await backfillKeepWarm.pingIfIdle()
         const parsed = await parseSyncedMessage({ accountEmail: settings.email, folder, msg })
         if (parsed) {
           try {

--- a/packages/api/src/mailbox/verify.ts
+++ b/packages/api/src/mailbox/verify.ts
@@ -10,6 +10,7 @@
  */
 
 import { ImapFlow } from 'imapflow'
+import { attachSessionErrorSink, type ImapClientLike } from './imap-session.js'
 import { verifySmtpLogin } from './smtp.js'
 import type { MailboxAccountSettings, MailboxVerifyResult } from './types.js'
 
@@ -56,6 +57,13 @@ async function defaultVerifyImap(settings: MailboxAccountSettings): Promise<void
     logger: false,
     verifyOnly: true,
   })
+  // While `connect()` is pending imapflow's own `initialReject` owns the error
+  // path, so a failed login rejects here and is classified below. The moment it
+  // resolves that ownership ends and any later failure becomes a bare `'error'`
+  // EVENT — which Node rethrows as an uncaughtException when unlistened, taking
+  // the process down. This route runs on the user-traffic service, so the sink
+  // goes on before `connect()`, not after. See `attachSessionErrorSink`.
+  attachSessionErrorSink(client as unknown as ImapClientLike, settings.email)
   await client.connect()
   try {
     await client.logout()

--- a/packages/core/src/workflow/__tests__/run-queue.test.ts
+++ b/packages/core/src/workflow/__tests__/run-queue.test.ts
@@ -12,10 +12,15 @@ import {
  * contract (bounded concurrency, drain-until-empty, reap-first, error
  * isolation, nudge coalescing) is what's under test.
  */
-function makeStore(queue: ClaimedRun[]) {
-  const store: RunQueueStore & { claims: number; reaps: number } = {
+function makeStore(queue: ClaimedRun[], opts?: { abandoned?: number }) {
+  const store: RunQueueStore & {
+    claims: number
+    reaps: number
+    abandonedSweeps: Array<{ abandonedSeconds: number }>
+  } = {
     claims: 0,
     reaps: 0,
+    abandonedSweeps: [],
     async claimNextPendingRunSystem() {
       store.claims++
       return queue.shift() ?? null
@@ -26,6 +31,10 @@ function makeStore(queue: ClaimedRun[]) {
     },
     async requeueStaleRunningRunsSystem() {
       return 0
+    },
+    async failAbandonedInlineRunsSystem(params) {
+      store.abandonedSweeps.push(params)
+      return opts?.abandoned ?? 0
     },
   }
   return store
@@ -124,6 +133,9 @@ describe('[COMP:workflow/run-queue] createRunQueueWorker', () => {
       async requeueStaleRunningRunsSystem() {
         return 0
       },
+      async failAbandonedInlineRunsSystem() {
+        return 0
+      },
     }
     const worker = createRunQueueWorker({ store, onError, advance: async () => {} })
     await expect(worker.tick()).resolves.toBeUndefined()
@@ -170,5 +182,81 @@ describe('[COMP:workflow/run-queue] createRunQueueWorker', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+})
+
+describe('[COMP:workflow/run-queue] abandoned inline-run reaper', () => {
+  // The queue refuses to CLAIM an inline-path run (schedule / manual / button)
+  // because re-running it re-fires its delivery. That left orphaned
+  // inline runs with no owner at all: a SIGKILL mid-advance writes no status, so
+  // the row shows in-flight forever. This sweep is the "leave it dead" half —
+  // mark, never resurrect.
+
+  it('sweeps on every tick, alongside the queue-owned reapers', async () => {
+    const store = makeStore([])
+    const worker = createRunQueueWorker({ store, advance: async () => {} })
+    await worker.tick()
+    expect(store.abandonedSweeps).toHaveLength(1)
+    expect(store.reaps).toBe(1)
+  })
+
+  it('passes a window far wider than the stale-running one, since nothing is retried off it', async () => {
+    const store = makeStore([])
+    const worker = createRunQueueWorker({ store, advance: async () => {}, staleSeconds: 1_800 })
+    await worker.tick()
+    expect(store.abandonedSweeps[0].abandonedSeconds).toBeGreaterThan(1_800)
+  })
+
+  it('honours an explicit window', async () => {
+    const store = makeStore([])
+    const worker = createRunQueueWorker({ store, advance: async () => {}, abandonedSeconds: 7_200 })
+    await worker.tick()
+    expect(store.abandonedSweeps[0]).toEqual({ abandonedSeconds: 7_200 })
+  })
+
+  it('reports what it failed, so the sweep is not silent', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const store = makeStore([], { abandoned: 216 })
+      const worker = createRunQueueWorker({ store, advance: async () => {} })
+      await worker.tick()
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('216'))
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('says nothing on a clean sweep', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const store = makeStore([], { abandoned: 0 })
+      const worker = createRunQueueWorker({ store, advance: async () => {} })
+      await worker.tick()
+      expect(warn).not.toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('a sweep failure routes to onError and still lets the pass claim', async () => {
+    const onError = vi.fn()
+    const store = makeStore([run(1)])
+    store.failAbandonedInlineRunsSystem = async () => {
+      throw new Error('db down')
+    }
+    const advanced: string[] = []
+    const worker = createRunQueueWorker({
+      store,
+      onError,
+      advance: async (id) => {
+        advanced.push(id)
+      },
+    })
+    await worker.tick()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onError).toHaveBeenCalled()
+    // reap() swallows into onError and the drain still runs — a reaper outage
+    // must not stop event runs from advancing.
+    expect(advanced).toEqual(['r1'])
   })
 })

--- a/packages/core/src/workflow/run-queue.ts
+++ b/packages/core/src/workflow/run-queue.ts
@@ -73,6 +73,30 @@ export type RunQueueStore = {
     staleSeconds: number
     maxClaimAttempts: number
   }): Promise<number>
+  /**
+   * Mark ABANDONED inline-path runs dead — the runs this queue deliberately
+   * does NOT own (`trigger_kind <> 'event'`, i.e. `schedule`, `manual` — which
+   * webhook receivers also stamp — and `button`). Every other method here
+   * refuses to touch them, for a good reason
+   * documented at `claimNextPendingRunSystem`: re-running an inline run
+   * re-fires its delivery, and a reminder re-sent hours late is never right.
+   *
+   * But "never re-run" was implemented as "never look at them", which left a
+   * second failure mode with no owner. When the process advancing an inline run
+   * dies, SIGKILL writes no status: the row stays `pending` (killed before the
+   * first step write) or `running` (killed mid-step) forever. Nothing reaps it,
+   * the UI reports it as in-flight indefinitely, and the operator cannot tell a
+   * dead run from a slow one. On 2026-07-28 a crash-looping worker container
+   * minted 216 such rows in two days.
+   *
+   * So: **fail them, never re-queue them.** Failing is safe — it fires no side
+   * effect and only records what already happened. Resurrecting is the unsafe
+   * direction, and this method never does it. Runs parked legitimately
+   * (`awaiting_wait`, `awaiting_input`) are out of scope by status.
+   *
+   * Returns the number failed.
+   */
+  failAbandonedInlineRunsSystem(params: { abandonedSeconds: number }): Promise<number>
 }
 
 export type RunQueueWorkerDeps = {
@@ -87,6 +111,8 @@ export type RunQueueWorkerDeps = {
   maxConcurrent?: number
   leaseSeconds?: number
   staleSeconds?: number
+  /** Inactivity after which an inline-path run is presumed dead, not slow. */
+  abandonedSeconds?: number
   maxClaimAttempts?: number
   workspaceCap?: number
 }
@@ -112,6 +138,14 @@ export const RUN_QUEUE_DEFAULTS = {
    *  consult) with a wide margin — every step write bumps
    *  `last_active_at`. */
   staleSeconds: 1_800,
+  /**
+   * Inline-path runs only, and only to mark them dead. Deliberately much
+   * wider than `staleSeconds`: nothing is retried off the back of it, so the
+   * cost of waiting is a stale-looking row, while the cost of firing too early
+   * is calling a live run dead. An hour with zero step writes (12x the longest
+   * legal single step, the 300 s deep-tier consult) is not a slow run.
+   */
+  abandonedSeconds: 3_600,
   maxClaimAttempts: 3,
   workspaceCap: 3,
 } as const
@@ -121,6 +155,7 @@ export function createRunQueueWorker(deps: RunQueueWorkerDeps): RunQueueWorker {
   const maxConcurrent = deps.maxConcurrent ?? RUN_QUEUE_DEFAULTS.maxConcurrent
   const leaseSeconds = deps.leaseSeconds ?? RUN_QUEUE_DEFAULTS.leaseSeconds
   const staleSeconds = deps.staleSeconds ?? RUN_QUEUE_DEFAULTS.staleSeconds
+  const abandonedSeconds = deps.abandonedSeconds ?? RUN_QUEUE_DEFAULTS.abandonedSeconds
   const maxClaimAttempts = deps.maxClaimAttempts ?? RUN_QUEUE_DEFAULTS.maxClaimAttempts
   const workspaceCap = deps.workspaceCap ?? RUN_QUEUE_DEFAULTS.workspaceCap
   const onError = deps.onError ?? (() => {})
@@ -136,6 +171,17 @@ export function createRunQueueWorker(deps: RunQueueWorkerDeps): RunQueueWorker {
     try {
       await deps.store.failExhaustedPendingRunsSystem({ leaseSeconds, maxClaimAttempts })
       await deps.store.requeueStaleRunningRunsSystem({ staleSeconds, maxClaimAttempts })
+      // Inline-path runs the queue does not own, and never will. It reaps them
+      // anyway because this is the only ticking sweeper over `workflow_runs`,
+      // and the alternative is what shipped: nobody owning them at all. Marking
+      // dead is not claiming — see `failAbandonedInlineRunsSystem`.
+      const abandoned = await deps.store.failAbandonedInlineRunsSystem({ abandonedSeconds })
+      if (abandoned > 0) {
+        console.warn(
+          `[run-queue] failed ${abandoned} abandoned inline-path run(s) ` +
+          `(no step activity for ${abandonedSeconds}s — the process advancing them died)`,
+        )
+      }
     } catch (err) {
       onError(err, {})
     }


### PR DESCRIPTION
## The incident

From **2026-07-28** the single-instance `brian-api-workers` container crash-looped every ~100s for two days on `Error: Socket timeout` out of a mailbox backfill, taking all 19 background workers down on each cycle:

```
node:events:497
      throw er; // Unhandled 'error' event
Error: Socket timeout
    at TLSSocket._socketTimeout (imapflow/lib/imap-flow.js:951:29)
Emitted 'error' event on ImapFlow instance at:
    at ImapFlow.emitError (imapflow/lib/imap-flow.js:454:14)
  code: 'ETIMEOUT'
```

No run longer than the crash interval could finish. 216 scheduled workflow runs orphaned mid-flight (159 `pending` + 57 `running`, **every one** `trigger_kind='schedule'`) because a `SIGKILL` records no status, and the run queue's `trigger_kind='event'` gate meant no reaper could ever see them.

## Three fixes

**1. The `'error'` sink** (`attachSessionErrorSink`)

imapflow is an `EventEmitter` and reports every post-connect failure via `emit('error', err)`. Node rethrows `'error'` when unlistened - on the socket timer's stack, where no `try/catch` around any of our `await`s can catch it. Nothing ever attached a listener; `ImapClientLike` didn't even expose `on()`.

Not error-swallowing: `emitError` calls `closeAfter()` *before* emitting, so the connection is already dead and `usable` already false. The listener only stops process death, letting the failure path that already exists run - command rejects, `withClient` drops the dead session, `syncInstance` records `lastError`, next tick reconnects. Both construction sites covered: `createImapClient` and `defaultVerifyImap` (the latter runs on the user-traffic service).

**2. The socket keep-warm** (`createSocketKeepWarm`)

`socketTimeout` is **inactivity**-based and cannot tell a dead server from a busy client. Both insert loops fetch a chunk, release the mailbox lock, then spend up to 200 sequential MIME parses + archive inserts (+ brain routing on the delta path) with the session held and the socket silent - which passes 90s whenever inserts are slow (a starved 2-connection pool, statement timeouts).

Raising the timeout is the wrong lever: it exists for the hung-`FETCH` case and the poison-UID bisection needs the throw. Instead, one `NOOP` per 30s idle window, and a rethrow when the session is already gone - aborting the walk with its earned checkpoints persisted.

**3. `failAbandonedInlineRunsSystem`** - the run queue's inverse gate

"Never re-run an inline run" had been implemented as "never *look* at one", which left orphaned `schedule`/`manual`/`button` runs displaying as in-flight forever with no owner at all. The reap tick now marks them `failed` (`reason: 'run_abandoned'`) after an hour of no step activity:

- **Fail, never re-queue** - re-running re-fires a delivery (the 2026-07-06 reminder storm).
- **A much wider window** than `staleSeconds` (1h vs 30min): nothing is retried off it, so waiting costs a stale-looking row while firing early would call a live run dead.
- **Never touches `awaiting_wait` / `awaiting_input`** - idle by design.
- **Reports what it failed**, so the sweep is never silent about killing user-visible rows.

## Tests

- `imap-session.test.ts` (+8): the EventEmitter semantics both ways - an unlistened `emit('error')` **throws** (the crash itself), the sink makes it report instead; `createImapClient` ships with it attached; keep-warm asserts the real property (no socket gap ever reaches `MAILBOX_SOCKET_TIMEOUT_MS`, across 800s of simulated slow inserts) rather than a magic NOOP count.
- `sync-worker.test.ts` (+3): both insert loops go through the guard, and a keep-warm failure aborts the walk with `backfillLow` already advanced.
- `run-queue.test.ts` (+6): sweeps every tick, window wider than `staleSeconds`, reports non-zero counts, silent on a clean sweep, survives a sweep outage without blocking the drain.
- `workflow-run-queue-store.integration.test.ts` (+5): the SQL gate - fails every inline kind in both `pending` and `running`, never an `event` run, never a live run, never `awaiting_*`, idempotent.

## Verification

`pnpm test` (4246 passing), `pnpm smoke`, `pnpm typecheck` clean. Two unrelated pre-existing failures: `shopify/client.test.ts` (cold barrel-import timeout, passes isolated) and `knowledge-proposals.test.ts` (macOS `/var` vs `/private/var` realpath mismatch).

`pnpm check` adds **zero** new violations - verified by stashing all three repos and confirming pristine `develop` reports the identical 7 red checks with identical counts.

## Not included

The underlying capacity issue - `PG_POOL_MAX=2` shared by 19 workers against a 25-slot Cloud SQL instance - is deliberately out of scope. It is gated by `pool-budget.test.ts`, which pins the fleet total at exactly 14 and says spending that slack should be a decision, not a diff. The real unlock is Scale runbook Phase 1 (dedicated-core tier + managed pooling).

## Spec

`docs/architecture/integrations/mailbox-imap.md` → "Session error handling (the two rules)" and `docs/architecture/features/workflow.md` → "Abandoned inline-path runs", with both `brian-kb/` pairs and the component map, ship in the superproject PR.