### PR TITLE
fix(browser): re-stamp CURRENT_EXTENSION_BUILD after the capture change

### DIFF
--- a/apps/browser-extension/src/__tests__/popup-status.test.ts
+++ b/apps/browser-extension/src/__tests__/popup-status.test.ts
@@ -67,7 +67,7 @@ describe('[COMP:ext/agent] Popup status line', () => {
  * eleven days stale, from a folder orphaned by the open-core cutover, and
  * nothing on any surface said so.
  */
-describe('[COMP:ext/agent] Popup build status', () => {
+describe('[COMP:ext/build-stamp] Popup build status', () => {
   it('warns only when the relay actually said the build is stale', () => {
     expect(buildWarning({ staleBuild: true })).toMatch(/out of date/i)
     expect(buildWarning({ staleBuild: false })).toBeNull()

--- a/packages/shared/src/browser-extension-build.ts
+++ b/packages/shared/src/browser-extension-build.ts
@@ -19,7 +19,7 @@
  * Do not hand-edit. `pnpm check` (`invariants/browser-extension-build-stamp`)
  * prints the value to paste when extension source moves.
  */
-export const CURRENT_EXTENSION_BUILD = 'f0c49f289acc'
+export const CURRENT_EXTENSION_BUILD = 'b24d13c4f67d'
 
 /**
  * A reported build is stale unless it matches exactly.


### PR DESCRIPTION
Session capture (#146) moved `executor.ts` and `background.ts`, so the extension source now hashes to `b24d13c4f67d` while `CURRENT_EXTENSION_BUILD` still read `f0c49f289acc`.

The relay judges staleness once at hello against that constant, so every freshly-built extension would have been told it was out of date - the exact failure the stamp exists to prevent, caused by the stamp itself.

Caught by `pnpm check` (`invariants/browser-extension-build-stamp`) only after the platform gitlink advanced, because that check lives in the platform tree and cannot run against an OSS PR. Worth noting as a gap: an OSS-only contributor changing extension source has no local signal for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)