### PR TITLE
feat(chat-archive): add local channel history search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,13 @@ BROWSER_USE_MODEL=
 # Point at an external Postgres connection string to use it instead of the
 # embedded PGLite brain.
 DATABASE_URL=
+# Local chat archive sidecar. The launcher automatically discovers a sibling
+# brian-message-store checkout, generates/persists the HMAC secret, and binds
+# the service to 127.0.0.1:8092. These are source-checkout overrides only.
+# BRIAN_MESSAGE_STORE_ENABLED=0
+# BRIAN_MESSAGE_STORE_DIR=/absolute/path/to/brian-message-store
+# BRIAN_MESSAGE_STORE_BIN=/absolute/path/to/brian-message-store
+# BRIAN_MESSAGE_STORE_MAX_BODY_BYTES=8388608
 # Auto-generated and persisted to ~/.usebrian/config.json if left unset.
 JWT_SECRET=
 # Shared secret for the API <-> doc-sync internal routes (the auto-on-save brain
@@ -169,6 +176,12 @@ DISCORD_CONNECTOR_SECRET=
 # credential persistence and call back to `${API_URL}`.
 WA_CONNECTOR_URL=
 WA_CONNECTOR_SECRET=
+
+# WeChat bot pairing and inbound polling use the local iLink bridge. `pnpm
+# start` launches it on port 8093 and generates/persists the shared secret.
+# Set these only when running that bridge separately on this machine.
+WECHAT_CONNECTOR_URL=
+WECHAT_CONNECTOR_SECRET=
 
 # ── Connectors (optional) ───────────────────────────────────────────────────
 # Built-in connectors (Google Calendar/Gmail/Drive, Notion, Fathom, Microsoft

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -100,6 +100,12 @@ const env: OpenApiEnv = {
   // supplies both values; bare API boots leave WhatsApp unavailable when unset.
   WA_CONNECTOR_URL: process.env.WA_CONNECTOR_URL,
   WA_CONNECTOR_SECRET: process.env.WA_CONNECTOR_SECRET,
+  // Optional local WeChat iLink bridge. The launcher starts it and supplies
+  // both values so Studio QR pairing and inbound polling are available.
+  WECHAT_CONNECTOR_URL: process.env.WECHAT_CONNECTOR_URL,
+  WECHAT_CONNECTOR_SECRET: process.env.WECHAT_CONNECTOR_SECRET,
+  BRIAN_MESSAGE_STORE_URL: process.env.BRIAN_MESSAGE_STORE_URL,
+  BRIAN_MESSAGE_STORE_HMAC_SECRET: process.env.BRIAN_MESSAGE_STORE_HMAC_SECRET,
 }
 
 // Wire the OPEN Pipeline B episode ingestors so brain distillation (doc-page

--- a/apps/api/src/migrate-pglite.ts
+++ b/apps/api/src/migrate-pglite.ts
@@ -17,12 +17,26 @@ function withoutOuterTransaction(sql: string, file: string): string {
   return sql.replace(/^BEGIN;\s*$/m, '').replace(/^COMMIT;\s*$/m, '')
 }
 
+function concurrentIndexStatements(sql: string): string[] | null {
+  if (!/concurrently/i.test(sql) || /^\s*BEGIN/im.test(sql)) return null
+  return sql
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/--[^\n]*/g, '')
+    .split(';')
+    .map((statement) => statement.trim())
+    .filter(Boolean)
+}
+
 /**
  * Apply the open migration baseline (+ any post-squash open migrations) to an
  * embedded PGLite brain. Local boot is OPEN-ONLY — no closed overlay.
  *
- * Each file and its `_migrations` row commit atomically in one runner-owned
- * transaction. Outer BEGIN/COMMIT wrappers are removed before execution. The
+ * Each ordinary file and its `_migrations` row commit atomically in one
+ * runner-owned transaction. Outer BEGIN/COMMIT wrappers are removed before
+ * execution. `CREATE INDEX CONCURRENTLY` files are the deliberate exception:
+ * PostgreSQL and PGLite reject those statements inside a transaction, so the
+ * runner applies their idempotent statements one at a time and records the
+ * file afterwards. The
  * squash separates schema from seed rows with a `-- Seed data` marker (see
  * `000_open_schema_v1.sql`); its DDL runs in one exec and each seed INSERT in a
  * separate exec inside that same transaction. Calls sharing a PGlite instance
@@ -85,6 +99,26 @@ async function migratePgliteExclusive(db: PGlite, migrationsDir: string): Promis
         return true
       })
       if (applied) count++
+      continue
+    }
+
+    // Match the node-postgres migration runner: concurrent indexes must be
+    // separate, top-level statements. The repository's concurrent-index
+    // migrations use IF NOT EXISTS, so a process crash between statements is
+    // safe to resume before the ledger row is written.
+    const concurrentStatements = concurrentIndexStatements(sql)
+    if (concurrentStatements) {
+      const existing = await db.query<{ name: string }>(
+        'SELECT name FROM public._migrations WHERE name = $1',
+        [file],
+      )
+      if (existing.rows.length > 0) continue
+
+      for (const statement of concurrentStatements) {
+        await db.exec(statement)
+      }
+      await db.query('INSERT INTO public._migrations (name) VALUES ($1)', [file])
+      count++
       continue
     }
 

--- a/apps/wechat-connector/src/pairing-manager.ts
+++ b/apps/wechat-connector/src/pairing-manager.ts
@@ -130,6 +130,7 @@ export function createPairingManager(): PairingManager {
       }
       if (signal.aborted) return
 
+      const previousStatus = session.snapshot.status
       switch (status.status) {
         case 'wait':
           break
@@ -151,20 +152,26 @@ export function createPairingManager(): PairingManager {
           session.pendingVerifyCode = undefined
           session.snapshot.status = 'error'
           session.snapshot.error = 'verify_code_blocked'
+          console.warn(`[wechat-pairing] ${session.snapshot.pairingId}: verify code blocked`)
           return
         case 'scaned_but_redirect':
           if (status.redirect_host) {
             session.pollBaseUrl = `https://${status.redirect_host}`
+            console.info(
+              `[wechat-pairing] ${session.snapshot.pairingId}: redirected after scan to ${status.redirect_host}`,
+            )
           }
           break
         case 'binded_redirect':
           // Already bound to this deployment — nothing new is issued.
           session.snapshot.status = 'already_bound'
+          console.info(`[wechat-pairing] ${session.snapshot.pairingId}: bot is already bound`)
           return
         case 'expired': {
           session.qrRefreshes += 1
           if (session.qrRefreshes > MAX_QR_REFRESHES) {
             session.snapshot.status = 'expired'
+            console.info(`[wechat-pairing] ${session.snapshot.pairingId}: QR session expired`)
             return
           }
           try {
@@ -176,6 +183,7 @@ export function createPairingManager(): PairingManager {
           } catch (err) {
             session.snapshot.status = 'error'
             session.snapshot.error = `QR refresh failed: ${String(err)}`
+            console.warn(`[wechat-pairing] ${session.snapshot.pairingId}: QR refresh failed:`, err)
             return
           }
           break
@@ -184,6 +192,7 @@ export function createPairingManager(): PairingManager {
           if (!status.bot_token || !status.ilink_bot_id) {
             session.snapshot.status = 'error'
             session.snapshot.error = 'iLink confirmed the login but returned no credentials'
+            console.warn(`[wechat-pairing] ${session.snapshot.pairingId}: confirmed without credentials`)
             return
           }
           session.snapshot.status = 'confirmed'
@@ -194,8 +203,15 @@ export function createPairingManager(): PairingManager {
             ilinkBotId: status.ilink_bot_id,
             boundUserId: status.ilink_user_id,
           }
+          console.info(`[wechat-pairing] ${session.snapshot.pairingId}: pairing confirmed`)
           return
         }
+      }
+
+      if (session.snapshot.status !== previousStatus) {
+        console.info(
+          `[wechat-pairing] ${session.snapshot.pairingId}: ${previousStatus} -> ${session.snapshot.status}`,
+        )
       }
 
       await sleep(POLL_GAP_MS, signal)
@@ -220,6 +236,7 @@ export function createPairingManager(): PairingManager {
         abort: new AbortController(),
       }
       sessions.set(pairingId, session)
+      console.info(`[wechat-pairing] ${pairingId}: QR session started`)
       void runStatusLoop(session).catch((err) => {
         console.error(`[wechat-pairing] ${pairingId}: status loop crashed:`, err)
         session.snapshot.status = 'error'

--- a/apps/wechat-connector/src/poller-manager.ts
+++ b/apps/wechat-connector/src/poller-manager.ts
@@ -120,7 +120,18 @@ export function createPollerManager(options: PollerManagerOptions): PollerManage
     const dedup = createDedupBuffer()
     const signal = state.abort.signal
 
-    await client.notifyStart().catch(() => {})
+    try {
+      const notified = await client.notifyStart()
+      if (notified.ret !== undefined && notified.ret !== 0) {
+        console.warn(
+          `[wechat-poller] ${channelId}: notifystart returned ret=${notified.ret} errmsg=${notified.errmsg ?? ''}`,
+        )
+      }
+    } catch (err) {
+      // Tencent treats this as online reconciliation rather than the transport
+      // itself, so keep polling but retain the reason behind an offline badge.
+      console.warn(`[wechat-poller] ${channelId}: notifystart failed:`, err)
+    }
 
     let getUpdatesBuf = input.getUpdatesBuf ?? ''
     let nextTimeoutMs = LONG_POLL_TIMEOUT_MS
@@ -188,7 +199,9 @@ export function createPollerManager(options: PollerManagerOptions): PollerManage
     }
 
     state.snapshot.status = 'stopped'
-    await client.notifyStop().catch(() => {})
+    await client.notifyStop().catch((err) => {
+      console.warn(`[wechat-poller] ${channelId}: notifystop failed:`, err)
+    })
   }
 
   return {

--- a/packages/api/migrations/395_chat_message_archive.sql
+++ b/packages/api/migrations/395_chat_message_archive.sql
@@ -1,0 +1,172 @@
+-- 395_chat_message_archive.sql  (OPEN tables -> use-brian/packages/api/migrations/)
+--
+-- Local provider-neutral interactive-chat archive and search projection.
+-- `brian-message-store` consumes ub.ingest.append.v1 and writes these tables;
+-- the platform remains the schema owner and supplies embeddings, enrichment,
+-- retrieval, RLS projection, and agent tools.
+--
+-- Person-compartmented like email_archive (migration 359): chat history belongs
+-- to one owner even inside a shared workspace. The immutable raw row and the
+-- derived search segment stay separate so embedding / Pipeline B failures can
+-- never affect append durability.
+--
+-- PGLite compatibility is required: local boot applies this migration through
+-- migrate-pglite.ts with pgvector + pg_trgm already loaded.
+--
+-- See docs/architecture/integrations/chat-message-store.md.
+
+BEGIN;
+
+CREATE TABLE chat_archive_messages (
+  id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id             UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  instance_id              UUID NOT NULL REFERENCES connector_instance(id) ON DELETE CASCADE,
+  owner_user_id            UUID NOT NULL,
+  source                   TEXT NOT NULL CHECK (length(source) > 0),
+  provider_message_id      TEXT NOT NULL CHECK (length(provider_message_id) > 0),
+  conversation_id          TEXT NOT NULL CHECK (length(conversation_id) > 0),
+  sender_id                TEXT NOT NULL DEFAULT '',
+  sender_display           TEXT,
+  sent_at                  TIMESTAMPTZ NOT NULL,
+  direction                TEXT NOT NULL CHECK (direction IN ('inbound', 'outbound')),
+  kind                     TEXT NOT NULL CHECK (kind IN ('text', 'image', 'voice', 'file', 'link')),
+  body_text                TEXT,
+  -- Attachment metadata only; bytes stay in the platform local-file backend.
+  media_ref                JSONB,
+  reply_to_provider_id     TEXT,
+  -- Sanitized provider payload retained for explicit reparsing only.
+  raw_provider_blob        JSONB,
+  received_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  UNIQUE (instance_id, provider_message_id)
+);
+
+CREATE INDEX idx_chat_archive_messages_owner_sent
+  ON chat_archive_messages (owner_user_id, sent_at DESC);
+CREATE INDEX idx_chat_archive_messages_conversation_sent
+  ON chat_archive_messages (instance_id, conversation_id, sent_at, id);
+CREATE INDEX idx_chat_archive_messages_reply
+  ON chat_archive_messages (instance_id, reply_to_provider_id)
+  WHERE reply_to_provider_id IS NOT NULL;
+
+ALTER TABLE chat_archive_messages ENABLE ROW LEVEL SECURITY;
+CREATE POLICY chat_archive_messages_owner ON chat_archive_messages
+  USING (owner_user_id = (current_setting('app.current_user_id'::text, true))::uuid);
+
+CREATE TABLE chat_archive_segments (
+  id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id             UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  message_id               UUID NOT NULL REFERENCES chat_archive_messages(id) ON DELETE CASCADE,
+  instance_id              UUID NOT NULL,
+  conversation_id          TEXT NOT NULL,
+  segment_index            INT NOT NULL DEFAULT 0,
+  segment_text             TEXT NOT NULL CHECK (length(segment_text) > 0),
+
+  -- Universal retrieval projection columns, matching email/file/transcript
+  -- segments. The person-owner axis is mandatory; assistant scope is absent.
+  user_id                  UUID NOT NULL,
+  assistant_id             UUID,
+  source                   TEXT NOT NULL DEFAULT 'chat_archive',
+  sensitivity              TEXT NOT NULL DEFAULT 'internal',
+  compartments             TEXT[] NOT NULL DEFAULT '{}',
+  tags                     TEXT[],
+  metadata                 JSONB,
+  verified_by_user_id      UUID,
+  verified_at              TIMESTAMPTZ,
+  valid_from               TIMESTAMPTZ NOT NULL,
+  valid_to                 TIMESTAMPTZ,
+  superseded_by            UUID,
+  retracted_at             TIMESTAMPTZ,
+  retracted_by_user_id     UUID,
+  retracted_reason         TEXT,
+  created_by_user_id       UUID NOT NULL,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  -- Standard six-column embedding scaffold.
+  embedding                VECTOR(768),
+  embedding_model_id       TEXT,
+  content_hash             TEXT,
+  embedding_failed_at      TIMESTAMPTZ,
+  embedding_failure_reason TEXT,
+  embedding_updated_at     TIMESTAMPTZ,
+
+  UNIQUE (message_id, segment_index)
+);
+
+CREATE INDEX idx_chat_archive_segments_instance_conversation
+  ON chat_archive_segments (instance_id, conversation_id, valid_from);
+CREATE INDEX idx_chat_archive_segments_embedding
+  ON chat_archive_segments
+  USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);
+CREATE INDEX idx_chat_archive_segments_trgm
+  ON chat_archive_segments USING gin (segment_text gin_trgm_ops);
+CREATE INDEX idx_chat_archive_segments_embed_queue_valid_from
+  ON chat_archive_segments (valid_from)
+  WHERE embedding IS NULL AND embedding_failed_at IS NULL;
+
+ALTER TABLE chat_archive_segments ENABLE ROW LEVEL SECURITY;
+CREATE POLICY chat_archive_segments_owner ON chat_archive_segments
+  USING (user_id = (current_setting('app.current_user_id'::text, true))::uuid);
+
+-- Evidence-backed acquisition windows. Ordinary silence is not a gap; the
+-- writer extends/merges a window for forward delivery and leaves disjoint
+-- windows only for independently acquired history ranges.
+CREATE TABLE chat_archive_coverage_windows (
+  id                        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id              UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  instance_id               UUID NOT NULL REFERENCES connector_instance(id) ON DELETE CASCADE,
+  owner_user_id             UUID NOT NULL,
+  conversation_id           TEXT NOT NULL CHECK (length(conversation_id) > 0),
+  window_start              TIMESTAMPTZ NOT NULL,
+  window_end                TIMESTAMPTZ NOT NULL,
+  first_provider_message_id TEXT NOT NULL,
+  last_provider_message_id  TEXT NOT NULL,
+  source_cursor             JSONB,
+  created_at                TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at                TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CHECK (window_start <= window_end),
+  UNIQUE (instance_id, conversation_id, window_start, window_end)
+);
+
+CREATE INDEX idx_chat_archive_coverage_lookup
+  ON chat_archive_coverage_windows (instance_id, conversation_id, window_start);
+
+ALTER TABLE chat_archive_coverage_windows ENABLE ROW LEVEL SECURITY;
+CREATE POLICY chat_archive_coverage_windows_owner ON chat_archive_coverage_windows
+  USING (owner_user_id = (current_setting('app.current_user_id'::text, true))::uuid);
+
+-- Resumable offline import ledger. The input fingerprint identifies an export
+-- or decrypted database without storing its local path in the shared brain.
+CREATE TABLE chat_archive_backfill_runs (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id          UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  instance_id           UUID NOT NULL REFERENCES connector_instance(id) ON DELETE CASCADE,
+  owner_user_id         UUID NOT NULL,
+  source                TEXT NOT NULL CHECK (length(source) > 0),
+  input_kind            TEXT NOT NULL CHECK (length(input_kind) > 0),
+  input_fingerprint     TEXT NOT NULL CHECK (length(input_fingerprint) > 0),
+  status                TEXT NOT NULL DEFAULT 'pending'
+                        CHECK (status IN ('pending', 'running', 'completed', 'failed', 'cancelled')),
+  checkpoint            JSONB,
+  discovered_count      BIGINT NOT NULL DEFAULT 0 CHECK (discovered_count >= 0),
+  accepted_count        BIGINT NOT NULL DEFAULT 0 CHECK (accepted_count >= 0),
+  duplicate_count       BIGINT NOT NULL DEFAULT 0 CHECK (duplicate_count >= 0),
+  rejected_count        BIGINT NOT NULL DEFAULT 0 CHECK (rejected_count >= 0),
+  last_error            TEXT,
+  started_at            TIMESTAMPTZ,
+  completed_at          TIMESTAMPTZ,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  UNIQUE (instance_id, source, input_kind, input_fingerprint)
+);
+
+CREATE INDEX idx_chat_archive_backfill_runs_owner_created
+  ON chat_archive_backfill_runs (owner_user_id, created_at DESC);
+
+ALTER TABLE chat_archive_backfill_runs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY chat_archive_backfill_runs_owner ON chat_archive_backfill_runs
+  USING (owner_user_id = (current_setting('app.current_user_id'::text, true))::uuid);
+
+COMMIT;

--- a/packages/api/migrations/396_local_chat_archive_sink.sql
+++ b/packages/api/migrations/396_local_chat_archive_sink.sql
@@ -1,0 +1,28 @@
+-- 396_local_chat_archive_sink.sql  (OPEN tables -> packages/api/migrations/)
+--
+-- Marks the one platform-managed, loopback-only brian-message-store sink per
+-- connector instance. Manual external sinks keep managed_by NULL and are never
+-- touched by local lifecycle reconciliation.
+
+BEGIN;
+
+ALTER TABLE ingest_external_sink
+  ADD COLUMN managed_by TEXT;
+
+ALTER TABLE ingest_external_sink
+  ADD CONSTRAINT ingest_external_sink_managed_by_check
+  CHECK (managed_by IS NULL OR managed_by = 'local_chat_archive');
+
+CREATE UNIQUE INDEX idx_ingest_external_sink_managed_instance
+  ON ingest_external_sink (connector_instance_id, managed_by)
+  WHERE managed_by IS NOT NULL;
+
+-- The live writer reuses an existing provider instance when one exists. This
+-- partial identity applies only to its credential-free fallback rows, so real
+-- multi-account connector instances remain unrestricted.
+CREATE UNIQUE INDEX idx_connector_instance_local_archive_fallback
+  ON connector_instance (workspace_id, provider)
+  WHERE scope = 'workspace'
+    AND config->>'managedBy' = 'local_chat_archive';
+
+COMMIT;

--- a/packages/api/migrations/397_chat_archive_enrichment.sql
+++ b/packages/api/migrations/397_chat_archive_enrichment.sql
@@ -1,0 +1,56 @@
+-- 397_chat_archive_enrichment.sql  (OPEN tables -> packages/api/migrations/)
+-- Platform-owned Pipeline B window ledger for raw chat archive messages.
+
+BEGIN;
+
+CREATE TABLE chat_archive_enrichment_windows (
+  id                         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id               UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  instance_id                UUID NOT NULL REFERENCES connector_instance(id) ON DELETE CASCADE,
+  owner_user_id              UUID NOT NULL,
+  conversation_id            TEXT NOT NULL,
+  first_message_id           UUID NOT NULL REFERENCES chat_archive_messages(id) ON DELETE CASCADE,
+  last_message_id            UUID NOT NULL REFERENCES chat_archive_messages(id) ON DELETE CASCADE,
+  first_provider_message_id  TEXT NOT NULL,
+  last_provider_message_id   TEXT NOT NULL,
+  window_start               TIMESTAMPTZ NOT NULL,
+  window_end                 TIMESTAMPTZ NOT NULL,
+  message_count              INT NOT NULL CHECK (message_count > 0),
+  content_hash               TEXT NOT NULL,
+  status                     TEXT NOT NULL DEFAULT 'pending'
+                             CHECK (status IN ('pending', 'processing', 'completed', 'failed', 'dead')),
+  attempt_count              INT NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+  next_attempt_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  locked_until               TIMESTAMPTZ,
+  last_error                 TEXT,
+  completed_at               TIMESTAMPTZ,
+  created_at                 TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at                 TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CHECK (window_start <= window_end),
+  UNIQUE (instance_id, conversation_id, first_message_id, last_message_id)
+);
+
+CREATE INDEX idx_chat_archive_enrichment_due
+  ON chat_archive_enrichment_windows (next_attempt_at, created_at)
+  WHERE status IN ('pending', 'failed');
+
+CREATE TABLE chat_archive_enrichment_messages (
+  message_id UUID PRIMARY KEY REFERENCES chat_archive_messages(id) ON DELETE CASCADE,
+  window_id  UUID NOT NULL REFERENCES chat_archive_enrichment_windows(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_chat_archive_enrichment_messages_window
+  ON chat_archive_enrichment_messages (window_id);
+
+ALTER TABLE chat_archive_enrichment_windows ENABLE ROW LEVEL SECURITY;
+CREATE POLICY chat_archive_enrichment_windows_system ON chat_archive_enrichment_windows
+  USING (current_setting('app.system_bypass', true) = 'true')
+  WITH CHECK (current_setting('app.system_bypass', true) = 'true');
+
+ALTER TABLE chat_archive_enrichment_messages ENABLE ROW LEVEL SECURITY;
+CREATE POLICY chat_archive_enrichment_messages_system ON chat_archive_enrichment_messages
+  USING (current_setting('app.system_bypass', true) = 'true')
+  WITH CHECK (current_setting('app.system_bypass', true) = 'true');
+
+COMMIT;

--- a/packages/api/migrations/398_chat_archive_owner_cascade.sql
+++ b/packages/api/migrations/398_chat_archive_owner_cascade.sql
@@ -1,0 +1,22 @@
+-- 398_chat_archive_owner_cascade.sql  (OPEN tables -> packages/api/migrations/)
+-- Account deletion must remove every person-compartmented chat archive root.
+
+BEGIN;
+
+ALTER TABLE chat_archive_messages
+  ADD CONSTRAINT chat_archive_messages_owner_fkey
+  FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE CASCADE;
+
+ALTER TABLE chat_archive_coverage_windows
+  ADD CONSTRAINT chat_archive_coverage_owner_fkey
+  FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE CASCADE;
+
+ALTER TABLE chat_archive_backfill_runs
+  ADD CONSTRAINT chat_archive_backfill_owner_fkey
+  FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE CASCADE;
+
+ALTER TABLE chat_archive_enrichment_windows
+  ADD CONSTRAINT chat_archive_enrichment_owner_fkey
+  FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE CASCADE;
+
+COMMIT;

--- a/packages/api/src/agent-surface/toolset.ts
+++ b/packages/api/src/agent-surface/toolset.ts
@@ -50,6 +50,8 @@ const BRIDGE_READ_NAMES = [
   'recentEpisodes',
   'provenance',
   'getRowHistory',
+  // Person-compartmented local chat archive
+  'searchChatHistory',
   // Scheduling + ingest reads
   'searchScheduledJobs',
   'listIngestRules',

--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -171,6 +171,7 @@ import { EXTRACTION_MODEL } from './build-episode-ingestors.js'
 import { createMailboxSyncWorker } from './mailbox/sync-worker.js'
 import { setGlobalMailboxArchiveDeps } from './mailbox/archive-search-tool.js'
 import { setGlobalMailboxSyncDeps } from './mailbox/sync-tool.js'
+import { createChatArchiveTools } from './chat-archive/chat-tools.js'
 import { resolveIngestPlaceholders } from './ingest/placeholder-resolver.js'
 import { createMeteredProfileStore } from './db/metered-profile-store.js'
 import { createWorkspaceModelDefaultsStore } from './db/workspace-model-defaults-store.js'
@@ -251,7 +252,11 @@ import { createConnectorInstanceStore } from './db/connector-instance-store.js'
 import { createConnectorAppCredentialStore } from './db/connector-app-credential-store.js'
 import { createIngestSinkStore } from './db/ingest-sink-store.js'
 import { createIngestOutboxStore } from './db/ingest-outbox-store.js'
+import { createChatArchiveEnrichmentStore } from './db/chat-archive-enrichment-store.js'
+import { createExternalSinkFanout } from './ingest/external-sink-fanout.js'
 import { createExternalSinkRelay } from './ingest/external-sink-relay.js'
+import { createLiveChatArchiveWriter, setGlobalLiveChatArchiveWriter } from './chat-archive/live-writer.js'
+import { createChatArchiveEnrichmentWorker } from './chat-archive/enrichment-worker.js'
 import { createWorkspaceToolPolicyStore } from './db/workspace-tool-policy-store.js'
 import { buildOpenSyncCredentials } from './build-sync-credentials.js'
 import { createDbAssistantConnectorStore } from './db/assistant-connector-store.js'
@@ -584,6 +589,9 @@ export interface OpenApiEnv {
    */
   WECHAT_CONNECTOR_URL?: string
   WECHAT_CONNECTOR_SECRET?: string
