### PR TITLE
fix(files): renumber the ingest-mode migration 402 -> 404

### DIFF
--- a/packages/api/migrations/404_file_ingest_jobs_mode.sql
+++ b/packages/api/migrations/404_file_ingest_jobs_mode.sql
@@ -1,4 +1,4 @@
--- 402_file_ingest_jobs_mode.sql  (OPEN table -> use-brian/packages/api/migrations/)
+-- 404_file_ingest_jobs_mode.sql  (OPEN table -> use-brian/packages/api/migrations/)
 --
 -- Provenance flag on the async file-ingest queue: which boundary enqueued the
 -- job, and therefore whether the worker may spend a model distill on it.
@@ -18,8 +18,11 @@
 --
 -- See docs/architecture/brain/file-artifacts.md -> "Async ingest".
 --
--- Latest applied migration is 401 (chunked_file_uploads). Filenames are globally
--- unique across BOTH migration dirs (one shared _migrations table); next free is 403.
+-- Filenames are globally unique across BOTH migration dirs (one shared
+-- _migrations table). This landed as 402 and was renumbered to 404: the office
+-- work took 402 and 403 in parallel, and a duplicate prefix is exactly what the
+-- graded `migrations` check exists to catch. Never applied under the old name.
+-- Next free is 405.
 
 BEGIN;
 

--- a/packages/api/src/db/__tests__/file-ingest-jobs-store.test.ts
+++ b/packages/api/src/db/__tests__/file-ingest-jobs-store.test.ts
@@ -35,7 +35,7 @@ describe('[COMP:files/file-ingest-jobs-store] file-ingest job queue', () => {
   })
 
   it('enqueue defaults source_label to "upload", assistant_id to NULL, mode to "silent"', async () => {
-    // `silent` is the conservative default on purpose (migration 402): it is the
+    // `silent` is the conservative default on purpose (migration 404): it is the
     // mode that never spends a model distill, so a caller that forgets to say
     // what it is cannot accidentally buy one.
     mockQuery.mockResolvedValueOnce({ rows: [{ id: 'job-1' }] } as never)

--- a/packages/api/src/db/file-ingest-jobs-store.ts
+++ b/packages/api/src/db/file-ingest-jobs-store.ts
@@ -21,7 +21,7 @@ import { query } from './client.js'
 export type FileIngestJobStatus = 'pending' | 'processing' | 'done' | 'failed'
 
 /**
- * Which boundary enqueued the job (migration 402). `explicit` = the user asked
+ * Which boundary enqueued the job (migration 404). `explicit` = the user asked
  * for this file to be ingested, so the worker may spend a model distill on a
  * PDF / image; `silent` = artifact promotion of a chat attachment or paste,
  * which stays store-only for those types. See `file-ingest-worker.ts`.
@@ -69,7 +69,7 @@ export async function enqueueFileIngestJob(input: {
   actingUserId: string
   assistantId?: string | null
   sourceLabel?: string
-  /** Defaults to `silent` — the conservative, no-distill path (migration 402). */
+  /** Defaults to `silent` — the conservative, no-distill path (migration 404). */
   mode?: FileIngestJobMode
 }): Promise<{ enqueued: boolean; jobId: string | null }> {
   const { rows } = await query<{ id: string }>(

--- a/packages/api/src/files/__tests__/file-ingest-worker.test.ts
+++ b/packages/api/src/files/__tests__/file-ingest-worker.test.ts
@@ -103,7 +103,7 @@ describe('[COMP:files/file-ingest-worker] file-ingest drain loop', () => {
     expect(deps.markDone).toHaveBeenCalledWith('job-1')
   })
 
-  // ── mode gating (migration 402) ───────────────────────────────────────────
+  // ── mode gating (migration 404) ───────────────────────────────────────────
   //
   // POST /ingest moved onto this queue, and it used to distill PDFs/images
   // inline. The port is therefore wired now — but a distill is a model charge,

--- a/packages/api/src/files/file-ingest-worker.ts
+++ b/packages/api/src/files/file-ingest-worker.ts
@@ -72,7 +72,7 @@ export type FileIngestWorkerDeps = {
    * user asked for that file to be ingested. Silent artifact promotion (chat
    * attachments, large pastes) keeps PDFs/images store-only however this port
    * is wired: nobody asked for the distill, so the queue must not buy one. See
-   * plan §"Explicitly NOT in v1" and migration 402.
+   * plan §"Explicitly NOT in v1" and migration 404.
    */
   distill?: (input: { buffer: Buffer; mime: string }) => Promise<string>
   intervalMs?: number

--- a/packages/api/src/routes/files.ts
+++ b/packages/api/src/routes/files.ts
@@ -377,7 +377,7 @@ export function fileRoutes(
         }
         // Explicit ingest: the user asked for this file to be interpreted, so
         // the job carries `mode: 'explicit'` and the worker may distill a
-        // PDF/image for it (migration 402).
+        // PDF/image for it (migration 404).
         const { enqueued, jobId } = await enqueueFileIngestJob({
           fileId: r.fileId,
           workspaceId: ctx.workspaceId,
@@ -678,7 +678,7 @@ export function fileRoutes(
       assistantId: assistant.id,
       sourceLabel: file.sourceEpisodeId ? 'reingest' : 'upload',
       // User-initiated, so the worker may distill a PDF/image for it — the same
-      // coverage a fresh POST /ingest gets (migration 402).
+      // coverage a fresh POST /ingest gets (migration 404).
       mode: 'explicit',
     })
     if (!enqueued) {


### PR DESCRIPTION
Follow-up to #155.

`402_file_ingest_jobs_mode.sql` landed beside `402_office_template_routing.sql` - the office series took 402 and 403 while #155 was open. Both migration dirs share one `_migrations` table, so prefixes must be globally unique; `pnpm check`'s `migrations` invariant flags it, and it was only invisible from the platform tree because the gitlink still points at `main`.

Renamed to **404** (403 is `403_office_spreadsheets.sql`). Never applied under the old name, so nothing to reconcile. The `migration 402` comments in `file-ingest-jobs-store.ts`, `file-ingest-worker.ts`, `routes/files.ts` and the two test files move with it.

Verified: `pnpm typecheck` 31/31, and the three affected suites (`file-ingest-jobs-store`, `file-ingest-worker`, `files` route) 60/60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)