### PR TITLE
fix(home-apps): name the bundle wildcard so the API can boot

### DIFF
--- a/packages/api/src/routes/__tests__/home-apps.test.ts
+++ b/packages/api/src/routes/__tests__/home-apps.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Bundle-serving route tests.
+ * Component tag: [COMP:api/home-app-bundle-route].
+ *
+ * The first test is the important one. `homeAppRoutes()` registers its routes
+ * eagerly, so a pattern Express cannot parse throws while the router is being
+ * built — inside `bootOpenApi`, before the API ever listens. That is a
+ * whole-service boot crash wearing the costume of a single broken route, and
+ * nothing else in the suite constructs this router, which is how a bare `*`
+ * wildcard (illegal under Express 5's path-to-regexp v8) reached a deploy.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+
+vi.mock('../../db/home-apps-store.js', () => ({
+  consumeHomeAppBudget: vi.fn(),
+  createHomeApp: vi.fn(),
+  deleteHomeApp: vi.fn(),
+  getHomeApp: vi.fn(),
+  recordHomeAppSyncError: vi.fn(),
+  grantHomeApp: vi.fn(),
+  setHomeAppStatus: vi.fn(),
+  getHomeAppState: vi.fn(),
+  isRenderableHomeApp: vi.fn(() => true),
+  listHomeApps: vi.fn(),
+  putHomeAppState: vi.fn(),
+}))
+vi.mock('../../db/workspace-store.js', () => ({
+  getWorkspaceMembershipWithClearanceSystem: vi.fn(),
+  getWorkspaceRoleSystem: vi.fn(),
+}))
+vi.mock('../../brain-stream/notify.js', () => ({ notifyWorkspaceChange: vi.fn() }))
+vi.mock('../../home-apps/tools.js', () => ({ writeHomeAppBundle: vi.fn() }))
+
+import { homeAppRoutes } from '../home-apps.js'
+import { getHomeApp } from '../../db/home-apps-store.js'
+import { mintBundleToken } from '../../home-apps/tokens.js'
+
+const mockGetHomeApp = vi.mocked(getHomeApp)
+
+const SECRET = 'test-signing-secret'
+const APP_ID = '11111111-1111-4111-8111-111111111111'
+
+const APP_ROW = {
+  id: APP_ID,
+  workspaceId: '22222222-2222-4222-8222-222222222222',
+  createdBy: '33333333-3333-4333-8333-333333333333',
+  status: 'active',
+  grantedScopes: { net: [] },
+  manifest: { scopes: { net: [] } },
+} as never
+
+/** Records every path the route asks storage for, so traversal is observable. */
+const readPaths: string[] = []
+
+function makeApp() {
+  const filesApi = {
+    readBytes: vi.fn(async (_ctx: unknown, path: string) => {
+      readPaths.push(path)
+      return { ok: true as const, value: { bytes: Buffer.from('<!doctype html>') } }
+    }),
+    search: vi.fn(async () => []),
+    delete: vi.fn(async () => undefined),
+  }
+  const app = express()
+  app.use(
+    '/api/home-apps',
+    homeAppRoutes({
+      requireAuth: ((_req, _res, next) => next()) as express.RequestHandler,
+      filesApi: filesApi as never,
+      signingSecret: SECRET,
+      apiOrigin: 'https://api.example.com',
+    }),
+  )
+  return { app, filesApi }
+}
+
+function bundleUrl(path: string): string {
+  const token = mintBundleToken({ appId: APP_ID, secret: SECRET })
+  return `/api/home-apps/${APP_ID}/bundle/${path}?t=${encodeURIComponent(token)}`
+}
+
+describe('[COMP:api/home-app-bundle-route] Home app bundle route', () => {
+  beforeEach(() => {
+    readPaths.length = 0
+    mockGetHomeApp.mockResolvedValue(APP_ROW)
+  })
+
+  it('builds the router without throwing (boot-crash regression)', () => {
+    expect(() => makeApp()).not.toThrow()
+  })
+
+  it('serves a bundle file for a valid token', async () => {
+    const { app } = makeApp()
+    const res = await request(app).get(bundleUrl('index.html'))
+    expect(res.status).toBe(200)
+    expect(res.headers['content-type']).toContain('text/html')
+    expect(res.headers['x-content-type-options']).toBe('nosniff')
+    expect(readPaths).toEqual([`/apps/${APP_ID}/index.html`])
+  })
+
+  it('rejoins a nested sub-resource path across segments', async () => {
+    const { app } = makeApp()
+    const res = await request(app).get(bundleUrl('assets/js/app.js'))
+    expect(res.status).toBe(200)
+    expect(readPaths).toEqual([`/apps/${APP_ID}/assets/js/app.js`])
+  })
+
+  it('404s a percent-encoded traversal instead of reading another app', async () => {
+    const { app } = makeApp()
+    // Express decodes before the handler sees it, so this arrives as a single
+    // segment containing `../../` — a plain join would escape the app prefix.
+    const res = await request(app).get(bundleUrl('%2e%2e%2f%2e%2e%2fother/index.html'))
+    expect(res.status).toBe(404)
+    expect(readPaths).toEqual([])
+  })
+
+  it('401s without a token', async () => {
+    const { app } = makeApp()
+    const res = await request(app).get(`/api/home-apps/${APP_ID}/bundle/index.html`)
+    expect(res.status).toBe(401)
+    expect(readPaths).toEqual([])
+  })
+})

--- a/packages/api/src/routes/home-apps.ts
+++ b/packages/api/src/routes/home-apps.ts
@@ -522,7 +522,10 @@ export function homeAppRoutes(opts: HomeAppRouteOptions): Router {
    * requests accept the token from either the query or the Referer's query,
    * and fall back to 401.
    */
-  router.get('/:appId/bundle/*', async (req, res) => {
+  // The wildcard MUST be named (`*splat`). Express 5's path-to-regexp v8
+  // rejects a bare `*` by throwing at registration time, which crashes the API
+  // on boot rather than failing this one route.
+  router.get('/:appId/bundle/*splat', async (req, res) => {
     const appId = String(req.params.appId)
     const token = readBundleToken(req)
     if (!token) { res.status(401).json({ error: 'Missing bundle token' }); return }
@@ -530,9 +533,22 @@ export function homeAppRoutes(opts: HomeAppRouteOptions): Router {
     const verified = verifyBundleToken({ token, appId, secret: opts.signingSecret })
     if (!verified.ok) { res.status(401).json({ error: 'Invalid bundle token' }); return }
 
-    // Express puts the `*` wildcard capture at index 0 of `params`.
-    const wildcard = (req.params as unknown as Record<string, unknown>)['0']
-    const rawPath = typeof wildcard === 'string' ? wildcard : ''
+    // Express 5 hands a named wildcard back as an array of already-DECODED
+    // segments. Decoding before we see it is what makes the guard necessary:
+    // `%2e%2e%2f` arrives as `../` *inside* one segment, so a plain join would
+    // let a request climb out of this app's prefix into another app's bundle.
+    const wildcard = (req.params as unknown as Record<string, unknown>).splat
+    const segments = Array.isArray(wildcard)
+      ? wildcard.map((segment) => String(segment))
+      : typeof wildcard === 'string' ? [wildcard] : []
+    const traversal = segments.some((segment) =>
+      segment === '' || segment === '.' || segment === '..'
+      || segment.includes('/') || segment.includes('\\') || segment.includes('\0'))
+    if (segments.length === 0 || traversal) {
+      res.status(404).json({ error: 'Not found' })
+      return
+    }
+    const rawPath = segments.join('/')
     const contentType = contentTypeFor(rawPath)
     // Pinned from an allowlist, never sniffed: the bytes are third-party, and
     // letting the response type follow the content would let an app choose how


### PR DESCRIPTION
`router.get('/:appId/bundle/*', …)` is not a lax route under Express 5 — path-to-regexp v8 requires a **named** wildcard and throws `PathError: Missing parameter name` when the route is *registered*, inside `bootOpenApi`, before the server ever listens.

The result is a whole-service boot crash wearing the costume of one broken route. A self-hosted box taking the previous release crash-looped on every start and auto-rolled-back; the hosted API boots through the same `bootOpenApi`, so it would have done the same on its next deploy.

Nothing local caught it: the pattern is just a string (typechecks), no test constructed the router, and `pnpm smoke` has no HTTP layer.

## Changes

- `/:appId/bundle/*` → `/:appId/bundle/*splat`.
- **Traversal guard.** Naming the wildcard also changes the capture's shape: Express hands back an array of already-**decoded** segments. `%2e%2e%2f` survives browser normalization and arrives as `../` inside a single segment, so a plain join would climb out of `/apps/<appId>/` into another app's bundle — with the extension allowlist happily approving `../../<other>/index.html`. Any segment that is empty, `.`, `..`, or carries a slash, backslash, or NUL is now rejected before the path is joined.
- **The missing route test.** Constructing the router is itself the regression assertion, plus nested-path rejoin, traversal rejection, and the no-token 401.

Graded in the platform repo as `invariants/express-route-patterns`, which scans route-registering calls in both trees for unnamed wildcards and unnamed `:` parameters.

## Verification

`pnpm --filter @use-brian/api test` — 372 files / 4371 tests pass. `pnpm typecheck` 35/35. `pnpm smoke` OK. Confirmed non-vacuous: the old pattern throws at `Router().get(...)` under the installed express 5.2.1, the new one registers cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)