+  /** Local-only chat archive sidecar. Both values are required together. */
+  BRIAN_MESSAGE_STORE_URL?: string
+  BRIAN_MESSAGE_STORE_HMAC_SECRET?: string
   LLM_PROVIDER_KEY_ENCRYPTION_KEY?: string
   // Blob storage. GCS wins when set; LOCAL_FILES_DIR enables durable
   // self-hosted local storage; otherwise non-Cloud-Run dev falls back to /tmp.
@@ -1796,6 +1804,14 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     )
     tools.set('listRecordings', createListRecordingsTool())
 
+    // Provider-neutral local chat history. These are base read tools rather
+    // than connector API tools: the archive remains available when a live
+    // WhatsApp / WeChat connection is offline, and every call owner-binds from
+    // ToolContext. The same instances are bridged into native agent surfaces.
+    for (const tool of createChatArchiveTools({ embedder: sharedEmbedder })) {
+      tools.set(tool.name, tool)
+    }
+
     // Bug report tool — the create sink is a port; open default returns a
     // synthetic id (no persistence). The platform injects its bug-report store.
     const reportBugTool = createReportBugTool({
@@ -1891,6 +1907,14 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
   const chatEpisodeIngestor: ChatEpisodeIngestor =
     builtIngestors?.chatEpisodeIngestor ?? (async () => {})
   const brainEpisodeIngestor: BrainEpisodeIngestor | undefined = builtIngestors?.brainEpisodeIngestor
+  const chatArchiveEnrichmentWorker = brainEpisodeIngestor
+    ? createChatArchiveEnrichmentWorker({
+        store: createChatArchiveEnrichmentStore(),
+        ingest: brainEpisodeIngestor,
+        resolveAssistantId: resolvePrimaryAssistantForWorkspace,
+      })
+    : null
+  if (runWorkers) chatArchiveEnrichmentWorker?.start()
 
   // Structural-synthesis P4 — the RESEARCH fill. A research-tier `assistant_call`
   // step with a `blueprintId` + page anchor fills the blueprint into the anchored
@@ -5338,6 +5362,33 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
   // advances only on ack (X3). See ingest-external-sink.md.
   const ingestSinkStore = createIngestSinkStore(credKey)
   const ingestOutboxStore = createIngestOutboxStore()
+  const externalSinkFanout = createExternalSinkFanout({
+    sinks: ingestSinkStore,
+    outbox: ingestOutboxStore,
+  })
+  if (
+    env.BRIAN_MESSAGE_STORE_URL
+    && env.BRIAN_MESSAGE_STORE_HMAC_SECRET
+    && credKey
+  ) {
+    setGlobalLiveChatArchiveWriter(createLiveChatArchiveWriter({
+      endpointUrl: env.BRIAN_MESSAGE_STORE_URL,
+      secret: env.BRIAN_MESSAGE_STORE_HMAC_SECRET,
+      sinks: ingestSinkStore,
+      fanout: externalSinkFanout,
+    }))
+  } else {
+    setGlobalLiveChatArchiveWriter(null)
+    const disabled = await ingestSinkStore.disableManagedLocalChatArchive()
+    if (disabled > 0) {
+      console.log(`[chat-archive] disabled ${disabled} stale managed sink(s)`)
+    }
+    if (env.BRIAN_MESSAGE_STORE_URL || env.BRIAN_MESSAGE_STORE_HMAC_SECRET) {
+      console.warn(
+        '[chat-archive] disabled: URL, HMAC secret, and CHANNEL_CREDENTIAL_KEY are all required',
+      )
+    }
+  }
   const externalSinkRelay = createExternalSinkRelay({
     outbox: ingestOutboxStore,
     sinks: ingestSinkStore,
@@ -5581,6 +5632,16 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
             userContentBlocks: [{ type: 'text', text: input.text }],
             isGroupChat: input.isGroup,
             incomingChannelMessageId: input.messageId,
+            archiveIncoming: {
+              userId: input.senderPnJid ?? input.senderJid,
+              channelId: input.chatJid,
+              messageId: input.messageId,
+              text: input.text,
+              isGroupChat: input.isGroup,
+              timestamp: input.timestamp,
+              raw: null,
+            },
+            archiveConnectorInstanceId: channel.connectorInstanceId,
             modelAlias: undefined,
             adaptiveResearchEnabled: true,
             abortController,
@@ -5745,6 +5806,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     knowledgeSyncWorker.stop()
     mailboxSyncWorker.stop()
     externalSinkRelay.stop()
+    chatArchiveEnrichmentWorker?.stop()
     stuckSessionSweeper.stop()
     fileIngestWorker?.stop()
     linkedinImportWorker?.stop()

--- a/packages/api/src/chat-archive/__tests__/chat-tools.test.ts
+++ b/packages/api/src/chat-archive/__tests__/chat-tools.test.ts
@@ -1,0 +1,44 @@
+/** [COMP:tools/chat-archive] Native owner-bound chat history tools. */
+
+import { describe, expect, it, vi } from 'vitest'
+import type { ToolContext } from '@use-brian/core'
+import { createChatArchiveTools } from '../chat-tools.js'
+import { CHAT_ARCHIVE_SEARCH_TOOL } from '../tool-catalog.js'
+
+const context = { userId: 'owner-from-context' } as ToolContext
+
+describe('[COMP:tools/chat-archive] native chat archive tools', () => {
+  it('exposes exactly one search tool', () => {
+    const names = createChatArchiveTools().map((tool) => tool.name)
+    expect(names).toEqual(['searchChatHistory'])
+  })
+
+  it('routes personal identity questions to chat history before public sources', () => {
+    expect(CHAT_ARCHIVE_SEARCH_TOOL.description).toContain('Who is X?')
+    expect(CHAT_ARCHIVE_SEARCH_TOOL.description).toContain('before using public web search')
+  })
+
+  it('binds search ownership from ToolContext and returns coverage disclosure', async () => {
+    const search = vi.fn(async (_input: unknown) => ({
+      hits: [{ message_id: 'm-1' }],
+      embeddingCoverage: { partial: true, unembeddedInScope: 5, capped: false, note: 'partial' },
+    }))
+    const tool = createChatArchiveTools({ search: search as never })[0]!
+    const result = await tool.execute({ query: 'deposit', source: 'whatsapp', kind: 'text' }, context)
+    expect(search.mock.calls[0]?.[0]).toMatchObject({
+      ownerUserId: 'owner-from-context',
+      query: 'deposit',
+      source: 'whatsapp',
+      kind: 'text',
+    })
+    expect(result.data).toEqual({ hits: [{ message_id: 'm-1' }], embeddingCoverage: 'partial' })
+  })
+
+  it('rejects an invalid time before calling the store', async () => {
+    const search = vi.fn()
+    const tool = createChatArchiveTools({ search: search as never })[0]!
+    const result = await tool.execute({ query: 'deposit', since: 'not-a-date' }, context)
+    expect(result.isError).toBe(true)
+    expect(search).not.toHaveBeenCalled()
+  })
+})

--- a/packages/api/src/chat-archive/__tests__/enrichment-worker.test.ts
+++ b/packages/api/src/chat-archive/__tests__/enrichment-worker.test.ts
@@ -1,0 +1,67 @@
+/** [COMP:brain/chat-archive-enrichment] Existing Pipeline B window routing. */
+
+import { describe, expect, it, vi } from 'vitest'
+import { createChatArchiveEnrichmentWorker, renderChatArchiveWindow } from '../enrichment-worker.js'
+import type { ChatArchiveEnrichmentWindow } from '../../db/chat-archive-enrichment-store.js'
+
+function window(): ChatArchiveEnrichmentWindow {
+  return {
+    id: 'window-1', workspaceId: 'workspace-1', instanceId: 'instance-1',
+    ownerUserId: 'owner-1', source: 'wechat', conversationId: 'conversation-1',
+    firstMessageId: 'message-1', lastMessageId: 'message-2',
+    firstProviderMessageId: 'provider-1', lastProviderMessageId: 'provider-2',
+    windowStart: new Date('2026-08-01T00:00:00Z'),
+    windowEnd: new Date('2026-08-01T00:01:00Z'), attemptCount: 1,
+    messages: [{
+      id: 'message-1', providerMessageId: 'provider-1', senderId: 'wxid-a',
+      senderDisplay: 'Alice', sentAt: new Date('2026-08-01T00:00:00Z'),
+      direction: 'inbound', kind: 'text', bodyText: 'The launch is Friday.', mediaRef: null,
+    }, {
+      id: 'message-2', providerMessageId: 'provider-2', senderId: 'assistant',
+      senderDisplay: 'Brian', sentAt: new Date('2026-08-01T00:01:00Z'),
+      direction: 'outbound', kind: 'file', bodyText: null,
+      mediaRef: { filename: 'plan.pdf', mime: 'application/pdf', size_bytes: 42 },
+    }],
+  }
+}
+
+describe('[COMP:brain/chat-archive-enrichment] worker', () => {
+  it('renders bounded chronological sender context', () => {
+    expect(renderChatArchiveWindow(window())).toContain('Alice (inbound): The launch is Friday.')
+    expect(renderChatArchiveWindow(window())).toContain('Brian (outbound): [file: plan.pdf]')
+  })
+
+  it('routes a claimed window through the existing brain ingestor', async () => {
+    const claimed = window()
+    const store = {
+      claimNext: vi.fn(async () => claimed), complete: vi.fn(async () => {}), fail: vi.fn(async () => {}),
+    }
+    const ingest = vi.fn(async () => ({}))
+    const worker = createChatArchiveEnrichmentWorker({
+      store, ingest: ingest as never, resolveAssistantId: async () => 'assistant-1',
+    })
+    await expect(worker.runOnce()).resolves.toBe(true)
+    expect(ingest).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'owner-1', assistantId: 'assistant-1', sourceKind: 'channel_window',
+      sourceRef: expect.objectContaining({
+        archive_instance_id: 'instance-1',
+        message_id_range: ['message-1', 'message-2'],
+      }),
+    }))
+    expect(store.complete).toHaveBeenCalledWith('window-1')
+    expect(store.fail).not.toHaveBeenCalled()
+  })
+
+  it('records a retry without changing raw messages when Pipeline B fails', async () => {
+    const store = {
+      claimNext: vi.fn(async () => window()), complete: vi.fn(), fail: vi.fn(async () => {}),
+    }
+    const worker = createChatArchiveEnrichmentWorker({
+      store, ingest: vi.fn(async () => { throw new Error('model unavailable') }) as never,
+      resolveAssistantId: async () => 'assistant-1',
+    })
+    await expect(worker.runOnce()).resolves.toBe(false)
+    expect(store.fail).toHaveBeenCalledWith('window-1', 1, 'model unavailable')
+    expect(store.complete).not.toHaveBeenCalled()
+  })
+})

--- a/packages/api/src/chat-archive/__tests__/live-writer.test.ts
+++ b/packages/api/src/chat-archive/__tests__/live-writer.test.ts
@@ -1,0 +1,122 @@
+/** [COMP:api/chat-archive-live-capture] Transactional live archive writer. */
+
+import { describe, expect, it, vi } from 'vitest'
+import { createLiveChatArchiveWriter } from '../live-writer.js'
+
+const context = {
+  source: 'slack' as const,
+  ownerUserId: '11111111-1111-4111-8111-111111111111',
+  workspaceId: '22222222-2222-4222-8222-222222222222',
+  assistantId: '33333333-3333-4333-8333-333333333333',
+  assistantName: 'Brian',
+  conversationId: 'channel-1',
+}
+
+function harness() {
+  const order: string[] = []
+  const client = {
+    query: vi.fn(async (sql: string) => {
+      order.push(sql)
+      return { rows: [], rowCount: 0 }
+    }),
+    release: vi.fn(() => order.push('RELEASE')),
+  }
+  const pool = {
+    query: vi.fn(async () => ({ rows: [{ id: 'instance-1' }], rowCount: 1 })),
+    connect: vi.fn(async () => client),
+  }
+  const sinks = {
+    ensureManagedLocalChatArchive: vi.fn(async () => ({ id: 'sink-1' })),
+  }
+  const fanout = {
+    fanout: vi.fn(async () => ({ enqueued: [] })),
+  }
+  const writer = createLiveChatArchiveWriter({
+    endpointUrl: 'http://127.0.0.1:8092',
+    secret: 'secret',
+    sinks: sinks as never,
+    fanout: fanout as never,
+    pool: pool as never,
+  })
+  return { writer, order, client, pool, sinks, fanout }
+}
+
+describe('[COMP:api/chat-archive-live-capture] live writer', () => {
+  it('rejects any non-loopback destination', () => {
+    expect(() => createLiveChatArchiveWriter({
+      endpointUrl: 'https://archive.example.com',
+      secret: 'secret',
+      sinks: {} as never,
+      fanout: {} as never,
+      pool: {} as never,
+    })).toThrow(/loopback/)
+  })
+
+  it('commits inbound session persistence and fanout in one transaction', async () => {
+    const { writer, order, client, sinks, fanout } = harness()
+    const persist = vi.fn(async () => {
+      order.push('PERSIST')
+      return { id: 'session-message-1' }
+    })
+    const result = await writer.persistInbound({
+      ...context,
+      message: {
+        userId: 'slack-user', channelId: 'channel-1', messageId: 'slack-ts',
+        text: 'hello', isGroupChat: false, timestamp: 1_700_000_000, raw: {},
+      },
+    }, persist)
+
+    expect(result).toEqual({ id: 'session-message-1' })
+    expect(order).toEqual(['BEGIN', 'PERSIST', 'COMMIT', 'RELEASE'])
+    expect(persist).toHaveBeenCalledWith(client)
+    expect(fanout.fanout).toHaveBeenCalledWith(expect.objectContaining({
+      connectorInstanceId: 'instance-1',
+      source: 'slack',
+      messages: [expect.objectContaining({ provider_message_id: 'slack-ts' })],
+    }), client)
+    expect(sinks.ensureManagedLocalChatArchive).toHaveBeenCalledWith(expect.objectContaining({
+      endpointUrl: 'http://127.0.0.1:8092/append',
+    }))
+  })
+
+  it('binds archive delivery to the exact channel connector instance', async () => {
+    const { writer, pool, fanout } = harness()
+    pool.query.mockResolvedValueOnce({ rows: [{ id: 'channel-instance-1' }], rowCount: 1 })
+    await writer.persistInbound({
+      ...context,
+      connectorInstanceId: 'channel-instance-1',
+      message: {
+        userId: 'slack-user', channelId: 'channel-1', messageId: 'slack-ts',
+        text: 'hello', isGroupChat: false, timestamp: 1_700_000_000, raw: {},
+      },
+    }, async () => ({ id: 'session-message-1' }))
+
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('WHERE id = $1 AND provider = $2'),
+      [
+        'channel-instance-1',
+        'slack',
+        context.workspaceId,
+        context.ownerUserId,
+      ],
+    )
+    expect(fanout.fanout).toHaveBeenCalledWith(expect.objectContaining({
+      connectorInstanceId: 'channel-instance-1',
+    }), expect.anything())
+  })
+
+  it('keeps session chat available when archive setup fails before BEGIN', async () => {
+    const { writer, sinks, pool } = harness()
+    sinks.ensureManagedLocalChatArchive.mockRejectedValueOnce(new Error('archive unavailable'))
+    const persist = vi.fn(async () => ({ id: 'session-message-1' }))
+    await expect(writer.persistInbound({
+      ...context,
+      message: {
+        userId: 'u', channelId: 'channel-1', messageId: 'm', text: 'hello',
+        isGroupChat: false, timestamp: 1, raw: {},
+      },
+    }, persist)).resolves.toEqual({ id: 'session-message-1' })
+    expect(persist).toHaveBeenCalledWith()
+    expect(pool.connect).not.toHaveBeenCalled()
+  })
+})

