### PR TITLE
fix(tools): tolerate stringified enum lists, and stop hiding union errors

### DIFF
--- a/packages/core/src/engine/__tests__/tool-executor.test.ts
+++ b/packages/core/src/engine/__tests__/tool-executor.test.ts
@@ -337,6 +337,82 @@ describe('[COMP:engine/tool-executor] error result caps', () => {
     // The failing field path is surfaced, not buried.
     expect(content).toContain('count:')
   })
+
+  // A union mismatch renders in zod as the bare word "Invalid input", naming
+  // neither what arrived nor what was allowed. Collapsing the branch errors
+  // wholesale (the 2026-06-01 over-correction) made every union param
+  // unactionable: the model cannot retry what it cannot see, so it gives up.
+  // `listTasks({status})` failed this way 35 times between 2026-07-08 and
+  // 2026-08-03, silently dropping a person from each morning digest.
+  const STATUSES = ['todo', 'in_progress', 'in_review', 'blocked', 'done', 'archived'] as const
+  const statusUnion = z.enum(STATUSES).or(z.array(z.enum(STATUSES)))
+
+  async function formatFor(input: Record<string, unknown>): Promise<string> {
+    const tools = new Map<string, Tool>([
+      ['listish', buildTool({
+        name: 'listish',
+        description: 'Tool with a single-or-array enum param.',
+        inputSchema: z.object({ status: statusUnion.optional() }),
+        isConcurrencySafe: true,
+        isReadOnly: true,
+        async execute() { return { data: 'ok' } },
+      })],
+    ])
+    const executor = createToolExecutor({ tools, context: ctx, loopDetector: createLoopDetector() })
+    executor.addTool('call_1', 'listish', input)
+    const results = await drainResults(executor)
+    return String((results[0] as Extract<ContentBlock, { type: 'tool_result' }>).content)
+  }
+
+  it('names the received value and the allowed set on a union mismatch', async () => {
+    // The production shape: a JSON-stringified array.
+    const content = await formatFor({ status: '["todo","in_progress","blocked"]' })
+    expect(content).toContain('status:')
+    // The whole point — the bare zod message is no longer the entire story.
+    expect(content).not.toMatch(/status: Invalid input\s*$/)
+    // What was allowed…
+    expect(content).toContain('todo')
+    expect(content).toContain('archived')
+    // …and what actually arrived.
+    expect(content).toContain('received')
+  })
+
+  it('surfaces the offending ARRAY ELEMENT, which is a level deeper than the union', async () => {
+    const content = await formatFor({ status: ['todo', 'pending'] })
+    // The array branch blames `status.1`; that path is the most useful line in
+    // the whole error and must survive the collapse.
+    expect(content).toContain('status.1')
+    expect(content).toContain('pending')
+  })
+
+  it('stays bounded — the caps, not the detail, are what prevent the 2026-06-01 blob', async () => {
+    // A union whose branches are themselves large: without caps this is the
+    // recursive dump that cost ~60k tokens per loop iteration.
+    const fat = z.union([
+      z.object({ a: z.string(), b: z.string(), c: z.string(), d: z.string() }),
+      z.object({ e: z.string(), f: z.string(), g: z.string(), h: z.string() }),
+      z.object({ i: z.string(), j: z.string(), k: z.string(), l: z.string() }),
+      z.object({ m: z.string(), n: z.string(), o: z.string(), p: z.string() }),
+    ])
+    const tools = new Map<string, Tool>([
+      ['fat', buildTool({
+        name: 'fat',
+        description: 'Tool with a fat union param.',
+        inputSchema: z.object({ payload: fat }),
+        isConcurrencySafe: true,
+        isReadOnly: true,
+        async execute() { return { data: 'ok' } },
+      })],
+    ])
+    const executor = createToolExecutor({ tools, context: ctx, loopDetector: createLoopDetector() })
+    executor.addTool('call_1', 'fat', { payload: { zzz: 1 } })
+    const results = await drainResults(executor)
+    const content = String((results[0] as Extract<ContentBlock, { type: 'tool_result' }>).content)
+    expect(content).not.toContain('unionErrors')
+    // 320-char detail budget + the surrounding line, nowhere near the cap.
+    expect(content.length).toBeLessThan(1_000)
+    expect(content).not.toContain(TRUNCATION_MARKER)
+  })
 })
 
 describe('[COMP:engine/tool-executor] loop detector integration', () => {

--- a/packages/core/src/engine/tool-executor.ts
+++ b/packages/core/src/engine/tool-executor.ts
@@ -93,6 +93,58 @@ export type ToolExecutorOptions = {
 
 // ── Error formatting ───────────────────────────────────────────
 
+/** One zod issue, duck-typed (see `formatToolError` on why not `instanceof`). */
+type ZodIssueLike = {
+  path?: unknown[]
+  message?: string
+  code?: string
+  unionErrors?: Array<{ issues?: ZodIssueLike[] }>
+}
+
+/** Branches rendered for one union issue. Beyond this the model is not
+ *  learning more, it is just paying tokens. */
+const MAX_UNION_BRANCHES = 3
+/** Issues rendered per branch. */
+const MAX_UNION_ISSUES_PER_BRANCH = 2
+/** Hard character budget for ONE union issue's rendered detail. */
+const MAX_UNION_DETAIL_CHARS = 320
+
+/**
+ * Turn an `invalid_union` issue's branch errors into a bounded, actionable
+ * suffix — or null when there is nothing useful to add.
+ *
+ * Zod renders a union mismatch as the bare word "Invalid input", which names
+ * neither what arrived nor what was allowed. The branch errors underneath do
+ * carry that (`Invalid enum value. Expected 'todo' | … , received '["todo"]'`),
+ * so the fix is to surface a capped slice of them rather than the recursive
+ * blob that caused the 2026-06-01 incident.
+ *
+ * Branch issues can sit DEEPER than the union's own path (an array-branch
+ * failure reports `status.1`, naming the offending element) and that is
+ * usually the most useful line of all, so paths are rendered per issue rather
+ * than filtered to the union's own depth.
+ */
+function describeUnionIssue(issue: ZodIssueLike): string | null {
+  const branches = issue.unionErrors
+  if (!Array.isArray(branches) || branches.length === 0) return null
+  const seen = new Set<string>()
+  for (const branch of branches.slice(0, MAX_UNION_BRANCHES)) {
+    for (const sub of (branch.issues ?? []).slice(0, MAX_UNION_ISSUES_PER_BRANCH)) {
+      const message = sub.message
+      if (!message) continue
+      // Re-path only when the branch blames something deeper than the union
+      // itself; at the same depth the caller already prints the path.
+      const deeper = (sub.path?.length ?? 0) > (issue.path?.length ?? 0)
+      seen.add(deeper ? `${(sub.path ?? []).join('.')}: ${message}` : message)
+    }
+  }
+  if (seen.size === 0) return null
+  const joined = [...seen].join(' OR ')
+  return joined.length > MAX_UNION_DETAIL_CHARS
+    ? `${joined.slice(0, MAX_UNION_DETAIL_CHARS)}…`
+    : joined
+}
+
 /**
  * Render a thrown tool error as a compact, model-actionable string.
  *
@@ -107,15 +159,25 @@ export type ToolExecutorOptions = {
  * is the single chokepoint for both `inputSchema.parse` failures and
  * ZodErrors thrown from inside a tool's own `execute()`.
  *
+ * Union issues get a **bounded** slice of their branch errors appended
+ * (`describeUnionIssue`). Dropping them wholesale was over-correction: a bare
+ * "status: Invalid input" is unactionable, so the model cannot retry and
+ * gives up — 35 silent `listTasks` failures between 2026-07-08 and 2026-08-03,
+ * each one dropping a person's section from the morning digest. The caps
+ * (3 branches × 2 issues, 320 chars per union issue, 20 issues overall) are
+ * what keep this from becoming the 2026-06-01 blob again.
+ *
  * Duck-typed on `.issues` rather than `instanceof ZodError` so a tool that
  * bundles its own zod copy (a different class identity) still matches.
  */
 export function formatToolError(err: unknown): string {
   if (err && typeof err === 'object' && Array.isArray((err as { issues?: unknown }).issues)) {
-    const issues = (err as { issues: Array<{ path?: unknown[]; message?: string }> }).issues
-    const lines = issues
-      .slice(0, 20)
-      .map((i) => `${(i.path ?? []).join('.') || '(root)'}: ${i.message ?? 'invalid'}`)
+    const issues = (err as { issues: ZodIssueLike[] }).issues
+    const lines = issues.slice(0, 20).map((i) => {
+      const path = (i.path ?? []).join('.') || '(root)'
+      const detail = i.code === 'invalid_union' ? describeUnionIssue(i) : null
+      return `${path}: ${detail ?? i.message ?? 'invalid'}`
+    })
     const more = issues.length > 20 ? `\n…and ${issues.length - 20} more issue(s)` : ''
     return `Validation failed:\n${lines.join('\n')}${more}`
   }

--- a/packages/core/src/tasks/__tests__/tools.test.ts
+++ b/packages/core/src/tasks/__tests__/tools.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { buildCitationIndex } from '@use-brian/shared'
 import { createTaskTools, type TaskToolEvent } from '../tools.js'
+import { formatToolError } from '../../engine/tool-executor.js'
 import type { TaskRecord, TaskStore } from '../types.js'
 
 // The real store persists provenance (source*, mig 316/334) but does NOT
@@ -440,6 +441,40 @@ describe('[COMP:tasks/tools] listTasks', () => {
     const result = await listTasks.execute({ status: ['todo', 'in_progress'] }, ctx)
     const data = result.data as Array<{ status: string }>
     expect(data.map((r) => r.status).sort()).toEqual(['in_progress', 'todo'])
+  })
+
+  // Production regression (2026-07-08 → 2026-08-03, 35 occurrences): the model
+  // serialises this list param loosely and the strict `enum | enum[]` union
+  // rejected it as "status: Invalid input". Every occurrence was a workflow
+  // step that still reported `completed` while emptying one person's digest
+  // section, so the failure was invisible. See `tolerantEnumArray`.
+  it('accepts a status list the model serialised as a string', async () => {
+    const store = makeFakeStore()
+    await seed(store)
+    const { listTasks } = createTaskTools(store)
+
+    for (const loose of ['["todo","in_progress"]', 'todo,in_progress', 'todo, in_progress']) {
+      const parsed = listTasks.inputSchema.safeParse({ status: loose })
+      expect(parsed.success, `should accept ${loose}`).toBe(true)
+      const result = await listTasks.execute(
+        (parsed as { data: Record<string, unknown> }).data,
+        ctx,
+      )
+      expect(result.isError).toBeFalsy()
+      const data = result.data as Array<{ status: string }>
+      expect(data.map((r) => r.status).sort()).toEqual(['in_progress', 'todo'])
+    }
+  })
+
+  it('still rejects an unknown status, and now says what was allowed', () => {
+    const { listTasks } = createTaskTools(makeFakeStore())
+    const res = listTasks.inputSchema.safeParse({ status: 'pending' })
+    expect(res.success).toBe(false)
+    if (!res.success) {
+      // Tolerance is not coercion — an invalid member is still a hard failure,
+      // and the message has to name the legal set or the model cannot retry.
+      expect(formatToolError(res.error)).toContain('todo')
+    }
   })
 
   it('filters by assignee + tag together', async () => {

--- a/packages/core/src/tasks/tools.ts
+++ b/packages/core/src/tasks/tools.ts
@@ -3,7 +3,7 @@ import { extractCitations, formatStamp, type CitationIndex } from '@use-brian/sh
 import type { AccessContext } from '../security/access-context.js'
 import { unionCompartments } from '../security/compartments.js'
 import { buildTool, type Tool } from '../tools/types.js'
-import { tolerantBoolean, tolerantInt } from '../tools/schema-tolerance.js'
+import { tolerantBoolean, tolerantEnumArray, tolerantInt } from '../tools/schema-tolerance.js'
 import {
   applyExplicitCloses,
   applyExplicitLinks,
@@ -403,7 +403,10 @@ export function createTaskTools(
       'Default excludes archived tasks (set `include_archived: true` to include them). Default limit is 25 (max 100). Status accepts a single value or an array (e.g. `["todo", "in_progress"]`).',
     inputSchema: z.object({
       assignee_id: idShape.optional(),
-      status: statusEnum.or(z.array(statusEnum)).optional(),
+      // Tolerant because this is the param models serialise loosely — a
+      // stringified or comma-joined list reads as neither branch of the union
+      // and failed 35 times in production. See `tolerantEnumArray`.
+      status: tolerantEnumArray(TASK_STATUSES).optional(),
       due_before: isoDateOrDateTime.optional(),
       due_after: isoDateOrDateTime.optional(),
       tag: z.string().min(1).max(64).optional(),

--- a/packages/core/src/tools/__tests__/schema-tolerance.test.ts
+++ b/packages/core/src/tools/__tests__/schema-tolerance.test.ts
@@ -15,6 +15,7 @@ import {
   tolerantInt,
   uuidId,
   tolerantObject,
+  tolerantEnumArray,
 } from '../schema-tolerance.js'
 
 describe('[COMP:engine/tool-input-tolerance] schema tolerance helpers', () => {
@@ -78,6 +79,61 @@ describe('[COMP:engine/tool-input-tolerance] schema tolerance helpers', () => {
     it('invalid JSON string still errors cleanly (raw value reaches the schema)', () => {
       expect(() => tolerantObject(shape).parse('{not json')).toThrow()
       expect(() => tolerantObject(shape).parse('"just a string"')).toThrow()
+    })
+  })
+
+  describe('tolerantEnumArray', () => {
+    // The listTasks `status` shape. A "single value or a list" param is exactly
+    // what a model serialises loosely, and this one failed validation 35 times
+    // in production between 2026-07-08 and 2026-08-03 — every occurrence inside
+    // a workflow step, each silently emptying one person's digest section.
+    const STATUSES = ['todo', 'in_progress', 'in_review', 'blocked', 'done', 'archived'] as const
+    const status = tolerantEnumArray(STATUSES)
+
+    it('accepts the strict forms unchanged — one member, or a real array', () => {
+      expect(status.parse('todo')).toBe('todo')
+      expect(status.parse(['todo', 'blocked'])).toEqual(['todo', 'blocked'])
+    })
+
+    it('does NOT wrap a valid single member into an array', () => {
+      // The union accepts both shapes, so preserving what the model sent keeps
+      // the recorded tool input honest.
+      expect(status.parse('in_progress')).toBe('in_progress')
+    })
+
+    it('accepts a JSON-stringified array — the production failure', () => {
+      expect(status.parse('["todo","in_progress","blocked"]')).toEqual([
+        'todo',
+        'in_progress',
+        'blocked',
+      ])
+    })
+
+    it('accepts a comma-separated list, with or without spaces', () => {
+      expect(status.parse('todo,blocked')).toEqual(['todo', 'blocked'])
+      expect(status.parse('todo, in_progress , blocked')).toEqual([
+        'todo',
+        'in_progress',
+        'blocked',
+      ])
+    })
+
+    it('still REJECTS a genuinely invalid member — tolerance is not coercion', () => {
+      expect(status.safeParse('pending').success).toBe(false)
+      expect(status.safeParse(['todo', 'pending']).success).toBe(false)
+      expect(status.safeParse('["todo","pending"]').success).toBe(false)
+      expect(status.safeParse(42).success).toBe(false)
+    })
+
+    it('a malformed JSON array falls through to a normal error, not a crash', () => {
+      expect(status.safeParse('["todo",').success).toBe(false)
+    })
+
+    it('rejects an empty or whitespace-only list instead of inventing an empty filter', () => {
+      // An empty array would silently mean "no status filter", quietly widening
+      // the query rather than reporting the bad input.
+      expect(status.safeParse('').success).toBe(false)
+      expect(status.safeParse(' , , ').success).toBe(false)
     })
   })
 })

--- a/packages/core/src/tools/schema-tolerance.ts
+++ b/packages/core/src/tools/schema-tolerance.ts
@@ -72,6 +72,55 @@ export function tolerantInt(opts?: { min?: number; max?: number }): z.ZodType<nu
   return schema
 }
 
+// ── tolerantEnumArray ────────────────────────────────────────────────────────
+
+/**
+ * Accepts ONE enum member, an array of members, a JSON-stringified array
+ * (`'["todo","in_progress"]'`), or a comma-separated list
+ * (`'todo, in_progress'`). Anything else falls through to normal validation.
+ *
+ * Use for any "single value or a list" filter param. The earlier tolerance
+ * sweep (2026-07-07) only covered *primitive* params, so a
+ * `status: enum | enum[]` union stayed strict — and it is precisely the shape
+ * a model serialises loosely, because a list is the thing worth serialising.
+ * `listTasks({status: ["todo","in_progress","blocked"]})` failed validation 35
+ * times between 2026-07-08 and 2026-08-03, every one of them inside a
+ * workflow step, each silently dropping one person's section from the morning
+ * digest (the step still reported `completed`).
+ *
+ * A value that is already a valid single member is returned **unchanged**, not
+ * wrapped into an array: the union accepts both, and preserving the model's
+ * own shape keeps the tool's returned/logged input honest.
+ */
+export function tolerantEnumArray<T extends readonly [string, ...string[]]>(
+  values: T,
+): z.ZodType<T[number] | T[number][], z.ZodTypeDef, unknown> {
+  const members = new Set<string>(values)
+  const enumSchema = z.enum(values as unknown as [string, ...string[]])
+  return z.preprocess((raw) => {
+    if (typeof raw !== 'string') return raw
+    const trimmed = raw.trim()
+    // Already exactly one member — leave the single-value shape alone.
+    if (members.has(trimmed)) return trimmed
+    if (trimmed.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(trimmed)
+        if (Array.isArray(parsed)) return parsed
+      } catch {
+        // Not JSON after all — fall through to the comma split / raw value.
+      }
+    }
+    if (trimmed.includes(',')) {
+      const parts = trimmed
+        .split(',')
+        .map((p) => p.trim())
+        .filter((p) => p.length > 0)
+      if (parts.length > 0) return parts
+    }
+    return raw
+  }, enumSchema.or(z.array(enumSchema))) as z.ZodType<T[number] | T[number][], z.ZodTypeDef, unknown>
+}
+
 // ── uuidId ───────────────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## The symptom

Morning-digest run `a5096adb`, step `gather_ken`:

```json
{"errors":["Validation failed: status: Invalid input"],
 "up_next":[],"blockers":[],"in_progress":[]}
```

The step reported `completed`. The run reported `completed`. One person's digest section was simply empty, with nothing to alert on.

## What actually happened

Not a workflow bug. Analytics for that second shows two real `listTasks` calls — one rejected, one fine:

```
tool_executed  {"success": false, "tool_name": "listTasks",
                "error_message": "Error: Validation failed: status: Invalid input"}
task_listed    {"hit": true, "result_count": 2}
tool_executed  {"success": true,  "tool_name": "listTasks"}
```

All five `gather_*` steps carry a byte-identical instruction — `listTasks({assignee_id: "…", status: ["todo","in_progress","blocked"], limit: 100})` — and four succeeded. The model serialised that one call's list loosely, and the strict `enum | enum[]` union rejected it.

**35 occurrences, 2026-07-08 → 2026-08-03, every one inside a workflow step.** Not a regression: array support for `status` has been unchanged since the 2026-06-18 open-source release. Two latent defects finally met a caller that used the array form daily.

## Defect 1 — the tolerance sweep skipped compound params

`c02f4043` (2026-07-08, "schema tolerance") wrapped `include_archived` and `limit` and left `status` bare; `docs/architecture/engine/tool-input-tolerance.md` confirms it, listing applied sites as `tasks/tools.ts (include_archived, limit)` and framing the rule around *primitive* params.

But "single value or a list" is precisely the shape a model serialises loosely — a list is the thing worth serialising. `tolerantEnumArray` accepts a member, a real array, a JSON-stringified array, or a comma-separated list.

- A valid single member is returned **unchanged**, never wrapped, so the recorded tool input still reflects what the model sent.
- Tolerance is **not** coercion: an invalid member (`"pending"`) is still a hard failure, in every input form.

## Defect 2 — union errors said nothing

Zod renders a union mismatch as the bare word `"Invalid input"`, naming neither the value received nor the set allowed. `formatToolError` discarded the branch errors underneath — a correct reaction to the 2026-06-01 "AI Trading" incident (a `patchPage` op-union `ZodError.message` serialised to ~245k chars / ~60k tokens, re-sent every loop iteration) but an over-correction. It made every union param unactionable: the model cannot retry what it cannot see, so it gives up on the first attempt, which is exactly what `gather_ken` did.

It now appends a **bounded** slice — 3 branches × 2 issues, 320 chars per union issue, under the existing 20-issue cap. Branch issues blaming something *deeper* than the union's own path keep their full path; that line names the offending array element and is usually the most useful in the whole error.

```
before  status: Invalid input
after   status: Invalid enum value. Expected 'todo' | 'in_progress' | … ,
                received '["todo","in_progress"]' OR Expected array, received string

array member case →  status.1: Invalid enum value. … received 'pending'
```

The caps, not the omission, are what prevent a repeat of 2026-06-01 — and the pre-existing boundedness test (`not.toContain('unionErrors')`, length under 2k) still passes untouched.

This also makes the **second-largest** offender diagnosable without changing it: `patchPage ops.N.block.level: Invalid input` (~30 occurrences) is a bare `z.union([z.literal(1)…literal(4)])` in `views/a2ui.ts:666` with no preprocess, unlike its twin in `views/blocks.ts:459`. Its tolerance half is logged as a follow-up in the spec.

## Tests

- `schema-tolerance.test.ts` (+7) — strict forms unchanged, single member never wrapped, stringified array, comma list with and without spaces, invalid member still rejected in every form, malformed JSON falls through, empty/whitespace list rejected rather than silently widening the query to "no filter".
- `tool-executor.test.ts` (+3) — the union message names the received value and the allowed set; the array-element path (`status.1`) survives the collapse; a fat 4-branch union stays bounded and free of `unionErrors`.
- `tasks/tools.test.ts` (+2) — end-to-end on the real `listTasks` tool for all three loose forms, and an unknown status still failing with the legal set named.

## Verification

`@use-brian/core` 4377 passing, `pnpm smoke` OK, core `tsc` clean. `pnpm check` adds zero new violations (the 2 `dead-exports` hits are in `apps/app-web/src/lib/feed*.ts`, untouched here).

Pre-existing and unrelated on this branch: `@use-brian/brian-app` and `jszip` are not installed, which fails 8 `api` test files at collection and the `brian-app` package's own script; and `sessions-questions.test.ts` flakes under full-suite load (passes isolated).

## Note

This makes the digest **succeed** instead of silently emitting an empty section. It does not change the prompt's "if the tool call fails, emit `errors[]`" escape hatch — a workflow step can still report `completed` while reporting an internal failure. Whether those should fail the run loudly is a separate product decision.