--- a/packages/api/src/chat-archive/__tests__/normalize.test.ts
+++ b/packages/api/src/chat-archive/__tests__/normalize.test.ts
@@ -1,0 +1,80 @@
+/** [COMP:api/chat-archive-live-capture] Shared channel normalization. */
+
+import { describe, expect, it } from 'vitest'
+import type { IncomingMessage } from '@use-brian/channels'
+import { normalizeInboundChatMessage, normalizeOutboundChatMessage } from '../normalize.js'
+
+function incoming(overrides: Partial<IncomingMessage> = {}): IncomingMessage {
+  return {
+    userId: 'provider-user-1',
+    channelId: 'conversation-1',
+    text: 'hello',
+    isGroupChat: false,
+    timestamp: 1_700_000_000,
+    raw: { token: 'must-not-survive' },
+    ...overrides,
+  }
+}
+
+describe('[COMP:api/chat-archive-live-capture] normalizer', () => {
+  it('preserves canonical inbound identity while dropping the raw webhook', () => {
+    const result = normalizeInboundChatMessage({
+      source: 'wechat',
+      message: incoming({ messageId: 'wx-1', replyToMessageId: 'wx-0' }),
+    })
+    expect(result).toMatchObject({
+      provider_message_id: 'wx-1',
+      conversation_id: 'conversation-1',
+      sender_id: 'provider-user-1',
+      sent_at: '2023-11-14T22:13:20.000Z',
+      direction: 'inbound',
+      kind: 'text',
+      body_text: 'hello',
+      reply_to_provider_id: 'wx-0',
+      raw_provider_blob: null,
+    })
+  })
+
+  it('derives a stable id when a channel supplies none', () => {
+    const message = incoming()
+    const first = normalizeInboundChatMessage({ source: 'email', message })
+    const second = normalizeInboundChatMessage({ source: 'email', message })
+    expect(first.provider_message_id).toBe(second.provider_message_id)
+    expect(first.provider_message_id).toMatch(/^derived:[a-f0-9]{64}$/)
+  })
+
+  it('maps attachment metadata without copying bytes or URLs', () => {
+    const result = normalizeInboundChatMessage({
+      source: 'telegram',
+      message: incoming({
+        mediaType: 'voice',
+        mediaUrl: 'https://signed.example/secret',
+        mediaMime: 'audio/ogg',
+        mediaName: 'note.ogg',
+        mediaSizeBytes: 1234,
+      }),
+    })
+    expect(result.kind).toBe('voice')
+    expect(result.media_ref).toEqual({ filename: 'note.ogg', mime: 'audio/ogg', size_bytes: 1234 })
+    expect(JSON.stringify(result)).not.toContain('signed.example')
+  })
+
+  it('normalizes final outbound text and document metadata', () => {
+    const result = normalizeOutboundChatMessage({
+      providerMessageId: 'slack-ts-1',
+      conversationId: 'c-1',
+      assistantId: 'a-1',
+      assistantName: 'Brian',
+      text: 'report attached',
+      sentAt: new Date('2026-08-04T00:00:00Z'),
+      documents: [{ filename: 'report.pdf', mime: 'application/pdf', data: new Uint8Array(7) }],
+    })
+    expect(result).toMatchObject({
+      provider_message_id: 'slack-ts-1',
+      sender_display: 'Brian',
+      direction: 'outbound',
+      kind: 'file',
+      media_ref: { filename: 'report.pdf', mime: 'application/pdf', size_bytes: 7 },
+    })
+  })
+})

--- a/packages/api/src/chat-archive/chat-tools.ts
+++ b/packages/api/src/chat-archive/chat-tools.ts
@@ -1,0 +1,105 @@
+/**
+ * Native agent tools over the provider-neutral local chat archive.
+ * Owner identity comes from ToolContext on every call; the model can narrow a
+ * source/instance/conversation but can never choose whose archive to read.
+ *
+ * [COMP:tools/chat-archive]
+ */
+
+import { z } from 'zod'
+import { buildTool, type Embedder, type Tool } from '@use-brian/core'
+import { searchChatArchive } from '../db/chat-archive-store.js'
+import { CHAT_ARCHIVE_SEARCH_TOOL } from './tool-catalog.js'
+
+export type ChatArchiveToolDeps = {
+  embedder?: Pick<Embedder, 'embed'>
+  search?: typeof searchChatArchive
+}
+
+const sourceFilter = z
+  .string()
+  .min(1)
+  .optional()
+  .describe('Provider source, for example `whatsapp` or `wechat`. Omit to search every archived chat source.')
+
+const instanceFilter = z
+  .string()
+  .uuid()
+  .optional()
+  .describe('Optional connector instance id, from a prior chat-history result.')
+
+const timeFilters = {
+  since: z.string().optional().describe('ISO 8601 lower time bound, inclusive.'),
+  before: z.string().optional().describe('ISO 8601 upper time bound, exclusive.'),
+}
+
+function parseTime(value: string | undefined, field: string): string | undefined | { error: string } {
+  if (value === undefined) return undefined
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return { error: `${field} is not a valid ISO 8601 date/time: ${value}` }
+  }
+  return parsed.toISOString()
+}
+
+function toolError(name: string, err: unknown): { data: string; isError: true } {
+  return { data: `${name} failed: ${err instanceof Error ? err.message : String(err)}`, isError: true }
+}
+
+export function createChatArchiveTools(deps: ChatArchiveToolDeps = {}): Tool[] {
+  const search = deps.search ?? searchChatArchive
+
+  const searchTool = buildTool({
+    name: CHAT_ARCHIVE_SEARCH_TOOL.name,
+    description: CHAT_ARCHIVE_SEARCH_TOOL.description,
+    inputSchema: z.object({
+      query: z.string().min(1).describe('What to find in chat history, in natural language.'),
+      topK: z.number().int().min(1).max(20).optional().describe('Results to return (default 8, max 20).'),
+      source: sourceFilter,
+      instanceId: instanceFilter,
+      conversationId: z.string().min(1).optional().describe('Exact provider conversation id from a prior result.'),
+      sender: z.string().min(1).optional().describe('Sender id or display-name substring.'),
+      direction: z.enum(['inbound', 'outbound']).optional(),
+      kind: z.enum(['text', 'image', 'voice', 'file', 'link']).optional(),
+      ...timeFilters,
+    }),
+    isReadOnly: true,
+    isConcurrencySafe: true,
+    requiresConfirmation: false,
+    timeoutMs: 30_000,
+    async execute(input, context) {
+      const since = parseTime(input.since, 'since')
+      if (since && typeof since !== 'string') return { data: since.error, isError: true }
+      const before = parseTime(input.before, 'before')
+      if (before && typeof before !== 'string') return { data: before.error, isError: true }
+      try {
+        const result = await search(
+          {
+            ownerUserId: context.userId,
+            query: input.query,
+            topK: input.topK,
+            source: input.source,
+            instanceId: input.instanceId,
+            conversationId: input.conversationId,
+            sender: input.sender,
+            direction: input.direction,
+            kind: input.kind,
+            since,
+            before,
+          },
+          deps.embedder ? { embedder: deps.embedder } : undefined,
+        )
+        return {
+          data: {
+            hits: result.hits,
+            embeddingCoverage: result.embeddingCoverage.note ?? 'complete for the selected filters',
+          },
+        }
+      } catch (err) {
+        return toolError('searchChatHistory', err)
+      }
+    },
+  })
+
+  return [searchTool]
+}

--- a/packages/api/src/chat-archive/enrichment-worker.ts
+++ b/packages/api/src/chat-archive/enrichment-worker.ts
@@ -1,0 +1,103 @@
+/** Routes raw archive windows through the existing platform Pipeline B seam. */
+
+import type { BrainEpisodeIngestor } from '../ingest-port.js'
+import type {
+  ChatArchiveEnrichmentStore,
+  ChatArchiveEnrichmentWindow,
+} from '../db/chat-archive-enrichment-store.js'
+
+export function renderChatArchiveWindow(window: ChatArchiveEnrichmentWindow): string {
+  return window.messages.map((message) => {
+    const sender = message.senderDisplay || message.senderId || 'unknown'
+    const body = message.bodyText?.trim() || [
+      `[${message.kind}`,
+      message.mediaRef?.filename ? `: ${message.mediaRef.filename}` : '',
+      ']',
+    ].join('')
+    return `[${message.sentAt.toISOString()}] ${sender} (${message.direction}): ${body.slice(0, 2000)}`
+  }).join('\n').slice(0, 16_000)
+}
+
+export type ChatArchiveEnrichmentWorker = {
+  runOnce(): Promise<boolean>
+  start(): void
+  stop(): void
+}
+
+export function createChatArchiveEnrichmentWorker(deps: {
+  store: ChatArchiveEnrichmentStore
+  ingest: BrainEpisodeIngestor
+  resolveAssistantId: (workspaceId: string) => Promise<string | null>
+  intervalMs?: number
+}): ChatArchiveEnrichmentWorker {
+  const intervalMs = deps.intervalMs ?? 30_000
+  let timer: ReturnType<typeof setInterval> | null = null
+  let running = false
+
+  const runOnce = async (): Promise<boolean> => {
+    if (running) return false
+    running = true
+    let window: ChatArchiveEnrichmentWindow | null = null
+    try {
+      window = await deps.store.claimNext()
+      if (!window) return false
+      const assistantId = await deps.resolveAssistantId(window.workspaceId)
+      if (!assistantId) throw new Error('no primary assistant for archive workspace')
+      const content = renderChatArchiveWindow(window)
+      if (!content.trim()) throw new Error('archive window has no enrichable content')
+      await deps.ingest({
+        workspaceId: window.workspaceId,
+        userId: window.ownerUserId,
+        assistantId,
+        content,
+        occurredAt: window.windowStart,
+        sourceLabel: `${window.source} chat history`,
+        sourceKind: 'channel_window',
+        sourceRef: {
+          source_kind: 'channel_window',
+          archive_instance_id: window.instanceId,
+          conversation_id: window.conversationId,
+          message_id_range: [window.firstMessageId, window.lastMessageId],
+          provider_message_id_range: [
+            window.firstProviderMessageId,
+            window.lastProviderMessageId,
+          ],
+        },
+        contentRef: {
+          source_kind: 'channel_window',
+          archive_instance_id: window.instanceId,
+          conversation_id: window.conversationId,
+          message_id_range: [window.firstMessageId, window.lastMessageId],
+        },
+      })
+      await deps.store.complete(window.id)
+      return true
+    } catch (err) {
+      if (window) {
+        await deps.store.fail(
+          window.id,
+          window.attemptCount,
+          err instanceof Error ? err.message : String(err),
+        ).catch(() => {})
+      }
+      console.warn('[chat-archive] enrichment failed:', err)
+      return false
+    } finally {
+      running = false
+    }
+  }
+
+  return {
+    runOnce,
+    start() {
+      if (timer) return
+      timer = setInterval(() => void runOnce(), intervalMs)
+      timer.unref?.()
+      void runOnce()
+    },
+    stop() {
+      if (timer) clearInterval(timer)
+      timer = null
+    },
+  }
+}

--- a/packages/api/src/chat-archive/live-writer.ts
+++ b/packages/api/src/chat-archive/live-writer.ts
@@ -1,0 +1,219 @@
+/**
+ * Local chat-archive producer. It owns no provider parsing: adapters pass an
+ * IncomingMessage and normalize.ts emits the shared append contract.
+ */
+
+import type pg from 'pg'
+import type { IncomingMessage, OutgoingDocument } from '@use-brian/channels'
+import { getPool } from '../db/client.js'
+import type { IngestSinkStore } from '../db/ingest-sink-store.js'
+import type { ExternalSinkFanout } from '../ingest/external-sink-fanout.js'
+import { normalizeInboundChatMessage, normalizeOutboundChatMessage } from './normalize.js'
+
+type Queryable = Pick<pg.ClientBase, 'query'>
+type ChannelSource = 'whatsapp' | 'telegram' | 'slack' | 'discord' | 'email' | 'msteams' | 'wechat'
+
+export type LiveArchiveContext = {
+  source: ChannelSource
+  ownerUserId: string
+  workspaceId: string | null
+  /** Exact channel connector when the route has one; avoids cross-account mixing. */
+  connectorInstanceId?: string | null
+  assistantId: string
+  assistantName: string
+  conversationId: string
+}
+
+export type LiveChatArchiveWriter = {
+  persistInbound<T>(
+    input: LiveArchiveContext & { message: IncomingMessage },
+    persist: (client?: Queryable) => Promise<T>,
+  ): Promise<T>
+  appendOutbound(input: LiveArchiveContext & {
+    sessionMessageId: string
+    providerMessageId?: string | null
+    text: string
+    documents?: OutgoingDocument[]
+    replyToProviderId?: string | null
+  }): Promise<void>
+}
+
+function assertLoopbackAppendUrl(value: string): string {
+  const url = new URL(value)
+  const hosts = new Set(['127.0.0.1', 'localhost', '[::1]'])
+  if (url.protocol !== 'http:' || !hosts.has(url.hostname)) {
+    throw new Error('BRIAN_MESSAGE_STORE_URL must be an http loopback URL')
+  }
+  if (url.pathname === '/' || url.pathname === '') url.pathname = '/append'
+  return url.toString()
+}
+
+export function createLiveChatArchiveWriter(deps: {
+  endpointUrl: string
+  secret: string
+  sinks: Pick<IngestSinkStore, 'ensureManagedLocalChatArchive'>
+  fanout: Pick<ExternalSinkFanout, 'fanout'>
+  pool?: pg.Pool
+}): LiveChatArchiveWriter {
+  const endpointUrl = assertLoopbackAppendUrl(deps.endpointUrl)
+  const pool = deps.pool ?? getPool()
+  const bindings = new Map<string, Promise<{ instanceId: string; workspaceId: string } | null>>()
+
+  async function resolveBinding(input: LiveArchiveContext): Promise<{ instanceId: string; workspaceId: string } | null> {
+    let workspaceId = input.workspaceId
+    if (!workspaceId) {
+      const workspace = await pool.query<{ id: string }>(
+        `SELECT id FROM workspaces
+          WHERE owner_user_id = $1 AND is_personal = true
+          ORDER BY created_at ASC LIMIT 1`,
+        [input.ownerUserId],
+      )
+      workspaceId = workspace.rows[0]?.id ?? null
+    }
+    if (!workspaceId) return null
+
+    const key = `${workspaceId}:${input.source}:${input.connectorInstanceId ?? 'auto'}`
+    let pending = bindings.get(key)
+    if (!pending) {
+      pending = (async () => {
+        const existing = input.connectorInstanceId
+          ? await pool.query<{ id: string }>(
+              `SELECT id FROM connector_instance
+                WHERE id = $1 AND provider = $2
+                  AND (
+                    (scope = 'workspace' AND workspace_id = $3)
+                    OR ingest_workspace_id = $3
+                    OR (scope = 'user' AND user_id = $4)
+                  )
+                LIMIT 1`,
+              [input.connectorInstanceId, input.source, workspaceId, input.ownerUserId],
+            )
+          : await pool.query<{ id: string }>(
+              `SELECT id FROM connector_instance
+                WHERE scope = 'workspace' AND workspace_id = $1 AND provider = $2
+                ORDER BY (config->>'managedBy' = 'local_chat_archive') ASC,
+                         connected DESC, created_at ASC
+                LIMIT 1`,
+              [workspaceId, input.source],
+            )
+        let instanceId = existing.rows[0]?.id
+        if (input.connectorInstanceId && !instanceId) return null
+        if (!instanceId) {
+          const inserted = await pool.query<{ id: string }>(
+            `INSERT INTO connector_instance
+               (scope, user_id, workspace_id, provider, label, custom,
+                credentials_type, config, sensitivity, connected,
+                ingestion_enabled, created_by)
+             VALUES ('workspace', NULL, $1, $2, $3, false, 'none',
+                     '{"managedBy":"local_chat_archive"}'::jsonb,
+                     'internal', true, false, $4)
+             ON CONFLICT DO NOTHING
+             RETURNING id`,
+            [workspaceId, input.source, `${input.source} chat archive`, input.ownerUserId],
+          )
+          instanceId = inserted.rows[0]?.id
+          if (!instanceId) {
+            const raced = await pool.query<{ id: string }>(
+              `SELECT id FROM connector_instance
+                WHERE scope = 'workspace' AND workspace_id = $1 AND provider = $2
+                  AND config->>'managedBy' = 'local_chat_archive'
+                LIMIT 1`,
+              [workspaceId, input.source],
+            )
+            instanceId = raced.rows[0]?.id
+          }
+        }
+        if (!instanceId) return null
+        await deps.sinks.ensureManagedLocalChatArchive({
+          connectorInstanceId: instanceId,
+          workspaceId,
+          endpointUrl,
+          secret: deps.secret,
+        })
+        return { instanceId, workspaceId }
+      })()
+      bindings.set(key, pending)
+      pending.catch(() => bindings.delete(key))
+    }
+    return pending
+  }
+
+  return {
+    async persistInbound(input, persist) {
+      let binding: { instanceId: string; workspaceId: string } | null
+      try {
+        binding = await resolveBinding(input)
+      } catch (err) {
+        console.warn('[chat-archive] inbound setup failed; saving session turn without archive:', err)
+        return persist()
+      }
+      if (!binding) return persist()
+
+      const client = await pool.connect()
+      try {
+        await client.query('BEGIN')
+        const stored = await persist(client)
+        await deps.fanout.fanout({
+          connectorInstanceId: binding.instanceId,
+          workspaceId: binding.workspaceId,
+          ownerUserId: input.ownerUserId,
+          source: input.source,
+          messages: [normalizeInboundChatMessage({ source: input.source, message: input.message })],
+          sourceCursor: { provider_message_id: input.message.messageId ?? null },
+        }, client)
+        await client.query('COMMIT')
+        return stored
+      } catch (err) {
+        await client.query('ROLLBACK').catch(() => {})
+        throw err
+      } finally {
+        client.release()
+      }
+    },
+
+    async appendOutbound(input) {
+      const binding = await resolveBinding(input)
+      if (!binding) return
+      await deps.fanout.fanout({
+        connectorInstanceId: binding.instanceId,
+        workspaceId: binding.workspaceId,
+        ownerUserId: input.ownerUserId,
+        source: input.source,
+        messages: [normalizeOutboundChatMessage({
+          providerMessageId: input.providerMessageId || `session:${input.sessionMessageId}`,
+          conversationId: input.conversationId,
+          assistantId: input.assistantId,
+          assistantName: input.assistantName,
+          text: input.text,
+          documents: input.documents,
+          replyToProviderId: input.replyToProviderId,
+        })],
+        sourceCursor: { session_message_id: input.sessionMessageId },
+      })
+    },
+  }
+}
+
+let globalWriter: LiveChatArchiveWriter | null = null
+
+export function setGlobalLiveChatArchiveWriter(writer: LiveChatArchiveWriter | null): void {
+  globalWriter = writer
+}
+
+export async function persistInboundChatArchive<T>(
+  input: LiveArchiveContext & { message: IncomingMessage },
+  persist: (client?: Queryable) => Promise<T>,
+): Promise<T> {
+  return globalWriter ? globalWriter.persistInbound(input, persist) : persist()
+}
+
+export async function appendOutboundChatArchive(input: Parameters<LiveChatArchiveWriter['appendOutbound']>[0]): Promise<void> {
+  if (!globalWriter) return
+  try {
+    await globalWriter.appendOutbound(input)
+  } catch (err) {
+    // Delivery already happened. Keep the channel available and leave the
+    // persisted assistant row as the explicit repair source.
+    console.warn('[chat-archive] outbound enqueue failed:', err)
+  }
+}

--- a/packages/api/src/chat-archive/normalize.ts
+++ b/packages/api/src/chat-archive/normalize.ts
@@ -1,0 +1,93 @@
+/** Provider-neutral live-channel normalization for the local chat archive. */
+
+import { createHash } from 'node:crypto'
+import type { IncomingMessage, OutgoingDocument } from '@use-brian/channels'
+import type { CanonicalIngestMessage } from '@use-brian/shared'
+
+function sentAt(value: number): string {
+  const millis = Number.isFinite(value) ? (value < 1_000_000_000_000 ? value * 1000 : value) : 0
+  return new Date(millis).toISOString()
+}
+
+function derivedMessageId(source: string, message: IncomingMessage): string {
+  return `derived:${createHash('sha256').update(JSON.stringify({
+    source,
+    conversationId: message.channelId,
+    senderId: message.userId,
+    timestamp: message.timestamp,
+    text: message.text,
+    mediaType: message.mediaType ?? null,
+    mediaUrl: message.mediaUrl ?? message.files?.[0]?.url ?? null,
+    replyTo: message.replyToMessageId ?? null,
+  })).digest('hex')}`
+}
+
+function mediaKind(message: IncomingMessage): CanonicalIngestMessage['kind'] {
+  if (message.mediaType === 'photo') return 'image'
+  if (message.mediaType === 'voice' || message.mediaType === 'audio') return 'voice'
+  if (message.mediaType || message.files?.length) return 'file'
+  if (/^https?:\/\/\S+$/i.test(message.text.trim())) return 'link'
+  return 'text'
+}
+
+function mediaRef(message: IncomingMessage): CanonicalIngestMessage['media_ref'] {
+  const file = message.files?.[0]
+  if (!message.mediaType && !message.mediaUrl && !file) return null
+  return {
+    filename: message.mediaName || file?.name || 'attachment',
+    mime: message.mediaMime || file?.mimeType || 'application/octet-stream',
+    size_bytes: Math.max(0, Math.trunc(message.mediaSizeBytes ?? 0)),
+  }
+}
+
+export function normalizeInboundChatMessage(input: {
+  source: string
+  message: IncomingMessage
+}): CanonicalIngestMessage {
+  const { source, message } = input
+  return {
+    provider_message_id: message.messageId || derivedMessageId(source, message),
+    conversation_id: message.channelId,
+    sender_id: message.userId,
+    sender_display: null,
+    sent_at: sentAt(message.timestamp),
+    direction: 'inbound',
+    kind: mediaKind(message),
+    body_text: message.text.length > 0 ? message.text : null,
+    media_ref: mediaRef(message),
+    reply_to_provider_id: message.replyToMessageId ?? null,
+    // Provider payloads can contain tokens and connector secrets. Live capture
+    // needs no reparsing, so the safest sanitized payload is no payload.
+    raw_provider_blob: null,
+  }
+}
+
+export function normalizeOutboundChatMessage(input: {
+  providerMessageId: string
+  conversationId: string
+  assistantId: string
+  assistantName: string
+  text: string
+  sentAt?: Date
+  documents?: OutgoingDocument[]
+  replyToProviderId?: string | null
+}): CanonicalIngestMessage {
+  const document = input.documents?.[0]
+  return {
+    provider_message_id: input.providerMessageId,
+    conversation_id: input.conversationId,
+    sender_id: input.assistantId,
+    sender_display: input.assistantName,
+    sent_at: (input.sentAt ?? new Date()).toISOString(),
+    direction: 'outbound',
+    kind: document ? 'file' : (/^https?:\/\/\S+$/i.test(input.text.trim()) ? 'link' : 'text'),
+    body_text: input.text.length > 0 ? input.text : null,
+    media_ref: document ? {
+      filename: document.filename,
+      mime: document.mime,
+      size_bytes: document.data.byteLength,
+    } : null,
+    reply_to_provider_id: input.replyToProviderId ?? null,
+    raw_provider_blob: null,
+  }
+}

--- a/packages/api/src/chat-archive/tool-catalog.ts
+++ b/packages/api/src/chat-archive/tool-catalog.ts
@@ -1,0 +1,14 @@
+/** The single agent-facing capability exposed by a local chat archive. */
+export const CHAT_ARCHIVE_SEARCH_TOOL = {
+  name: 'searchChatHistory',
+  description:
+    "Hybrid meaning and keyword search over the user's locally archived WeChat and WhatsApp history. " +
+    'Use this first for questions about a named person, how the user knows them, their relationship, ' +
+    'what they discussed, past decisions, promises, or anything that may come from personal chats. ' +
+    'For a personal identity question such as "Who is X?", search the exact name before using public ' +
+    'web search or CRM/contact tools; chat evidence is personal context, not a public biography. ' +
+    'Filters can narrow the source, conversation, sender, direction, message kind, or time range. ' +
+    'Keyword recall covers every archived message; the result states when semantic indexing is partial.',
+  classification: 'read',
+  defaultPolicy: 'allow',
+} as const

--- a/packages/api/src/db/__tests__/chat-archive-store.test.ts
+++ b/packages/api/src/db/__tests__/chat-archive-store.test.ts
@@ -1,0 +1,210 @@
+/** [COMP:api/chat-archive-store] Owner-gated hybrid chat archive retrieval. */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { queryWithRLS } = vi.hoisted(() => ({ queryWithRLS: vi.fn() }))
+vi.mock('../client.js', () => ({ queryWithRLS }))
+
+import {
+  getChatCoverage,
+  getChatMessageWithContext,
+  listChatConversations,
+  searchChatArchive,
+} from '../chat-archive-store.js'
+
+const baseRow = {
+  segment_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  message_id: '11111111-1111-4111-8111-111111111111',
+  instance_id: '22222222-2222-4222-8222-222222222222',
+  source: 'whatsapp',
+  provider_message_id: 'wamid.1',
+  conversation_id: 'chat-1',
+  sender_id: 'sender-1',
+  sender_display: 'Ada',
+  sent_at: new Date('2026-08-04T10:00:00Z'),
+  direction: 'inbound' as const,
+  kind: 'text',
+  body_text: 'The deposit is due Friday',
+  media_ref: null,
+  reply_to_provider_id: null,
+  segment_index: 0,
+  segment_text: 'The deposit is due Friday',
+}
+
+beforeEach(() => queryWithRLS.mockReset())
+
+describe('[COMP:api/chat-archive-store] chat archive reads', () => {
+  it('fuses vector and tokenized lexical arms while owner-binding every query', async () => {
+    const second = {
+      ...baseRow,
+      segment_id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      message_id: '33333333-3333-4333-8333-333333333333',
+      provider_message_id: 'wamid.2',
+      conversation_id: 'chat-2',
+      sent_at: new Date('2026-08-03T10:00:00Z'),
+      body_text: 'Payment timing',
+      segment_text: 'Payment timing',
+    }
+    queryWithRLS.mockImplementation(async (...args: unknown[]) => {
+      const sql = String(args[1] ?? '')
+      if (sql.includes('s.embedding <=>')) return { rows: [{ ...baseRow, distance: 0.1 }] }
+      if (sql.includes('AS term_hits')) return { rows: [baseRow, second] }
+      if (sql.includes('count(*)::text')) return { rows: [{ n: '2' }] }
+      return { rows: [] }
+    })
+
+    const result = await searchChatArchive(
+      {
+        ownerUserId: '99999999-9999-4999-8999-999999999999',
+        query: 'when is the deposit due',
+        source: 'whatsapp',
+        sender: 'Ada',
+        kind: 'text',
+      },
+      { embedder: { embed: async () => [[0.1, 0.2]] } },
+    )
+
+    expect(result.hits.map((hit) => hit.message_id)).toContain(baseRow.message_id)
+    expect(result.hits.map((hit) => hit.message_id)).toContain(second.message_id)
+    expect(result.embeddingCoverage.partial).toBe(true)
+    for (const call of queryWithRLS.mock.calls) {
+      expect(call[0]).toBe('99999999-9999-4999-8999-999999999999')
+      expect(call[1]).toContain('m.owner_user_id')
+    }
+    const lexicalSql = queryWithRLS.mock.calls.find((call) => String(call[1]).includes('AS term_hits'))?.[1]
+    expect(lexicalSql).toContain('s.segment_text ILIKE')
+    expect(lexicalSql).toContain('m.kind =')
+    expect(lexicalSql).not.toContain("ILIKE '%when is the deposit due%'")
+  })
+
+  it('focuses an exact sender-name lookup on that person instead of unrelated vector matches', async () => {
+    const exactOlder = {
+      ...baseRow,
+      segment_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2',
+      message_id: '11111111-1111-4111-8111-111111111112',
+      provider_message_id: 'wx-older',
+      conversation_id: 'wx-person',
+      sender_id: 'wxid-person',
+      sender_display: '鄭運英',
+      sent_at: new Date('2024-11-16T10:00:00Z'),
+      body_text: '星期一返香港',
+      segment_text: '星期一返香港',
+    }
+    const exactNewer = {
+      ...exactOlder,
+      segment_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3',
+      message_id: '11111111-1111-4111-8111-111111111113',
+      provider_message_id: 'wx-newer',
+      sent_at: new Date('2026-02-17T10:00:00Z'),
+      body_text: '[transfer]',
+      segment_text: '[transfer]',
+    }
+    const unrelatedVector = {
+      ...baseRow,
+      segment_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa4',
+      message_id: '11111111-1111-4111-8111-111111111114',
+      provider_message_id: 'wx-unrelated',
+      sender_display: 'Someone Else',
+    }
+    queryWithRLS.mockImplementation(async (...args: unknown[]) => {
+      const sql = String(args[1] ?? '')
+      if (sql.includes('s.embedding <=>')) return { rows: [unrelatedVector] }
+      if (sql.includes('AS term_hits')) return { rows: [exactNewer, exactOlder, unrelatedVector] }
+      if (sql.includes('count(*)::text')) return { rows: [{ n: '0' }] }
+      return { rows: [] }
+    })
+
+    const result = await searchChatArchive(
+      { ownerUserId: '99999999-9999-4999-8999-999999999999', query: '鄭運英' },
+      { embedder: { embed: async () => [[0.1, 0.2]] } },
+    )
+
+    expect(result.hits).toHaveLength(2)
+    expect(result.hits.every((hit) => hit.sender_display === '鄭運英')).toBe(true)
+    expect(result.hits.map((hit) => hit.provider_message_id)).not.toContain('wx-unrelated')
+  })
+
+  it('returns bounded chronological neighbors around a message', async () => {
+    const target = { ...baseRow }
+    const previous = {
+      ...target,
+      message_id: '00000000-0000-4000-8000-000000000001',
+      provider_message_id: 'wamid.0',
+      sent_at: new Date('2026-08-04T09:59:00Z'),
+    }
+    const following = {
+      ...target,
+      message_id: '44444444-4444-4444-8444-444444444444',
+      provider_message_id: 'wamid.2',
+      sent_at: new Date('2026-08-04T10:01:00Z'),
+    }
+    queryWithRLS
+      .mockResolvedValueOnce({ rows: [target] })
+      .mockResolvedValueOnce({ rows: [previous] })
+      .mockResolvedValueOnce({ rows: [following] })
+
+    const result = await getChatMessageWithContext({
+      ownerUserId: 'owner-1',
+      messageId: target.message_id,
+      before: 1,
+      after: 1,
+    })
+    expect(result?.messages.map((message) => message.provider_message_id)).toEqual([
+      'wamid.0',
+      'wamid.1',
+      'wamid.2',
+    ])
+    expect(result?.targetIndex).toBe(1)
+    expect(queryWithRLS.mock.calls.every((call) => call[0] === 'owner-1')).toBe(true)
+  })
+
+  it('lists conversations newest-first and normalizes aggregate values', async () => {
+    queryWithRLS.mockResolvedValue({
+      rows: [{
+        instance_id: baseRow.instance_id,
+        source: 'whatsapp',
+        conversation_id: 'chat-1',
+        message_count: '42',
+        first_sent_at: new Date('2026-01-01T00:00:00Z'),
+        last_sent_at: new Date('2026-08-04T10:00:00Z'),
+        last_message_preview: 'hello',
+        last_sender_id: 'sender-1',
+        last_sender_display: 'Ada',
+        last_direction: 'inbound',
+      }],
+    })
+    const rows = await listChatConversations({ ownerUserId: 'owner-1' })
+    expect(rows[0]?.message_count).toBe(42)
+    expect(rows[0]?.last_sent_at).toBe('2026-08-04T10:00:00.000Z')
+    expect(queryWithRLS.mock.calls[0]?.[1]).toContain('row_number() OVER')
+  })
+
+  it('reports only gaps between independently acquired windows', async () => {
+    queryWithRLS.mockResolvedValue({
+      rows: [
+        {
+          instance_id: baseRow.instance_id,
+          conversation_id: 'chat-1',
+          window_start: new Date('2026-01-01T00:00:00Z'),
+          window_end: new Date('2026-01-31T00:00:00Z'),
+          first_provider_message_id: 'a',
+          last_provider_message_id: 'b',
+        },
+        {
+          instance_id: baseRow.instance_id,
+          conversation_id: 'chat-1',
+          window_start: new Date('2026-03-01T00:00:00Z'),
+          window_end: new Date('2026-04-01T00:00:00Z'),
+          first_provider_message_id: 'c',
+          last_provider_message_id: 'd',
+        },
+      ],
+    })
+    const rows = await getChatCoverage({ ownerUserId: 'owner-1' })
+    expect(rows[0]?.gaps).toEqual([{
+      from: '2026-01-31T00:00:00.000Z',
+      to: '2026-03-01T00:00:00.000Z',
+      evidence: 'between_acquired_windows',
+    }])
+  })
+})

--- a/packages/api/src/db/__tests__/embedding-store.test.ts
+++ b/packages/api/src/db/__tests__/embedding-store.test.ts
@@ -204,6 +204,16 @@ describe('[COMP:brain/embedding-store] withClaimedRows', () => {
     }
   })
 
+  it('keys chat history on the provider message time, not the append clock', async () => {
+    await store.withClaimedRows('chat_segment', 10, async () => undefined)
+    for (const claim of claims()) {
+      expect(claim.text).toContain('FROM chat_archive_segments')
+      expect(claim.text).toContain('ORDER BY valid_from ASC')
+      expect(claim.text).toContain("valid_from > now() - INTERVAL '12 months'")
+      expect(claim.text).not.toContain('created_at')
+    }
+  })
+
   it('keys a primitive whose row IS the event on created_at', async () => {
     await store.withClaimedRows('memories', 10, async () => undefined)
     for (const claim of claims()) {
@@ -294,6 +304,7 @@ describe('[COMP:brain/embedding-store] withClaimedRows', () => {
       ['workspace_files', 'FROM workspace_files'],
       ['transcript_segment', 'FROM transcript_segments'],
       ['file_segment', 'FROM file_segments'],
+      ['chat_segment', 'FROM chat_archive_segments'],
     ] as const) {
       queries.length = 0
       await store.withClaimedRows(primitive, 10, async () => undefined)

--- a/packages/api/src/db/__tests__/ingest-sink-store.test.ts
+++ b/packages/api/src/db/__tests__/ingest-sink-store.test.ts
@@ -42,6 +42,7 @@ function makeRow(over: Record<string, unknown> = {}): Record<string, unknown> {
     authKind: 'hmac',
     mode: 'all',
     enabled: true,
+    managedBy: null,
     hasSecret: true,
     lastAckCursor: null,
     lastDeliveredAt: null,
@@ -123,6 +124,18 @@ describe('[COMP:api/ingest-sink-store] listEnabledByInstance', () => {
     expect(poolQueries[0].text).toContain('enabled = true')
     expect(poolQueries[0].values).toEqual(['ci-1'])
   })
+
+  it('reuses a caller transaction instead of checking out another pool client', async () => {
+    const transactionClient = {
+      query: vi.fn(async () => ({ rows: [makeRow()], rowCount: 1 })),
+    }
+
+    const sinks = await store.listEnabledByInstance('ci-1', transactionClient as never)
+
+    expect(sinks).toHaveLength(1)
+    expect(transactionClient.query).toHaveBeenCalledOnce()
+    expect(fakePool.query).not.toHaveBeenCalled()
+  })
 })
 
 describe('[COMP:api/ingest-sink-store] recordAck', () => {
@@ -145,5 +158,27 @@ describe('[COMP:api/ingest-sink-store] update', () => {
     expect(sql).not.toContain('endpoint_url =')
     const blob = poolQueries[0].values!.find((v) => Buffer.isBuffer(v)) as Buffer
     expect(decryptCredentials<{ secret: string }>(blob, KEY).secret).toBe('rotated-secret-value')
+  })
+})
+
+describe('[COMP:api/ingest-sink-store] managed local archive', () => {
+  it('upserts one encrypted HMAC mode-all sink per instance', async () => {
+    poolResults = [makeRow({ managedBy: 'local_chat_archive' })]
+    await store.ensureManagedLocalChatArchive({
+      connectorInstanceId: 'ci-1',
+      workspaceId: 'ws-1',
+      endpointUrl: 'http://127.0.0.1:8092/append',
+      secret: 'managed-secret',
+    })
+    expect(poolQueries[0].text).toContain("managed_by")
+    expect(poolQueries[0].text).toContain("mode = 'all'")
+    const blob = poolQueries[0].values![3] as Buffer
+    expect(decryptCredentials<{ secret: string }>(blob, KEY).secret).toBe('managed-secret')
+  })
+
+  it('disables only managed sinks when local config is absent', async () => {
+    poolRowCount = 2
+    await expect(store.disableManagedLocalChatArchive()).resolves.toBe(2)
+    expect(poolQueries[0].text).toContain("managed_by = 'local_chat_archive'")
   })
 })

--- a/packages/api/src/db/chat-archive-enrichment-store.ts
+++ b/packages/api/src/db/chat-archive-enrichment-store.ts
@@ -1,0 +1,223 @@
+/** System-level leased window ledger for chat archive Pipeline B enrichment. */
+
+import { createHash } from 'node:crypto'
+import type pg from 'pg'
+import { getPool } from './client.js'
+
+export type ChatArchiveEnrichmentMessage = {
+  id: string
+  providerMessageId: string
+  senderId: string
+  senderDisplay: string | null
+  sentAt: Date
+  direction: 'inbound' | 'outbound'
+  kind: 'text' | 'image' | 'voice' | 'file' | 'link'
+  bodyText: string | null
+  mediaRef: { filename?: string; mime?: string; size_bytes?: number } | null
+}
+
+export type ChatArchiveEnrichmentWindow = {
+  id: string
+  workspaceId: string
+  instanceId: string
+  ownerUserId: string
+  source: string
+  conversationId: string
+  firstMessageId: string
+  lastMessageId: string
+  firstProviderMessageId: string
+  lastProviderMessageId: string
+  windowStart: Date
+  windowEnd: Date
+  attemptCount: number
+  messages: ChatArchiveEnrichmentMessage[]
+}
+
+export type ChatArchiveEnrichmentStore = {
+  claimNext(): Promise<ChatArchiveEnrichmentWindow | null>
+  complete(id: string): Promise<void>
+  fail(id: string, attemptCount: number, message: string): Promise<void>
+}
+
+type WindowRow = Omit<ChatArchiveEnrichmentWindow, 'source' | 'messages'>
+
+const WINDOW_COLS = `
+  id,
+  workspace_id              AS "workspaceId",
+  instance_id               AS "instanceId",
+  owner_user_id              AS "ownerUserId",
+  conversation_id           AS "conversationId",
+  first_message_id           AS "firstMessageId",
+  last_message_id            AS "lastMessageId",
+  first_provider_message_id  AS "firstProviderMessageId",
+  last_provider_message_id   AS "lastProviderMessageId",
+  window_start               AS "windowStart",
+  window_end                 AS "windowEnd",
+  attempt_count              AS "attemptCount"
+`
+
+async function loadMessages(client: Pick<pg.ClientBase, 'query'>, windowId: string) {
+  const result = await client.query<ChatArchiveEnrichmentMessage & { source: string }>(
+    `SELECT m.id,
+            m.provider_message_id AS "providerMessageId",
+            m.sender_id AS "senderId", m.sender_display AS "senderDisplay",
+            m.sent_at AS "sentAt", m.direction, m.kind,
+            m.body_text AS "bodyText", m.media_ref AS "mediaRef", m.source
+       FROM chat_archive_enrichment_messages em
+       JOIN chat_archive_messages m ON m.id = em.message_id
+      WHERE em.window_id = $1
+      ORDER BY m.sent_at ASC, m.id ASC`,
+    [windowId],
+  )
+  return result.rows
+}
+
+export function createChatArchiveEnrichmentStore(
+  pool: pg.Pool = getPool(),
+  windowSize = 20,
+): ChatArchiveEnrichmentStore {
+  return {
+    async claimNext() {
+      const client = await pool.connect()
+      try {
+        await client.query('BEGIN')
+        await client.query(
+          `UPDATE chat_archive_enrichment_windows
+              SET status = 'failed', next_attempt_at = now(), locked_until = NULL,
+                  last_error = 'lease expired', updated_at = now()
+            WHERE status = 'processing' AND locked_until < now()`,
+        )
+
+        const existing = await client.query<WindowRow>(
+          `SELECT ${WINDOW_COLS}
+             FROM chat_archive_enrichment_windows
+            WHERE status IN ('pending', 'failed') AND next_attempt_at <= now()
+            ORDER BY next_attempt_at ASC, created_at ASC
+            FOR UPDATE SKIP LOCKED
+            LIMIT 1`,
+        )
+        let row = existing.rows[0]
+        if (row) {
+          const updated = await client.query<WindowRow>(
+            `UPDATE chat_archive_enrichment_windows
+                SET status = 'processing', attempt_count = attempt_count + 1,
+                    locked_until = now() + interval '10 minutes', updated_at = now()
+              WHERE id = $1
+              RETURNING ${WINDOW_COLS}`,
+            [row.id],
+          )
+          row = updated.rows[0]!
+        } else {
+          const anchorResult = await client.query<{
+            workspaceId: string
+            instanceId: string
+            ownerUserId: string
+            conversationId: string
+          }>(
+            `SELECT m.workspace_id AS "workspaceId", m.instance_id AS "instanceId",
+                    m.owner_user_id AS "ownerUserId", m.conversation_id AS "conversationId"
+               FROM chat_archive_messages m
+              WHERE (m.body_text IS NOT NULL OR m.media_ref IS NOT NULL)
+                AND NOT EXISTS (
+                  SELECT 1 FROM chat_archive_enrichment_messages em WHERE em.message_id = m.id
+                )
+              ORDER BY m.sent_at ASC, m.id ASC
+              FOR UPDATE OF m SKIP LOCKED
+              LIMIT 1`,
+          )
+          const anchor = anchorResult.rows[0]
+          if (!anchor) {
+            await client.query('COMMIT')
+            return null
+          }
+          const candidates = await client.query<{
+            id: string
+            providerMessageId: string
+            sentAt: Date
+          }>(
+            `SELECT m.id, m.provider_message_id AS "providerMessageId", m.sent_at AS "sentAt"
+               FROM chat_archive_messages m
+              WHERE m.instance_id = $1 AND m.conversation_id = $2
+                AND (m.body_text IS NOT NULL OR m.media_ref IS NOT NULL)
+                AND NOT EXISTS (
+                  SELECT 1 FROM chat_archive_enrichment_messages em WHERE em.message_id = m.id
+                )
+              ORDER BY m.sent_at ASC, m.id ASC
+              FOR UPDATE OF m SKIP LOCKED
+              LIMIT $3`,
+            [anchor.instanceId, anchor.conversationId, windowSize],
+          )
+          if (candidates.rows.length === 0) {
+            await client.query('COMMIT')
+            return null
+          }
+          const first = candidates.rows[0]!
+          const last = candidates.rows[candidates.rows.length - 1]!
+          const contentHash = createHash('sha256')
+            .update(candidates.rows.map((message) => message.id).join('\n'))
+            .digest('hex')
+          const inserted = await client.query<WindowRow>(
+            `INSERT INTO chat_archive_enrichment_windows (
+               workspace_id, instance_id, owner_user_id, conversation_id,
+               first_message_id, last_message_id,
+               first_provider_message_id, last_provider_message_id,
+               window_start, window_end, message_count, content_hash,
+               status, attempt_count, locked_until
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
+                       'processing', 1, now() + interval '10 minutes')
+             RETURNING ${WINDOW_COLS}`,
+            [
+              anchor.workspaceId, anchor.instanceId, anchor.ownerUserId, anchor.conversationId,
+              first.id, last.id, first.providerMessageId, last.providerMessageId,
+              first.sentAt, last.sentAt, candidates.rows.length, contentHash,
+            ],
+          )
+          row = inserted.rows[0]!
+          for (const message of candidates.rows) {
+            await client.query(
+              `INSERT INTO chat_archive_enrichment_messages (message_id, window_id)
+               VALUES ($1, $2) ON CONFLICT (message_id) DO NOTHING`,
+              [message.id, row.id],
+            )
+          }
+        }
+
+        const messages = await loadMessages(client, row.id)
+        await client.query('COMMIT')
+        return {
+          ...row,
+          source: messages[0]?.source ?? 'chat',
+          messages: messages.map(({ source: _source, ...message }) => message),
+        }
+      } catch (err) {
+        await client.query('ROLLBACK').catch(() => {})
+        throw err
+      } finally {
+        client.release()
+      }
+    },
+
+    async complete(id) {
+      await pool.query(
+        `UPDATE chat_archive_enrichment_windows
+            SET status = 'completed', locked_until = NULL, last_error = NULL,
+                completed_at = now(), updated_at = now()
+          WHERE id = $1`,
+        [id],
+      )
+    },
+
+    async fail(id, attemptCount, message) {
+      const dead = attemptCount >= 5
+      const backoffSeconds = Math.min(2 ** Math.max(1, attemptCount) * 15, 3600)
+      await pool.query(
+        `UPDATE chat_archive_enrichment_windows
+            SET status = $2, locked_until = NULL, last_error = $3,
+                next_attempt_at = now() + ($4 * interval '1 second'),
+                updated_at = now()
+          WHERE id = $1`,
+        [id, dead ? 'dead' : 'failed', message.slice(0, 2000), backoffSeconds],
+      )
+    },
+  }
+}

--- a/packages/api/src/db/chat-archive-store.ts
+++ b/packages/api/src/db/chat-archive-store.ts
@@ -1,0 +1,620 @@
+/**
+ * Provider-neutral chat archive reads (WhatsApp / WeChat, migration 395).
+ *
+ * Every public read is owner-bound twice: an explicit owner predicate and the
+ * owner-scoped RLS policy through queryWithRLS. Search combines the platform's
+ * existing segment-corpus primitives: tokenized trigram recall, pgvector,
+ * reciprocal-rank fusion, a candidate-only recency arm, and MMR diversity.
+ *
+ * [COMP:api/chat-archive-store]
+ */
+
+import {
+  DEFAULT_MMR_LAMBDA,
+  RRF_METHOD,
+  mmrRerank,
+  rrfFuse,
+} from '@use-brian/core'
+import { queryWithRLS } from './client.js'
+import {
+  COVERAGE_PROBE_LIMIT,
+  FULL_COVERAGE,
+  buildSegmentCoverage,
+  type SegmentCoverage,
+} from './segment-coverage.js'
+import { buildLexicalMatch, tokenizeSearchTerms } from './segment-lexical.js'
+
+const TOP_K_DEFAULT = 8
+const TOP_K_MAX = 20
+const CANDIDATE_MAX = 80
+
+export type ChatDirection = 'inbound' | 'outbound'
+export type ChatKind = 'text' | 'image' | 'voice' | 'file' | 'link'
+
+export type ChatArchiveHit = {
+  segment_id: string
+  message_id: string
+  instance_id: string
+  source: string
+  provider_message_id: string
+  conversation_id: string
+  sender_id: string
+  sender_display: string | null
+  sent_at: string
+  direction: ChatDirection
+  kind: string
+  body_text: string | null
+  media_ref: unknown | null
+  reply_to_provider_id: string | null
+  segment_index: number
+  segment_text: string
+}
+
+type ChatArchiveRow = Omit<ChatArchiveHit, 'sent_at' | 'segment_index'> & {
+  sent_at: string | Date
+  segment_index: number | string
+  distance?: number | string | null
+}
+
+export type SearchChatArchiveInput = {
+  ownerUserId: string
+  query: string
+  topK?: number
+  source?: string
+  instanceId?: string
+  conversationId?: string
+  sender?: string
+  direction?: ChatDirection
+  kind?: ChatKind
+  since?: string
+  before?: string
+}
+
+export type SearchChatArchiveResult = {
+  hits: ChatArchiveHit[]
+  embeddingCoverage: SegmentCoverage
+}
+
+type ChatEmbedder = { embed(texts: string[]): Promise<number[][]> }
+
+/** Hybrid owner-scoped recall across chat archive segments. */
+export async function searchChatArchive(
+  input: SearchChatArchiveInput,
+  deps?: { embedder?: ChatEmbedder },
+): Promise<SearchChatArchiveResult> {
+  const topK = Math.min(Math.max(input.topK ?? TOP_K_DEFAULT, 1), TOP_K_MAX)
+  const candidateLimit = Math.min(topK * 4, CANDIDATE_MAX)
+  const text = input.query.trim()
+  const baseWhere = buildSearchWhere(input)
+  const selectCols = `
+    s.id::text AS segment_id,
+    m.id::text AS message_id,
+    m.instance_id::text AS instance_id,
+    m.source,
+    m.provider_message_id,
+    m.conversation_id,
+    m.sender_id,
+    m.sender_display,
+    m.sent_at,
+    m.direction,
+    m.kind,
+    m.body_text,
+    m.media_ref,
+    m.reply_to_provider_id,
+    s.segment_index,
+    s.segment_text`
+
+  const vectorRows: ChatArchiveRow[] = []
+  if (deps?.embedder && text) {
+    try {
+      const [embedding] = await deps.embedder.embed([text])
+      if (embedding?.length) {
+        const values: unknown[] = []
+        const where = baseWhere(values)
+        values.push(`[${embedding.join(',')}]`)
+        const vectorIdx = values.length
+        values.push(candidateLimit)
+        const limitIdx = values.length
+        const res = await queryWithRLS<ChatArchiveRow>(
+          input.ownerUserId,
+          `SELECT ${selectCols}, s.embedding <=> $${vectorIdx}::vector AS distance
+             FROM chat_archive_segments s
+             JOIN chat_archive_messages m ON m.id = s.message_id
+            WHERE ${where}
+              AND s.embedding IS NOT NULL
+            ORDER BY s.embedding <=> $${vectorIdx}::vector
+            LIMIT $${limitIdx}`,
+          values,
+        )
+        vectorRows.push(...res.rows)
+      }
+    } catch (err) {
+      console.warn(
+        '[searchChatArchive] vector arm failed; lexical-only:',
+        err instanceof Error ? err.message : String(err),
+      )
+    }
+  }
+
+  const lexicalRows: ChatArchiveRow[] = []
+  const terms = tokenizeSearchTerms(text)
+  if (terms.length > 0) {
+    const values: unknown[] = []
+    const where = baseWhere(values)
+    const match = buildLexicalMatch({
+      terms,
+      columns: ['s.segment_text', 'm.sender_display', 'm.sender_id'],
+      values,
+    })!
+    values.push(candidateLimit)
+    const limitIdx = values.length
+    const res = await queryWithRLS<ChatArchiveRow>(
+      input.ownerUserId,
+      `SELECT ${selectCols}, (${match.hits}) AS term_hits
+         FROM chat_archive_segments s
+         JOIN chat_archive_messages m ON m.id = s.message_id
+        WHERE ${where}
+          AND ${match.where}
+        ORDER BY term_hits DESC, m.sent_at DESC, s.segment_index
+        LIMIT $${limitIdx}`,
+      values,
+    )
+    lexicalRows.push(...res.rows)
+  }
+
+  // An exact sender-name/id query is an identity lookup, not a broad semantic
+  // discovery request. Keep the candidate set focused on that person so MMR
+  // does not replace their conversation with superficially similar messages
+  // from unrelated chats (the common "Who is X?" path).
+  const normalizedQuery = normalizeIdentity(text)
+  const exactSenderRows = normalizedQuery
+    ? lexicalRows.filter((row) =>
+        [row.sender_display, row.sender_id].some(
+          (value) => normalizeIdentity(value ?? '') === normalizedQuery,
+        ),
+      )
+    : []
+  const focusedSender = exactSenderRows.length > 0
+  const rankedVectorRows = focusedSender ? [] : vectorRows
+  const rankedLexicalRows = focusedSender ? exactSenderRows : lexicalRows
+
+  const candidates = new Map<string, ChatArchiveRow>()
+  for (const row of [...rankedVectorRows, ...rankedLexicalRows]) candidates.set(row.segment_id, row)
+  const recentIds = [...candidates.values()]
+    .sort((a, b) => toMillis(b.sent_at) - toMillis(a.sent_at))
+    .map((row) => row.segment_id)
+
+  const fused = rrfFuse([
+    {
+      method: RRF_METHOD.vector,
+      ranked: rankedVectorRows.map((row) => row.segment_id),
+    },
+    {
+      method: RRF_METHOD.fts,
+      ranked: rankedLexicalRows.map((row) => row.segment_id),
+    },
+    {
+      method: RRF_METHOD.recency,
+      // Candidate-only: recency may reorder retrieved evidence, never create a
+      // match for an unrelated recent message.
+      ranked: recentIds,
+    },
+  ])
+
+  const maxScore = fused[0]?.score ?? 1
+  const diversified = mmrRerank(
+    fused.flatMap((item) => {
+      const row = candidates.get(item.id)
+      return row ? [{ ...row, id: item.id, relevance: item.score / maxScore }] : []
+    }),
+    {
+      k: topK,
+      // Exact identity lookup wants several pieces of evidence from the same
+      // conversation; general discovery still benefits from diversity.
+      lambda: focusedSender ? 1 : Math.max(DEFAULT_MMR_LAMBDA, 0.75),
+      sim: chatCandidateSimilarity,
+    },
+  )
+
+  return {
+    hits: diversified.map(toChatArchiveHit),
+    embeddingCoverage: await probeEmbeddingCoverage(input, baseWhere),
+  }
+}
+
+function normalizeIdentity(value: string): string {
+  return value.normalize('NFKC').trim().toLocaleLowerCase()
+}
+
+function buildSearchWhere(
+  input: SearchChatArchiveInput,
+): (values: unknown[]) => string {
+  return (values: unknown[]): string => {
+    values.push(input.ownerUserId)
+    const ownerIdx = values.length
+    const clauses = [
+      `s.user_id = $${ownerIdx}::uuid`,
+      `m.owner_user_id = $${ownerIdx}::uuid`,
+      's.retracted_at IS NULL',
+    ]
+    if (input.source?.trim()) {
+      values.push(input.source.trim().toLowerCase())
+      clauses.push(`lower(m.source) = $${values.length}`)
+    }
+    if (input.instanceId) {
+      values.push(input.instanceId)
+      clauses.push(`m.instance_id = $${values.length}::uuid`)
+    }
+    if (input.conversationId?.trim()) {
+      values.push(input.conversationId.trim())
+      clauses.push(`m.conversation_id = $${values.length}`)
+    }
+    if (input.sender?.trim()) {
+      values.push(`%${input.sender.trim()}%`)
+      clauses.push(`(m.sender_id ILIKE $${values.length} OR m.sender_display ILIKE $${values.length})`)
+    }
+    if (input.direction) {
+      values.push(input.direction)
+      clauses.push(`m.direction = $${values.length}`)
+    }
+    if (input.kind) {
+      values.push(input.kind)
+      clauses.push(`m.kind = $${values.length}`)
+    }
+    if (input.since) {
+      values.push(input.since)
+      clauses.push(`m.sent_at >= $${values.length}::timestamptz`)
+    }
+    if (input.before) {
+      values.push(input.before)
+      clauses.push(`m.sent_at < $${values.length}::timestamptz`)
+    }
+    return clauses.join(' AND ')
+  }
+}
+
+async function probeEmbeddingCoverage(
+  input: SearchChatArchiveInput,
+  baseWhere: (values: unknown[]) => string,
+): Promise<SegmentCoverage> {
+  try {
+    const values: unknown[] = []
+    const where = baseWhere(values)
+    values.push(COVERAGE_PROBE_LIMIT)
+    const limitIdx = values.length
+    const res = await queryWithRLS<{ n: string }>(
+      input.ownerUserId,
+      `SELECT count(*)::text AS n FROM (
+         SELECT 1
+           FROM chat_archive_segments s
+           JOIN chat_archive_messages m ON m.id = s.message_id
+          WHERE ${where}
+            AND s.embedding IS NULL
+            AND s.embedding_failed_at IS NULL
+          LIMIT $${limitIdx}
+       ) pending`,
+      values,
+    )
+    return buildSegmentCoverage(Number(res.rows[0]?.n ?? 0), 'chat archive')
+  } catch (err) {
+    console.warn(
+      '[searchChatArchive] coverage probe failed; reporting full coverage:',
+      err instanceof Error ? err.message : String(err),
+    )
+    return FULL_COVERAGE
+  }
+}
+
+function chatCandidateSimilarity(a: ChatArchiveRow, b: ChatArchiveRow): number {
+  if (a.segment_id === b.segment_id) return 1
+  let similarity = 0
+  if (a.instance_id === b.instance_id && a.conversation_id === b.conversation_id) similarity += 0.65
+  if (a.sender_id && a.sender_id === b.sender_id) similarity += 0.15
+  if (a.source === b.source) similarity += 0.05
+  return Math.min(similarity, 1)
+}
+
+function toChatArchiveHit(row: ChatArchiveRow): ChatArchiveHit {
+  return {
+    segment_id: row.segment_id,
+    message_id: row.message_id,
+    instance_id: row.instance_id,
+    source: row.source,
+    provider_message_id: row.provider_message_id,
+    conversation_id: row.conversation_id,
+    sender_id: row.sender_id,
+    sender_display: row.sender_display,
+    sent_at: new Date(row.sent_at).toISOString(),
+    direction: row.direction,
+    kind: row.kind,
+    body_text: row.body_text,
+    media_ref: row.media_ref,
+    reply_to_provider_id: row.reply_to_provider_id,
+    segment_index: Number(row.segment_index),
+    segment_text: row.segment_text,
+  }
+}
+
+function toMillis(value: string | Date): number {
+  const ms = new Date(value).getTime()
+  return Number.isFinite(ms) ? ms : 0
+}
+
+// ── Contextual get ─────────────────────────────────────────────
+
+export type ChatArchiveMessage = Omit<ChatArchiveHit, 'segment_id' | 'segment_index' | 'segment_text'>
+
+type ChatArchiveMessageRow = Omit<ChatArchiveMessage, 'sent_at'> & { sent_at: string | Date }
+
+const MESSAGE_COLS = `
+  m.id::text AS message_id,
+  m.instance_id::text AS instance_id,
+  m.source,
+  m.provider_message_id,
+  m.conversation_id,
+  m.sender_id,
+  m.sender_display,
+  m.sent_at,
+  m.direction,
+  m.kind,
+  m.body_text,
+  m.media_ref,
+  m.reply_to_provider_id`
+
+export type GetChatMessageResult = {
+  target: ChatArchiveMessage
+  messages: ChatArchiveMessage[]
+  targetIndex: number
+}
+
+/** Return one archive message plus bounded chronological neighbors. */
+export async function getChatMessageWithContext(input: {
+  ownerUserId: string
+  messageId: string
+  before?: number
+  after?: number
+}): Promise<GetChatMessageResult | null> {
+  const before = Math.min(Math.max(input.before ?? 5, 0), 20)
+  const after = Math.min(Math.max(input.after ?? 5, 0), 20)
+  const targetRes = await queryWithRLS<ChatArchiveMessageRow>(
+    input.ownerUserId,
+    `SELECT ${MESSAGE_COLS}
+       FROM chat_archive_messages m
+      WHERE m.id = $2::uuid AND m.owner_user_id = $1::uuid`,
+    [input.ownerUserId, input.messageId],
+  )
+  const targetRow = targetRes.rows[0]
+  if (!targetRow) return null
+
+  const commonValues = [
+    input.ownerUserId,
+    targetRow.instance_id,
+    targetRow.conversation_id,
+    targetRow.sent_at,
+    targetRow.message_id,
+  ]
+  const beforeRes = before > 0
+    ? await queryWithRLS<ChatArchiveMessageRow>(
+        input.ownerUserId,
+        `SELECT ${MESSAGE_COLS}
+           FROM chat_archive_messages m
+          WHERE m.owner_user_id = $1::uuid
+            AND m.instance_id = $2::uuid
+            AND m.conversation_id = $3
+            AND (m.sent_at < $4::timestamptz OR (m.sent_at = $4::timestamptz AND m.id::text < $5))
+          ORDER BY m.sent_at DESC, m.id DESC
+          LIMIT $6`,
+        [...commonValues, before],
+      )
+    : { rows: [] as ChatArchiveMessageRow[] }
+  const afterRes = after > 0
+    ? await queryWithRLS<ChatArchiveMessageRow>(
+        input.ownerUserId,
+        `SELECT ${MESSAGE_COLS}
+           FROM chat_archive_messages m
+          WHERE m.owner_user_id = $1::uuid
+            AND m.instance_id = $2::uuid
+            AND m.conversation_id = $3
+            AND (m.sent_at > $4::timestamptz OR (m.sent_at = $4::timestamptz AND m.id::text > $5))
+          ORDER BY m.sent_at ASC, m.id ASC
+          LIMIT $6`,
+        [...commonValues, after],
+      )
+    : { rows: [] as ChatArchiveMessageRow[] }
+
+  const previous = [...beforeRes.rows].reverse().map(toChatArchiveMessage)
+  const target = toChatArchiveMessage(targetRow)
+  const following = afterRes.rows.map(toChatArchiveMessage)
+  return {
+    target,
+    messages: [...previous, target, ...following],
+    targetIndex: previous.length,
+  }
+}
+
+function toChatArchiveMessage(row: ChatArchiveMessageRow): ChatArchiveMessage {
+  return { ...row, sent_at: new Date(row.sent_at).toISOString() }
+}
+
+// ── Conversation listing ───────────────────────────────────────
+
+export type ChatConversation = {
+  instance_id: string
+  source: string
+  conversation_id: string
+  message_count: number
+  first_sent_at: string
+  last_sent_at: string
+  last_message_preview: string
+  last_sender_id: string
+  last_sender_display: string | null
+  last_direction: ChatDirection
+}
+
+type ChatConversationRow = Omit<ChatConversation, 'message_count' | 'first_sent_at' | 'last_sent_at'> & {
+  message_count: string | number
+  first_sent_at: string | Date
+  last_sent_at: string | Date
+}
+
+export async function listChatConversations(input: {
+  ownerUserId: string
+  source?: string
+  instanceId?: string
+  since?: string
+  before?: string
+  limit?: number
+}): Promise<ChatConversation[]> {
+  const values: unknown[] = [input.ownerUserId]
+  const clauses = ['m.owner_user_id = $1::uuid']
+  if (input.source?.trim()) {
+    values.push(input.source.trim().toLowerCase())
+    clauses.push(`lower(m.source) = $${values.length}`)
+  }
+  if (input.instanceId) {
+    values.push(input.instanceId)
+    clauses.push(`m.instance_id = $${values.length}::uuid`)
+  }
+  if (input.since) {
+    values.push(input.since)
+    clauses.push(`m.sent_at >= $${values.length}::timestamptz`)
+  }
+  if (input.before) {
+    values.push(input.before)
+    clauses.push(`m.sent_at < $${values.length}::timestamptz`)
+  }
+  values.push(Math.min(Math.max(input.limit ?? 20, 1), 50))
+  const limitIdx = values.length
+  const res = await queryWithRLS<ChatConversationRow>(
+    input.ownerUserId,
+    `WITH ranked AS (
+       SELECT m.instance_id::text AS instance_id,
+              m.source,
+              m.conversation_id,
+              count(*) OVER (PARTITION BY m.instance_id, m.conversation_id) AS message_count,
+              min(m.sent_at) OVER (PARTITION BY m.instance_id, m.conversation_id) AS first_sent_at,
+              max(m.sent_at) OVER (PARTITION BY m.instance_id, m.conversation_id) AS last_sent_at,
+              left(coalesce(nullif(m.body_text, ''), m.kind), 240) AS last_message_preview,
+              m.sender_id AS last_sender_id,
+              m.sender_display AS last_sender_display,
+              m.direction AS last_direction,
+              row_number() OVER (
+                PARTITION BY m.instance_id, m.conversation_id
+                ORDER BY m.sent_at DESC, m.id DESC
+              ) AS row_rank
+         FROM chat_archive_messages m
+        WHERE ${clauses.join(' AND ')}
+     )
+     SELECT instance_id, source, conversation_id, message_count,
+            first_sent_at, last_sent_at, last_message_preview,
+            last_sender_id, last_sender_display, last_direction
+       FROM ranked
+      WHERE row_rank = 1
+      ORDER BY last_sent_at DESC
+      LIMIT $${limitIdx}`,
+    values,
+  )
+  return res.rows.map((row) => ({
+    ...row,
+    message_count: Number(row.message_count),
+    first_sent_at: new Date(row.first_sent_at).toISOString(),
+    last_sent_at: new Date(row.last_sent_at).toISOString(),
+  }))
+}
+
+// ── Acquisition coverage ───────────────────────────────────────
+
+export type ChatCoverageWindow = {
+  from: string
+  to: string
+  firstProviderMessageId: string
+  lastProviderMessageId: string
+}
+
+export type ChatCoverageGap = {
+  from: string
+  to: string
+  evidence: 'between_acquired_windows'
+}
+
+export type ChatConversationCoverage = {
+  instanceId: string
+  conversationId: string
+  windows: ChatCoverageWindow[]
+  gaps: ChatCoverageGap[]
+}
+
+type CoverageRow = {
+  instance_id: string
+  conversation_id: string
+  window_start: string | Date
+  window_end: string | Date
+  first_provider_message_id: string
+  last_provider_message_id: string
+}
+
+/**
+ * Return only evidence-backed acquisition windows. Time before the first and
+ * after the last window is an unknown horizon, not asserted as a gap.
+ */
+export async function getChatCoverage(input: {
+  ownerUserId: string
+  instanceId?: string
+  conversationId?: string
+  limit?: number
+}): Promise<ChatConversationCoverage[]> {
+  const values: unknown[] = [input.ownerUserId]
+  const clauses = ['owner_user_id = $1::uuid']
+  if (input.instanceId) {
+    values.push(input.instanceId)
+    clauses.push(`instance_id = $${values.length}::uuid`)
+  }
+  if (input.conversationId?.trim()) {
+    values.push(input.conversationId.trim())
+    clauses.push(`conversation_id = $${values.length}`)
+  }
+  values.push(Math.min(Math.max(input.limit ?? 200, 1), 1000))
+  const limitIdx = values.length
+  const res = await queryWithRLS<CoverageRow>(
+    input.ownerUserId,
+    `SELECT instance_id::text, conversation_id, window_start, window_end,
+            first_provider_message_id, last_provider_message_id
+       FROM chat_archive_coverage_windows
+      WHERE ${clauses.join(' AND ')}
+      ORDER BY instance_id, conversation_id, window_start
+      LIMIT $${limitIdx}`,
+    values,
+  )
+
+  const grouped = new Map<string, { instanceId: string; conversationId: string; windows: ChatCoverageWindow[] }>()
+  for (const row of res.rows) {
+    const key = `${row.instance_id}\u0000${row.conversation_id}`
+    let group = grouped.get(key)
+    if (!group) {
+      group = { instanceId: row.instance_id, conversationId: row.conversation_id, windows: [] }
+      grouped.set(key, group)
+    }
+    group.windows.push({
+      from: new Date(row.window_start).toISOString(),
+      to: new Date(row.window_end).toISOString(),
+      firstProviderMessageId: row.first_provider_message_id,
+      lastProviderMessageId: row.last_provider_message_id,
+    })
+  }
+
+  return [...grouped.values()].map((group) => {
+    const gaps: ChatCoverageGap[] = []
+    for (let index = 1; index < group.windows.length; index++) {
+      const previous = group.windows[index - 1]!
+      const next = group.windows[index]!
+      if (new Date(previous.to).getTime() < new Date(next.from).getTime()) {
+        gaps.push({
+          from: previous.to,
+          to: next.from,
+          evidence: 'between_acquired_windows',
+        })
+      }
+    }
+    return { ...group, gaps }
+  })
+}

--- a/packages/api/src/db/embedding-store.ts
+++ b/packages/api/src/db/embedding-store.ts
@@ -164,6 +164,14 @@ const PRIMITIVE_CONFIGS: Partial<Record<EmbeddingPrimitive, PrimitiveConfig>> = 
     // tier, is what bounds them.
     recencyExpr: 'valid_from',
   },
+  // WhatsApp / WeChat archive segments — live delivery and history backfill
+  // share the same provider-neutral projection. `valid_from` is the original
+  // message clock; `created_at` is merely when the sidecar appended it.
+  chat_segment: {
+    table: 'chat_archive_segments',
+    textExpr: 'segment_text',
+    recencyExpr: 'valid_from',
+  },
 }
 
 function sha256(text: string): string {

--- a/packages/api/src/db/ingest-sink-store.ts
+++ b/packages/api/src/db/ingest-sink-store.ts
@@ -24,8 +24,11 @@
  * [COMP:api/ingest-sink-store]
  */
 
+import type pg from 'pg'
 import { getPool } from './client.js'
 import { decryptCredentials, encryptCredentials } from './credential-crypto.js'
+
+type Queryable = Pick<pg.ClientBase, 'query'>
 
 export type IngestSinkAuthKind = 'bearer' | 'hmac'
 export type IngestSinkMode = 'all' | 'rule_filtered'
@@ -38,6 +41,7 @@ export type IngestExternalSink = {
   authKind: IngestSinkAuthKind
   mode: IngestSinkMode
   enabled: boolean
+  managedBy?: 'local_chat_archive' | null
   hasSecret: boolean
   /** Opaque — last cursor the sink durably acked (X3). */
   lastAckCursor: unknown
@@ -73,6 +77,7 @@ const COLS = `
   auth_kind             AS "authKind",
   mode,
   enabled,
+  managed_by            AS "managedBy",
   (secret_ciphertext IS NOT NULL) AS "hasSecret",
   last_ack_cursor       AS "lastAckCursor",
   last_delivered_at     AS "lastDeliveredAt",
@@ -88,6 +93,7 @@ function rowToSink(row: Record<string, unknown>): IngestExternalSink {
     authKind: row.authKind as IngestSinkAuthKind,
     mode: row.mode as IngestSinkMode,
     enabled: row.enabled as boolean,
+    managedBy: (row.managedBy as 'local_chat_archive' | null) ?? null,
     hasSecret: row.hasSecret as boolean,
     lastAckCursor: row.lastAckCursor ?? null,
     lastDeliveredAt: (row.lastDeliveredAt as Date | null) ?? null,
@@ -100,7 +106,10 @@ export type IngestSinkStore = {
   get(id: string): Promise<IngestExternalSink | null>
   listByInstance(connectorInstanceId: string): Promise<IngestExternalSink[]>
   /** The fan-out read — only sinks that should receive events right now. */
-  listEnabledByInstance(connectorInstanceId: string): Promise<IngestExternalSink[]>
+  listEnabledByInstance(
+    connectorInstanceId: string,
+    client?: Queryable,
+  ): Promise<IngestExternalSink[]>
   update(id: string, patch: UpdateIngestSinkPatch): Promise<IngestExternalSink | null>
   remove(id: string): Promise<boolean>
   /** Decrypted outbound-auth secret — relay-only. Null when none stored. */
@@ -110,6 +119,15 @@ export type IngestSinkStore = {
    * stored opaquely; `last_delivered_at` stamps alongside it.
    */
   recordAck(id: string, ackCursor: unknown): Promise<void>
+  /** Upsert the one platform-owned loopback archive sink for an instance. */
+  ensureManagedLocalChatArchive(params: {
+    connectorInstanceId: string
+    workspaceId: string
+    endpointUrl: string
+    secret: string
+  }): Promise<IngestExternalSink>
+  /** Disable stale managed archive sinks without touching manual sinks. */
+  disableManagedLocalChatArchive(): Promise<number>
 }
 
 export function createIngestSinkStore(encryptionKey: Buffer | null): IngestSinkStore {
@@ -162,8 +180,8 @@ export function createIngestSinkStore(encryptionKey: Buffer | null): IngestSinkS
       return result.rows.map((r) => rowToSink(r as Record<string, unknown>))
     },
 
-    async listEnabledByInstance(connectorInstanceId) {
-      const result = await getPool().query(
+    async listEnabledByInstance(connectorInstanceId, client) {
+      const result = await (client ?? getPool()).query(
         `SELECT ${COLS} FROM ingest_external_sink
           WHERE connector_instance_id = $1 AND enabled = true
           ORDER BY created_at ASC`,
@@ -227,6 +245,41 @@ export function createIngestSinkStore(encryptionKey: Buffer | null): IngestSinkS
           WHERE id = $1`,
         [id, ackCursor === undefined ? null : JSON.stringify(ackCursor)],
       )
+    },
+
+    async ensureManagedLocalChatArchive(params) {
+      const result = await getPool().query(
+        `INSERT INTO ingest_external_sink
+           (connector_instance_id, workspace_id, endpoint_url, auth_kind,
+            secret_ciphertext, mode, enabled, managed_by)
+         VALUES ($1, $2, $3, 'hmac', $4, 'all', true, 'local_chat_archive')
+         ON CONFLICT (connector_instance_id, managed_by)
+           WHERE managed_by IS NOT NULL
+         DO UPDATE SET
+           workspace_id = EXCLUDED.workspace_id,
+           endpoint_url = EXCLUDED.endpoint_url,
+           auth_kind = 'hmac',
+           secret_ciphertext = EXCLUDED.secret_ciphertext,
+           mode = 'all',
+           enabled = true
+         RETURNING ${COLS}`,
+        [
+          params.connectorInstanceId,
+          params.workspaceId,
+          params.endpointUrl,
+          encryptSecret(params.secret),
+        ],
+      )
+      return rowToSink(result.rows[0] as Record<string, unknown>)
+    },
+
+    async disableManagedLocalChatArchive() {
+      const result = await getPool().query(
+        `UPDATE ingest_external_sink
+            SET enabled = false
+          WHERE managed_by = 'local_chat_archive' AND enabled = true`,
+      )
+      return result.rowCount ?? 0
     },
   }
 }

--- a/packages/api/src/db/sessions.ts
+++ b/packages/api/src/db/sessions.ts
@@ -1,3 +1,4 @@
+import type pg from 'pg'
 import { query } from './client.js'
 
 export type Session = {
@@ -752,8 +753,8 @@ export async function addSessionMessage(params: {
   senderAssistantId?: string | null
   /** Outbound file attachments (assistant rows only — `sendFile`, migration 273). */
   attachments?: SessionMessageAttachment[]
-}): Promise<SessionMessage> {
-  const result = await query<SessionMessage>(
+}, client?: Pick<pg.ClientBase, 'query'>): Promise<SessionMessage> {
+  const sql =
     `INSERT INTO session_messages
        (session_id, role, content, sequence_num,
         reply_to_text, topic_label, topic_confidence, channel_message_id, sender_user_id, sender_assistant_id, attachments)
@@ -769,8 +770,8 @@ export async function addSessionMessage(params: {
                channel_message_id as "channelMessageId",
                sender_user_id as "senderUserId",
                sender_assistant_id as "senderAssistantId",
-               attachments`,
-    [
+               attachments`
+  const values = [
       params.sessionId,
       params.role,
       JSON.stringify(params.content),
@@ -781,8 +782,10 @@ export async function addSessionMessage(params: {
       params.senderUserId ?? null,
       params.senderAssistantId ?? null,
       JSON.stringify(params.attachments ?? []),
-    ],
-  )
+    ]
+  const result = client
+    ? await client.query<SessionMessage>(sql, values)
+    : await query<SessionMessage>(sql, values)
 
   return result.rows[0]
 }

--- a/packages/api/src/ingest/__tests__/external-sink-fanout.test.ts
+++ b/packages/api/src/ingest/__tests__/external-sink-fanout.test.ts
@@ -138,12 +138,13 @@ describe('[COMP:brain/ingest-outbox] landIngestEvent — atomic capture (D10)', 
   })
 
   it('commits the brain batch row and the outbox rows in ONE transaction', async () => {
+    const listEnabledByInstance = vi.fn(async () => [makeSink()])
     const enqueue = vi.fn(async (_params: unknown, client: { query: (t: string) => unknown }) => {
       await client.query('INSERT INTO ingest_outbox (test)')
       return { id: 'ob-1' }
     })
     const fanout = createExternalSinkFanout({
-      sinks: { listEnabledByInstance: async () => [makeSink()] },
+      sinks: { listEnabledByInstance },
       outbox: { enqueue: enqueue as never },
     })
 
@@ -169,6 +170,7 @@ describe('[COMP:brain/ingest-outbox] landIngestEvent — atomic capture (D10)', 
     expect(outboxIdx).toBeGreaterThan(batchIdx)
     expect(clientQueries).not.toContain('ROLLBACK')
     // the outbox enqueue rode the SAME transaction client
+    expect(listEnabledByInstance).toHaveBeenCalledWith('ci-1', fakeClient)
     expect(enqueue.mock.calls[0][1]).toBe(fakeClient)
     expect(fakeClient.release).toHaveBeenCalledOnce()
   })

--- a/packages/api/src/ingest/external-sink-fanout.ts
+++ b/packages/api/src/ingest/external-sink-fanout.ts
@@ -103,7 +103,10 @@ export function createExternalSinkFanout(deps: {
     client?: Queryable,
   ): Promise<FanoutResult> => {
     if (event.messages.length === 0) return { enqueued: [] }
-    const sinks = await deps.sinks.listEnabledByInstance(event.connectorInstanceId)
+    // When the producer supplied a transaction client, every database step
+    // must reuse it. Checking sinks out through the pool here can deadlock a
+    // saturated local pool while the caller is already holding this client.
+    const sinks = await deps.sinks.listEnabledByInstance(event.connectorInstanceId, client)
     const receiving = sinks.filter((s) => sinkAcceptsEvent(s.mode, event.decision))
     const enqueued: IngestOutboxRow[] = []
     for (const sink of receiving) {

--- a/packages/api/src/routes/__tests__/connectors.test.ts
+++ b/packages/api/src/routes/__tests__/connectors.test.ts
@@ -242,6 +242,20 @@ describe('[COMP:api/connectors-route] /api/connectors', () => {
     })
   })
 
+  it('GET /wechat/tools exposes only the native archive search tool', async () => {
+    const { app } = makeApp('u1')
+    const res = await request(app).get('/api/connectors/wechat/tools')
+    expect(res.status).toBe(200)
+    expect(res.body.serverName).toBe('WeChat chat archive')
+    expect(res.body.tools).toEqual([
+      expect.objectContaining({
+        name: 'searchChatHistory',
+        classification: 'read',
+        policy: 'allow',
+      }),
+    ])
+  })
+
   it('GET /:provider/tools live-discovers a custom connector\'s tools', async () => {
     // A custom connector (provider = UUID, not in OFFICIAL_CONNECTOR_TOOLS) is
     // discovered live, so the Tools tab matches the settings-tab probe instead

--- a/packages/api/src/routes/__tests__/wechat-auth.test.ts
+++ b/packages/api/src/routes/__tests__/wechat-auth.test.ts
@@ -13,7 +13,25 @@
 import { describe, it, expect, vi } from 'vitest'
 import express from 'express'
 import request from 'supertest'
-import { wechatRoutes } from '../wechat.js'
+import { isBoundWechatOwner, wechatRoutes } from '../wechat.js'
+
+describe('[COMP:api/wechat-inbound] QR-bound owner identity', () => {
+  const credentials = {
+    bot_token: 'token',
+    base_url: 'https://ilink.example',
+    ilink_bot_id: 'bot@im.bot',
+    bound_user_id: 'owner@im.wechat',
+  }
+
+  it('recognizes only the WeChat account that performed the QR binding', () => {
+    expect(isBoundWechatOwner('owner@im.wechat', credentials)).toBe(true)
+    expect(isBoundWechatOwner('another-contact@im.wechat', credentials)).toBe(false)
+  })
+
+  it('fails closed for legacy credentials without a bound user', () => {
+    expect(isBoundWechatOwner('owner@im.wechat', { ...credentials, bound_user_id: undefined })).toBe(false)
+  })
+})
 
 function buildApp(connectorSecret: string) {
   const integrationStore = {

--- a/packages/api/src/routes/channel-pipeline.ts
+++ b/packages/api/src/routes/channel-pipeline.ts
@@ -27,7 +27,7 @@ import {
   EvidenceAccumulator, matchesDisputedFigure, buildDisputeContextNote,
 } from '@use-brian/core'
 import type { FilesApi, OutboundAttachment } from '@use-brian/core'
-import type { OutgoingDocument } from '@use-brian/channels'
+import type { IncomingMessage, OutgoingDocument } from '@use-brian/channels'
 import { parseFollowUps } from '@use-brian/shared'
 import { runProactiveCompaction } from './proactive-compaction.js'
 import { notifyBrainWriteIfMatch } from '../brain-stream/notify.js'
@@ -77,6 +77,7 @@ import {
 import { billingPartyForAssistant } from '../billing-party.js'
 import { promotePastedText, shouldPromotePaste } from '../files/paste-promotion.js'
 import type { ArtifactPromoter } from '../files/artifact-promote.js'
+import { appendOutboundChatArchive, persistInboundChatArchive } from '../chat-archive/live-writer.js'
 
 /**
  * Per-turn memory index cap — see chat.ts for the rationale and
@@ -364,6 +365,14 @@ export type ChannelPipelineParams = {
    * message id; Telegram: message_id.
    */
   incomingChannelMessageId?: string | number | null
+  /**
+   * Parsed provider message for the shared local archive normalizer. Keeping
+   * this at the common pipeline boundary prevents per-adapter
+   * archive writers. Raw provider payloads are discarded by the normalizer.
+   */
+  archiveIncoming?: IncomingMessage
+  /** Exact connector backing this route, when known. */
+  archiveConnectorInstanceId?: string | null
 
   // ── Model ──
   /** The model alias string from the assistant record. */
@@ -756,21 +765,34 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
   }
 
   // ── Persist inbound message (with topic label + reply context) ──
-  const userMessageRow = await addSessionMessage({
-    sessionId: session.id,
-    role: 'user',
-    content: userContentBlocks,
-    replyToText: replyResolved?.text ?? null,
-    topicLabel: classification?.topic_label ?? null,
-    topicConfidence: classification?.confidence ?? null,
-    channelMessageId:
-      incomingChannelMessageId !== undefined && incomingChannelMessageId !== null
-        ? String(incomingChannelMessageId)
-        : null,
-    // Per-message author for collaborative draft sessions. Other
-    // channels and personal sessions pass null/undefined.
-    senderUserId: senderUserId ?? null,
-  })
+  const persistUserMessage = (client?: Parameters<typeof addSessionMessage>[1]) =>
+    addSessionMessage({
+      sessionId: session.id,
+      role: 'user',
+      content: userContentBlocks,
+      replyToText: replyResolved?.text ?? null,
+      topicLabel: classification?.topic_label ?? null,
+      topicConfidence: classification?.confidence ?? null,
+      channelMessageId:
+        incomingChannelMessageId !== undefined && incomingChannelMessageId !== null
+          ? String(incomingChannelMessageId)
+          : null,
+      // Per-message author for collaborative draft sessions. Other
+      // channels and personal sessions pass null/undefined.
+      senderUserId: senderUserId ?? null,
+    }, client)
+  const userMessageRow = params.archiveIncoming
+    ? await persistInboundChatArchive({
+        source: channelType,
+        ownerUserId: ownerId,
+        workspaceId: assistant.workspaceId,
+        connectorInstanceId: params.archiveConnectorInstanceId,
+        assistantId: assistant.id,
+        assistantName: assistant.name,
+        conversationId: channelId,
+        message: params.archiveIncoming,
+      }, persistUserMessage)
+    : await persistUserMessage()
 
   // Surface the persisted user-message row to streaming channels so
   // the client can attach feedback / edit / retry actions to it, and
@@ -1308,6 +1330,22 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
           err instanceof Error ? err.message : String(err),
         )
       }
+    }
+    if (lastFlushedAssistantRowId && params.archiveIncoming) {
+      await appendOutboundChatArchive({
+        source: channelType,
+        ownerUserId: ownerId,
+        workspaceId: assistant.workspaceId,
+        connectorInstanceId: params.archiveConnectorInstanceId,
+        assistantId: assistant.id,
+        assistantName: assistant.name,
+        conversationId: channelId,
+        sessionMessageId: lastFlushedAssistantRowId,
+        providerMessageId: channelMessageId,
+        text,
+        documents,
+        replyToProviderId: params.archiveIncoming.messageId ?? null,
+      })
     }
   }
 

--- a/packages/api/src/routes/connectors.ts
+++ b/packages/api/src/routes/connectors.ts
@@ -82,6 +82,7 @@ import { readMailboxSyncState, type MailboxBackfillScope, type MailboxSyncState 
 import { getGlobalMailboxSyncDeps } from '../mailbox/sync-tool.js'
 import { countEmailArchiveMessages } from '../db/email-archive-store.js'
 import type { MailboxAccountSettings } from '../mailbox/types.js'
+import { CHAT_ARCHIVE_SEARCH_TOOL } from '../chat-archive/tool-catalog.js'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -1226,6 +1227,22 @@ export function connectorRoutes(opts: ConnectorRouteOptions): Router {
     const userId = req.userId
     if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return }
     const provider = req.params.provider
+
+    // Local WeChat archive instances are platform-managed connector rows, not
+    // remote MCP servers. Their whole interactive surface is one owner-bound
+    // native search tool; ingestion, coverage, and enrichment stay internal.
+    if (provider === 'wechat') {
+      res.json({
+        serverName: 'WeChat chat archive',
+        tools: [{
+          name: CHAT_ARCHIVE_SEARCH_TOOL.name,
+          description: CHAT_ARCHIVE_SEARCH_TOOL.description,
+          classification: CHAT_ARCHIVE_SEARCH_TOOL.classification,
+          policy: CHAT_ARCHIVE_SEARCH_TOOL.defaultPolicy,
+        }],
+      })
+      return
+    }
 
     // CLI catalogs are dynamic and instance-specific. The frontend addresses
     // them by connector_instance UUID so multiple local MCP servers do not

--- a/packages/api/src/routes/discord.ts
+++ b/packages/api/src/routes/discord.ts
@@ -291,7 +291,17 @@ export function discordRoutes(options: DiscordRouteOptions): Router {
 
       // 7. Sequentialize per Discord channel.
       await withChatLock(`discord:${incoming.channelId}`, () =>
-        processMessage({ adapter, incoming, assistant, channelUserId, ownerId, isIdentified, routing, ingestChannelMediaRef: options.ingestChannelMediaRef }),
+        processMessage({
+          adapter,
+          incoming,
+          assistant,
+          channelUserId,
+          ownerId,
+          isIdentified,
+          routing,
+          ingestChannelMediaRef: options.ingestChannelMediaRef,
+          archiveConnectorInstanceId: integration.connectorInstanceId,
+        }),
       )
     } catch (err) {
       console.error(`[discord] error processing message for channel ${incoming.channelId}:`, err)
@@ -360,6 +370,7 @@ export function discordRoutes(options: DiscordRouteOptions): Router {
     isIdentified: boolean
     routing: { assistantId: string; modelAlias: string }
     ingestChannelMediaRef?: DiscordRouteOptions['ingestChannelMediaRef']
+    archiveConnectorInstanceId?: string | null
   }): Promise<void> {
     const { adapter, incoming, assistant, channelUserId, ownerId, isIdentified, routing, ingestChannelMediaRef } = params
     const channelId = incoming.channelId
@@ -520,6 +531,8 @@ export function discordRoutes(options: DiscordRouteOptions): Router {
       isGroupChat: incoming.isGroupChat,
       replyToMessageId: incoming.replyToMessageId ?? null,
       incomingChannelMessageId: incoming.messageId ?? null,
+      archiveIncoming: incoming,
+      archiveConnectorInstanceId: params.archiveConnectorInstanceId,
       modelAlias: routing.modelAlias,
       adaptiveResearchEnabled: true,
       abortController,

--- a/packages/api/src/routes/msteams.ts
+++ b/packages/api/src/routes/msteams.ts
@@ -274,7 +274,16 @@ export function msteamsRoutes(options: MsTeamsRouteOptions): Router {
 
       // 10. Sequentialize per Teams conversation.
       await withChatLock(`msteams:${incoming.channelId}`, () =>
-        processMessage({ adapter, incoming, assistant, channelUserId, ownerId, isIdentified, routing }),
+        processMessage({
+          adapter,
+          incoming,
+          assistant,
+          channelUserId,
+          ownerId,
+          isIdentified,
+          routing,
+          archiveConnectorInstanceId: integration.connectorInstanceId,
+        }),
       )
     } catch (err) {
       console.error(`[msteams] error processing message for channel ${channelId}:`, err)
@@ -289,6 +298,7 @@ export function msteamsRoutes(options: MsTeamsRouteOptions): Router {
     ownerId: string
     isIdentified: boolean
     routing: { assistantId: string; modelAlias: string }
+    archiveConnectorInstanceId?: string | null
   }): Promise<void> {
     const { adapter, incoming, assistant, channelUserId, ownerId, isIdentified, routing } = params
     const channelId = incoming.channelId
@@ -382,6 +392,8 @@ export function msteamsRoutes(options: MsTeamsRouteOptions): Router {
       isGroupChat: incoming.isGroupChat,
       replyToMessageId: incoming.replyToMessageId ?? null,
       incomingChannelMessageId: incoming.messageId ?? null,
+      archiveIncoming: incoming,
+      archiveConnectorInstanceId: params.archiveConnectorInstanceId,
       modelAlias: routing.modelAlias,
       adaptiveResearchEnabled: true,
       abortController,

--- a/packages/api/src/routes/slack.ts
+++ b/packages/api/src/routes/slack.ts
@@ -638,6 +638,7 @@ export function slackRoutes(options: SlackRouteOptions): Router {
           channelUserId,
           ownerId,
           isIdentified,
+          archiveConnectorInstanceId: integration.connectorInstanceId,
           threadTs,
           botToken: slackCreds.bot_token,
           ...options,
@@ -985,6 +986,7 @@ type ProcessMessageParams = {
   channelUserId: string
   ownerId: string
   isIdentified: boolean
+  archiveConnectorInstanceId?: string | null
   threadTs?: string
   botToken: string
   ingestChannelMediaRef?: SlackRouteOptions['ingestChannelMediaRef']
@@ -1211,6 +1213,8 @@ async function processMessage(params: ProcessMessageParams): Promise<void> {
     isGroupChat: incoming.isGroupChat,
     replyToMessageId: incoming.replyToMessageId ?? null,
     incomingChannelMessageId: incoming.messageId ?? null,
+    archiveIncoming: incoming,
+    archiveConnectorInstanceId: params.archiveConnectorInstanceId,
     modelAlias: assistant.slackModelAlias,
     adaptiveResearchEnabled: true,
     abortController,

--- a/packages/api/src/routes/telegram-byo.ts
+++ b/packages/api/src/routes/telegram-byo.ts
@@ -954,6 +954,7 @@ export function telegramByoRoutes(options: TelegramByoRouteOptions): Router {
           channelUserId,
           ownerId: routedOwnerId,
           isIdentified,
+          archiveConnectorInstanceId: boundIntegration.connectorInstanceId,
           ...options,
           pendingConfResolvers,
         }),
@@ -1049,6 +1050,7 @@ type ProcessMessageParams = {
   channelUserId: string
   ownerId: string
   isIdentified: boolean
+  archiveConnectorInstanceId?: string | null
   provider: LLMProvider
   systemPrompt: string
   tools: Map<string, Tool>
@@ -1414,6 +1416,8 @@ async function processMessage(params: ProcessMessageParams): Promise<void> {
     replyToMessageId: incoming.replyToMessageId ?? null,
     replyRaw: incoming.raw,
     incomingChannelMessageId: incoming.messageId ?? null,
+    archiveIncoming: incoming,
+    archiveConnectorInstanceId: params.archiveConnectorInstanceId,
     modelAlias: assistant.telegramModelAlias,
     adaptiveResearchEnabled: true,
     abortController: new AbortController(),

--- a/packages/api/src/routes/wechat.ts
+++ b/packages/api/src/routes/wechat.ts
@@ -13,10 +13,12 @@
  *
  * `channelId` is the workspace `channels` row id (which bot); the DM peer is
  * `message.channelId` (== the sender's `ilink_user_id` — DMs only, W2). The
- * answering assistant resolves via `channel_assistants`, the sender maps to a
- * tier-2 shadow user (iLink exposes no email), and the turn runs through the
- * shared `processChannelMessage` pipeline. Outbound replies go API → iLink
- * REST directly (the adapter), never back through the connector (W3).
+ * answering assistant resolves via `channel_assistants`. The WeChat account
+ * that performed the QR binding maps to the assistant owner (the binding is
+ * the identity proof); every other sender maps to a tier-2 shadow user because
+ * iLink exposes no email. The turn then runs through the shared
+ * `processChannelMessage` pipeline. Outbound replies go API → iLink REST
+ * directly (the adapter), never back through the connector (W3).
  *
  * WeChat has no message edits and no buttons: tool confirmations are
  * text-only (yes / no / always / never), and instead of an edit-in-place
@@ -96,6 +98,11 @@ const MAX_MEDIA_BYTES = 25 * 1024 * 1024
 
 // Refresh the native typing indicator at most this often while a turn runs.
 const TYPING_REFRESH_MS = 5_000
+
+/** QR binding is the only reliable identity proof iLink supplies. */
+export function isBoundWechatOwner(senderId: string, credentials: WechatCredentials): boolean {
+  return Boolean(credentials.bound_user_id && credentials.bound_user_id === senderId)
+}
 
 const inboundSchema = z.object({
   channelId: z.string().min(1),
@@ -257,12 +264,11 @@ export function wechatRoutes(options: WechatRouteOptions): Router {
         workspaceId: assistant.workspaceId ?? null,
       })
 
-      // 4. Resolve the WeChat sender → a platform user (tier-2 shadow user:
-      //    iLink exposes no email or display name, so identity stays
-      //    anonymous — session only, no memory consolidation).
+      // 4. Resolve the WeChat sender → a platform user. The QR-bound account
+      //    is the owner identity; all other contacts stay tier-2 shadows.
       let channelUserId = ownerId
       let isIdentified = true
-      if (options.channelUserStore && incoming.userId) {
+      if (!isBoundWechatOwner(incoming.userId, creds) && options.channelUserStore && incoming.userId) {
         try {
           const resolved = await resolveChannelUser(
             options.channelUserStore,
@@ -304,7 +310,19 @@ export function wechatRoutes(options: WechatRouteOptions): Router {
 
       // 7. Sequentialize per DM peer.
       await withChatLock(`wechat:${channelId}:${peerId}`, () =>
-        processMessage({ adapter, incoming, assistant, channelUserId, ownerId, isIdentified, routing, channelId, creds, confirmKey }),
+        processMessage({
+          adapter,
+          incoming,
+          assistant,
+          channelUserId,
+          ownerId,
+          isIdentified,
+          routing,
+          channelId,
+          creds,
+          confirmKey,
+          archiveConnectorInstanceId: integration.connectorInstanceId,
+        }),
       )
     } catch (err) {
       console.error(`[wechat] error processing message for channel ${channelId}:`, err)
@@ -322,6 +340,7 @@ export function wechatRoutes(options: WechatRouteOptions): Router {
     channelId: string
     creds: WechatCredentials
     confirmKey: string
+    archiveConnectorInstanceId?: string | null
   }): Promise<void> {
     const { adapter, incoming, assistant, channelUserId, ownerId, isIdentified, routing, channelId, creds, confirmKey } = params
     const peerId = incoming.channelId
@@ -422,6 +441,8 @@ export function wechatRoutes(options: WechatRouteOptions): Router {
       isGroupChat: false,
       replyToMessageId: incoming.replyToMessageId ?? null,
       incomingChannelMessageId: incoming.messageId ?? null,
+      archiveIncoming: incoming,
+      archiveConnectorInstanceId: params.archiveConnectorInstanceId,
       modelAlias: routing.modelAlias,
       adaptiveResearchEnabled: true,
       abortController,

--- a/packages/api/src/support-diagnostics/bundle.ts
+++ b/packages/api/src/support-diagnostics/bundle.ts
@@ -177,6 +177,12 @@ export class SupportCapsuleBuilder {
       messages: string
       analytics: string
       failedWorkflows: string
+      archiveMessages: string
+      archiveUnembedded: string
+      archiveOutboxPending: string
+      archiveOutboxDead: string
+      archiveEnrichmentFailed: string
+      archiveBackfillsFailed: string
     }>(
       `SELECT
          (SELECT count(*)::text FROM sessions s
@@ -189,7 +195,25 @@ export class SupportCapsuleBuilder {
          (SELECT count(*)::text FROM analytics_events e
           WHERE e.user_id = $2 AND e.created_at BETWEEN $3 AND $4) AS analytics,
          (SELECT count(*)::text FROM workflow_runs
-          WHERE workspace_id = $1 AND status IN ('failed', 'timeout')) AS "failedWorkflows"`,
+          WHERE workspace_id = $1 AND status IN ('failed', 'timeout')) AS "failedWorkflows",
+         (SELECT count(*)::text FROM chat_archive_messages
+          WHERE workspace_id = $1) AS "archiveMessages",
+         (SELECT count(*)::text FROM chat_archive_segments
+          WHERE workspace_id = $1 AND embedding IS NULL) AS "archiveUnembedded",
+         (SELECT count(*)::text FROM ingest_outbox o
+          JOIN ingest_external_sink s ON s.id = o.sink_id
+          WHERE o.workspace_id = $1
+            AND s.managed_by = 'local_chat_archive'
+            AND o.status IN ('pending', 'processing')) AS "archiveOutboxPending",
+         (SELECT count(*)::text FROM ingest_outbox o
+          JOIN ingest_external_sink s ON s.id = o.sink_id
+          WHERE o.workspace_id = $1
+            AND s.managed_by = 'local_chat_archive'
+            AND o.status = 'dead') AS "archiveOutboxDead",
+         (SELECT count(*)::text FROM chat_archive_enrichment_windows
+          WHERE workspace_id = $1 AND status IN ('failed', 'dead')) AS "archiveEnrichmentFailed",
+         (SELECT count(*)::text FROM chat_archive_backfill_runs
+          WHERE workspace_id = $1 AND status = 'failed') AS "archiveBackfillsFailed"`,
       [capture.workspaceId, capture.userId, capture.startedAt, capture.expiresAt],
     )
 
@@ -256,6 +280,9 @@ export class SupportCapsuleBuilder {
           dashscope: Boolean(process.env.DASHSCOPE_API_KEY),
           localFiles: Boolean(process.env.LOCAL_FILES_DIR),
           browserRelay: Boolean(process.env.BROWSER_RELAY_URL),
+          localMessageStore: Boolean(
+            process.env.BRIAN_MESSAGE_STORE_URL && process.env.BRIAN_MESSAGE_STORE_HMAC_SECRET,
+          ),
         },
       },
       database: {
@@ -265,6 +292,12 @@ export class SupportCapsuleBuilder {
           messages: Number.parseInt(healthResult.rows[0]?.messages ?? '0', 10),
           analytics: Number.parseInt(healthResult.rows[0]?.analytics ?? '0', 10),
           failedWorkflows: Number.parseInt(healthResult.rows[0]?.failedWorkflows ?? '0', 10),
+          archiveMessages: Number.parseInt(healthResult.rows[0]?.archiveMessages ?? '0', 10),
+          archiveUnembedded: Number.parseInt(healthResult.rows[0]?.archiveUnembedded ?? '0', 10),
+          archiveOutboxPending: Number.parseInt(healthResult.rows[0]?.archiveOutboxPending ?? '0', 10),
+          archiveOutboxDead: Number.parseInt(healthResult.rows[0]?.archiveOutboxDead ?? '0', 10),
+          archiveEnrichmentFailed: Number.parseInt(healthResult.rows[0]?.archiveEnrichmentFailed ?? '0', 10),
+          archiveBackfillsFailed: Number.parseInt(healthResult.rows[0]?.archiveBackfillsFailed ?? '0', 10),
         },
       },
       captureEvents: events.map((event) => ({

--- a/packages/channels/src/__tests__/wechat.test.ts
+++ b/packages/channels/src/__tests__/wechat.test.ts
@@ -9,6 +9,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createCipheriv } from 'node:crypto'
 import {
   createWechatAdapter,
+  createIlinkClient,
+  fetchBotQrcode,
+  ILINK_CHANNEL_VERSION,
   markdownToWechat,
   parseIlinkAesKey,
   decryptAesEcb,
@@ -37,6 +40,49 @@ function userMessage(overrides: Partial<WeixinMessage> = {}): WeixinMessage {
 }
 
 describe('[COMP:channels/wechat-adapter] WeChat adapter', () => {
+  describe('iLink client identity', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('advertises the current Tencent wire version during QR pairing', async () => {
+      const fetchMock = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+        const headers = new Headers(init?.headers)
+        expect(headers.get('iLink-App-Id')).toBe('bot')
+        expect(headers.get('iLink-App-ClientVersion')).toBe('132102')
+        const body = JSON.parse(String(init?.body ?? '{}')) as {
+          base_info?: { channel_version?: string; bot_agent?: string }
+        }
+        expect(body.base_info).toEqual({
+          channel_version: '2.4.6',
+          bot_agent: 'UseBrian/2.4.6',
+        })
+        return new Response(
+          JSON.stringify({ qrcode: 'qr-1', qrcode_img_content: 'https://qr.example/1' }),
+          { status: 200 },
+        )
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      expect(ILINK_CHANNEL_VERSION).toBe('2.4.6')
+      await expect(fetchBotQrcode()).resolves.toEqual({
+        qrcode: 'qr-1',
+        qrcode_img_content: 'https://qr.example/1',
+      })
+    })
+
+    it('returns notifystart reconciliation failures to the poller', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () =>
+          new Response(JSON.stringify({ ret: -1, errmsg: 'not online' }), { status: 200 }),
+        ),
+      )
+      const client = createIlinkClient({ baseUrl: 'https://ilink.example', token: 'tok' })
+      await expect(client.notifyStart()).resolves.toEqual({ ret: -1, errmsg: 'not online' })
+    })
+  })
+
   describe('parseIncoming', () => {
     const adapter = createWechatAdapter({ baseUrl: 'https://ilink.example', botToken: 'tok' })
 

--- a/packages/channels/src/wechat/ilink.ts
+++ b/packages/channels/src/wechat/ilink.ts
@@ -140,8 +140,15 @@ function encodeClientVersion(version: string): number {
   return ((major & 0xff) << 16) | ((minor & 0xff) << 8) | (patch & 0xff)
 }
 
-const CLIENT_VERSION = '1.0.0'
-const BOT_AGENT = `UseBrian/${CLIENT_VERSION}`
+/**
+ * iLink wire/client version. Keep this aligned with the current Tencent
+ * `@tencent-weixin/openclaw-weixin` protocol release: the value is sent both
+ * as the encoded `iLink-App-ClientVersion` header and as
+ * `base_info.channel_version`. A stale value can fetch a QR but fail the
+ * post-scan client claim, which WeChat surfaces as unable to connect.
+ */
+export const ILINK_CHANNEL_VERSION = '2.4.6'
+const BOT_AGENT = `UseBrian/${ILINK_CHANNEL_VERSION}`
 
 /** X-WECHAT-UIN: random uint32 → decimal string → base64. */
 function randomWechatUin(): string {
@@ -153,7 +160,7 @@ function buildHeaders(token?: string): Record<string, string> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     'iLink-App-Id': 'bot',
-    'iLink-App-ClientVersion': String(encodeClientVersion(CLIENT_VERSION)),
+    'iLink-App-ClientVersion': String(encodeClientVersion(ILINK_CHANNEL_VERSION)),
     AuthorizationType: 'ilink_bot_token',
     'X-WECHAT-UIN': randomWechatUin(),
   }
@@ -181,7 +188,10 @@ async function postJson<T>(params: {
     const res = await fetch(joinUrl(params.baseUrl, params.endpoint), {
       method: 'POST',
       headers: buildHeaders(params.token),
-      body: JSON.stringify({ ...(params.body as object), base_info: { channel_version: CLIENT_VERSION, bot_agent: BOT_AGENT } }),
+      body: JSON.stringify({
+        ...(params.body as object),
+        base_info: { channel_version: ILINK_CHANNEL_VERSION, bot_agent: BOT_AGENT },
+      }),
       signal: controller.signal,
     })
     const text = await res.text()
@@ -232,7 +242,7 @@ export async function pollQrcodeStatus(params: {
       method: 'GET',
       headers: {
         'iLink-App-Id': 'bot',
-        'iLink-App-ClientVersion': String(encodeClientVersion(CLIENT_VERSION)),
+        'iLink-App-ClientVersion': String(encodeClientVersion(ILINK_CHANNEL_VERSION)),
       },
       signal: controller.signal,
     })
@@ -270,8 +280,8 @@ export type IlinkClient = {
   /** Typing indicator. `status` 1 = typing, 2 = cancel. */
   sendTyping(params: { ilinkUserId: string; typingTicket: string; status: 1 | 2 }): Promise<void>
   /** Presence handshake around the long-poll loop lifecycle. Best-effort. */
-  notifyStart(): Promise<void>
-  notifyStop(): Promise<void>
+  notifyStart(): Promise<{ ret?: number; errmsg?: string }>
+  notifyStop(): Promise<{ ret?: number; errmsg?: string }>
 }
 
 export function createIlinkClient(options: { baseUrl: string; token: string }): IlinkClient {
@@ -330,11 +340,11 @@ export function createIlinkClient(options: { baseUrl: string; token: string }): 
     },
 
     async notifyStart() {
-      await postJson({ baseUrl, endpoint: 'ilink/bot/msg/notifystart', body: {}, token, timeoutMs: CONFIG_TIMEOUT_MS })
+      return postJson({ baseUrl, endpoint: 'ilink/bot/msg/notifystart', body: {}, token, timeoutMs: CONFIG_TIMEOUT_MS })
     },
 
     async notifyStop() {
-      await postJson({ baseUrl, endpoint: 'ilink/bot/msg/notifystop', body: {}, token, timeoutMs: CONFIG_TIMEOUT_MS })
+      return postJson({ baseUrl, endpoint: 'ilink/bot/msg/notifystop', body: {}, token, timeoutMs: CONFIG_TIMEOUT_MS })
     },
   }
 }

--- a/packages/channels/src/wechat/index.ts
+++ b/packages/channels/src/wechat/index.ts
@@ -6,6 +6,7 @@ export {
   pollQrcodeStatus,
   ILINK_DEFAULT_BASE_URL,
   ILINK_CDN_BASE_URL,
+  ILINK_CHANNEL_VERSION,
   ILINK_STALE_TOKEN_ERRCODE,
   WeixinMessageType,
   WeixinItemType,

--- a/packages/core/src/embeddings/adapters.ts
+++ b/packages/core/src/embeddings/adapters.ts
@@ -39,6 +39,7 @@ export const VERTEX_EMBEDDING_MODEL_ID = GEMINI_EMBEDDING_MODEL_ID
 /** DashScope's multilingual embedding model; v3 supports an explicit `dimensions`. */
 const DASHSCOPE_EMBEDDING_MODEL = 'text-embedding-v3'
 export const DASHSCOPE_EMBEDDING_MODEL_ID = 'dashscope:text-embedding-v3'
+const DASHSCOPE_EMBEDDING_BATCH_MAX = 10
 
 const COST_PER_M_TOKENS_USD = 0.025
 
@@ -163,46 +164,53 @@ export function createDashScopeEmbedder(
     async embed(texts: string[]): Promise<number[][]> {
       if (texts.length === 0) return []
 
-      const response = await fetch(`${baseUrl}/embeddings`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
-        },
-        body: JSON.stringify({
-          model: DASHSCOPE_EMBEDDING_MODEL,
-          input: texts,
-          // Explicit, never defaulted — see the dimensions invariant above.
-          dimensions: GEMINI_EMBEDDING_DIMENSIONS,
-          encoding_format: 'float',
-        }),
-        signal: opts.signal,
-      })
+      const vectors: number[][] = []
+      for (let offset = 0; offset < texts.length; offset += DASHSCOPE_EMBEDDING_BATCH_MAX) {
+        const chunk = texts.slice(offset, offset + DASHSCOPE_EMBEDDING_BATCH_MAX)
+        const response = await fetch(`${baseUrl}/embeddings`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: JSON.stringify({
+            model: DASHSCOPE_EMBEDDING_MODEL,
+            input: chunk,
+            // Explicit, never defaulted — see the dimensions invariant above.
+            dimensions: GEMINI_EMBEDDING_DIMENSIONS,
+            encoding_format: 'float',
+          }),
+          signal: opts.signal,
+        })
 
-      if (!response.ok) {
-        const errBody = await response.text()
-        throw new Error(`DashScope embedding API error ${response.status}: ${errBody}`)
-      }
+        if (!response.ok) {
+          const errBody = await response.text()
+          throw new Error(`DashScope embedding API error ${response.status}: ${errBody}`)
+        }
 
-      const json = (await response.json()) as DashScopeEmbedResponse
-      const data = json.data ?? []
-      if (data.length !== texts.length) {
-        throw new Error(
-          `DashScope embedding API returned ${data.length} vectors for ${texts.length} inputs`,
-        )
-      }
-
-      const ordered = [...data].sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
-      return ordered.map((d, i) => {
-        if (!d.embedding) throw new Error(`DashScope embedding API returned no vector for input ${i}`)
-        if (d.embedding.length !== GEMINI_EMBEDDING_DIMENSIONS) {
+        const json = (await response.json()) as DashScopeEmbedResponse
+        const data = json.data ?? []
+        if (data.length !== chunk.length) {
           throw new Error(
-            `DashScope returned ${d.embedding.length}-dim vector, expected ${GEMINI_EMBEDDING_DIMENSIONS}. ` +
-            `The stored vector column is fixed-width — refusing to write a mismatched vector.`,
+            `DashScope embedding API returned ${data.length} vectors for ${chunk.length} inputs`,
           )
         }
-        return d.embedding
-      })
+
+        const ordered = [...data].sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
+        vectors.push(...ordered.map((d, i) => {
+          if (!d.embedding) {
+            throw new Error(`DashScope embedding API returned no vector for input ${offset + i}`)
+          }
+          if (d.embedding.length !== GEMINI_EMBEDDING_DIMENSIONS) {
+            throw new Error(
+              `DashScope returned ${d.embedding.length}-dim vector, expected ${GEMINI_EMBEDDING_DIMENSIONS}. ` +
+              `The stored vector column is fixed-width — refusing to write a mismatched vector.`,
+            )
+          }
+          return d.embedding
+        }))
+      }
+      return vectors
     },
   }
 }

--- a/packages/core/src/embeddings/worker.ts
+++ b/packages/core/src/embeddings/worker.ts
@@ -96,6 +96,10 @@ export const EMBEDDED_PRIMITIVES = [
   // full-mailbox corpus — subject-prefixed embed text via the
   // PRIMITIVE_CONFIGS entry. See docs/architecture/integrations/mailbox-imap.md.
   'email_segment',
+  // Provider-neutral WhatsApp / WeChat archive segments. The local sidecar
+  // appends these rows; the platform's shared worker owns their embeddings.
+  // See docs/architecture/integrations/chat-message-store.md.
+  'chat_segment',
 ] as const
 
 export type EmbeddingPrimitive = typeof EMBEDDED_PRIMITIVES[number]

--- a/packages/core/src/providers/__tests__/adapters.test.ts
+++ b/packages/core/src/providers/__tests__/adapters.test.ts
@@ -324,6 +324,26 @@ describe('[COMP:embeddings/adapters] Per-adapter embedders', () => {
     const e = createDashScopeEmbedder('k', 'https://ds.test/v1')
     await expect(withFetch(fetchFn, () => e.embed(['hi']))).rejects.toThrow(/768|fixed-width/)
   })
+
+  it('DashScope splits large jobs into API-sized batches and preserves input order', async () => {
+    const fetchFn = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const input = (JSON.parse(String(init?.body)) as { input: string[] }).input
+      const data = input.map((value, index) => ({
+        index,
+        embedding: new Array(768).fill(Number(value.slice(1))),
+      })).reverse()
+      return new Response(JSON.stringify({ data }), { status: 200 })
+    })
+    const e = createDashScopeEmbedder('k', 'https://ds.test/v1')
+    const out = await withFetch(fetchFn as unknown as typeof fetch, () =>
+      e.embed(Array.from({ length: 11 }, (_, i) => `v${i}`)),
+    )
+
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    expect((JSON.parse(String(fetchFn.mock.calls[0]?.[1]?.body)) as { input: string[] }).input).toHaveLength(10)
+    expect((JSON.parse(String(fetchFn.mock.calls[1]?.[1]?.body)) as { input: string[] }).input).toHaveLength(1)
+    expect(out.map((vector) => vector[0])).toEqual(Array.from({ length: 11 }, (_, i) => i))
+  })
 })
 
 describe('[COMP:engine/tool-pairing] Signature strip is provider-gated', () => {

--- a/scripts/__tests__/message-store-launch.test.mjs
+++ b/scripts/__tests__/message-store-launch.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { resolveMessageStoreLaunch } from '../message-store-launch.mjs'
+
+const root = '/repo/sidanclaw-platform/use-brian'
+
+test('[COMP:platform/local-message-store-lifecycle] discovers the sibling Go checkout', () => {
+  const result = resolveMessageStoreLaunch({
+    root,
+    env: {},
+    exists: (path) => path === '/repo/brian-message-store/go.mod',
+  })
+  assert.deepEqual(result, {
+    enabled: true,
+    cmd: 'go',
+    args: ['run', './cmd/brian-message-store'],
+    cwd: '/repo/brian-message-store',
+    source: 'source',
+  })
+})
+
+test('[COMP:platform/local-message-store-lifecycle] prefers an explicit binary', () => {
+  const result = resolveMessageStoreLaunch({
+    root,
+    env: { BRIAN_MESSAGE_STORE_BIN: '/opt/usebrian/message-store' },
+    exists: (path) => path === '/opt/usebrian/message-store',
+  })
+  assert.equal(result.enabled, true)
+  assert.equal(result.cmd, '/opt/usebrian/message-store')
+  assert.equal(result.source, 'binary')
+})
+
+test('[COMP:platform/local-message-store-lifecycle] can be explicitly disabled', () => {
+  assert.deepEqual(
+    resolveMessageStoreLaunch({ root, env: { BRIAN_MESSAGE_STORE_ENABLED: '0' } }),
+    { enabled: false, reason: 'disabled' },
+  )
+})
+
+test('[COMP:platform/local-message-store-lifecycle] explicit enable fails when missing', () => {
+  assert.throws(
+    () => resolveMessageStoreLaunch({
+      root,
+      env: { BRIAN_MESSAGE_STORE_ENABLED: '1' },
+      exists: () => false,
+    }),
+    /no binary or Go checkout was found/,
+  )
+})

--- a/scripts/launch.mjs
+++ b/scripts/launch.mjs
@@ -12,8 +12,9 @@
  *   3. start the embedded PGLite brain server (pg-wire socket on :54329) and wait
  *      until it accepts connections - it migrates open-schema-v1 on first boot.
  *   4. start the api (:4000), doc-sync sidecar (:8080), app-web (:3003), local
- *      Discord Gateway connector (:8090), and local WhatsApp connector (:8091),
- *      all pointed at the local API; single-process event buses.
+ *      Discord Gateway connector (:8090), local WhatsApp connector (:8091),
+ *      local chat archive (:8092), and local WeChat connector (:8093), all
+ *      pointed at the local API; single-process event buses.
  *   5. open the browser straight into an authenticated session as the local
  *      owner (/auth/local-session auto-provisions one Personal workspace — no
  *      /login, no /teams, no "dev" identity).
@@ -30,6 +31,7 @@ import { fileURLToPath } from 'node:url'
 import { randomBytes } from 'node:crypto'
 import { createRequire } from 'node:module'
 import { createInterface } from 'node:readline/promises'
+import { resolveMessageStoreLaunch } from './message-store-launch.mjs'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const CONFIG_DIR = join(homedir(), '.usebrian')
@@ -82,7 +84,7 @@ loadDotEnv(join(ROOT, '.env'))
 
 // The embedded brain uses a distinctive high port so it never collides with a
 // developer's local Postgres on the default 5432 (verified failure mode).
-const PORTS = { pglite: 54329, api: 4000, docSync: 8080, appWeb: 3003, discordConnector: 8090, waConnector: 8091 }
+const PORTS = { pglite: 54329, api: 4000, docSync: 8080, appWeb: 3003, discordConnector: 8090, waConnector: 8091, messageStore: 8092, wechatConnector: 8093 }
 
 // ── config (ChatGPT sign-in OR one API credential) ──────────────────
 mkdirSync(CONFIG_DIR, { recursive: true })
@@ -153,6 +155,13 @@ const discordConnectorSecret = process.env.DISCORD_CONNECTOR_SECRET || config.di
 // processes and persists the generated value; explicit env values support an
 // externally deployed connector.
 const waConnectorSecret = process.env.WA_CONNECTOR_SECRET || config.waConnectorSecret || randomBytes(32).toString('hex')
+// Shared API <-> WeChat iLink bridge secret. Pairing and long-polling require
+// the bridge even for local-only use, so the launcher owns and persists it.
+const wechatConnectorSecret = process.env.WECHAT_CONNECTOR_SECRET || config.wechatConnectorSecret || randomBytes(32).toString('hex')
+// Loopback API -> chat archive append authentication. The launcher owns both
+// processes, so this follows the same generate-once/persist lifecycle as the
+// other local bridge secrets and is never printed.
+const messageStoreHmacSecret = process.env.BRIAN_MESSAGE_STORE_HMAC_SECRET || config.messageStoreHmacSecret || randomBytes(32).toString('hex')
 // AES-GCM key that encrypts connector OAuth refresh-tokens / PATs at rest in
 // `connector_instance.credentials`. Without it the api boots with a null
 // credential key and `/api/connectors/:provider/store-credentials` returns 503,
@@ -162,7 +171,7 @@ const waConnectorSecret = process.env.WA_CONNECTOR_SECRET || config.waConnectorS
 const channelCredentialKey = config.channelCredentialKey || randomBytes(32).toString('base64')
 writeFileSync(
   CONFIG_FILE,
-  JSON.stringify({ ...config, ...(geminiKey ? { geminiApiKey: geminiKey } : {}), ...(preferredProvider ? { preferredProvider } : {}), jwtSecret, docSyncSecret, discordConnectorSecret, waConnectorSecret, channelCredentialKey, ownerName }, null, 2),
+  JSON.stringify({ ...config, ...(geminiKey ? { geminiApiKey: geminiKey } : {}), ...(preferredProvider ? { preferredProvider } : {}), jwtSecret, docSyncSecret, discordConnectorSecret, waConnectorSecret, wechatConnectorSecret, messageStoreHmacSecret, channelCredentialKey, ownerName }, null, 2),
 )
 
 // External-store escape hatch: a real Postgres URL skips the embedded brain.
@@ -170,6 +179,8 @@ const useEmbedded = !process.env.DATABASE_URL
 const databaseUrl = process.env.DATABASE_URL || `postgres://localhost:${PORTS.pglite}/postgres`
 const useLocalDiscordConnector = !process.env.DISCORD_CONNECTOR_URL
 const useLocalWaConnector = !process.env.WA_CONNECTOR_URL
+const useLocalWechatConnector = !process.env.WECHAT_CONNECTOR_URL
+const messageStoreLaunch = resolveMessageStoreLaunch({ root: ROOT, env: process.env })
 
 const env = {
   ...process.env,
@@ -194,6 +205,15 @@ const env = {
   DISCORD_CONNECTOR_SECRET: discordConnectorSecret,
   WA_CONNECTOR_URL: process.env.WA_CONNECTOR_URL || `http://127.0.0.1:${PORTS.waConnector}`,
   WA_CONNECTOR_SECRET: waConnectorSecret,
+  WECHAT_CONNECTOR_URL: process.env.WECHAT_CONNECTOR_URL || `http://127.0.0.1:${PORTS.wechatConnector}`,
+  WECHAT_CONNECTOR_SECRET: wechatConnectorSecret,
+  ...(messageStoreLaunch.enabled
+    ? {
+        BRIAN_MESSAGE_STORE_URL: `http://127.0.0.1:${PORTS.messageStore}`,
+        BRIAN_MESSAGE_STORE_HMAC_SECRET: messageStoreHmacSecret,
+        BRIAN_MESSAGE_STORE_ADDR: `127.0.0.1:${PORTS.messageStore}`,
+      }
+    : {}),
   API_INTERNAL_URL: `http://127.0.0.1:${PORTS.api}`,
   // The embedded brain is one PGLite instance with a single shared session;
   // concurrent pool connections clobber its unnamed prepared statement. Force
@@ -223,13 +243,19 @@ const children = []
 // OOMs alone, run()'s exit handler names it, and the launcher shuts down
 // cleanly. The platform repo already caps its API dev process the same way.
 // Sized generously above observed steady-state; override with USEBRIAN_HEAP_MB.
-const HEAP_MB = { pglite: 1024, api: 2048, 'doc-sync': 1024, 'app-web': 2048, 'discord-connector': 512, 'wa-connector': 512 }
-function run(label, cmd, args, extraEnv = {}) {
+const HEAP_MB = { pglite: 1024, api: 2048, 'doc-sync': 1024, 'app-web': 2048, 'discord-connector': 512, 'wa-connector': 512, 'wechat-connector': 512 }
+function run(label, cmd, args, extraEnv = {}, cwd = ROOT) {
   const heapMb = Number(process.env.USEBRIAN_HEAP_MB) || HEAP_MB[label]
   const nodeOptions = heapMb
     ? { NODE_OPTIONS: `${env.NODE_OPTIONS ?? ''} --max-old-space-size=${heapMb}`.trim() }
     : {}
-  const child = spawn(cmd, args, { cwd: ROOT, env: { ...env, ...nodeOptions, ...extraEnv }, stdio: ['ignore', 'inherit', 'inherit'] })
+  const child = spawn(cmd, args, { cwd, env: { ...env, ...nodeOptions, ...extraEnv }, stdio: ['ignore', 'inherit', 'inherit'] })
+  child.on('error', (err) => {
+    if (!shuttingDown) {
+      console.error(`[launch] could not start ${label}: ${err.message}`)
+      shutdown(1)
+    }
+  })
   child.on('exit', (code) => {
     if (!shuttingDown && code) { console.error(`[launch] ${label} exited with code ${code}; shutting down.`); shutdown(1) }
   })
@@ -374,6 +400,20 @@ if (useEmbedded) {
   console.log('[launch] DATABASE_URL set — using external Postgres (run migrations separately).')
 }
 
+if (messageStoreLaunch.enabled) {
+  console.log(`[launch] starting local chat message store (:${PORTS.messageStore}, ${messageStoreLaunch.source}) ...`)
+  run(
+    'message-store',
+    messageStoreLaunch.cmd,
+    messageStoreLaunch.args,
+    {},
+    messageStoreLaunch.cwd,
+  )
+  await waitForPort(PORTS.messageStore, 'chat message store')
+} else if (messageStoreLaunch.reason === 'not_found') {
+  console.log('[launch] chat message store checkout not found — local chat archive is disabled for this session.')
+}
+
 console.log('[launch] starting api (:4000), doc-sync (:8080), app-web (:3003) ...')
 run('api', 'pnpm', ['--filter', '@use-brian/api-open', 'exec', 'tsx', 'src/index.ts'])
 run('doc-sync', 'pnpm', ['--filter', '@use-brian/doc-sync', 'exec', 'tsx', 'src/index.ts'],
@@ -413,10 +453,20 @@ if (useLocalWaConnector) {
   })
   await waitForPort(PORTS.waConnector, 'WhatsApp connector')
 }
+if (useLocalWechatConnector) {
+  console.log(`[launch] starting WeChat connector (:${PORTS.wechatConnector}) ...`)
+  run('wechat-connector', 'pnpm', ['--filter', '@use-brian/wechat-connector', 'exec', 'tsx', 'src/index.ts'], {
+    PORT: String(PORTS.wechatConnector),
+    USEBRIAN_API_URL: `http://127.0.0.1:${PORTS.api}`,
+  })
+  await waitForPort(PORTS.wechatConnector, 'WeChat connector')
+}
 const entryUrl = `http://localhost:${PORTS.appWeb}/api/auth/local-session`
 const discordStatus = useLocalDiscordConnector ? ` · discord :${PORTS.discordConnector}` : ' · discord external'
 const waStatus = useLocalWaConnector ? ` · whatsapp :${PORTS.waConnector}` : ' · whatsapp external'
-console.log(`\n[launch] Use Brian is up. Opening ${entryUrl}\n  (api :${PORTS.api} · doc-sync :${PORTS.docSync} · app-web :${PORTS.appWeb}${discordStatus}${waStatus})\n  Ctrl-C to stop everything.\n`)
+const messageStoreStatus = messageStoreLaunch.enabled ? ` · chat-archive :${PORTS.messageStore}` : ' · chat-archive off'
+const wechatStatus = useLocalWechatConnector ? ` · wechat :${PORTS.wechatConnector}` : ' · wechat external'
+console.log(`\n[launch] Use Brian is up. Opening ${entryUrl}\n  (api :${PORTS.api} · doc-sync :${PORTS.docSync} · app-web :${PORTS.appWeb}${discordStatus}${waStatus}${messageStoreStatus}${wechatStatus})\n  Ctrl-C to stop everything.\n`)
 if (preferredProvider === 'openai-codex') {
   console.log('[launch] Open Settings → AI providers to complete ChatGPT sign-in.')
 }

--- a/scripts/message-store-launch.mjs
+++ b/scripts/message-store-launch.mjs
@@ -1,0 +1,49 @@
+import { existsSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+
+/**
+ * Resolve the optional local chat archive child without touching process
+ * state. Kept pure/injected enough for the launcher's discovery rules to be
+ * tested without starting the product.
+ *
+ * [COMP:platform/local-message-store-lifecycle]
+ */
+export function resolveMessageStoreLaunch({ root, env, exists = existsSync }) {
+  const explicitEnabled = env.BRIAN_MESSAGE_STORE_ENABLED
+  if (explicitEnabled === '0' || explicitEnabled === 'false') {
+    return { enabled: false, reason: 'disabled' }
+  }
+
+  const sourceDir = resolve(
+    env.BRIAN_MESSAGE_STORE_DIR || join(root, '..', '..', 'brian-message-store'),
+  )
+  const explicitBin = env.BRIAN_MESSAGE_STORE_BIN
+    ? resolve(env.BRIAN_MESSAGE_STORE_BIN)
+    : null
+  const checkoutBin = join(sourceDir, 'bin', 'brian-message-store')
+
+  if (explicitBin) {
+    if (!exists(explicitBin)) {
+      throw new Error(`BRIAN_MESSAGE_STORE_BIN does not exist: ${explicitBin}`)
+    }
+    return { enabled: true, cmd: explicitBin, args: [], cwd: dirname(explicitBin), source: 'binary' }
+  }
+  if (exists(checkoutBin)) {
+    return { enabled: true, cmd: checkoutBin, args: [], cwd: sourceDir, source: 'binary' }
+  }
+  if (exists(join(sourceDir, 'go.mod'))) {
+    return {
+      enabled: true,
+      cmd: 'go',
+      args: ['run', './cmd/brian-message-store'],
+      cwd: sourceDir,
+      source: 'source',
+    }
+  }
+  if (explicitEnabled === '1' || explicitEnabled === 'true') {
+    throw new Error(
+      `BRIAN_MESSAGE_STORE_ENABLED is set, but no binary or Go checkout was found at ${sourceDir}`,
+    )
+  }
+  return { enabled: false, reason: 'not_found', sourceDir }
+}


### PR DESCRIPTION
## Summary

- Add the local `brian-message-store` lifecycle, platform-owned schema, managed HMAC outbox sink, and resumable archive enrichment.
- Normalize live interactive-channel messages once in the shared pipeline and archive inbound/outbound turns without retaining raw provider payloads.
- Expose exactly one owner-bound agent capability, `searchChatHistory`, with hybrid lexical/vector recall, exact sender handling for “Who is X?”, and embedding-coverage disclosure.
- Update the WeChat iLink client identity and QR-bound owner mapping used by the verified local connection.

This capability is local-only. This PR contains no remote-runtime guidance.

## Verification

- Fresh in-memory PGLite migration: all 113 open migrations applied, including upstream 393–394 and chat archive 395–398.
- `pnpm typecheck`: 27/27 tasks passed.
- Focused API suites: 10 files, 109 tests passed.
- Channel and connector suites: 20 WeChat channel tests and 9 WeChat connector tests passed.
- Provider/embedding suite: 24 tests passed.
- Local launcher suite: 4 tests passed.
- `pnpm smoke`: passed.
- Full monorepo test run completed with four order/resource-sensitive failures; the four affected files immediately passed together, 118/118, with no feature failures.
- Sidecar: `go test ./...`, `go vet ./...`, and gofmt passed.

## Local E2E evidence

- Imported 3,590 authorized WeChat history rows with 0 rejects; live archive then held 3,608 messages across 28 conversations.
- Verified real WeChat inbound write, agent reply, outbound delivery, durable outbox acknowledgement, and search-tool invocation.
- Verified the built agent surface exposes exactly `searchChatHistory`; an actual agent session called it once for `Who is 鄭運英?` and answered from the returned personal chat evidence.
- Verified a signed WhatsApp canonical append through the running sidecar and found it through the actual `searchChatHistory` tool; the synthetic connector/message was removed afterward. No WhatsApp device was provisioned locally, so device pairing/delivery remains covered by the existing connector tests rather than a real-device loop.

## Related repositories

- Sidecar branch: `use-brian/brian-message-store@5a634d5` on `codex/feat-local-chat-archive`. The repository currently has no base branch, so no sidecar PR can be opened yet.
- brian-kb `main`: `use-brian/brian-kb@dc9f65d`.

## Local dependency

The launcher discovers a sibling `brian-message-store` checkout or an explicit local binary. The sidecar source is maintained in its separate repository.