### PR TITLE
feat(chat-archive): support media ingestion and search

### DIFF
--- a/apps/api/src/migrate-pglite.ts
+++ b/apps/api/src/migrate-pglite.ts
@@ -7,6 +7,17 @@ import { toPgliteMigrationSql } from '@use-brian/api/migrations/pglite-sql.js'
 const migrationRuns = new WeakMap<PGlite, Promise<void>>()
 const OSS_CHANNELS_330 = '330_oss_channels.sql'
 const OSS_CHANNELS_330_SHA256 = '64aeddde4c05bd186b638be0b0c02f477dd16afb20358c00446b2e9d0d739c1e'
+// The chat archive migrations were exercised locally before their feature
+// branch was rebased onto newer develop migrations. The rebase changed only
+// their sequence prefixes. Preserve those existing local brains by recording
+// the final filename when the exact pre-rebase filename is already applied.
+const LEGACY_MIGRATION_ALIASES: Readonly<Record<string, readonly string[]>> = {
+  '405_chat_message_archive.sql': ['395_chat_message_archive.sql', '393_chat_message_archive.sql'],
+  '406_local_chat_archive_sink.sql': ['396_local_chat_archive_sink.sql', '394_local_chat_archive_sink.sql'],
+  '407_chat_archive_enrichment.sql': ['397_chat_archive_enrichment.sql', '395_chat_archive_enrichment.sql'],
+  '408_chat_archive_owner_cascade.sql': ['398_chat_archive_owner_cascade.sql', '396_chat_archive_owner_cascade.sql'],
+  '409_chat_archive_media.sql': ['402_chat_archive_media.sql'],
+}
 
 function concurrentIndexStatements(sql: string): string[] | null {
   if (!/concurrently/i.test(sql) || /^\s*BEGIN/im.test(sql)) return null
@@ -55,6 +66,25 @@ async function migratePgliteExclusive(db: PGlite, migrationsDir: string): Promis
 
   let count = 0
   for (const file of files) {
+    const legacyNames = LEGACY_MIGRATION_ALIASES[file]
+    if (legacyNames) {
+      const aliasState = await db.transaction(async (tx) => {
+        const existing = await tx.query<{ name: string }>(
+          'SELECT name FROM public._migrations WHERE name = ANY($1::text[])',
+          [[file, ...legacyNames]],
+        )
+        if (existing.rows.some((row) => row.name === file)) return 'current'
+        if (!existing.rows.some((row) => legacyNames.includes(row.name))) return 'missing'
+
+        await tx.query('INSERT INTO public._migrations (name) VALUES ($1)', [file])
+        return 'aliased'
+      })
+      if (aliasState !== 'missing') {
+        if (aliasState === 'aliased') count++
+        continue
+      }
+    }
+
     const sql = await readFile(join(migrationsDir, file), 'utf8')
 
     // Migration 326 already creates every OSS channel table. Released migration

--- a/apps/wa-connector/package.json
+++ b/apps/wa-connector/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@google-cloud/storage": "^7.15.0",
-    "@whiskeysockets/baileys": "7.0.0-rc13",
+    "@whiskeysockets/baileys": "7.0.0-rc14",
     "express": "^5",
     "pg": "^8",
     "pino": "^9.6.0",

--- a/apps/wa-connector/src/__tests__/socket-manager.test.ts
+++ b/apps/wa-connector/src/__tests__/socket-manager.test.ts
@@ -543,6 +543,38 @@ describe('[COMP:wa-connector/media-routing] inbound media relay routing', () => 
     vi.unstubAllGlobals()
   })
 
+  it('reuses an already-stored archive asset without downloading or uploading again', async () => {
+    const { downloadMediaMessage } = await import('@whiskeysockets/baileys')
+    const fetchMock = vi.fn(async (url: unknown, _init?: { method?: string }) => {
+      if (String(url).endsWith('/internal/whatsapp/media-upload-url')) {
+        return {
+          ok: true,
+          json: async () => ({
+            assetId: '4a1e6bd8-0000-4000-8000-000000000001',
+            alreadyStored: true,
+            gcsKey: 'workspace/chat-archive-asset',
+            storageUri: 'file://workspace/chat-archive-asset',
+            sizeBytes: 9_000_000,
+            uploadUrl: 'http://127.0.0.1:4000/internal/chat-archive/media/asset/content',
+          }),
+        }
+      }
+      return { ok: true }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    await connected()
+
+    await emitMedia({ videoMessage: { mimetype: 'video/mp4', fileLength: 9_000_000 } })
+
+    expect(vi.mocked(downloadMediaMessage)).not.toHaveBeenCalled()
+    expect(inboundBody(fetchMock).mediaRef).toMatchObject({
+      assetId: '4a1e6bd8-0000-4000-8000-000000000001',
+      sizeBytes: 9_000_000,
+    })
+    expect(fetchMock.mock.calls.some((call) => (call[1] as { method?: string })?.method === 'PUT')).toBe(false)
+    vi.unstubAllGlobals()
+  })
+
   it('includes the API response body when upload URL minting fails', async () => {
     const { downloadMediaMessage } = await import('@whiskeysockets/baileys')
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/apps/wa-connector/src/message-parser.ts
+++ b/apps/wa-connector/src/message-parser.ts
@@ -434,6 +434,8 @@ export type WhatsAppIncomingMessage = {
    * routes this through the channel-media intake.
    */
   mediaRef?: {
+    /** Local chat-archive staging asset, completed by the API on inbound. */
+    assetId?: string
     gcsKey: string
     /** BYO storage URI (bytes live in the workspace's own bucket); echoed from the mint. */
     storageUri?: string

--- a/apps/wa-connector/src/socket-manager.ts
+++ b/apps/wa-connector/src/socket-manager.ts
@@ -358,33 +358,48 @@ export function createSocketManager(options: SocketManagerOptions): SocketManage
     const res = await fetch(`${apiUrl}/internal/whatsapp/media-upload-url`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-Connector-Secret': connectorSecret },
-      body: JSON.stringify({ channelId, mime: mediaInfo.mimeType, fileName: mediaInfo.fileName ?? null }),
+      body: JSON.stringify({
+        channelId,
+        providerMessageId: msg.key.id,
+        kind: mediaInfo.mimeType.startsWith('image/') ? 'image'
+          : mediaInfo.mimeType.startsWith('video/') ? 'video'
+            : mediaInfo.mimeType.startsWith('audio/') ? 'voice' : 'file',
+        mime: mediaInfo.mimeType,
+        fileName: mediaInfo.fileName ?? null,
+        sizeBytes: mediaInfo.fileLength ?? 0,
+      }),
     })
     if (!res.ok) {
       const detail = (await res.text().catch(() => '')).slice(0, 300)
       throw new Error(`media-upload-url failed: ${res.status} ${res.statusText}${detail ? `: ${detail}` : ''}`)
     }
-    const { gcsKey, uploadUrl, storageUri } = (await res.json()) as { gcsKey: string; uploadUrl: string; storageUri?: string }
+    const { assetId, alreadyStored, gcsKey, uploadUrl, storageUri, sizeBytes } = (await res.json()) as {
+      assetId?: string; alreadyStored?: boolean; gcsKey: string; uploadUrl: string
+      storageUri?: string; sizeBytes?: number
+    }
 
-    const stream = (await downloadMediaMessage(msg, 'stream', {})) as unknown as import('node:stream').Readable
-    const headers: Record<string, string> = { 'Content-Type': mediaInfo.mimeType }
-    if (mediaInfo.fileLength) headers['Content-Length'] = String(mediaInfo.fileLength)
-    const put = await fetch(uploadUrl, {
-      method: 'PUT',
-      headers,
-      body: stream as unknown as ReadableStream,
-      duplex: 'half', // Node streaming request body requires half-duplex.
-    } as RequestInit & { duplex: 'half' })
-    if (!put.ok) throw new Error(`GCS PUT failed: ${put.status} ${put.statusText}`)
+    if (!alreadyStored) {
+      const stream = (await downloadMediaMessage(msg, 'stream', {})) as unknown as import('node:stream').Readable
+      const headers: Record<string, string> = { 'Content-Type': mediaInfo.mimeType }
+      if (mediaInfo.fileLength) headers['Content-Length'] = String(mediaInfo.fileLength)
+      const put = await fetch(uploadUrl, {
+        method: 'PUT',
+        headers,
+        body: stream as unknown as ReadableStream,
+        duplex: 'half', // Node streaming request body requires half-duplex.
+      } as RequestInit & { duplex: 'half' })
+      if (!put.ok) throw new Error(`media PUT failed: ${put.status} ${put.statusText}`)
+    }
 
     return {
+      ...(assetId ? { assetId } : {}),
       gcsKey,
       // Echo the BYO storage URI back with the bytes so the API stamps the exact
       // bucket the bytes were PUT to (race-free vs. recomputing at /inbound).
       ...(storageUri ? { storageUri } : {}),
       mimeType: mediaInfo.mimeType,
       ...(mediaInfo.fileName ? { fileName: mediaInfo.fileName } : {}),
-      ...(mediaInfo.fileLength ? { sizeBytes: mediaInfo.fileLength } : {}),
+      ...(sizeBytes || mediaInfo.fileLength ? { sizeBytes: sizeBytes || mediaInfo.fileLength } : {}),
     }
   }
 
@@ -722,6 +737,8 @@ export function createSocketManager(options: SocketManagerOptions): SocketManage
     if (!editInfo && isDownloadableMedia(msg.message ?? undefined)) {
       const mediaInfo = extractMediaInfo(msg.message ?? undefined)
       if (mediaInfo) {
+        mediaMimeType = mediaInfo.mimeType
+        mediaFileName = mediaInfo.fileName
         if (shouldStreamMedia(mediaInfo, MAX_MEDIA_BYTES)) {
           try {
             mediaRef = await streamMediaToGcs(channelId, msg, mediaInfo)
@@ -734,8 +751,6 @@ export function createSocketManager(options: SocketManagerOptions): SocketManage
             const buffer = (await downloadMediaMessage(msg, 'buffer', {})) as Buffer
             if (buffer.length <= MAX_MEDIA_BYTES) {
               mediaBase64 = buffer.toString('base64')
-              mediaMimeType = mediaInfo.mimeType
-              mediaFileName = mediaInfo.fileName
             } else {
               // fileLength under-reported the true size — stream it instead of dropping.
               try {
@@ -778,7 +793,9 @@ export function createSocketManager(options: SocketManagerOptions): SocketManage
       quotedMessageId: replyContext?.id,
       quotedBody: replyContext?.body,
       ...(editInfo && { isEdit: true, editedMessageId: editInfo.editedMessageId }),
-      ...(mediaBase64 && { mediaBase64, mediaMimeType, mediaFileName }),
+      ...(mediaBase64 && { mediaBase64 }),
+      ...(mediaMimeType && { mediaMimeType }),
+      ...(mediaFileName && { mediaFileName }),
       ...(mediaRef && { mediaRef }),
     }
 

--- a/packages/api/migrations/405_chat_message_archive.sql
+++ b/packages/api/migrations/405_chat_message_archive.sql
@@ -1,4 +1,4 @@
--- 395_chat_message_archive.sql  (OPEN tables -> use-brian/packages/api/migrations/)
+-- 405_chat_message_archive.sql  (OPEN tables -> use-brian/packages/api/migrations/)
 --
 -- Local provider-neutral interactive-chat archive and search projection.
 -- `brian-message-store` consumes ub.ingest.append.v1 and writes these tables;

--- a/packages/api/migrations/406_local_chat_archive_sink.sql
+++ b/packages/api/migrations/406_local_chat_archive_sink.sql
@@ -1,4 +1,4 @@
--- 396_local_chat_archive_sink.sql  (OPEN tables -> packages/api/migrations/)
+-- 406_local_chat_archive_sink.sql  (OPEN tables -> packages/api/migrations/)
 --
 -- Marks the one platform-managed, loopback-only brian-message-store sink per
 -- connector instance. Manual external sinks keep managed_by NULL and are never

--- a/packages/api/migrations/407_chat_archive_enrichment.sql
+++ b/packages/api/migrations/407_chat_archive_enrichment.sql
@@ -1,4 +1,4 @@
--- 397_chat_archive_enrichment.sql  (OPEN tables -> packages/api/migrations/)
+-- 407_chat_archive_enrichment.sql  (OPEN tables -> packages/api/migrations/)
 -- Platform-owned Pipeline B window ledger for raw chat archive messages.
 
 BEGIN;

--- a/packages/api/migrations/408_chat_archive_owner_cascade.sql
+++ b/packages/api/migrations/408_chat_archive_owner_cascade.sql
@@ -1,4 +1,4 @@
--- 398_chat_archive_owner_cascade.sql  (OPEN tables -> packages/api/migrations/)
+-- 408_chat_archive_owner_cascade.sql  (OPEN tables -> packages/api/migrations/)
 -- Account deletion must remove every person-compartmented chat archive root.
 
 BEGIN;

--- a/packages/api/migrations/409_chat_archive_media.sql
+++ b/packages/api/migrations/409_chat_archive_media.sql
@@ -1,0 +1,118 @@
+-- 409_chat_archive_media.sql (OPEN tables -> packages/api/migrations/)
+-- Durable local media for the provider-neutral chat archive.
+
+BEGIN;
+
+ALTER TABLE chat_archive_messages
+  DROP CONSTRAINT chat_archive_messages_kind_check;
+ALTER TABLE chat_archive_messages
+  ADD CONSTRAINT chat_archive_messages_kind_check
+  CHECK (kind IN ('text', 'image', 'video', 'voice', 'file', 'link'));
+
+ALTER TABLE chat_archive_backfill_runs
+  ADD COLUMN media_discovered_count BIGINT NOT NULL DEFAULT 0 CHECK (media_discovered_count >= 0),
+  ADD COLUMN media_stored_count BIGINT NOT NULL DEFAULT 0 CHECK (media_stored_count >= 0),
+  ADD COLUMN media_missing_count BIGINT NOT NULL DEFAULT 0 CHECK (media_missing_count >= 0),
+  ADD COLUMN media_failed_count BIGINT NOT NULL DEFAULT 0 CHECK (media_failed_count >= 0);
+
+CREATE TABLE chat_archive_media_assets (
+  id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id             UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  instance_id              UUID NOT NULL REFERENCES connector_instance(id) ON DELETE CASCADE,
+  owner_user_id            UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  message_id               UUID REFERENCES chat_archive_messages(id) ON DELETE CASCADE,
+  source                   TEXT NOT NULL CHECK (length(source) > 0),
+  provider_message_id      TEXT NOT NULL CHECK (length(provider_message_id) > 0),
+  kind                     TEXT NOT NULL CHECK (kind IN ('image', 'video', 'voice', 'file')),
+  filename                 TEXT NOT NULL DEFAULT '',
+  mime                     TEXT NOT NULL DEFAULT 'application/octet-stream',
+  size_bytes               BIGINT NOT NULL DEFAULT 0 CHECK (size_bytes >= 0),
+  expected_sha256          TEXT CHECK (expected_sha256 IS NULL OR expected_sha256 ~ '^[a-f0-9]{64}$'),
+  sha256                   TEXT CHECK (sha256 IS NULL OR sha256 ~ '^[a-f0-9]{64}$'),
+  storage_key              TEXT NOT NULL CHECK (length(storage_key) > 0),
+  storage_uri              TEXT NOT NULL CHECK (length(storage_uri) > 0),
+  upload_status            TEXT NOT NULL DEFAULT 'uploading'
+                           CHECK (upload_status IN ('uploading', 'uploaded', 'stored', 'failed')),
+  extraction_status        TEXT NOT NULL DEFAULT 'pending'
+                           CHECK (extraction_status IN ('pending', 'processing', 'ready', 'failed', 'unsupported')),
+  last_error               TEXT,
+  linked_at                TIMESTAMPTZ,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  UNIQUE (instance_id, provider_message_id)
+);
+
+CREATE INDEX idx_chat_archive_media_assets_message
+  ON chat_archive_media_assets (message_id) WHERE message_id IS NOT NULL;
+CREATE INDEX idx_chat_archive_media_assets_owner_created
+  ON chat_archive_media_assets (owner_user_id, created_at DESC);
+CREATE INDEX idx_chat_archive_media_assets_unlinked_cleanup
+  ON chat_archive_media_assets (created_at)
+  WHERE message_id IS NULL;
+
+ALTER TABLE chat_archive_media_assets ENABLE ROW LEVEL SECURITY;
+CREATE POLICY chat_archive_media_assets_owner ON chat_archive_media_assets
+  USING (owner_user_id = (current_setting('app.current_user_id'::text, true))::uuid);
+
+CREATE TABLE chat_archive_media_jobs (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  asset_id            UUID NOT NULL UNIQUE REFERENCES chat_archive_media_assets(id) ON DELETE CASCADE,
+  status              TEXT NOT NULL DEFAULT 'pending'
+                      CHECK (status IN ('pending', 'processing', 'completed', 'failed', 'dead', 'unsupported')),
+  attempt_count       INT NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+  next_attempt_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  locked_until        TIMESTAMPTZ,
+  last_error          TEXT,
+  completed_at        TIMESTAMPTZ,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_chat_archive_media_jobs_due
+  ON chat_archive_media_jobs (next_attempt_at, created_at)
+  WHERE status IN ('pending', 'failed');
+
+ALTER TABLE chat_archive_media_jobs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY chat_archive_media_jobs_system ON chat_archive_media_jobs
+  USING (current_setting('app.system_bypass', true) = 'true')
+  WITH CHECK (current_setting('app.system_bypass', true) = 'true');
+
+-- Filesystem deletion cannot happen inside a database cascade. Queue the
+-- storage location before the asset row disappears; the local media worker
+-- drains this table idempotently.
+CREATE TABLE chat_archive_media_deletions (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id    UUID NOT NULL,
+  storage_key     TEXT NOT NULL,
+  storage_uri     TEXT NOT NULL,
+  attempt_count   INT NOT NULL DEFAULT 0,
+  next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_error      TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (storage_uri, storage_key)
+);
+
+CREATE INDEX idx_chat_archive_media_deletions_due
+  ON chat_archive_media_deletions (next_attempt_at, created_at);
+
+ALTER TABLE chat_archive_media_deletions ENABLE ROW LEVEL SECURITY;
+CREATE POLICY chat_archive_media_deletions_system ON chat_archive_media_deletions
+  USING (current_setting('app.system_bypass', true) = 'true')
+  WITH CHECK (current_setting('app.system_bypass', true) = 'true');
+
+CREATE FUNCTION queue_chat_archive_media_deletion() RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  INSERT INTO chat_archive_media_deletions (workspace_id, storage_key, storage_uri)
+  VALUES (OLD.workspace_id, OLD.storage_key, OLD.storage_uri)
+  ON CONFLICT (storage_uri, storage_key) DO NOTHING;
+  RETURN OLD;
+END;
+$$;
+
+CREATE TRIGGER chat_archive_media_assets_queue_delete
+BEFORE DELETE ON chat_archive_media_assets
+FOR EACH ROW EXECUTE FUNCTION queue_chat_archive_media_deletion();
+
+COMMIT;

--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -58,6 +58,7 @@ import {
   createReportBugTool,
   createConfirmRecordingProcessingTool,
   geminiTranscriber,
+  qwenAsrTranscriber,
   qwenFiletransTranscriber,
   withTranscriberFallback,
   type RecordingTranscriber,
@@ -255,10 +256,18 @@ import { createConnectorAppCredentialStore } from './db/connector-app-credential
 import { createIngestSinkStore } from './db/ingest-sink-store.js'
 import { createIngestOutboxStore } from './db/ingest-outbox-store.js'
 import { createChatArchiveEnrichmentStore } from './db/chat-archive-enrichment-store.js'
+import { createChatArchiveMediaStore } from './db/chat-archive-media-store.js'
 import { createExternalSinkFanout } from './ingest/external-sink-fanout.js'
 import { createExternalSinkRelay } from './ingest/external-sink-relay.js'
-import { createLiveChatArchiveWriter, setGlobalLiveChatArchiveWriter } from './chat-archive/live-writer.js'
+import {
+  appendInboundChatArchive,
+  createLiveChatArchiveWriter,
+  setGlobalLiveChatArchiveWriter,
+} from './chat-archive/live-writer.js'
 import { createChatArchiveEnrichmentWorker } from './chat-archive/enrichment-worker.js'
+import { chatArchiveMediaRoutes } from './chat-archive/media-routes.js'
+import { createChatArchiveMediaService, type ChatArchiveMediaService } from './chat-archive/media-service.js'
+import { createChatArchiveMediaWorker, type ChatArchiveMediaWorker } from './chat-archive/media-worker.js'
 import { createWorkspaceToolPolicyStore } from './db/workspace-tool-policy-store.js'
 import { buildOpenSyncCredentials } from './build-sync-credentials.js'
 import { createDbAssistantConnectorStore } from './db/assistant-connector-store.js'
@@ -1124,7 +1133,10 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
   app.use((req, res, next) => {
     // Signed local-file PUTs are raw byte streams. Let their route consume the
     // request directly even when the uploaded file itself is JSON.
-    if (req.path === '/api/local-files') {
+    if (
+      req.path === '/api/local-files'
+      || (req.method === 'PUT' && /^\/internal\/chat-archive\/media\/[^/]+\/content$/.test(req.path))
+    ) {
       next()
       return
     }
@@ -2118,6 +2130,8 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
   let filesApi: ReturnType<typeof createFilesApi> | null = null
   let filesResolver: FilesClientResolver | null = null
   let chunkedFileUploads: ChunkedFileUploadService | null = null
+  let chatArchiveMediaService: ChatArchiveMediaService | null = null
+  let chatArchiveMediaWorker: ChatArchiveMediaWorker | null = null
 
   const calleeExecutor = createCalleeExecutor({
     provider,
@@ -5718,6 +5732,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     recordingTranscribers.push(geminiTranscriber({ apiKey: env.GEMINI_API_KEY }))
   }
   if (env.DASHSCOPE_API_KEY) {
+    recordingTranscribers.push(qwenAsrTranscriber({ apiKey: env.DASHSCOPE_API_KEY }))
     recordingTranscribers.push(qwenFiletransTranscriber({ apiKey: env.DASHSCOPE_API_KEY }))
   }
   const recordingTranscriber = recordingTranscribers.length === 0
@@ -5725,6 +5740,27 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     : recordingTranscribers.length === 1
       ? recordingTranscribers[0]
       : withTranscriberFallback(recordingTranscribers[0], ...recordingTranscribers.slice(1))
+
+  if (filesResolver && env.BRIAN_MESSAGE_STORE_HMAC_SECRET) {
+    const mediaStore = createChatArchiveMediaStore()
+    chatArchiveMediaService = createChatArchiveMediaService({ store: mediaStore, filesResolver })
+    chatArchiveMediaWorker = createChatArchiveMediaWorker({
+      store: mediaStore,
+      filesResolver,
+      transcriber: recordingTranscriber,
+      resolveTranscriptionLanguage: async (workspaceId) =>
+        (await getWorkspaceTranscriptionPrefs(workspaceId)).languageCode,
+      distill: async ({ buffer, mime, prompt }) =>
+        (await distillFileToText({ buffer, mime }, { backend: mediaBackend, prompt })).text,
+    })
+    app.use('/internal/chat-archive', chatArchiveMediaRoutes({
+      service: chatArchiveMediaService,
+      hmacSecret: env.BRIAN_MESSAGE_STORE_HMAC_SECRET,
+      baseUrl: `http://127.0.0.1:${port}`,
+    }))
+    if (runWorkers) chatArchiveMediaWorker.start()
+  }
+
   const recordingProcessWorker = filesResolver && filesBlobClient && filesApi
     ? createOpenRecordingProcessWorker({
         claim: claimNextRecordingJob,
@@ -6163,12 +6199,19 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
               userId: input.senderPnJid ?? input.senderJid,
               channelId: input.chatJid,
               messageId: input.messageId,
-              text: input.text,
+              text: /^<media:[^>]+>$/.test(input.text.trim()) ? '' : input.text,
+              mediaType: input.archiveMediaType,
+              mediaMime: input.archiveMediaMime,
+              mediaName: input.archiveMediaName,
+              mediaSizeBytes: input.archiveMediaSizeBytes,
+              archiveMediaRef: input.archiveMediaRef,
+              archiveMediaAvailability: input.archiveMediaAvailability,
               isGroupChat: input.isGroup,
               timestamp: input.timestamp,
               raw: null,
             },
             archiveConnectorInstanceId: channel.connectorInstanceId,
+            archiveInboundAlreadyPersisted: input.archiveInboundPersisted,
             modelAlias: undefined,
             adaptiveResearchEnabled: true,
             abortController,
@@ -6211,6 +6254,19 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
         ingestor: whatsapp.ingestor,
         bot: whatsapp.bot,
         filesResolver: filesResolver ?? undefined,
+        archiveMedia: chatArchiveMediaService ?? undefined,
+        archiveMediaHmacSecret: env.BRIAN_MESSAGE_STORE_HMAC_SECRET,
+        archiveMediaBaseUrl: `http://127.0.0.1:${port}`,
+        archiveIncoming: (input) => appendInboundChatArchive({
+          source: 'whatsapp',
+          workspaceId: input.workspaceId,
+          ownerUserId: input.ownerUserId,
+          connectorInstanceId: input.connectorInstanceId,
+          assistantId: '',
+          assistantName: '',
+          conversationId: input.message.channelId,
+          message: input.message,
+        }),
         passUnknownToFallback: ports.whatsappOfficialFallback,
       }))
     }
@@ -6294,6 +6350,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
           workerManager, connectorStore, mcpSettingsStore, assistantConnectorStore, connectorGrantStore,
           connectorInstanceStore, knowledgeStore, gdriveFilesStore, workspaceFilesStore, analytics,
           skillStore, episodicStore, sessionStateStore,
+          archiveMedia: chatArchiveMediaService ?? undefined,
         }))
       }
     }
@@ -6334,6 +6391,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     mailboxSyncWorker.stop()
     externalSinkRelay.stop()
     chatArchiveEnrichmentWorker?.stop()
+    chatArchiveMediaWorker?.stop()
     stuckSessionSweeper.stop()
     fileIngestWorker?.stop()
     linkedinImportWorker?.stop()

--- a/packages/api/src/chat-archive/__tests__/chat-tools.test.ts
+++ b/packages/api/src/chat-archive/__tests__/chat-tools.test.ts
@@ -22,6 +22,7 @@ describe('[COMP:tools/chat-archive] native chat archive tools', () => {
     const search = vi.fn(async (_input: unknown) => ({
       hits: [{ message_id: 'm-1' }],
       embeddingCoverage: { partial: true, unembeddedInScope: 5, capped: false, note: 'partial' },
+	  mediaCoverage: { total: 2, ready: 1, pending: 1, missing: 0, failed: 0, unsupported: 0 },
     }))
     const tool = createChatArchiveTools({ search: search as never })[0]!
     const result = await tool.execute({ query: 'deposit', source: 'whatsapp', kind: 'text' }, context)
@@ -31,7 +32,11 @@ describe('[COMP:tools/chat-archive] native chat archive tools', () => {
       source: 'whatsapp',
       kind: 'text',
     })
-    expect(result.data).toEqual({ hits: [{ message_id: 'm-1' }], embeddingCoverage: 'partial' })
+	expect(result.data).toEqual({
+		hits: [{ message_id: 'm-1' }],
+		embeddingCoverage: 'partial',
+		mediaCoverage: { total: 2, ready: 1, pending: 1, missing: 0, failed: 0, unsupported: 0 },
+	})
   })
 
   it('rejects an invalid time before calling the store', async () => {

--- a/packages/api/src/chat-archive/__tests__/media-routes.test.ts
+++ b/packages/api/src/chat-archive/__tests__/media-routes.test.ts
@@ -1,0 +1,123 @@
+import express from 'express'
+import request from 'supertest'
+import { describe, expect, it, vi } from 'vitest'
+import { INGEST_APPEND_SIGNATURE_HEADER } from '@use-brian/shared'
+import { signIngestAppendBody } from '../../ingest/append-signing.js'
+import { chatArchiveMediaRoutes } from '../media-routes.js'
+
+const secret = 'local-media-secret'
+const assetId = '4a1e6bd8-0000-4000-8000-000000000001'
+const initBody = {
+  workspace_id: '4a1e6bd8-0000-4000-8000-000000000002',
+  instance_id: '4a1e6bd8-0000-4000-8000-000000000003',
+  owner_user_id: '4a1e6bd8-0000-4000-8000-000000000004',
+  source: 'wechat',
+  provider_message_id: 'wx-1',
+  kind: 'image',
+  filename: 'photo.jpg',
+  mime: 'image/jpeg',
+  size_bytes: 5,
+  sha256: 'a'.repeat(64),
+}
+
+function makeApp() {
+  const asset = {
+    id: assetId,
+    workspaceId: initBody.workspace_id,
+    instanceId: initBody.instance_id,
+    ownerUserId: initBody.owner_user_id,
+    messageId: null,
+    source: 'wechat',
+    providerMessageId: 'wx-1',
+    kind: 'image',
+    filename: 'photo.jpg',
+    mime: 'image/jpeg',
+    sizeBytes: 5,
+    expectedSha256: 'a'.repeat(64),
+    sha256: 'a'.repeat(64),
+    storageKey: 'workspace/chat-archive-asset',
+    storageUri: 'file://workspace/chat-archive-asset',
+    uploadStatus: 'stored',
+    extractionStatus: 'pending',
+    lastError: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }
+  const service = {
+    init: vi.fn(async () => ({ asset, alreadyStored: false })),
+    upload: vi.fn(async () => asset),
+    complete: vi.fn(async () => asset),
+    storeBuffer: vi.fn(),
+  }
+  const app = express()
+  app.use(express.json({ verify(req, _res, buffer) {
+    ;(req as express.Request & { rawBody?: string }).rawBody = buffer.toString('utf8')
+  } }))
+  app.use('/internal/chat-archive', chatArchiveMediaRoutes({
+    service: service as never,
+    hmacSecret: secret,
+    baseUrl: 'http://127.0.0.1:4000',
+    uploadTtlSec: 60,
+  }))
+  return { app, service }
+}
+
+describe('[COMP:api/chat-archive-media] HMAC staging routes', () => {
+  it('rejects an unsigned init and accepts the exact signed body', async () => {
+    const { app, service } = makeApp()
+    await request(app).post('/internal/chat-archive/media/init').send(initBody).expect(401)
+
+    const raw = JSON.stringify(initBody)
+    const response = await request(app)
+      .post('/internal/chat-archive/media/init')
+      .set('content-type', 'application/json')
+      .set(INGEST_APPEND_SIGNATURE_HEADER, signIngestAppendBody(raw, secret))
+      .send(raw)
+      .expect(200)
+    expect(response.body.asset_id).toBe(assetId)
+    expect(response.body.upload_url).toMatch(/^http:\/\/127\.0\.0\.1:4000\/internal\/chat-archive\/media\//)
+    expect(service.init).toHaveBeenCalledOnce()
+  })
+
+  it('returns the v2 media reference only after signed completion', async () => {
+    const { app } = makeApp()
+    const raw = '{}'
+    const response = await request(app)
+      .post(`/internal/chat-archive/media/${assetId}/complete`)
+      .set('content-type', 'application/json')
+      .set(INGEST_APPEND_SIGNATURE_HEADER, signIngestAppendBody(raw, secret))
+      .send(raw)
+      .expect(200)
+    expect(response.body.media_ref).toMatchObject({
+      asset_id: assetId,
+      availability: 'stored',
+      sha256: 'a'.repeat(64),
+    })
+  })
+
+  it('accepts only the signed, unexpired upload URL issued by init', async () => {
+    const { app, service } = makeApp()
+    const raw = JSON.stringify(initBody)
+    const initialized = await request(app)
+      .post('/internal/chat-archive/media/init')
+      .set('content-type', 'application/json')
+      .set(INGEST_APPEND_SIGNATURE_HEADER, signIngestAppendBody(raw, secret))
+      .send(raw)
+      .expect(200)
+    const upload = new URL(initialized.body.upload_url)
+
+    await request(app)
+      .put(upload.pathname)
+      .query({ expires: upload.searchParams.get('expires'), token: 'modified' })
+      .set('content-type', 'image/jpeg')
+      .send(Buffer.from('photo'))
+      .expect(401)
+
+    await request(app)
+      .put(upload.pathname + upload.search)
+      .set('content-type', 'image/jpeg')
+      .send(Buffer.from('photo'))
+      .expect(200)
+    expect(service.upload).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/api/src/chat-archive/__tests__/media-service.test.ts
+++ b/packages/api/src/chat-archive/__tests__/media-service.test.ts
@@ -1,0 +1,142 @@
+import { createHash } from 'node:crypto'
+import { Readable, Writable } from 'node:stream'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  CHAT_ARCHIVE_SMALL_MEDIA_MAX_BYTES,
+  ChatArchiveMediaTooLargeError,
+  createChatArchiveMediaService,
+} from '../media-service.js'
+
+const ids = {
+  asset: '4a1e6bd8-0000-4000-8000-000000000001',
+  workspace: '4a1e6bd8-0000-4000-8000-000000000002',
+  instance: '4a1e6bd8-0000-4000-8000-000000000003',
+  owner: '4a1e6bd8-0000-4000-8000-000000000004',
+}
+
+function asset(overrides: Record<string, unknown> = {}) {
+  return {
+    id: ids.asset,
+    workspaceId: ids.workspace,
+    instanceId: ids.instance,
+    ownerUserId: ids.owner,
+    messageId: null,
+    source: 'whatsapp',
+    providerMessageId: 'wa-1',
+    kind: 'image',
+    filename: 'receipt.png',
+    mime: 'image/png',
+    sizeBytes: 0,
+    expectedSha256: null,
+    sha256: null,
+    storageKey: `${ids.workspace}/chat-archive-${ids.asset}`,
+    storageUri: `file://${ids.workspace}/chat-archive-${ids.asset}`,
+    uploadStatus: 'uploading',
+    extractionStatus: 'pending',
+    lastError: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+function harness(initialAsset = asset()) {
+  let current = initialAsset
+  const writeBlob = vi.fn(async () => {})
+  const writeStream = vi.fn(() => new Writable({ write(_chunk, _encoding, callback) { callback() } }))
+  const storage = {
+    writeBlob,
+    writeStream,
+    deleteBlob: vi.fn(async () => {}),
+  }
+  const store = {
+    bindingExists: vi.fn(async () => true),
+    getByProvider: vi.fn(async () => null),
+    upsertUploading: vi.fn(async (input: Record<string, unknown>) => {
+      current = asset(input)
+      return current
+    }),
+    markUploaded: vi.fn(async (_id: string, sha256: string, sizeBytes: number) => {
+      current = asset({ ...current, sha256, sizeBytes, uploadStatus: 'uploaded' })
+      return current
+    }),
+    markUploadFailed: vi.fn(async () => {}),
+    completeUpload: vi.fn(async () => asset({ ...current, uploadStatus: 'stored' })),
+    get: vi.fn(async () => current),
+  }
+  const service = createChatArchiveMediaService({
+    store: store as never,
+    filesResolver: {
+      forWorkspace: vi.fn(async () => ({
+        bucket: 'local', uriScheme: 'file', gcs: storage,
+      })),
+      forUri: vi.fn(async () => storage),
+    } as never,
+  })
+  return { service, store, writeBlob, writeStream }
+}
+
+const input = {
+  workspaceId: ids.workspace,
+  instanceId: ids.instance,
+  ownerUserId: ids.owner,
+  source: 'whatsapp',
+  providerMessageId: 'wa-1',
+  kind: 'image' as const,
+  filename: 'receipt.png',
+  mime: 'image/png',
+  sizeBytes: 0,
+}
+
+describe('[COMP:api/chat-archive-media] local media staging', () => {
+  it('fingerprints bytes and completes a durable asset', async () => {
+    const { service, store, writeBlob } = harness()
+    const stored = await service.storeBuffer({ ...input, bytes: Buffer.from('receipt bytes') })
+    expect(stored.uploadStatus).toBe('stored')
+    expect(store.markUploaded).toHaveBeenCalledWith(
+      expect.any(String),
+      createHash('sha256').update('receipt bytes').digest('hex'),
+      13,
+    )
+    expect(writeBlob).toHaveBeenCalledOnce()
+  })
+
+  it('rejects an oversized image before allocating storage', async () => {
+    const { service, store } = harness()
+    await expect(service.init({ ...input, sizeBytes: CHAT_ARCHIVE_SMALL_MEDIA_MAX_BYTES + 1 }))
+      .rejects.toBeInstanceOf(ChatArchiveMediaTooLargeError)
+    expect(store.upsertUploading).not.toHaveBeenCalled()
+  })
+
+  it('marks a streaming upload failed when the byte cap is crossed', async () => {
+    const { service, store } = harness()
+    await service.init(input)
+    await expect(service.upload({
+      assetId: ids.asset,
+      stream: Readable.from(Buffer.alloc(CHAT_ARCHIVE_SMALL_MEDIA_MAX_BYTES + 1)),
+    })).rejects.toBeInstanceOf(ChatArchiveMediaTooLargeError)
+    expect(store.markUploadFailed).toHaveBeenCalledOnce()
+  })
+
+  it('reuses an already stored provider asset without another upload', async () => {
+    const { service, store } = harness()
+    const stored = asset({
+      uploadStatus: 'stored',
+      extractionStatus: 'ready',
+      sha256: 'a'.repeat(64),
+    })
+    store.getByProvider.mockResolvedValue(stored as never)
+
+    const initialized = await service.init({ ...input, sha256: 'a'.repeat(64) })
+    expect(initialized).toEqual({ asset: stored, alreadyStored: true })
+    expect(store.upsertUploading).not.toHaveBeenCalled()
+  })
+
+  it('acknowledges a repeated PUT without replacing stored bytes', async () => {
+    const stored = asset({ uploadStatus: 'stored', extractionStatus: 'ready', sha256: 'a'.repeat(64) })
+    const { service, writeStream } = harness(stored)
+    const result = await service.upload({ assetId: ids.asset, stream: Readable.from(Buffer.from('replacement')) })
+    expect(result).toBe(stored)
+    expect(writeStream).not.toHaveBeenCalled()
+  })
+})

--- a/packages/api/src/chat-archive/__tests__/media-worker.test.ts
+++ b/packages/api/src/chat-archive/__tests__/media-worker.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createChatArchiveMediaWorker } from '../media-worker.js'
+
+function asset(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '4a1e6bd8-0000-4000-8000-000000000001',
+    workspaceId: '4a1e6bd8-0000-4000-8000-000000000002',
+    instanceId: '4a1e6bd8-0000-4000-8000-000000000003',
+    ownerUserId: '4a1e6bd8-0000-4000-8000-000000000004',
+    messageId: '4a1e6bd8-0000-4000-8000-000000000005',
+    source: 'whatsapp',
+    providerMessageId: 'wa-1',
+    kind: 'image',
+    filename: 'receipt.png',
+    mime: 'image/png',
+    sizeBytes: 5,
+    expectedSha256: null,
+    sha256: 'a'.repeat(64),
+    storageKey: 'workspace/chat-archive-asset',
+    storageUri: 'file://workspace/chat-archive-asset',
+    uploadStatus: 'stored',
+    extractionStatus: 'pending',
+    lastError: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+function harness(mediaAsset = asset()) {
+  const store = {
+    claimNext: vi.fn(async () => ({ id: 'job-1', asset: mediaAsset, attemptCount: 1 })),
+    replaceDerivedSegments: vi.fn(async (_asset: unknown, _segments: unknown[]) => {}),
+    completeJob: vi.fn(async () => {}),
+    unsupportedJob: vi.fn(async () => {}),
+    failJob: vi.fn(async () => {}),
+    listUnlinkedBefore: vi.fn(async () => []),
+    remove: vi.fn(async () => {}),
+    listDeletions: vi.fn(async () => []),
+    completeDeletion: vi.fn(async () => {}),
+    failDeletion: vi.fn(async () => {}),
+  }
+  const storage = {
+    signedReadUrl: vi.fn(async () => 'file:///tmp/media'),
+    readBlob: vi.fn(async () => ({ bytes: Buffer.from('bytes'), metadata: {} })),
+    writeBlob: vi.fn(async () => {}),
+    deleteBlob: vi.fn(async () => {}),
+  }
+  const distill = vi.fn(async ({ prompt }: { prompt?: string }) =>
+    prompt?.startsWith('Transcribe') ? 'TOTAL 42.00' : 'A photographed shop receipt',
+  )
+  const worker = createChatArchiveMediaWorker({
+    store: store as never,
+    filesResolver: { forUri: vi.fn(async () => storage) } as never,
+    distill,
+  })
+  return { worker, store, distill }
+}
+
+describe('[COMP:api/chat-archive-media] derived segment worker', () => {
+  it('stores separate image OCR and semantic-description segments', async () => {
+    const { worker, store, distill } = harness()
+    expect(await worker.runOnce()).toBe(true)
+    expect(distill).toHaveBeenCalledTimes(2)
+    const segments = store.replaceDerivedSegments.mock.calls[0]![1]
+    expect(segments).toEqual(expect.arrayContaining([
+      expect.objectContaining({ text: 'TOTAL 42.00', metadata: expect.objectContaining({ modality: 'image_ocr' }) }),
+      expect.objectContaining({ text: 'A photographed shop receipt', metadata: expect.objectContaining({ modality: 'image_description' }) }),
+    ]))
+    expect(store.completeJob).toHaveBeenCalledWith('job-1', expect.any(String))
+  })
+
+  it('parks an unknown binary as unsupported while retaining the asset', async () => {
+    const { worker, store } = harness(asset({
+      kind: 'file', filename: 'legacy.bin', mime: 'application/octet-stream',
+    }))
+    expect(await worker.runOnce()).toBe(true)
+    expect(store.replaceDerivedSegments).not.toHaveBeenCalled()
+    expect(store.unsupportedJob).toHaveBeenCalledWith(
+      'job-1', expect.any(String), expect.stringContaining('unsupported'),
+    )
+  })
+
+  it('passes the workspace language preference to voice transcription', async () => {
+    const mediaAsset = asset({
+      kind: 'voice', filename: 'voice.ogg', mime: 'audio/ogg',
+    })
+    const store = {
+      claimNext: vi.fn(async () => ({ id: 'job-1', asset: mediaAsset, attemptCount: 1 })),
+      replaceDerivedSegments: vi.fn(async () => {}),
+      completeJob: vi.fn(async () => {}),
+      unsupportedJob: vi.fn(async () => {}),
+      failJob: vi.fn(async () => {}),
+      listUnlinkedBefore: vi.fn(async () => []),
+      remove: vi.fn(async () => {}),
+      listDeletions: vi.fn(async () => []),
+      completeDeletion: vi.fn(async () => {}),
+      failDeletion: vi.fn(async () => {}),
+    }
+    const storage = {
+      signedReadUrl: vi.fn(async () => 'file:///tmp/media'),
+      writeBlob: vi.fn(async () => {}),
+      deleteBlob: vi.fn(async () => {}),
+    }
+    const transcribe = vi.fn(async () => ({
+      utterances: [{ startMs: 0, endMs: 1_000, speaker: null, text: 'Hello, hello, hello.' }],
+      usages: [], windows: 1, truncated: false, degenerateWindows: 0,
+    }))
+    const worker = createChatArchiveMediaWorker({
+      store: store as never,
+      filesResolver: { forUri: vi.fn(async () => storage) } as never,
+      transcriber: { name: 'test', transcribe },
+      resolveTranscriptionLanguage: vi.fn(async () => 'en'),
+      probe: vi.fn(async () => 1_000),
+      extract: vi.fn(async () => ({ buffer: Buffer.from('audio'), mime: 'audio/mp4' })),
+    })
+
+    expect(await worker.runOnce()).toBe(true)
+    expect(transcribe).toHaveBeenCalledWith(expect.objectContaining({ language: 'en' }))
+    expect(store.replaceDerivedSegments).toHaveBeenCalledWith(
+      mediaAsset,
+      [expect.objectContaining({ text: 'Hello, hello, hello.' })],
+    )
+  })
+})

--- a/packages/api/src/chat-archive/__tests__/normalize.test.ts
+++ b/packages/api/src/chat-archive/__tests__/normalize.test.ts
@@ -59,6 +59,40 @@ describe('[COMP:api/chat-archive-live-capture] normalizer', () => {
     expect(JSON.stringify(result)).not.toContain('signed.example')
   })
 
+  it('preserves a durable video asset for the managed v2 sink', () => {
+    const result = normalizeInboundChatMessage({
+      source: 'whatsapp',
+      message: incoming({
+        mediaType: 'video',
+        mediaMime: 'video/mp4',
+        mediaName: 'walkthrough.mp4',
+        archiveMediaRef: {
+          assetId: '4a1e6bd8-0000-4000-8000-000000000004',
+          sha256: 'b'.repeat(64),
+          filename: 'walkthrough.mp4',
+          mime: 'video/mp4',
+          sizeBytes: 4096,
+        },
+      }),
+    })
+    expect(result.kind).toBe('video')
+    expect(result.media_ref).toMatchObject({ availability: 'stored', asset_id: expect.any(String) })
+  })
+
+  it('keeps an explicit failed media state instead of a placeholder-only success', () => {
+	const result = normalizeInboundChatMessage({
+		source: 'wechat',
+		message: incoming({
+			text: '', mediaType: 'voice', mediaMime: 'audio/silk', mediaName: 'voice.silk',
+			archiveMediaAvailability: 'failed',
+		}),
+	})
+	expect(result).toMatchObject({
+		kind: 'voice', body_text: null,
+		media_ref: { availability: 'failed', filename: 'voice.silk', mime: 'audio/silk' },
+	})
+  })
+
   it('normalizes final outbound text and document metadata', () => {
     const result = normalizeOutboundChatMessage({
       providerMessageId: 'slack-ts-1',

--- a/packages/api/src/chat-archive/__tests__/schema-contract.test.ts
+++ b/packages/api/src/chat-archive/__tests__/schema-contract.test.ts
@@ -1,0 +1,28 @@
+import { readFile } from 'node:fs/promises'
+import { describe, expect, it } from 'vitest'
+
+async function migration(name: string): Promise<string> {
+  return readFile(new URL(`../../../migrations/${name}`, import.meta.url), 'utf8')
+}
+
+describe('[COMP:integrations/chat-message-archive-schema] archive migration contract', () => {
+  it('keeps the archive migrations ordered and the raw message row immutable', async () => {
+    const [base, sink, enrichment, cascade, media] = await Promise.all([
+      migration('405_chat_message_archive.sql'),
+      migration('406_local_chat_archive_sink.sql'),
+      migration('407_chat_archive_enrichment.sql'),
+      migration('408_chat_archive_owner_cascade.sql'),
+      migration('409_chat_archive_media.sql'),
+    ])
+
+    expect(base).toContain('CREATE TABLE chat_archive_messages')
+    expect(base).toContain('CREATE TABLE chat_archive_segments')
+    expect(sink).toContain("managed_by = 'local_chat_archive'")
+    expect(enrichment).toContain('CREATE TABLE chat_archive_enrichment_windows')
+    expect(cascade).toContain('ON DELETE CASCADE')
+    expect(media).toContain('CREATE TABLE chat_archive_media_assets')
+    expect(media).toContain('CREATE TABLE chat_archive_media_jobs')
+    expect(media).toContain('CREATE TABLE chat_archive_media_deletions')
+    expect(media).not.toMatch(/ALTER TABLE chat_archive_messages[\s\S]*ADD COLUMN[\s\S]*(ocr|transcript|description)/i)
+  })
+})

--- a/packages/api/src/chat-archive/chat-tools.ts
+++ b/packages/api/src/chat-archive/chat-tools.ts
@@ -60,7 +60,7 @@ export function createChatArchiveTools(deps: ChatArchiveToolDeps = {}): Tool[] {
       conversationId: z.string().min(1).optional().describe('Exact provider conversation id from a prior result.'),
       sender: z.string().min(1).optional().describe('Sender id or display-name substring.'),
       direction: z.enum(['inbound', 'outbound']).optional(),
-      kind: z.enum(['text', 'image', 'voice', 'file', 'link']).optional(),
+      kind: z.enum(['text', 'image', 'video', 'voice', 'file', 'link']).optional(),
       ...timeFilters,
     }),
     isReadOnly: true,
@@ -93,6 +93,7 @@ export function createChatArchiveTools(deps: ChatArchiveToolDeps = {}): Tool[] {
           data: {
             hits: result.hits,
             embeddingCoverage: result.embeddingCoverage.note ?? 'complete for the selected filters',
+            mediaCoverage: result.mediaCoverage,
           },
         }
       } catch (err) {

--- a/packages/api/src/chat-archive/enrichment-worker.ts
+++ b/packages/api/src/chat-archive/enrichment-worker.ts
@@ -14,7 +14,9 @@ export function renderChatArchiveWindow(window: ChatArchiveEnrichmentWindow): st
       message.mediaRef?.filename ? `: ${message.mediaRef.filename}` : '',
       ']',
     ].join('')
-    return `[${message.sentAt.toISOString()}] ${sender} (${message.direction}): ${body.slice(0, 2000)}`
+    const derived = message.derivedText?.trim()
+    const content = derived ? `${body}\n[derived ${message.kind} content]\n${derived}` : body
+    return `[${message.sentAt.toISOString()}] ${sender} (${message.direction}): ${content.slice(0, 4000)}`
   }).join('\n').slice(0, 16_000)
 }
 
@@ -62,12 +64,14 @@ export function createChatArchiveEnrichmentWorker(deps: {
             window.firstProviderMessageId,
             window.lastProviderMessageId,
           ],
+          media_asset_ids: [...new Set(window.messages.flatMap((message) => message.assetId ? [message.assetId] : []))],
         },
         contentRef: {
           source_kind: 'channel_window',
           archive_instance_id: window.instanceId,
           conversation_id: window.conversationId,
           message_id_range: [window.firstMessageId, window.lastMessageId],
+          media_asset_ids: [...new Set(window.messages.flatMap((message) => message.assetId ? [message.assetId] : []))],
         },
       })
       await deps.store.complete(window.id)

--- a/packages/api/src/chat-archive/live-writer.ts
+++ b/packages/api/src/chat-archive/live-writer.ts
@@ -25,6 +25,7 @@ export type LiveArchiveContext = {
 }
 
 export type LiveChatArchiveWriter = {
+  appendInbound(input: LiveArchiveContext & { message: IncomingMessage }): Promise<void>
   persistInbound<T>(
     input: LiveArchiveContext & { message: IncomingMessage },
     persist: (client?: Queryable) => Promise<T>,
@@ -139,6 +140,19 @@ export function createLiveChatArchiveWriter(deps: {
   }
 
   return {
+    async appendInbound(input) {
+      const binding = await resolveBinding(input)
+      if (!binding) return
+      await deps.fanout.fanout({
+        connectorInstanceId: binding.instanceId,
+        workspaceId: binding.workspaceId,
+        ownerUserId: input.ownerUserId,
+        source: input.source,
+        messages: [normalizeInboundChatMessage({ source: input.source, message: input.message })],
+        sourceCursor: { provider_message_id: input.message.messageId ?? null },
+      })
+    },
+
     async persistInbound(input, persist) {
       let binding: { instanceId: string; workspaceId: string } | null
       try {
@@ -205,6 +219,13 @@ export async function persistInboundChatArchive<T>(
   persist: (client?: Queryable) => Promise<T>,
 ): Promise<T> {
   return globalWriter ? globalWriter.persistInbound(input, persist) : persist()
+}
+
+export async function appendInboundChatArchive(
+  input: Parameters<LiveChatArchiveWriter['appendInbound']>[0],
+): Promise<void> {
+  if (!globalWriter) return
+  await globalWriter.appendInbound(input)
 }
 
 export async function appendOutboundChatArchive(input: Parameters<LiveChatArchiveWriter['appendOutbound']>[0]): Promise<void> {

--- a/packages/api/src/chat-archive/media-routes.ts
+++ b/packages/api/src/chat-archive/media-routes.ts
@@ -1,0 +1,162 @@
+/** Loopback-only HMAC staging routes for brian-message-store backfill media. */
+
+import { createHmac, timingSafeEqual } from 'node:crypto'
+import type { Readable } from 'node:stream'
+import { Router, type Request } from 'express'
+import { z } from 'zod'
+import { INGEST_APPEND_SIGNATURE_HEADER } from '@use-brian/shared'
+import { verifyIngestAppendSignature } from '../ingest/append-signing.js'
+import type { ChatArchiveMediaService } from './media-service.js'
+import { ChatArchiveMediaTooLargeError, archiveMediaRef } from './media-service.js'
+
+const initSchema = z.object({
+  workspace_id: z.string().uuid(),
+  instance_id: z.string().uuid(),
+  owner_user_id: z.string().uuid(),
+  source: z.string().min(1),
+  provider_message_id: z.string().min(1),
+  kind: z.enum(['image', 'video', 'voice', 'file']),
+  filename: z.string(),
+  mime: z.string().min(1),
+  size_bytes: z.number().int().nonnegative(),
+  sha256: z.string().regex(/^[a-f0-9]{64}$/).nullable().optional(),
+})
+
+function isLoopback(req: Request): boolean {
+  const remote = req.socket.remoteAddress ?? ''
+  return remote === '::1' || remote.startsWith('127.') || remote.startsWith('::ffff:127.')
+}
+
+function uploadToken(secret: string, assetId: string, expires: number): string {
+  return createHmac('sha256', secret).update(`${assetId}\n${expires}`).digest('base64url')
+}
+
+export function signedChatArchiveMediaUploadUrl(input: {
+  secret: string
+  baseUrl: string
+  assetId: string
+  ttlSec?: number
+}): string {
+  const expires = Math.floor(Date.now() / 1000) + (input.ttlSec ?? 3600)
+  const url = new URL(`/internal/chat-archive/media/${input.assetId}/content`, input.baseUrl)
+  url.searchParams.set('expires', String(expires))
+  url.searchParams.set('token', uploadToken(input.secret, input.assetId, expires))
+  return url.toString()
+}
+
+function tokenMatches(secret: string, assetId: string, expires: number, provided: unknown): boolean {
+  if (!Number.isSafeInteger(expires) || expires < Math.floor(Date.now() / 1000)) return false
+  if (typeof provided !== 'string') return false
+  const expected = Buffer.from(uploadToken(secret, assetId, expires))
+  const actual = Buffer.from(provided)
+  return expected.length === actual.length && timingSafeEqual(expected, actual)
+}
+
+function authenticatedJson(req: Request, secret: string): boolean {
+  const raw = (req as Request & { rawBody?: string }).rawBody
+  const signature = req.headers[INGEST_APPEND_SIGNATURE_HEADER]
+  return typeof raw === 'string'
+    && typeof signature === 'string'
+    && verifyIngestAppendSignature(raw, secret, signature)
+}
+
+export function chatArchiveMediaRoutes(deps: {
+  service: ChatArchiveMediaService
+  hmacSecret: string
+  baseUrl: string
+  uploadTtlSec?: number
+}): Router {
+  const router = Router()
+  const ttl = deps.uploadTtlSec ?? 3600
+
+  router.use((req, res, next) => {
+    if (!isLoopback(req)) {
+      res.status(403).json({ error: 'loopback_only' })
+      return
+    }
+    next()
+  })
+
+  router.post('/media/init', async (req, res) => {
+    if (!authenticatedJson(req, deps.hmacSecret)) {
+      res.status(401).json({ error: 'invalid_signature' })
+      return
+    }
+    const parsed = initSchema.safeParse(req.body)
+    if (!parsed.success) {
+      res.status(400).json({ error: 'invalid_media_init', details: parsed.error.flatten() })
+      return
+    }
+    try {
+      const value = parsed.data
+      const initialized = await deps.service.init({
+        workspaceId: value.workspace_id,
+        instanceId: value.instance_id,
+        ownerUserId: value.owner_user_id,
+        source: value.source,
+        providerMessageId: value.provider_message_id,
+        kind: value.kind,
+        filename: value.filename,
+        mime: value.mime,
+        sizeBytes: value.size_bytes,
+        sha256: value.sha256,
+      })
+      res.json({
+        asset_id: initialized.asset.id,
+        upload_url: signedChatArchiveMediaUploadUrl({
+          secret: deps.hmacSecret,
+          baseUrl: deps.baseUrl,
+          assetId: initialized.asset.id,
+          ttlSec: ttl,
+        }),
+        already_stored: initialized.alreadyStored,
+      })
+    } catch (err) {
+      if (err instanceof ChatArchiveMediaTooLargeError) {
+        res.status(413).json({ error: 'media_too_large', max_bytes: err.maxBytes })
+        return
+      }
+      const message = err instanceof Error ? err.message : String(err)
+      res.status(message.includes('binding') ? 403 : 500).json({ error: message })
+    }
+  })
+
+  router.put('/media/:assetId/content', async (req, res) => {
+    const expires = Number(req.query.expires)
+    if (!tokenMatches(deps.hmacSecret, req.params.assetId, expires, req.query.token)) {
+      res.status(401).json({ error: 'invalid_upload_token' })
+      return
+    }
+    const declared = req.headers['content-length'] ? Number(req.headers['content-length']) : null
+    try {
+      const asset = await deps.service.upload({
+        assetId: req.params.assetId,
+        stream: req as unknown as Readable,
+        contentLength: declared != null && Number.isFinite(declared) ? declared : null,
+      })
+      res.json({ asset_id: asset.id, size_bytes: asset.sizeBytes, sha256: asset.sha256 })
+    } catch (err) {
+      if (err instanceof ChatArchiveMediaTooLargeError) {
+        res.status(413).json({ error: 'media_too_large', max_bytes: err.maxBytes })
+        return
+      }
+      res.status(500).json({ error: err instanceof Error ? err.message : String(err) })
+    }
+  })
+
+  router.post('/media/:assetId/complete', async (req, res) => {
+    if (!authenticatedJson(req, deps.hmacSecret)) {
+      res.status(401).json({ error: 'invalid_signature' })
+      return
+    }
+    try {
+      const asset = await deps.service.complete(req.params.assetId)
+      res.json({ asset_id: asset.id, media_ref: archiveMediaRef(asset) })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      res.status(message.includes('not found') ? 404 : message.includes('SHA-256') ? 422 : 409).json({ error: message })
+    }
+  })
+
+  return router
+}

--- a/packages/api/src/chat-archive/media-service.ts
+++ b/packages/api/src/chat-archive/media-service.ts
@@ -1,0 +1,197 @@
+/** Local archive media staging orchestration. Bytes never enter message rows. */
+
+import { createHash, randomUUID } from 'node:crypto'
+import { Transform, type Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+import type { CanonicalIngestMessageV2 } from '@use-brian/shared'
+import type { FilesClientResolver } from '../files/files-api.js'
+import { buildStorageKey, buildStorageUri } from '../files/gcs-client.js'
+import type {
+  ChatArchiveMediaAsset,
+  ChatArchiveMediaKind,
+  ChatArchiveMediaStore,
+} from '../db/chat-archive-media-store.js'
+
+export const CHAT_ARCHIVE_SMALL_MEDIA_MAX_BYTES = 25 * 1024 * 1024
+export const CHAT_ARCHIVE_LARGE_MEDIA_MAX_BYTES = 500 * 1024 * 1024
+
+export class ChatArchiveMediaTooLargeError extends Error {
+  constructor(readonly bytes: number, readonly maxBytes: number) {
+    super(`chat archive media exceeds ${maxBytes} bytes (saw ${bytes})`)
+    this.name = 'ChatArchiveMediaTooLargeError'
+  }
+}
+
+export type InitChatArchiveMedia = {
+  workspaceId: string
+  instanceId: string
+  ownerUserId: string
+  source: string
+  providerMessageId: string
+  kind: ChatArchiveMediaKind
+  filename: string
+  mime: string
+  sizeBytes: number
+  sha256?: string | null
+}
+
+export type ChatArchiveMediaService = ReturnType<typeof createChatArchiveMediaService>
+
+export function mediaByteLimit(kind: ChatArchiveMediaKind): number {
+  return kind === 'video' || kind === 'voice'
+    ? CHAT_ARCHIVE_LARGE_MEDIA_MAX_BYTES
+    : CHAT_ARCHIVE_SMALL_MEDIA_MAX_BYTES
+}
+
+export function archiveMediaRef(asset: ChatArchiveMediaAsset): NonNullable<CanonicalIngestMessageV2['media_ref']> {
+  if (asset.uploadStatus !== 'stored' || !asset.sha256) {
+    throw new Error('chat archive media asset is not durably stored')
+  }
+  return {
+    asset_id: asset.id,
+    sha256: asset.sha256,
+    availability: 'stored',
+    filename: asset.filename,
+    mime: asset.mime,
+    size_bytes: asset.sizeBytes,
+  }
+}
+
+export function createChatArchiveMediaService(deps: {
+  store: ChatArchiveMediaStore
+  filesResolver: FilesClientResolver
+}) {
+  async function resolveBinding(input: {
+    workspaceId: string
+    ownerUserId: string
+    source: string
+    instanceId?: string | null
+  }): Promise<string> {
+    const instanceId = await deps.store.ensureBinding(input)
+    if (!instanceId) throw new Error('unable to resolve local chat archive connector binding')
+    return instanceId
+  }
+
+  async function init(input: InitChatArchiveMedia): Promise<{ asset: ChatArchiveMediaAsset; alreadyStored: boolean }> {
+    input = { ...input, mime: input.mime.trim() || 'application/octet-stream' }
+    if (!(await deps.store.bindingExists(input))) {
+      throw new Error('instance/source/workspace/owner archive binding is invalid')
+    }
+    const limit = mediaByteLimit(input.kind)
+    if (input.sizeBytes > limit) throw new ChatArchiveMediaTooLargeError(input.sizeBytes, limit)
+
+    const existing = await deps.store.getByProvider({
+      instanceId: input.instanceId,
+      providerMessageId: input.providerMessageId,
+    })
+    if (
+      existing?.uploadStatus === 'stored'
+      && existing.sha256
+      && (!input.sha256 || existing.sha256 === input.sha256)
+    ) {
+      return { asset: existing, alreadyStored: true }
+    }
+
+    const id = existing?.id ?? randomUUID()
+    let storageKey = existing?.storageKey
+    let storageUri = existing?.storageUri
+    if (!storageKey || !storageUri) {
+      const resolved = await deps.filesResolver.forWorkspace(input.workspaceId)
+      const storageId = `chat-archive-${id}`
+      storageKey = buildStorageKey(input.workspaceId, storageId)
+      storageUri = buildStorageUri(
+        resolved.bucket,
+        input.workspaceId,
+        storageId,
+        resolved.uriScheme,
+      )
+    }
+    const asset = await deps.store.upsertUploading({
+      id,
+      ...input,
+      expectedSha256: input.sha256 ?? null,
+      storageKey,
+      storageUri,
+    })
+    return { asset, alreadyStored: asset.uploadStatus === 'stored' }
+  }
+
+  async function upload(input: {
+    assetId: string
+    stream: Readable
+    contentLength?: number | null
+  }): Promise<ChatArchiveMediaAsset> {
+    const asset = await deps.store.get(input.assetId)
+    if (!asset) throw new Error('chat archive media asset not found')
+    // A completed idempotency key is immutable. A retried PUT may still arrive
+    // after init reported the existing asset; acknowledge it without replacing
+    // durable bytes or resetting extraction.
+    if (asset.uploadStatus === 'stored') return asset
+    const maxBytes = mediaByteLimit(asset.kind)
+    if (input.contentLength != null && input.contentLength > maxBytes) {
+      throw new ChatArchiveMediaTooLargeError(input.contentLength, maxBytes)
+    }
+    const client = await deps.filesResolver.forUri(asset.workspaceId, asset.storageUri)
+    const hash = createHash('sha256')
+    let bytes = 0
+    const counter = new Transform({
+      transform(chunk: Buffer, _encoding, callback) {
+        bytes += chunk.length
+        if (bytes > maxBytes) {
+          callback(new ChatArchiveMediaTooLargeError(bytes, maxBytes))
+          return
+        }
+        hash.update(chunk)
+        callback(null, chunk)
+      },
+    })
+    try {
+      await pipeline(
+        input.stream,
+        counter,
+        client.writeStream(asset.storageKey, {
+          mime: asset.mime,
+          metadata: {
+            workspaceId: asset.workspaceId,
+            createdByUserId: asset.ownerUserId,
+            mime: asset.mime,
+          },
+        }),
+      )
+      return deps.store.markUploaded(asset.id, hash.digest('hex'), bytes)
+    } catch (err) {
+      await client.deleteBlob(asset.storageKey).catch(() => {})
+      await deps.store.markUploadFailed(asset.id, err instanceof Error ? err.message : String(err)).catch(() => {})
+      throw err
+    }
+  }
+
+  async function complete(assetId: string): Promise<ChatArchiveMediaAsset> {
+    return deps.store.completeUpload(assetId)
+  }
+
+  async function storeBuffer(input: InitChatArchiveMedia & { bytes: Buffer }): Promise<ChatArchiveMediaAsset> {
+    const sha256 = createHash('sha256').update(input.bytes).digest('hex')
+    const initialized = await init({ ...input, sizeBytes: input.bytes.byteLength, sha256 })
+    if (initialized.alreadyStored) return initialized.asset
+    const client = await deps.filesResolver.forUri(input.workspaceId, initialized.asset.storageUri)
+    try {
+      await client.writeBlob(initialized.asset.storageKey, input.bytes, {
+        workspaceId: input.workspaceId,
+        createdByUserId: input.ownerUserId,
+        mime: input.mime,
+      })
+      await deps.store.markUploaded(initialized.asset.id, sha256, input.bytes.byteLength)
+      return complete(initialized.asset.id)
+    } catch (err) {
+      await client.deleteBlob(initialized.asset.storageKey).catch(() => {})
+      await deps.store.markUploadFailed(
+        initialized.asset.id,
+        err instanceof Error ? err.message : String(err),
+      ).catch(() => {})
+      throw err
+    }
+  }
+
+  return { resolveBinding, init, upload, complete, storeBuffer }
+}

--- a/packages/api/src/chat-archive/media-worker.ts
+++ b/packages/api/src/chat-archive/media-worker.ts
@@ -1,0 +1,363 @@
+/** Extract chat media into derived archive segments, then let embeddings drain normally. */
+
+import { execFile } from 'node:child_process'
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join } from 'node:path'
+import { promisify } from 'node:util'
+import type { RecordingTranscriber } from '@use-brian/core'
+import { parseFileContent } from '@use-brian/core'
+import type { ChatArchiveMediaAsset, ChatArchiveMediaStore, DerivedMediaSegment } from '../db/chat-archive-media-store.js'
+import type { FilesClientResolver } from '../files/files-api.js'
+import { extractRecordingAudio, probeRecordingDuration } from '../recordings/ffmpeg.js'
+
+const execFileAsync = promisify(execFile)
+const MAX_VIDEO_FRAMES = 120
+const MAX_SEGMENT_CHARS = 1_800
+const SEGMENT_OVERLAP_CHARS = 200
+const MAX_DERIVED_SEGMENTS = 400
+
+const PARSEABLE_DOCUMENT_MIMES = new Set([
+  'application/json',
+  'application/xml',
+  'application/yaml',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+])
+
+const LEGACY_OR_UNKNOWN_MIMES = new Set([
+  'application/msword',
+  'application/vnd.ms-excel',
+  'application/vnd.ms-powerpoint',
+  'application/octet-stream',
+])
+
+function chunks(text: string, metadata: Record<string, unknown>): DerivedMediaSegment[] {
+  const clean = text.replace(/\r\n/g, '\n').trim()
+  if (!clean) return []
+  const out: DerivedMediaSegment[] = []
+  let offset = 0
+  while (offset < clean.length && out.length < MAX_DERIVED_SEGMENTS) {
+    let end = Math.min(clean.length, offset + MAX_SEGMENT_CHARS)
+    if (end < clean.length) {
+      const boundary = Math.max(clean.lastIndexOf('\n', end), clean.lastIndexOf(' ', end))
+      if (boundary > offset + Math.floor(MAX_SEGMENT_CHARS / 2)) end = boundary
+    }
+    out.push({ text: clean.slice(offset, end), metadata: { ...metadata, chunk: out.length } })
+    if (end >= clean.length) break
+    offset = Math.max(offset + 1, end - SEGMENT_OVERLAP_CHARS)
+  }
+  return out
+}
+
+async function decodeWechatSilk(
+  data: Buffer,
+  decoderBin = process.env.WECHAT_SILK_DECODER_BIN?.trim() || 'silk_v3_decoder',
+): Promise<{ buffer: Buffer; mime: string; durationMs: number }> {
+  const dir = await mkdtemp(join(tmpdir(), 'wechat-silk-'))
+  const input = join(dir, 'input.silk')
+  const pcm = join(dir, 'output.pcm')
+  const output = join(dir, 'output.m4a')
+  try {
+    await writeFile(input, data)
+    try {
+      await execFileAsync(decoderBin, [input, pcm, '-quiet'], { timeout: 120_000, maxBuffer: 1 << 20 })
+    } catch (err) {
+      throw new Error(`WeChat SILK decoder prerequisite failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
+    await execFileAsync('ffmpeg', [
+      '-v', 'error', '-y', '-f', 's16le', '-ar', '24000', '-ac', '1', '-i', pcm,
+      '-ar', '16000', '-c:a', 'aac', '-b:a', '24k', output,
+    ], { timeout: 120_000, maxBuffer: 1 << 20 })
+    const durationMs = await probeRecordingDuration(output)
+    return { buffer: await readFile(output), mime: 'audio/mp4', durationMs }
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+async function sampleVideoFrames(input: string): Promise<Array<{ data: Buffer; timeStartMs: number }>> {
+  const dir = await mkdtemp(join(tmpdir(), 'chat-video-'))
+  try {
+    const pattern = join(dir, 'frame-%03d.jpg')
+    const filter = [
+      'select=gt(scene\\,0.30)+isnan(prev_selected_t)+gte(t-prev_selected_t\\,10)',
+      'mpdecimate',
+      "scale='min(1280,iw)':-2",
+      'showinfo',
+    ].join(',')
+    const { stderr } = await execFileAsync('ffmpeg', [
+      '-v', 'info', '-y', '-i', input, '-vf', filter, '-vsync', 'vfr',
+      '-frames:v', String(MAX_VIDEO_FRAMES), '-q:v', '3', pattern,
+    ], { timeout: 900_000, maxBuffer: 8 << 20 })
+    const times = [...stderr.matchAll(/pts_time:([0-9.]+)/g)].map((match) => Math.round(Number(match[1]) * 1000))
+    const files = (await readdir(dir)).filter((name) => /^frame-\d+\.jpg$/.test(name)).sort()
+    return Promise.all(files.slice(0, MAX_VIDEO_FRAMES).map(async (name, index) => ({
+      data: await readFile(join(dir, name)),
+      timeStartMs: Number.isFinite(times[index]) ? times[index]! : index * 10_000,
+    })))
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+async function transcribeAsset(input: {
+  asset: ChatArchiveMediaAsset
+  signedUrl: string
+  storage: Awaited<ReturnType<FilesClientResolver['forUri']>>
+  transcriber?: RecordingTranscriber
+  modality?: 'audio_transcript' | 'video_transcript'
+  language?: string
+  probe?: typeof probeRecordingDuration
+  extract?: typeof extractRecordingAudio
+}): Promise<DerivedMediaSegment[]> {
+  if (!input.transcriber) throw new Error('chat archive media transcription prerequisite missing')
+  let audio: { buffer: Buffer; mime: string }
+  let durationMs: number
+  if (input.asset.mime === 'audio/silk' || input.asset.filename.toLowerCase().endsWith('.silk')) {
+    const blob = await input.storage.readBlob(input.asset.storageKey)
+    if (!blob) throw new Error('chat archive SILK media bytes are missing')
+    const decoded = await decodeWechatSilk(blob.bytes)
+    audio = decoded
+    durationMs = decoded.durationMs
+  } else {
+    durationMs = await (input.probe ?? probeRecordingDuration)(input.signedUrl)
+    if (durationMs > 180 * 60 * 1000) throw new Error('chat archive media exceeds the 180 minute limit')
+    audio = await (input.extract ?? extractRecordingAudio)(input.signedUrl)
+  }
+  if (durationMs > 180 * 60 * 1000) throw new Error('chat archive media exceeds the 180 minute limit')
+
+  const stagedKey = `${input.asset.storageKey}.transcription.m4a`
+  await input.storage.writeBlob(stagedKey, audio.buffer, {
+    workspaceId: input.asset.workspaceId,
+    createdByUserId: input.asset.ownerUserId,
+    mime: audio.mime,
+  })
+  try {
+    const sourceUrl = await input.storage.signedReadUrl(stagedKey, 3600)
+    const result = await input.transcriber.transcribe({
+      buffer: audio.buffer,
+      mime: audio.mime,
+      durationMs,
+      sourceUrl,
+      displayName: input.asset.filename || basename(input.asset.storageKey),
+      ...(input.language ? { language: input.language } : {}),
+    })
+    return result.utterances.flatMap((utterance, index) => {
+      const text = `${utterance.speaker ? `${utterance.speaker}: ` : ''}${utterance.text}`.trim()
+      return text ? [{
+        text,
+        metadata: {
+          modality: input.modality ?? 'audio_transcript',
+          utterance: index,
+          time_start_ms: utterance.startMs,
+          time_end_ms: utterance.endMs,
+          ...(utterance.speaker ? { speaker: utterance.speaker } : {}),
+        },
+      }] : []
+    })
+  } finally {
+    await input.storage.deleteBlob(stagedKey).catch(() => {})
+  }
+}
+
+export type ChatArchiveMediaWorker = {
+  runOnce(): Promise<boolean>
+  cleanupOnce(): Promise<number>
+  start(): void
+  stop(): void
+}
+
+export function createChatArchiveMediaWorker(deps: {
+  store: ChatArchiveMediaStore
+  filesResolver: FilesClientResolver
+  transcriber?: RecordingTranscriber
+  distill?: (input: { buffer: Buffer; mime: string; prompt?: string }) => Promise<string>
+  resolveTranscriptionLanguage?: (workspaceId: string) => Promise<string | undefined>
+  probe?: typeof probeRecordingDuration
+  extract?: typeof extractRecordingAudio
+  intervalMs?: number
+  cleanupAgeMs?: number
+}): ChatArchiveMediaWorker {
+  const intervalMs = deps.intervalMs ?? 15_000
+  const cleanupAgeMs = deps.cleanupAgeMs ?? 24 * 60 * 60 * 1000
+  let timer: ReturnType<typeof setInterval> | null = null
+  let running = false
+
+  async function derive(asset: ChatArchiveMediaAsset): Promise<DerivedMediaSegment[] | 'unsupported'> {
+    const storage = await deps.filesResolver.forUri(asset.workspaceId, asset.storageUri)
+    const signedUrl = await storage.signedReadUrl(asset.storageKey, 3600)
+
+    if (asset.kind === 'image') {
+      if (!deps.distill) throw new Error('chat archive image distillation prerequisite missing')
+      const blob = await storage.readBlob(asset.storageKey)
+      if (!blob) throw new Error('chat archive image bytes are missing')
+      const [ocr, description] = await Promise.all([
+        deps.distill({
+          buffer: blob.bytes,
+          mime: asset.mime,
+          prompt: 'Transcribe every visible word in this image faithfully. Preserve reading order. Return only the transcription.',
+        }),
+        deps.distill({
+          buffer: blob.bytes,
+          mime: asset.mime,
+          prompt: 'Describe the meaningful visual content of this image for semantic search, including people, objects, setting, actions, charts, and notable details. Do not invent hidden facts.',
+        }),
+      ])
+      return [
+        ...chunks(ocr, { modality: 'image_ocr' }),
+        ...chunks(description, { modality: 'image_description' }),
+      ]
+    }
+
+    if (asset.kind === 'voice') {
+      return transcribeAsset({
+        asset,
+        signedUrl,
+        storage,
+        transcriber: deps.transcriber,
+        language: await deps.resolveTranscriptionLanguage?.(asset.workspaceId),
+        probe: deps.probe,
+        extract: deps.extract,
+      })
+    }
+
+    if (asset.kind === 'video') {
+      const durationMs = await probeRecordingDuration(signedUrl)
+      if (durationMs > 180 * 60 * 1000) throw new Error('chat archive media exceeds the 180 minute limit')
+      const segments: DerivedMediaSegment[] = []
+      try {
+        segments.push(...await transcribeAsset({
+          asset,
+          signedUrl,
+          storage,
+          transcriber: deps.transcriber,
+          modality: 'video_transcript',
+          language: await deps.resolveTranscriptionLanguage?.(asset.workspaceId),
+          probe: deps.probe,
+          extract: deps.extract,
+        }))
+      } catch (err) {
+        console.warn('[chat-archive-media] video audio track unavailable:', err instanceof Error ? err.message : err)
+      }
+      if (!deps.distill) throw new Error('chat archive video vision prerequisite missing')
+      const frames = await sampleVideoFrames(signedUrl)
+      for (const frame of frames) {
+        const description = (await deps.distill({
+          buffer: frame.data,
+          mime: 'image/jpeg',
+          prompt: 'Describe this sampled video frame for semantic search. Include visible people, objects, setting, actions, text, and other concrete details. Do not invent context.',
+        })).trim()
+        if (description) {
+          segments.push({
+            text: description,
+            metadata: {
+              modality: 'video_frame',
+              time_start_ms: frame.timeStartMs,
+              time_end_ms: Math.min(durationMs, frame.timeStartMs + 10_000),
+            },
+          })
+        }
+      }
+      if (segments.length === 0) throw new Error('chat archive video produced no transcript or visual description')
+      return segments
+    }
+
+    if (LEGACY_OR_UNKNOWN_MIMES.has(asset.mime)) return 'unsupported'
+    const blob = await storage.readBlob(asset.storageKey)
+    if (!blob) throw new Error('chat archive document bytes are missing')
+    if (asset.mime === 'application/pdf') {
+      if (!deps.distill) throw new Error('chat archive PDF distillation prerequisite missing')
+      return chunks(
+        await deps.distill({ buffer: blob.bytes, mime: asset.mime }),
+        { modality: 'document', page: null },
+      )
+    }
+    if (!asset.mime.startsWith('text/') && !PARSEABLE_DOCUMENT_MIMES.has(asset.mime)) return 'unsupported'
+    if (asset.mime === 'application/xml' || asset.mime === 'application/yaml') {
+      return chunks(blob.bytes.toString('utf8'), { modality: 'document', page: null })
+    }
+    const parsed = await parseFileContent(blob.bytes, asset.mime, asset.filename)
+    return chunks(parsed.text, { modality: 'document', page: null })
+  }
+
+  const runOnce = async (): Promise<boolean> => {
+    if (running) return false
+    running = true
+    let job: Awaited<ReturnType<ChatArchiveMediaStore['claimNext']>> = null
+    try {
+      job = await deps.store.claimNext()
+      if (!job) return false
+      const derived = await derive(job.asset)
+      if (derived === 'unsupported') {
+        await deps.store.unsupportedJob(job.id, job.asset.id, `unsupported media extraction format: ${job.asset.mime}`)
+        return true
+      }
+      await deps.store.replaceDerivedSegments(job.asset, derived)
+      await deps.store.completeJob(job.id, job.asset.id)
+      return true
+    } catch (err) {
+      if (job) {
+        await deps.store.failJob(
+          job.id,
+          job.asset.id,
+          job.attemptCount,
+          err instanceof Error ? err.message : String(err),
+        ).catch(() => {})
+      }
+      console.warn('[chat-archive-media] processing failed:', err)
+      return false
+    } finally {
+      running = false
+    }
+  }
+
+  const cleanupOnce = async (): Promise<number> => {
+    const assets = await deps.store.listUnlinkedBefore(new Date(Date.now() - cleanupAgeMs))
+    let removed = 0
+    for (const asset of assets) {
+      try {
+        await deps.store.remove(asset.id)
+      } catch (err) {
+        console.warn('[chat-archive-media] orphan cleanup failed:', err)
+      }
+    }
+    const deletions = await deps.store.listDeletions()
+    for (const deletion of deletions) {
+      try {
+        const storage = await deps.filesResolver.forUri(deletion.workspaceId, deletion.storageUri)
+        await storage.deleteBlob(deletion.storageKey)
+        await deps.store.completeDeletion(deletion.id)
+        removed += 1
+      } catch (err) {
+        await deps.store.failDeletion(
+          deletion.id,
+          deletion.attemptCount,
+          err instanceof Error ? err.message : String(err),
+        ).catch(() => {})
+        console.warn('[chat-archive-media] byte deletion failed:', err)
+      }
+    }
+    return removed
+  }
+
+  return {
+    runOnce,
+    cleanupOnce,
+    start() {
+      if (timer) return
+      timer = setInterval(() => {
+        void runOnce()
+        void cleanupOnce()
+      }, intervalMs)
+      timer.unref?.()
+      void runOnce()
+      void cleanupOnce()
+    },
+    stop() {
+      if (timer) clearInterval(timer)
+      timer = null
+    },
+  }
+}

--- a/packages/api/src/chat-archive/normalize.ts
+++ b/packages/api/src/chat-archive/normalize.ts
@@ -2,7 +2,7 @@
 
 import { createHash } from 'node:crypto'
 import type { IncomingMessage, OutgoingDocument } from '@use-brian/channels'
-import type { CanonicalIngestMessage } from '@use-brian/shared'
+import type { AnyCanonicalIngestMessage, CanonicalIngestMessage, CanonicalIngestMessageV2 } from '@use-brian/shared'
 
 function sentAt(value: number): string {
   const millis = Number.isFinite(value) ? (value < 1_000_000_000_000 ? value * 1000 : value) : 0
@@ -22,17 +22,36 @@ function derivedMessageId(source: string, message: IncomingMessage): string {
   })).digest('hex')}`
 }
 
-function mediaKind(message: IncomingMessage): CanonicalIngestMessage['kind'] {
+function mediaKind(message: IncomingMessage): CanonicalIngestMessageV2['kind'] {
   if (message.mediaType === 'photo') return 'image'
   if (message.mediaType === 'voice' || message.mediaType === 'audio') return 'voice'
+  if (message.mediaType === 'video') return 'video'
   if (message.mediaType || message.files?.length) return 'file'
   if (/^https?:\/\/\S+$/i.test(message.text.trim())) return 'link'
   return 'text'
 }
 
-function mediaRef(message: IncomingMessage): CanonicalIngestMessage['media_ref'] {
+function mediaRef(message: IncomingMessage): CanonicalIngestMessage['media_ref'] | CanonicalIngestMessageV2['media_ref'] {
+  if (message.archiveMediaRef) {
+    return {
+      asset_id: message.archiveMediaRef.assetId,
+      sha256: message.archiveMediaRef.sha256,
+      availability: 'stored',
+      filename: message.archiveMediaRef.filename,
+      mime: message.archiveMediaRef.mime,
+      size_bytes: message.archiveMediaRef.sizeBytes,
+    }
+  }
   const file = message.files?.[0]
   if (!message.mediaType && !message.mediaUrl && !file) return null
+  if (message.archiveMediaAvailability) {
+    return {
+      availability: message.archiveMediaAvailability,
+      filename: message.mediaName ?? file?.name ?? '',
+      mime: message.mediaMime ?? file?.mimeType ?? '',
+      size_bytes: Math.max(0, message.mediaSizeBytes ?? 0),
+    }
+  }
   return {
     filename: message.mediaName || file?.name || 'attachment',
     mime: message.mediaMime || file?.mimeType || 'application/octet-stream',
@@ -43,7 +62,7 @@ function mediaRef(message: IncomingMessage): CanonicalIngestMessage['media_ref']
 export function normalizeInboundChatMessage(input: {
   source: string
   message: IncomingMessage
-}): CanonicalIngestMessage {
+}): AnyCanonicalIngestMessage {
   const { source, message } = input
   return {
     provider_message_id: message.messageId || derivedMessageId(source, message),
@@ -59,7 +78,7 @@ export function normalizeInboundChatMessage(input: {
     // Provider payloads can contain tokens and connector secrets. Live capture
     // needs no reparsing, so the safest sanitized payload is no payload.
     raw_provider_blob: null,
-  }
+  } as AnyCanonicalIngestMessage
 }
 
 export function normalizeOutboundChatMessage(input: {

--- a/packages/api/src/chat-archive/tool-catalog.ts
+++ b/packages/api/src/chat-archive/tool-catalog.ts
@@ -8,7 +8,8 @@ export const CHAT_ARCHIVE_SEARCH_TOOL = {
     'For a personal identity question such as "Who is X?", search the exact name before using public ' +
     'web search or CRM/contact tools; chat evidence is personal context, not a public biography. ' +
     'Filters can narrow the source, conversation, sender, direction, message kind, or time range. ' +
-    'Keyword recall covers every archived message; the result states when semantic indexing is partial.',
+	'Image OCR/descriptions, document passages, audio transcripts, and sampled video content are searched ' +
+	'alongside captions and message text. Results report both semantic-index and media-processing coverage.',
   classification: 'read',
   defaultPolicy: 'allow',
 } as const

--- a/packages/api/src/db/__tests__/chat-archive-media-store.test.ts
+++ b/packages/api/src/db/__tests__/chat-archive-media-store.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createChatArchiveMediaStore } from '../chat-archive-media-store.js'
+
+describe('[COMP:api/chat-archive-media] media job terminal states', () => {
+  it('keeps retryable extraction failures pending and marks only the fifth failure terminal', async () => {
+    const query = vi.fn(async (_sql: string, _values?: unknown[]) => ({ rows: [] }))
+    const store = createChatArchiveMediaStore({ query } as never)
+
+    await store.failJob('job-1', 'asset-1', 1, 'temporary')
+    await store.failJob('job-1', 'asset-1', 5, 'terminal')
+
+    expect(query.mock.calls[0]![0]).toContain("CASE WHEN $4 = 'dead' THEN 'failed' ELSE 'pending' END")
+    expect(query.mock.calls[0]![1]).toEqual(['job-1', 'asset-1', 'temporary', 'failed', 30])
+    expect(query.mock.calls[1]![1]).toEqual(['job-1', 'asset-1', 'terminal', 'dead', 480])
+  })
+})

--- a/packages/api/src/db/chat-archive-enrichment-store.ts
+++ b/packages/api/src/db/chat-archive-enrichment-store.ts
@@ -11,9 +11,12 @@ export type ChatArchiveEnrichmentMessage = {
   senderDisplay: string | null
   sentAt: Date
   direction: 'inbound' | 'outbound'
-  kind: 'text' | 'image' | 'voice' | 'file' | 'link'
+  kind: 'text' | 'image' | 'video' | 'voice' | 'file' | 'link'
   bodyText: string | null
   mediaRef: { filename?: string; mime?: string; size_bytes?: number } | null
+  derivedText?: string | null
+  assetId?: string | null
+  extractionStatus?: string | null
 }
 
 export type ChatArchiveEnrichmentWindow = {
@@ -62,9 +65,17 @@ async function loadMessages(client: Pick<pg.ClientBase, 'query'>, windowId: stri
             m.provider_message_id AS "providerMessageId",
             m.sender_id AS "senderId", m.sender_display AS "senderDisplay",
             m.sent_at AS "sentAt", m.direction, m.kind,
-            m.body_text AS "bodyText", m.media_ref AS "mediaRef", m.source
+            m.body_text AS "bodyText", m.media_ref AS "mediaRef", m.source,
+            derived.text AS "derivedText", a.id::text AS "assetId",
+            a.extraction_status AS "extractionStatus"
        FROM chat_archive_enrichment_messages em
        JOIN chat_archive_messages m ON m.id = em.message_id
+       LEFT JOIN chat_archive_media_assets a ON a.message_id = m.id
+       LEFT JOIN LATERAL (
+         SELECT string_agg(s.segment_text, E'\n' ORDER BY s.segment_index) AS text
+           FROM chat_archive_segments s
+          WHERE s.message_id = m.id AND s.segment_index > 0 AND s.retracted_at IS NULL
+       ) derived ON true
       WHERE em.window_id = $1
       ORDER BY m.sent_at ASC, m.id ASC`,
     [windowId],
@@ -118,6 +129,16 @@ export function createChatArchiveEnrichmentStore(
                     m.owner_user_id AS "ownerUserId", m.conversation_id AS "conversationId"
                FROM chat_archive_messages m
               WHERE (m.body_text IS NOT NULL OR m.media_ref IS NOT NULL)
+                AND (
+                  m.media_ref IS NULL
+                  OR NOT (m.media_ref ? 'availability')
+                  OR m.media_ref->>'availability' IN ('missing','failed')
+                  OR EXISTS (
+                    SELECT 1 FROM chat_archive_media_assets a
+                     WHERE a.message_id = m.id AND a.upload_status = 'stored'
+                       AND a.extraction_status IN ('ready','failed','unsupported')
+                  )
+                )
                 AND NOT EXISTS (
                   SELECT 1 FROM chat_archive_enrichment_messages em WHERE em.message_id = m.id
                 )
@@ -139,6 +160,16 @@ export function createChatArchiveEnrichmentStore(
                FROM chat_archive_messages m
               WHERE m.instance_id = $1 AND m.conversation_id = $2
                 AND (m.body_text IS NOT NULL OR m.media_ref IS NOT NULL)
+                AND (
+                  m.media_ref IS NULL
+                  OR NOT (m.media_ref ? 'availability')
+                  OR m.media_ref->>'availability' IN ('missing','failed')
+                  OR EXISTS (
+                    SELECT 1 FROM chat_archive_media_assets a
+                     WHERE a.message_id = m.id AND a.upload_status = 'stored'
+                       AND a.extraction_status IN ('ready','failed','unsupported')
+                  )
+                )
                 AND NOT EXISTS (
                   SELECT 1 FROM chat_archive_enrichment_messages em WHERE em.message_id = m.id
                 )

--- a/packages/api/src/db/chat-archive-media-store.ts
+++ b/packages/api/src/db/chat-archive-media-store.ts
@@ -1,0 +1,496 @@
+/** Durable asset + leased extraction-job store for chat archive media. */
+
+import type pg from 'pg'
+import { getPool } from './client.js'
+
+export type ChatArchiveMediaKind = 'image' | 'video' | 'voice' | 'file'
+export type ChatArchiveUploadStatus = 'uploading' | 'uploaded' | 'stored' | 'failed'
+export type ChatArchiveExtractionStatus = 'pending' | 'processing' | 'ready' | 'failed' | 'unsupported'
+
+export type ChatArchiveMediaAsset = {
+  id: string
+  workspaceId: string
+  instanceId: string
+  ownerUserId: string
+  messageId: string | null
+  source: string
+  providerMessageId: string
+  kind: ChatArchiveMediaKind
+  filename: string
+  mime: string
+  sizeBytes: number
+  expectedSha256: string | null
+  sha256: string | null
+  storageKey: string
+  storageUri: string
+  uploadStatus: ChatArchiveUploadStatus
+  extractionStatus: ChatArchiveExtractionStatus
+  lastError: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+export type ChatArchiveMediaJob = {
+  id: string
+  asset: ChatArchiveMediaAsset
+  attemptCount: number
+}
+
+export type DerivedMediaSegment = {
+  text: string
+  metadata: Record<string, unknown>
+}
+
+export type ChatArchiveMediaDeletion = {
+  id: string
+  workspaceId: string
+  storageKey: string
+  storageUri: string
+  attemptCount: number
+}
+
+const ASSET_COLS = `
+  id,
+  workspace_id        AS "workspaceId",
+  instance_id         AS "instanceId",
+  owner_user_id       AS "ownerUserId",
+  message_id          AS "messageId",
+  source,
+  provider_message_id AS "providerMessageId",
+  kind,
+  filename,
+  mime,
+  size_bytes          AS "sizeBytes",
+  expected_sha256     AS "expectedSha256",
+  sha256,
+  storage_key         AS "storageKey",
+  storage_uri         AS "storageUri",
+  upload_status       AS "uploadStatus",
+  extraction_status   AS "extractionStatus",
+  last_error          AS "lastError",
+  created_at          AS "createdAt",
+  updated_at          AS "updatedAt"`
+
+function assetFromRow(row: Record<string, unknown>): ChatArchiveMediaAsset {
+  return {
+    id: String(row.id),
+    workspaceId: String(row.workspaceId),
+    instanceId: String(row.instanceId),
+    ownerUserId: String(row.ownerUserId),
+    messageId: row.messageId ? String(row.messageId) : null,
+    source: String(row.source),
+    providerMessageId: String(row.providerMessageId),
+    kind: row.kind as ChatArchiveMediaKind,
+    filename: String(row.filename ?? ''),
+    mime: String(row.mime ?? 'application/octet-stream'),
+    sizeBytes: Number(row.sizeBytes ?? 0),
+    expectedSha256: row.expectedSha256 ? String(row.expectedSha256) : null,
+    sha256: row.sha256 ? String(row.sha256) : null,
+    storageKey: String(row.storageKey),
+    storageUri: String(row.storageUri),
+    uploadStatus: row.uploadStatus as ChatArchiveUploadStatus,
+    extractionStatus: row.extractionStatus as ChatArchiveExtractionStatus,
+    lastError: row.lastError ? String(row.lastError) : null,
+    createdAt: new Date(row.createdAt as string | Date),
+    updatedAt: new Date(row.updatedAt as string | Date),
+  }
+}
+
+export type ChatArchiveMediaStore = ReturnType<typeof createChatArchiveMediaStore>
+
+export function createChatArchiveMediaStore(pool: pg.Pool = getPool()) {
+  return {
+    async ensureBinding(input: {
+      workspaceId: string
+      ownerUserId: string
+      source: string
+      instanceId?: string | null
+    }): Promise<string | null> {
+      if (input.instanceId) {
+        const supplied = await pool.query<{ found: boolean }>(
+          `SELECT EXISTS (
+             SELECT 1 FROM connector_instance
+              WHERE id = $1::uuid AND provider = $2
+                AND ((scope = 'workspace' AND workspace_id = $3::uuid)
+                  OR ingest_workspace_id = $3::uuid
+                  OR (scope = 'user' AND user_id = $4::uuid))
+           ) AS found`,
+          [input.instanceId, input.source, input.workspaceId, input.ownerUserId],
+        )
+        if (supplied.rows[0]?.found) return input.instanceId
+      }
+      const existing = await pool.query<{ id: string }>(
+        `SELECT id::text FROM connector_instance
+          WHERE provider = $1
+            AND ((scope = 'workspace' AND workspace_id = $2)
+              OR ingest_workspace_id = $2
+              OR (scope = 'user' AND user_id = $3))
+          ORDER BY (config->>'managedBy' = 'local_chat_archive') ASC,
+                   connected DESC, created_at ASC LIMIT 1`,
+        [input.source, input.workspaceId, input.ownerUserId],
+      )
+      if (existing.rows[0]) return existing.rows[0].id
+      const inserted = await pool.query<{ id: string }>(
+        `INSERT INTO connector_instance
+           (scope, user_id, workspace_id, provider, label, custom,
+            credentials_type, config, sensitivity, connected,
+            ingestion_enabled, created_by)
+         VALUES ('workspace', NULL, $1, $2, $3, false, 'none',
+                 '{"managedBy":"local_chat_archive"}'::jsonb,
+                 'internal', true, false, $4)
+         ON CONFLICT DO NOTHING
+         RETURNING id::text`,
+        [input.workspaceId, input.source, `${input.source} chat archive`, input.ownerUserId],
+      )
+      if (inserted.rows[0]) return inserted.rows[0].id
+      const raced = await pool.query<{ id: string }>(
+        `SELECT id::text FROM connector_instance
+          WHERE scope = 'workspace' AND workspace_id = $1 AND provider = $2
+            AND config->>'managedBy' = 'local_chat_archive'
+          LIMIT 1`,
+        [input.workspaceId, input.source],
+      )
+      return raced.rows[0]?.id ?? null
+    },
+
+    async bindingExists(input: {
+      instanceId: string
+      source: string
+      workspaceId: string
+      ownerUserId: string
+    }): Promise<boolean> {
+      const result = await pool.query<{ found: boolean }>(
+        `SELECT EXISTS (
+           SELECT 1 FROM connector_instance
+            WHERE id = $1::uuid AND provider = $2
+              AND (
+                (scope = 'workspace' AND workspace_id = $3::uuid)
+                OR ingest_workspace_id = $3::uuid
+                OR (scope = 'user' AND user_id = $4::uuid)
+              )
+         ) AS found`,
+        [input.instanceId, input.source, input.workspaceId, input.ownerUserId],
+      )
+      return result.rows[0]?.found === true
+    },
+
+    async get(id: string): Promise<ChatArchiveMediaAsset | null> {
+      const result = await pool.query(`SELECT ${ASSET_COLS} FROM chat_archive_media_assets WHERE id = $1`, [id])
+      return result.rows[0] ? assetFromRow(result.rows[0] as Record<string, unknown>) : null
+    },
+
+    async getByProvider(input: { instanceId: string; providerMessageId: string }): Promise<ChatArchiveMediaAsset | null> {
+      const result = await pool.query(
+        `SELECT ${ASSET_COLS} FROM chat_archive_media_assets
+          WHERE instance_id = $1 AND provider_message_id = $2`,
+        [input.instanceId, input.providerMessageId],
+      )
+      return result.rows[0] ? assetFromRow(result.rows[0] as Record<string, unknown>) : null
+    },
+
+    async upsertUploading(input: {
+      id: string
+      workspaceId: string
+      instanceId: string
+      ownerUserId: string
+      source: string
+      providerMessageId: string
+      kind: ChatArchiveMediaKind
+      filename: string
+      mime: string
+      sizeBytes: number
+      expectedSha256?: string | null
+      storageKey: string
+      storageUri: string
+    }): Promise<ChatArchiveMediaAsset> {
+      const result = await pool.query(
+        `INSERT INTO chat_archive_media_assets (
+           id, workspace_id, instance_id, owner_user_id, source,
+           provider_message_id, kind, filename, mime, size_bytes,
+           expected_sha256, storage_key, storage_uri,
+           upload_status, extraction_status
+         ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,'uploading','pending')
+         ON CONFLICT (instance_id, provider_message_id) DO UPDATE SET
+           filename = EXCLUDED.filename,
+           mime = EXCLUDED.mime,
+           size_bytes = EXCLUDED.size_bytes,
+           expected_sha256 = EXCLUDED.expected_sha256,
+           upload_status = CASE
+             WHEN chat_archive_media_assets.upload_status = 'stored'
+              AND (EXCLUDED.expected_sha256 IS NULL OR chat_archive_media_assets.sha256 = EXCLUDED.expected_sha256)
+             THEN 'stored' ELSE 'uploading' END,
+           extraction_status = CASE
+             WHEN chat_archive_media_assets.upload_status = 'stored'
+              AND (EXCLUDED.expected_sha256 IS NULL OR chat_archive_media_assets.sha256 = EXCLUDED.expected_sha256)
+             THEN chat_archive_media_assets.extraction_status ELSE 'pending' END,
+           last_error = NULL,
+           updated_at = now()
+         RETURNING ${ASSET_COLS}`,
+        [
+          input.id, input.workspaceId, input.instanceId, input.ownerUserId, input.source,
+          input.providerMessageId, input.kind, input.filename, input.mime, input.sizeBytes,
+          input.expectedSha256 ?? null, input.storageKey, input.storageUri,
+        ],
+      )
+      return assetFromRow(result.rows[0] as Record<string, unknown>)
+    },
+
+    async markUploaded(id: string, sha256: string, sizeBytes: number): Promise<ChatArchiveMediaAsset> {
+      const result = await pool.query(
+        `UPDATE chat_archive_media_assets
+            SET sha256 = $2, size_bytes = $3, upload_status = 'uploaded',
+                extraction_status = 'pending', last_error = NULL, updated_at = now()
+          WHERE id = $1
+          RETURNING ${ASSET_COLS}`,
+        [id, sha256, sizeBytes],
+      )
+      if (!result.rows[0]) throw new Error('chat archive media asset not found')
+      return assetFromRow(result.rows[0] as Record<string, unknown>)
+    },
+
+    async markUploadFailed(id: string, error: string): Promise<void> {
+      await pool.query(
+        `UPDATE chat_archive_media_assets
+            SET upload_status = 'failed', extraction_status = 'failed',
+                last_error = $2, updated_at = now()
+          WHERE id = $1`,
+        [id, error.slice(0, 2000)],
+      )
+    },
+
+    async completeUpload(id: string): Promise<ChatArchiveMediaAsset> {
+      const client = await pool.connect()
+      try {
+        await client.query('BEGIN')
+        const current = await client.query(
+          `SELECT ${ASSET_COLS} FROM chat_archive_media_assets WHERE id = $1 FOR UPDATE`,
+          [id],
+        )
+        if (!current.rows[0]) throw new Error('chat archive media asset not found')
+        const asset = assetFromRow(current.rows[0] as Record<string, unknown>)
+        if (asset.uploadStatus !== 'uploaded' && asset.uploadStatus !== 'stored') {
+          throw new Error(`chat archive media upload is ${asset.uploadStatus}`)
+        }
+        if (!asset.sha256) throw new Error('chat archive media upload has no fingerprint')
+        if (asset.expectedSha256 && asset.expectedSha256 !== asset.sha256) {
+          await client.query(
+            `UPDATE chat_archive_media_assets
+                SET upload_status = 'failed', extraction_status = 'failed',
+                    last_error = 'uploaded SHA-256 did not match expected fingerprint', updated_at = now()
+              WHERE id = $1`,
+            [id],
+          )
+          await client.query('COMMIT')
+          throw new Error('uploaded SHA-256 did not match expected fingerprint')
+        }
+        if (asset.uploadStatus === 'stored' && asset.extractionStatus !== 'pending') {
+          await client.query('COMMIT')
+          return asset
+        }
+        await client.query(
+          `UPDATE chat_archive_media_assets
+              SET upload_status = 'stored', last_error = NULL, updated_at = now()
+            WHERE id = $1`,
+          [id],
+        )
+        await client.query(
+          `INSERT INTO chat_archive_media_jobs (asset_id, status)
+           VALUES ($1, 'pending')
+           ON CONFLICT (asset_id) DO UPDATE SET
+             status = 'pending',
+             next_attempt_at = now(), locked_until = NULL, last_error = NULL, updated_at = now()`,
+          [id],
+        )
+        const updated = await client.query(`SELECT ${ASSET_COLS} FROM chat_archive_media_assets WHERE id = $1`, [id])
+        await client.query('COMMIT')
+        return assetFromRow(updated.rows[0] as Record<string, unknown>)
+      } catch (err) {
+        await client.query('ROLLBACK').catch(() => {})
+        throw err
+      } finally {
+        client.release()
+      }
+    },
+
+    async claimNext(): Promise<ChatArchiveMediaJob | null> {
+      const client = await pool.connect()
+      try {
+        await client.query('BEGIN')
+        await client.query(
+          `UPDATE chat_archive_media_jobs
+              SET status = 'failed', next_attempt_at = now(), locked_until = NULL,
+                  last_error = 'lease expired', updated_at = now()
+            WHERE status = 'processing' AND locked_until < now()`,
+        )
+        const claimed = await client.query<{ id: string; assetId: string; attemptCount: number }>(
+          `SELECT j.id, j.asset_id AS "assetId", j.attempt_count AS "attemptCount"
+             FROM chat_archive_media_jobs j
+             JOIN chat_archive_media_assets a ON a.id = j.asset_id
+            WHERE j.status IN ('pending','failed') AND j.next_attempt_at <= now()
+              AND a.message_id IS NOT NULL AND a.upload_status = 'stored'
+            ORDER BY j.next_attempt_at, j.created_at
+            FOR UPDATE OF j SKIP LOCKED LIMIT 1`,
+        )
+        const row = claimed.rows[0]
+        if (!row) {
+          await client.query('COMMIT')
+          return null
+        }
+        const updated = await client.query<{ attemptCount: number }>(
+          `UPDATE chat_archive_media_jobs
+              SET status = 'processing', attempt_count = attempt_count + 1,
+                  locked_until = now() + interval '15 minutes', updated_at = now()
+            WHERE id = $1 RETURNING attempt_count AS "attemptCount"`,
+          [row.id],
+        )
+        await client.query(
+          `UPDATE chat_archive_media_assets
+              SET extraction_status = 'processing', last_error = NULL, updated_at = now()
+            WHERE id = $1`,
+          [row.assetId],
+        )
+        const assetRow = await client.query(`SELECT ${ASSET_COLS} FROM chat_archive_media_assets WHERE id = $1`, [row.assetId])
+        await client.query('COMMIT')
+        if (!assetRow.rows[0]) return null
+        return { id: row.id, asset: assetFromRow(assetRow.rows[0] as Record<string, unknown>), attemptCount: updated.rows[0]!.attemptCount }
+      } catch (err) {
+        await client.query('ROLLBACK').catch(() => {})
+        throw err
+      } finally {
+        client.release()
+      }
+    },
+
+    async replaceDerivedSegments(asset: ChatArchiveMediaAsset, segments: DerivedMediaSegment[]): Promise<void> {
+      if (!asset.messageId) throw new Error('chat archive media asset is not linked to a message')
+      const client = await pool.connect()
+      try {
+        await client.query('BEGIN')
+        await client.query(
+          `DELETE FROM chat_archive_segments WHERE message_id = $1 AND segment_index > 0`,
+          [asset.messageId],
+        )
+        let index = 1
+        for (const segment of segments) {
+          const text = segment.text.trim()
+          if (!text) continue
+          await client.query(
+            `INSERT INTO chat_archive_segments (
+               workspace_id, message_id, instance_id, conversation_id,
+               segment_index, segment_text, user_id, assistant_id,
+               source, sensitivity, metadata, valid_from, created_by_user_id
+             )
+             SELECT m.workspace_id, m.id, m.instance_id, m.conversation_id,
+                    $2, $3, m.owner_user_id, NULL,
+                    'chat_archive_media', 'internal', $4::jsonb, m.sent_at, m.owner_user_id
+               FROM chat_archive_messages m WHERE m.id = $1
+             ON CONFLICT (message_id, segment_index) DO UPDATE SET
+               segment_text = EXCLUDED.segment_text,
+               metadata = EXCLUDED.metadata,
+               embedding = NULL, embedding_model_id = NULL, content_hash = NULL,
+               embedding_failed_at = NULL, embedding_failure_reason = NULL,
+               embedding_updated_at = NULL`,
+            [asset.messageId, index, text, JSON.stringify({ asset_id: asset.id, ...segment.metadata })],
+          )
+          index += 1
+        }
+        await client.query('COMMIT')
+      } catch (err) {
+        await client.query('ROLLBACK').catch(() => {})
+        throw err
+      } finally {
+        client.release()
+      }
+    },
+
+    async completeJob(jobId: string, assetId: string): Promise<void> {
+      await pool.query(
+        `WITH job AS (
+           UPDATE chat_archive_media_jobs
+              SET status = 'completed', locked_until = NULL, last_error = NULL,
+                  completed_at = now(), updated_at = now()
+            WHERE id = $1 RETURNING asset_id
+         )
+         UPDATE chat_archive_media_assets
+            SET extraction_status = 'ready', last_error = NULL, updated_at = now()
+          WHERE id = $2 AND EXISTS (SELECT 1 FROM job WHERE asset_id = $2)`,
+        [jobId, assetId],
+      )
+    },
+
+    async unsupportedJob(jobId: string, assetId: string, reason: string): Promise<void> {
+      await pool.query(
+        `WITH job AS (
+           UPDATE chat_archive_media_jobs
+              SET status = 'unsupported', locked_until = NULL, last_error = $3,
+                  completed_at = now(), updated_at = now()
+            WHERE id = $1 RETURNING asset_id
+         )
+         UPDATE chat_archive_media_assets
+            SET extraction_status = 'unsupported', last_error = $3, updated_at = now()
+          WHERE id = $2 AND EXISTS (SELECT 1 FROM job WHERE asset_id = $2)`,
+        [jobId, assetId, reason.slice(0, 2000)],
+      )
+    },
+
+    async failJob(jobId: string, assetId: string, attemptCount: number, error: string): Promise<void> {
+      const dead = attemptCount >= 5
+      const delay = Math.min(2 ** Math.max(1, attemptCount) * 15, 3600)
+      await pool.query(
+        `WITH job AS (
+           UPDATE chat_archive_media_jobs
+              SET status = $4, locked_until = NULL, last_error = $3,
+                  next_attempt_at = now() + ($5 * interval '1 second'), updated_at = now()
+            WHERE id = $1 RETURNING asset_id
+         )
+         UPDATE chat_archive_media_assets
+            SET extraction_status = CASE WHEN $4 = 'dead' THEN 'failed' ELSE 'pending' END,
+                last_error = $3, updated_at = now()
+          WHERE id = $2 AND EXISTS (SELECT 1 FROM job WHERE asset_id = $2)`,
+        [jobId, assetId, error.slice(0, 2000), dead ? 'dead' : 'failed', delay],
+      )
+    },
+
+    async listUnlinkedBefore(before: Date, limit = 100): Promise<ChatArchiveMediaAsset[]> {
+      const result = await pool.query(
+        `SELECT ${ASSET_COLS} FROM chat_archive_media_assets
+          WHERE message_id IS NULL AND created_at < $1
+          ORDER BY created_at LIMIT $2`,
+        [before, limit],
+      )
+      return result.rows.map((row) => assetFromRow(row as Record<string, unknown>))
+    },
+
+    async remove(id: string): Promise<void> {
+      await pool.query(`DELETE FROM chat_archive_media_assets WHERE id = $1`, [id])
+    },
+
+    async listDeletions(limit = 100): Promise<ChatArchiveMediaDeletion[]> {
+      const result = await pool.query(
+        `SELECT id::text, workspace_id::text AS "workspaceId",
+                storage_key AS "storageKey", storage_uri AS "storageUri",
+                attempt_count AS "attemptCount"
+           FROM chat_archive_media_deletions
+          WHERE next_attempt_at <= now()
+          ORDER BY next_attempt_at, created_at LIMIT $1`,
+        [limit],
+      )
+      return result.rows as ChatArchiveMediaDeletion[]
+    },
+
+    async completeDeletion(id: string): Promise<void> {
+      await pool.query(`DELETE FROM chat_archive_media_deletions WHERE id = $1`, [id])
+    },
+
+    async failDeletion(id: string, attemptCount: number, error: string): Promise<void> {
+      const delay = Math.min(2 ** Math.max(1, attemptCount + 1) * 15, 3600)
+      await pool.query(
+        `UPDATE chat_archive_media_deletions
+            SET attempt_count = attempt_count + 1, last_error = $2,
+                next_attempt_at = now() + ($3 * interval '1 second')
+          WHERE id = $1`,
+        [id, error.slice(0, 2000), delay],
+      )
+    },
+  }
+}

--- a/packages/api/src/db/chat-archive-store.ts
+++ b/packages/api/src/db/chat-archive-store.ts
@@ -29,7 +29,16 @@ const TOP_K_MAX = 20
 const CANDIDATE_MAX = 80
 
 export type ChatDirection = 'inbound' | 'outbound'
-export type ChatKind = 'text' | 'image' | 'voice' | 'file' | 'link'
+export type ChatKind = 'text' | 'image' | 'video' | 'voice' | 'file' | 'link'
+
+export type ChatArchiveMediaCoverage = {
+  total: number
+  ready: number
+  pending: number
+  missing: number
+  failed: number
+  unsupported: number
+}
 
 export type ChatArchiveHit = {
   segment_id: string
@@ -48,6 +57,13 @@ export type ChatArchiveHit = {
   reply_to_provider_id: string | null
   segment_index: number
   segment_text: string
+  segment_metadata: Record<string, unknown>
+  media_asset: {
+    asset_id: string
+    upload_status: string
+    extraction_status: string
+    last_error: string | null
+  } | null
 }
 
 type ChatArchiveRow = Omit<ChatArchiveHit, 'sent_at' | 'segment_index'> & {
@@ -73,6 +89,7 @@ export type SearchChatArchiveInput = {
 export type SearchChatArchiveResult = {
   hits: ChatArchiveHit[]
   embeddingCoverage: SegmentCoverage
+  mediaCoverage: ChatArchiveMediaCoverage
 }
 
 type ChatEmbedder = { embed(texts: string[]): Promise<number[][]> }
@@ -102,7 +119,14 @@ export async function searchChatArchive(
     m.media_ref,
     m.reply_to_provider_id,
     s.segment_index,
-    s.segment_text`
+    s.segment_text,
+    s.metadata AS segment_metadata,
+    CASE WHEN a.id IS NULL THEN NULL ELSE jsonb_build_object(
+      'asset_id', a.id,
+      'upload_status', a.upload_status,
+      'extraction_status', a.extraction_status,
+      'last_error', a.last_error
+    ) END AS media_asset`
 
   const vectorRows: ChatArchiveRow[] = []
   if (deps?.embedder && text) {
@@ -120,6 +144,7 @@ export async function searchChatArchive(
           `SELECT ${selectCols}, s.embedding <=> $${vectorIdx}::vector AS distance
              FROM chat_archive_segments s
              JOIN chat_archive_messages m ON m.id = s.message_id
+             LEFT JOIN chat_archive_media_assets a ON a.message_id = m.id
             WHERE ${where}
               AND s.embedding IS NOT NULL
             ORDER BY s.embedding <=> $${vectorIdx}::vector
@@ -153,6 +178,7 @@ export async function searchChatArchive(
       `SELECT ${selectCols}, (${match.hits}) AS term_hits
          FROM chat_archive_segments s
          JOIN chat_archive_messages m ON m.id = s.message_id
+         LEFT JOIN chat_archive_media_assets a ON a.message_id = m.id
         WHERE ${where}
           AND ${match.where}
         ORDER BY term_hits DESC, m.sent_at DESC, s.segment_index
@@ -219,6 +245,50 @@ export async function searchChatArchive(
   return {
     hits: diversified.map(toChatArchiveHit),
     embeddingCoverage: await probeEmbeddingCoverage(input, baseWhere),
+    mediaCoverage: await probeMediaCoverage(input, baseWhere),
+  }
+}
+
+async function probeMediaCoverage(
+  input: SearchChatArchiveInput,
+  baseWhere: (values: unknown[]) => string,
+): Promise<ChatArchiveMediaCoverage> {
+  const empty = { total: 0, ready: 0, pending: 0, missing: 0, failed: 0, unsupported: 0 }
+  try {
+    const values: unknown[] = []
+    const where = baseWhere(values)
+    const result = await queryWithRLS<Record<keyof ChatArchiveMediaCoverage, string>>(
+      input.ownerUserId,
+      `SELECT
+         (count(DISTINCT m.id) FILTER (WHERE m.media_ref IS NOT NULL))::text AS total,
+         (count(DISTINCT m.id) FILTER (WHERE a.extraction_status = 'ready'))::text AS ready,
+         (count(DISTINCT m.id) FILTER (
+           WHERE a.id IS NOT NULL
+             AND (a.upload_status IN ('uploading','uploaded') OR a.extraction_status IN ('pending','processing'))
+         ))::text AS pending,
+         (count(DISTINCT m.id) FILTER (
+           WHERE m.media_ref->>'availability' = 'missing'
+              OR (a.id IS NULL AND NOT (m.media_ref ? 'availability'))
+         ))::text AS missing,
+         (count(DISTINCT m.id) FILTER (
+           WHERE m.media_ref->>'availability' = 'failed'
+              OR a.upload_status = 'failed' OR a.extraction_status = 'failed'
+         ))::text AS failed,
+         (count(DISTINCT m.id) FILTER (WHERE a.extraction_status = 'unsupported'))::text AS unsupported
+       FROM chat_archive_segments s
+       JOIN chat_archive_messages m ON m.id = s.message_id
+       LEFT JOIN chat_archive_media_assets a ON a.message_id = m.id
+       WHERE ${where}`,
+      values,
+    )
+    const row = result.rows[0]
+    if (!row) return empty
+    return Object.fromEntries(
+      Object.keys(empty).map((key) => [key, Number(row[key as keyof ChatArchiveMediaCoverage] ?? 0)]),
+    ) as ChatArchiveMediaCoverage
+  } catch (err) {
+    console.warn('[searchChatArchive] media coverage probe failed:', err instanceof Error ? err.message : String(err))
+    return empty
   }
 }
 
@@ -332,6 +402,8 @@ function toChatArchiveHit(row: ChatArchiveRow): ChatArchiveHit {
     reply_to_provider_id: row.reply_to_provider_id,
     segment_index: Number(row.segment_index),
     segment_text: row.segment_text,
+    segment_metadata: row.segment_metadata ?? {},
+    media_asset: row.media_asset ?? null,
   }
 }
 
@@ -342,7 +414,8 @@ function toMillis(value: string | Date): number {
 
 // ── Contextual get ─────────────────────────────────────────────
 
-export type ChatArchiveMessage = Omit<ChatArchiveHit, 'segment_id' | 'segment_index' | 'segment_text'>
+export type ChatArchiveMessage = Omit<ChatArchiveHit,
+  'segment_id' | 'segment_index' | 'segment_text' | 'segment_metadata' | 'media_asset'>
 
 type ChatArchiveMessageRow = Omit<ChatArchiveMessage, 'sent_at'> & { sent_at: string | Date }
 

--- a/packages/api/src/ingest/__tests__/external-sink-relay.test.ts
+++ b/packages/api/src/ingest/__tests__/external-sink-relay.test.ts
@@ -18,9 +18,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import {
   INGEST_APPEND_CONTRACT_V1,
+  INGEST_APPEND_CONTRACT_V2,
   INGEST_APPEND_IDEMPOTENCY_HEADER,
   INGEST_APPEND_SIGNATURE_HEADER,
   ingestAppendRequestSchema,
+  ingestAppendRequestV2Schema,
 } from '@use-brian/shared'
 import { createExternalSinkRelay, buildAppendRequest } from '../external-sink-relay.js'
 import { signIngestAppendBody, verifyIngestAppendSignature } from '../append-signing.js'
@@ -318,6 +320,32 @@ describe('[COMP:api/ingest-external-relay] request shape + outbound auth', () =>
     expect(req.instance_id).toBe('4a1e6bd8-0000-4000-8000-000000000001')
     expect(req.owner_user_id).toBe('4a1e6bd8-0000-4000-8000-000000000003')
     expect(req.source).toBe('wechat')
+  })
+
+  it('emits v2 assets only for the managed local archive and downgrades video for v1 sinks', () => {
+	const row = makeRow({
+		messages: [{
+			...MESSAGES[1],
+			kind: 'video',
+			media_ref: {
+				asset_id: '4a1e6bd8-0000-4000-8000-000000000004',
+				sha256: 'a'.repeat(64),
+				availability: 'stored',
+				filename: 'clip.mp4', mime: 'video/mp4', size_bytes: 99,
+			},
+		}],
+	})
+	const managed = buildAppendRequest(row, true)
+	expect(managed.contract).toBe(INGEST_APPEND_CONTRACT_V2)
+	expect(ingestAppendRequestV2Schema.safeParse(managed).success).toBe(true)
+	expect(managed.messages[0]).toMatchObject({ kind: 'video', media_ref: { asset_id: expect.any(String) } })
+
+	const external = buildAppendRequest(row)
+	expect(ingestAppendRequestSchema.safeParse(external).success).toBe(true)
+	expect(external.messages[0]).toMatchObject({
+		kind: 'file', media_ref: { filename: 'clip.mp4', mime: 'video/mp4', size_bytes: 99 },
+	})
+	expect(JSON.stringify(external)).not.toContain('asset_id')
   })
 })
 

--- a/packages/api/src/ingest/external-sink-fanout.ts
+++ b/packages/api/src/ingest/external-sink-fanout.ts
@@ -24,7 +24,7 @@
  */
 
 import type pg from 'pg'
-import type { CanonicalIngestMessage } from '@use-brian/shared'
+import type { AnyCanonicalIngestMessage } from '@use-brian/shared'
 import { getPool } from '../db/client.js'
 import { appendBatchEvent } from '../db/pending-ingest-batches-store.js'
 import type { IngestOutboxRow, IngestOutboxStore } from '../db/ingest-outbox-store.js'
@@ -47,7 +47,7 @@ export type ExternalSinkEvent = {
   /** Compartment owner for person-scoped consumers (D3); omit when N/A. */
   ownerUserId?: string | null
   source: string
-  messages: CanonicalIngestMessage[]
+  messages: AnyCanonicalIngestMessage[]
   /** Opaque producer cursor, echoed back by the sink on ack. */
   sourceCursor?: unknown
   /**

--- a/packages/api/src/ingest/external-sink-relay.ts
+++ b/packages/api/src/ingest/external-sink-relay.ts
@@ -1,6 +1,6 @@
 /**
  * External-sink relay worker — drains `ingest_outbox` to each sink's
- * endpoint under `ub.ingest.append.v1`
+ * endpoint under v1, or v2 for the platform-managed local archive
  * (docs/architecture/brain/ingest-external-sink.md → "The relay").
  *
  * Loop shape follows `createBatchWorker` (setInterval + re-entry guard +
@@ -31,10 +31,13 @@
 import { sanitize } from '@use-brian/core'
 import {
   INGEST_APPEND_CONTRACT_V1,
+  INGEST_APPEND_CONTRACT_V2,
   INGEST_APPEND_IDEMPOTENCY_HEADER,
   INGEST_APPEND_SIGNATURE_HEADER,
-  ingestAppendResponseSchema,
-  type IngestAppendRequest,
+  anyIngestAppendResponseSchema,
+  type AnyIngestAppendRequest,
+  type CanonicalIngestMessage,
+  type CanonicalIngestMessageV2,
 } from '@use-brian/shared'
 import type { IngestOutboxRow, IngestOutboxStore } from '../db/ingest-outbox-store.js'
 import type { IngestSinkStore } from '../db/ingest-sink-store.js'
@@ -75,16 +78,47 @@ export type ExternalSinkRelay = {
   readonly isRunning: boolean
 }
 
-export function buildAppendRequest(row: IngestOutboxRow): IngestAppendRequest {
+function toV1Message(message: Record<string, unknown>): CanonicalIngestMessage {
+  const media = message.media_ref as Record<string, unknown> | null | undefined
   return {
-    contract: INGEST_APPEND_CONTRACT_V1,
+    ...(message as unknown as CanonicalIngestMessage),
+    kind: message.kind === 'video' ? 'file' : message.kind as CanonicalIngestMessage['kind'],
+    media_ref: media ? {
+      filename: String(media.filename ?? ''),
+      mime: String(media.mime ?? ''),
+      size_bytes: Math.max(0, Number(media.size_bytes ?? 0)),
+    } : null,
+  }
+}
+
+function toV2Message(message: Record<string, unknown>): CanonicalIngestMessageV2 {
+  const media = message.media_ref as Record<string, unknown> | null | undefined
+  if (!media) return { ...(message as unknown as CanonicalIngestMessageV2), media_ref: null }
+  const stored = media.availability === 'stored' && media.asset_id && media.sha256
+  return {
+    ...(message as unknown as CanonicalIngestMessageV2),
+    media_ref: {
+      ...(stored ? { asset_id: String(media.asset_id), sha256: String(media.sha256) } : {}),
+      availability: stored ? 'stored' : media.availability === 'failed' ? 'failed' : 'missing',
+      filename: String(media.filename ?? ''),
+      mime: String(media.mime ?? ''),
+      size_bytes: Math.max(0, Number(media.size_bytes ?? 0)),
+    },
+  }
+}
+
+export function buildAppendRequest(row: IngestOutboxRow, managedLocal = false): AnyIngestAppendRequest {
+  return {
+    contract: managedLocal ? INGEST_APPEND_CONTRACT_V2 : INGEST_APPEND_CONTRACT_V1,
     instance_id: row.connectorInstanceId,
     source: row.source,
     workspace_id: row.workspaceId,
     owner_user_id: row.ownerUserId,
     cursor: row.sourceCursor ?? null,
-    messages: row.messages as IngestAppendRequest['messages'],
-  }
+    messages: row.messages.map((message) => managedLocal
+      ? toV2Message(message as Record<string, unknown>)
+      : toV1Message(message as Record<string, unknown>)),
+  } as AnyIngestAppendRequest
 }
 
 export function createExternalSinkRelay(deps: ExternalSinkRelayDeps): ExternalSinkRelay {
@@ -117,7 +151,8 @@ export function createExternalSinkRelay(deps: ExternalSinkRelayDeps): ExternalSi
       return
     }
 
-    const body = JSON.stringify(buildAppendRequest(row))
+    const request = buildAppendRequest(row, sink.managedBy === 'local_chat_archive')
+    const body = JSON.stringify(request)
     const headers: Record<string, string> = {
       'content-type': 'application/json',
       [INGEST_APPEND_IDEMPOTENCY_HEADER]: row.batchId,
@@ -146,9 +181,9 @@ export function createExternalSinkRelay(deps: ExternalSinkRelayDeps): ExternalSi
     }
 
     if (res.status === 200) {
-      let parsed: ReturnType<typeof ingestAppendResponseSchema.safeParse>
+      let parsed: ReturnType<typeof anyIngestAppendResponseSchema.safeParse>
       try {
-        parsed = ingestAppendResponseSchema.safeParse(await res.json())
+        parsed = anyIngestAppendResponseSchema.safeParse(await res.json())
       } catch {
         await deps.outbox.fail(row.id, 'ack unreadable: response body is not JSON')
         return
@@ -158,6 +193,10 @@ export function createExternalSinkRelay(deps: ExternalSinkRelayDeps): ExternalSi
         return
       }
       const ack = parsed.data
+      if (ack.contract !== request.contract) {
+        await deps.outbox.fail(row.id, `ack contract ${ack.contract} does not match request ${request.contract}`)
+        return
+      }
       if (ack.accepted + ack.duplicates !== row.messages.length) {
         await deps.outbox.fail(
           row.id,

--- a/packages/api/src/routes/__tests__/whatsapp-byon.test.ts
+++ b/packages/api/src/routes/__tests__/whatsapp-byon.test.ts
@@ -96,4 +96,79 @@ describe('[COMP:api/whatsapp-byon-route] internal routing', () => {
     expect(response.status).toBe(200)
     expect(response.body).toEqual({ ok: true })
   })
+
+  it('completes a streamed archive asset before dispatch and marks the inbound enqueued', async () => {
+    const captured: Array<Record<string, unknown>> = []
+    const archiveIncoming = vi.fn(async () => {})
+    const app = express()
+    app.use(express.json())
+    app.use('/internal/whatsapp', whatsappByonRoutes({
+      connectorSecret: 'secret',
+      integrationStore: {
+        getByChannelForWebhook: vi.fn(async () => ({ connectorInstanceId: 'instance-1' })),
+      } as never,
+      ingestor: { isIngestChannel: vi.fn(async () => false) } as never,
+      bot: {
+        resolveHandler: vi.fn(async (input) => {
+          captured.push(input as unknown as Record<string, unknown>)
+          return { kind: 'bot' as const, handle: vi.fn(async () => {}) }
+        }),
+      },
+      archiveMedia: {
+        resolveBinding: vi.fn(async () => 'instance-1'),
+        complete: vi.fn(async () => ({
+          id: '4a1e6bd8-0000-4000-8000-000000000001',
+          workspaceId: 'workspace-1',
+          instanceId: 'instance-1',
+          ownerUserId: 'owner-1',
+          messageId: null,
+          source: 'whatsapp',
+          providerMessageId: 'm1',
+          kind: 'video',
+          filename: 'clip.mp4',
+          mime: 'video/mp4',
+          sizeBytes: 123,
+          expectedSha256: null,
+          sha256: 'a'.repeat(64),
+          storageKey: 'workspace-1/chat-archive-asset',
+          storageUri: 'file://workspace-1/chat-archive-asset',
+          uploadStatus: 'stored',
+          extractionStatus: 'pending',
+          lastError: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        })),
+      } as never,
+      archiveIncoming,
+      getChannel: vi.fn(async () => ({ workspaceId: 'workspace-1' })) as never,
+      getWorkspaceOwnerUserId: vi.fn(async () => 'owner-1'),
+    }))
+
+    const response = await request(app)
+      .post('/internal/whatsapp/inbound')
+      .set('X-Connector-Secret', 'secret')
+      .send({
+        ...payload,
+        text: '<media:video>',
+        mediaMimeType: 'video/mp4',
+        mediaRef: {
+          assetId: '4a1e6bd8-0000-4000-8000-000000000001',
+          gcsKey: 'workspace-1/chat-archive-asset',
+          mimeType: 'video/mp4',
+          fileName: 'clip.mp4',
+          sizeBytes: 123,
+        },
+      })
+
+    expect(response.status).toBe(200)
+    expect(archiveIncoming).toHaveBeenCalledOnce()
+    expect(captured[0]).toMatchObject({
+      archiveInboundPersisted: true,
+      archiveMediaType: 'video',
+      archiveMediaRef: {
+        assetId: '4a1e6bd8-0000-4000-8000-000000000001',
+        sha256: 'a'.repeat(64),
+      },
+    })
+  })
 })

--- a/packages/api/src/routes/channel-pipeline.ts
+++ b/packages/api/src/routes/channel-pipeline.ts
@@ -371,6 +371,8 @@ export type ChannelPipelineParams = {
    * archive writers. Raw provider payloads are discarded by the normalizer.
    */
   archiveIncoming?: IncomingMessage
+  /** The route already enqueued this inbound archive row before invoking the pipeline. */
+  archiveInboundAlreadyPersisted?: boolean
   /** Exact connector backing this route, when known. */
   archiveConnectorInstanceId?: string | null
 
@@ -781,7 +783,7 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
       // channels and personal sessions pass null/undefined.
       senderUserId: senderUserId ?? null,
     }, client)
-  const userMessageRow = params.archiveIncoming
+  const userMessageRow = params.archiveIncoming && !params.archiveInboundAlreadyPersisted
     ? await persistInboundChatArchive({
         source: channelType,
         ownerUserId: ownerId,

--- a/packages/api/src/routes/wechat.ts
+++ b/packages/api/src/routes/wechat.ts
@@ -52,6 +52,8 @@ import type { ConnectorStore } from '../db/connector-store.js'
 import { getToolDisplayName, formatConfirmationInput } from '@use-brian/shared'
 import { processChannelMessage } from './channel-pipeline.js'
 import { billingPartyForAssistant } from '../billing-party.js'
+import type { ChatArchiveMediaService } from '../chat-archive/media-service.js'
+import { archiveMediaRef } from '../chat-archive/media-service.js'
 
 export type WechatRouteOptions = {
   /** Servable background-lane model, resolved at boot; forwarded to the
@@ -82,6 +84,7 @@ export type WechatRouteOptions = {
   episodicStore?: import('@use-brian/core').EpisodicStore
   sessionStateStore?: import('@use-brian/core').SessionStateStore
   capabilityStore: import('@use-brian/core').CapabilityStore
+  archiveMedia?: ChatArchiveMediaService
 }
 
 // Natural-language → decision mapping for WeChat text-based confirmation
@@ -94,7 +97,8 @@ const DECISION_MAP: Record<string, ConfirmationDecision> = {
 }
 
 // Refuse media downloads above this — matches the document cap elsewhere.
-const MAX_MEDIA_BYTES = 25 * 1024 * 1024
+const MAX_SMALL_MEDIA_BYTES = 25 * 1024 * 1024
+const MAX_LARGE_MEDIA_BYTES = 500 * 1024 * 1024
 
 // Refresh the native typing indicator at most this often while a turn runs.
 const TYPING_REFRESH_MS = 5_000
@@ -353,16 +357,72 @@ export function wechatRoutes(options: WechatRouteOptions): Router {
     const userContentBlocks: ContentBlock[] = []
     const mediaItem = raw ? findWechatMediaItem(raw.item_list) : null
     if (mediaItem) {
+      const fallbackKind = mediaItem.video_item ? 'video'
+        : mediaItem.voice_item ? 'voice'
+          : mediaItem.image_item ? 'image' : 'file'
+      incoming.mediaType = fallbackKind === 'image' ? 'photo'
+        : fallbackKind === 'file' ? 'document' : fallbackKind
+      incoming.mediaMime = fallbackKind === 'image' ? 'image/jpeg'
+        : fallbackKind === 'video' ? 'video/mp4'
+          : fallbackKind === 'voice' ? 'audio/silk' : 'application/octet-stream'
+      incoming.mediaName = fallbackKind === 'image' ? 'image'
+        : fallbackKind === 'video' ? 'video.mp4'
+          : fallbackKind === 'voice' ? 'voice.silk' : mediaItem.file_item?.file_name ?? 'file.bin'
+      incoming.mediaSizeBytes = 0
+      incoming.archiveMediaAvailability = 'missing'
       try {
-        const media = await downloadWechatMediaItem(mediaItem)
-        if (media && media.data.length > MAX_MEDIA_BYTES) {
+        const maxBytes = fallbackKind === 'video' || fallbackKind === 'voice'
+          ? MAX_LARGE_MEDIA_BYTES : MAX_SMALL_MEDIA_BYTES
+        const media = await downloadWechatMediaItem(mediaItem, { maxBytes })
+        if (!media) throw new Error('iLink media item did not contain downloadable bytes')
+        const archiveKind = media.mime === 'image/gif' ? 'video' : media.kind
+        incoming.mediaType = archiveKind === 'image' ? 'photo'
+          : archiveKind === 'file' ? 'document' : archiveKind
+        incoming.mediaMime = media.mime
+        incoming.mediaName = media.name
+        incoming.mediaSizeBytes = media.data.length
+        if (
+          options.archiveMedia
+          && assistant.workspaceId
+          && incoming.messageId
+        ) {
+          try {
+            const instanceId = await options.archiveMedia.resolveBinding({
+              workspaceId: assistant.workspaceId,
+              ownerUserId: ownerId,
+              source: 'wechat',
+              instanceId: params.archiveConnectorInstanceId,
+            })
+            const asset = await options.archiveMedia.storeBuffer({
+              workspaceId: assistant.workspaceId,
+              instanceId,
+              ownerUserId: ownerId,
+              source: 'wechat',
+              providerMessageId: incoming.messageId,
+              kind: archiveKind,
+              filename: media.name,
+              mime: media.mime,
+              sizeBytes: media.data.length,
+              bytes: media.data,
+            })
+            const ref = archiveMediaRef(asset)
+            incoming.archiveMediaRef = {
+              assetId: ref.asset_id!, sha256: ref.sha256!, filename: ref.filename,
+              mime: ref.mime, sizeBytes: ref.size_bytes,
+            }
+          } catch (err) {
+            incoming.archiveMediaAvailability = 'failed'
+            console.error('[wechat] local archive media staging failed:', err)
+          }
+        }
+        if (media.data.length > maxBytes) {
           userContentBlocks.push({
             type: 'text',
-            text: `[The user sent a ${media.kind} over ${Math.round(MAX_MEDIA_BYTES / 1024 / 1024)} MB - too large to process on WeChat. Ask them to share it another way.]`,
+            text: `[The user sent a ${media.kind} over ${Math.round(maxBytes / 1024 / 1024)} MB - too large to process.]`,
           })
-        } else if (media?.kind === 'image') {
+        } else if (media.kind === 'image') {
           userContentBlocks.push({ type: 'image', mimeType: media.mime, data: media.data.toString('base64') })
-        } else if (media?.kind === 'file') {
+        } else if (media.kind === 'file') {
           if (media.mime === 'application/pdf') {
             userContentBlocks.push({ type: 'image', mimeType: media.mime, data: media.data.toString('base64') })
           } else {
@@ -383,20 +443,19 @@ export function wechatRoutes(options: WechatRouteOptions): Router {
               })
             }
           }
-        } else if (media?.kind === 'voice') {
-          // SILK-encoded voice without server STT — transcription is a
-          // documented v1 gap (docs/architecture/channels/wechat.md → Deferred).
+        } else if (media.kind === 'voice') {
           userContentBlocks.push({
             type: 'text',
-            text: '[The user sent a voice message that could not be transcribed. Ask them to type it instead.]',
+            text: '[The user sent a voice message. It is stored and being transcribed for chat-history search.]',
           })
-        } else if (media?.kind === 'video') {
+        } else if (media.kind === 'video') {
           userContentBlocks.push({
             type: 'text',
-            text: '[The user sent a video. Video is not supported on WeChat yet - let them know.]',
+            text: '[The user sent a video. It is stored and being processed for chat-history search.]',
           })
         }
       } catch (err) {
+        incoming.archiveMediaAvailability = 'failed'
         console.error('[wechat] media download/decrypt failed:', err)
         userContentBlocks.push({
           type: 'text',

--- a/packages/api/src/routes/whatsapp-bot-handler.ts
+++ b/packages/api/src/routes/whatsapp-bot-handler.ts
@@ -71,6 +71,21 @@ export type WhatsappBotInput = {
    * THIS video, not the user's latest. See channel-pipeline `mediaEpisodeId`.
    */
   mediaEpisodeId?: string
+  /** Durable local archive asset prepared by the inbound route. */
+  archiveMediaRef?: {
+    assetId: string
+    sha256: string
+    filename: string
+    mime: string
+    sizeBytes: number
+  }
+  archiveMediaType?: 'photo' | 'document' | 'voice' | 'audio' | 'video'
+  archiveMediaMime?: string
+  archiveMediaName?: string
+  archiveMediaSizeBytes?: number
+  archiveMediaAvailability?: 'missing' | 'failed'
+  /** Set only after the BYON route durably enqueues the archive append. */
+  archiveInboundPersisted?: boolean
 }
 
 /**

--- a/packages/api/src/routes/whatsapp-byon.ts
+++ b/packages/api/src/routes/whatsapp-byon.ts
@@ -3,12 +3,17 @@ import { Router } from 'express'
 import { z } from 'zod'
 import type { ChannelIntegrationStore } from '../db/channel-integrations.js'
 import type { WhatsappIngestor } from '../ingest/whatsapp-ingest.js'
-import type { WhatsappBot } from './whatsapp-bot-handler.js'
+import type { WhatsappBot, WhatsappBotInput } from './whatsapp-bot-handler.js'
 import { buildWhatsappListenerHandler } from './whatsapp-listener-handler.js'
 import { runHandlers, selectHandlers } from './whatsapp-dispatcher.js'
 import { getChannelForWebhook } from '../db/channels-store.js'
 import type { FilesClientResolver } from '../files/files-api.js'
 import { buildStorageKey, buildStorageUri } from '../files/gcs-client.js'
+import { query } from '../db/client.js'
+import type { ChatArchiveMediaService } from '../chat-archive/media-service.js'
+import { archiveMediaRef } from '../chat-archive/media-service.js'
+import { signedChatArchiveMediaUploadUrl } from '../chat-archive/media-routes.js'
+import type { IncomingMessage } from '@use-brian/channels'
 
 const inboundSchema = z.object({
   channelId: z.string().min(1),
@@ -20,6 +25,17 @@ const inboundSchema = z.object({
   text: z.string().default(''),
   timestamp: z.number(),
   isGroup: z.boolean(),
+  mediaBase64: z.string().optional(),
+  mediaMimeType: z.string().optional(),
+  mediaFileName: z.string().optional(),
+  mediaRef: z.object({
+    assetId: z.string().uuid().optional(),
+    gcsKey: z.string(),
+    storageUri: z.string().optional(),
+    mimeType: z.string(),
+    fileName: z.string().optional(),
+    sizeBytes: z.number().optional(),
+  }).optional(),
 }).passthrough()
 
 function secretMatches(provided: unknown, expected: string): boolean {
@@ -29,13 +45,31 @@ function secretMatches(provided: unknown, expected: string): boolean {
   return actual.length === wanted.length && timingSafeEqual(actual, wanted)
 }
 
+async function resolveWorkspaceOwnerUserId(workspaceId: string): Promise<string | null> {
+  const owner = await query<{ ownerUserId: string }>(
+    `SELECT owner_user_id AS "ownerUserId" FROM workspaces WHERE id = $1`,
+    [workspaceId],
+  )
+  return owner.rows[0]?.ownerUserId ?? null
+}
+
 export type WhatsappByonRoutesOptions = {
   connectorSecret: string
   integrationStore: ChannelIntegrationStore
   ingestor: WhatsappIngestor
   bot: WhatsappBot
   filesResolver?: FilesClientResolver
+  archiveMedia?: ChatArchiveMediaService
+  archiveMediaHmacSecret?: string
+  archiveMediaBaseUrl?: string
+  archiveIncoming?: (input: {
+    workspaceId: string
+    ownerUserId: string
+    connectorInstanceId?: string | null
+    message: IncomingMessage
+  }) => Promise<void>
   getChannel?: typeof getChannelForWebhook
+  getWorkspaceOwnerUserId?: (workspaceId: string) => Promise<string | null>
   /** Let a later closed router handle the shared official number. */
   passUnknownToFallback?: boolean
 }
@@ -54,8 +88,11 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
     }
     const parsed = z.object({
       channelId: z.string().min(1),
+      providerMessageId: z.string().min(1).optional(),
+      kind: z.enum(['image', 'video', 'voice', 'file']).optional(),
       mime: z.string().min(1),
       fileName: z.string().nullable().optional(),
+      sizeBytes: z.number().int().nonnegative().optional(),
     }).safeParse(req.body)
     if (!parsed.success) {
       res.status(400).json({ error: 'channelId and mime required' })
@@ -71,6 +108,53 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
       if (opts.passUnknownToFallback) next()
       else res.status(404).json({ error: 'channel not resolvable' })
       return
+    }
+
+    if (
+      opts.archiveMedia
+      && opts.archiveMediaHmacSecret
+      && opts.archiveMediaBaseUrl
+      && parsed.data.providerMessageId
+      && parsed.data.kind
+    ) {
+      const integration = await opts.integrationStore.getByChannelForWebhook(parsed.data.channelId, 'whatsapp')
+      const ownerUserId = await (opts.getWorkspaceOwnerUserId ?? resolveWorkspaceOwnerUserId)(channel.workspaceId)
+      if (ownerUserId) {
+        try {
+          const instanceId = await opts.archiveMedia.resolveBinding({
+            workspaceId: channel.workspaceId,
+            ownerUserId,
+            source: 'whatsapp',
+            instanceId: integration?.connectorInstanceId,
+          })
+          const initialized = await opts.archiveMedia.init({
+            workspaceId: channel.workspaceId,
+            instanceId,
+            ownerUserId,
+            source: 'whatsapp',
+            providerMessageId: parsed.data.providerMessageId,
+            kind: parsed.data.kind,
+            filename: parsed.data.fileName ?? '',
+            mime: parsed.data.mime,
+            sizeBytes: parsed.data.sizeBytes ?? 0,
+          })
+          res.json({
+            assetId: initialized.asset.id,
+            alreadyStored: initialized.alreadyStored,
+            gcsKey: initialized.asset.storageKey,
+            storageUri: initialized.asset.storageUri,
+            sizeBytes: initialized.asset.sizeBytes,
+            uploadUrl: signedChatArchiveMediaUploadUrl({
+              secret: opts.archiveMediaHmacSecret,
+              baseUrl: opts.archiveMediaBaseUrl,
+              assetId: initialized.asset.id,
+            }),
+          })
+          return
+        } catch (err) {
+          console.error('[whatsapp] archive media init failed; using generic storage:', err)
+        }
+      }
     }
 
     const fileId = `channel-media/${randomUUID()}`
@@ -114,15 +198,77 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
       res.status(400).json({ error: 'invalid inbound payload' })
       return
     }
-    const input = parsed.data
+    const input = parsed.data as typeof parsed.data & WhatsappBotInput
+    const inboundMime = input.mediaMimeType ?? input.mediaRef?.mimeType
+    if (inboundMime) {
+      const inboundKind = inboundMime.startsWith('image/') ? 'image'
+        : inboundMime.startsWith('video/') ? 'video'
+          : inboundMime.startsWith('audio/') ? 'voice' : 'file'
+      input.archiveMediaType = inboundKind === 'image' ? 'photo'
+        : inboundKind === 'video' ? 'video' : inboundKind === 'voice' ? 'voice' : 'document'
+      input.archiveMediaMime = inboundMime
+      input.archiveMediaName = input.mediaFileName ?? input.mediaRef?.fileName ?? ''
+      input.archiveMediaSizeBytes = input.mediaRef?.sizeBytes ?? 0
+      input.archiveMediaAvailability = input.mediaBase64 || input.mediaRef ? 'missing' : 'failed'
+    }
     // Hosted media intake is mounted as the later closed router. Let it own
     // streamed references; otherwise this BYON router ACKs first and the bytes
     // are uploaded successfully but never become a recording/document artifact.
-    if (input.mediaRef && opts.passUnknownToFallback) {
+    if (input.mediaRef && !input.mediaRef.assetId && opts.passUnknownToFallback) {
       next()
       return
     }
-    if (!input.text.trim() || input.text.trim() === '<media:sticker>') {
+
+    if (opts.archiveMedia && (input.mediaBase64 || input.mediaRef?.assetId)) {
+      try {
+        const integration = await opts.integrationStore.getByChannelForWebhook(input.channelId, 'whatsapp')
+        const channel = await (opts.getChannel ?? getChannelForWebhook)(input.channelId)
+        const ownerUserId = channel
+          ? await (opts.getWorkspaceOwnerUserId ?? resolveWorkspaceOwnerUserId)(channel.workspaceId)
+          : null
+        if (channel && ownerUserId) {
+          const instanceId = await opts.archiveMedia.resolveBinding({
+            workspaceId: channel.workspaceId,
+            ownerUserId,
+            source: 'whatsapp',
+            instanceId: integration?.connectorInstanceId,
+          })
+          const mime = input.mediaMimeType ?? input.mediaRef?.mimeType ?? 'application/octet-stream'
+          const kind = mime.startsWith('image/') ? 'image'
+            : mime.startsWith('video/') ? 'video'
+              : mime.startsWith('audio/') ? 'voice' : 'file'
+          const asset = input.mediaRef?.assetId
+            ? await opts.archiveMedia.complete(input.mediaRef.assetId)
+            : await opts.archiveMedia.storeBuffer({
+              workspaceId: channel.workspaceId,
+              instanceId,
+              ownerUserId,
+              source: 'whatsapp',
+              providerMessageId: input.messageId,
+              kind,
+              filename: input.mediaFileName ?? '',
+              mime,
+              sizeBytes: 0,
+              bytes: Buffer.from(input.mediaBase64!, 'base64'),
+            })
+          const ref = archiveMediaRef(asset)
+          input.archiveMediaRef = {
+            assetId: ref.asset_id!, sha256: ref.sha256!, filename: ref.filename,
+            mime: ref.mime, sizeBytes: ref.size_bytes,
+          }
+          input.archiveMediaType = kind === 'image' ? 'photo'
+            : kind === 'video' ? 'video' : kind === 'voice' ? 'voice' : 'document'
+          input.archiveMediaMime = ref.mime
+          input.archiveMediaName = ref.filename
+          input.archiveMediaSizeBytes = ref.size_bytes
+        }
+      } catch (err) {
+        input.archiveMediaAvailability = 'failed'
+        console.error('[whatsapp] archive media completion failed:', err)
+      }
+    }
+
+    if (!input.text.trim() && !input.mediaBase64 && !input.mediaRef) {
       res.json({ ok: true })
       return
     }
@@ -135,6 +281,43 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
       if (opts.passUnknownToFallback) next()
       else res.json({ ok: true })
       return
+    }
+
+    if (opts.archiveIncoming) {
+      try {
+        const [channel, integration] = await Promise.all([
+          (opts.getChannel ?? getChannelForWebhook)(input.channelId),
+          opts.integrationStore.getByChannelForWebhook(input.channelId, 'whatsapp'),
+        ])
+        const ownerUserId = channel
+          ? await (opts.getWorkspaceOwnerUserId ?? resolveWorkspaceOwnerUserId)(channel.workspaceId)
+          : null
+        if (channel && ownerUserId) {
+          await opts.archiveIncoming({
+            workspaceId: channel.workspaceId,
+            ownerUserId,
+            connectorInstanceId: integration?.connectorInstanceId,
+            message: {
+              userId: input.senderPnJid ?? input.senderJid,
+              channelId: input.chatJid,
+              messageId: input.messageId,
+              text: /^<media:[^>]+>$/.test(input.text.trim()) ? '' : input.text,
+              mediaType: input.archiveMediaType,
+              mediaMime: input.archiveMediaMime,
+              mediaName: input.archiveMediaName,
+              mediaSizeBytes: input.archiveMediaSizeBytes,
+              archiveMediaRef: input.archiveMediaRef,
+              archiveMediaAvailability: input.archiveMediaAvailability,
+              isGroupChat: input.isGroup,
+              timestamp: input.timestamp,
+              raw: null,
+            },
+          })
+          input.archiveInboundPersisted = true
+        }
+      } catch (err) {
+        console.error('[whatsapp] inbound archive enqueue failed:', err)
+      }
     }
 
     res.json({ ok: true })

--- a/packages/channels/src/__tests__/wechat.test.ts
+++ b/packages/channels/src/__tests__/wechat.test.ts
@@ -252,7 +252,7 @@ describe('[COMP:channels/wechat-adapter] WeChat adapter', () => {
       expect(sniffImageMime(Buffer.from('random data here'))).toBe('image/jpeg')
     })
 
-    it('prioritizes image > video > file > voice-without-STT', () => {
+    it('prioritizes image > video > file > voice and retains voice bytes with STT', () => {
       const voiceWithStt = {
         type: WeixinItemType.VOICE,
         voice_item: { media: { encrypt_query_param: 'v' }, text: 'stt' },
@@ -262,7 +262,7 @@ describe('[COMP:channels/wechat-adapter] WeChat adapter', () => {
         file_item: { media: { encrypt_query_param: 'f', aes_key: 'k' }, file_name: 'a.txt' },
       }
       expect(findWechatMediaItem([voiceWithStt, file])).toBe(file)
-      expect(findWechatMediaItem([voiceWithStt])).toBeNull()
+      expect(findWechatMediaItem([voiceWithStt])).toBe(voiceWithStt)
     })
 
     it('downloads and decrypts an encrypted image item', async () => {
@@ -287,6 +287,23 @@ describe('[COMP:channels/wechat-adapter] WeChat adapter', () => {
       expect(result!.kind).toBe('image')
       expect(result!.mime).toBe('image/png')
       expect(result!.data).toEqual(png)
+    })
+
+    it('stops a CDN response when media exceeds the caller limit', async () => {
+      const key = Buffer.from('0123456789abcdef')
+      const cipher = createCipheriv('aes-128-ecb', key, null)
+      const encrypted = Buffer.concat([cipher.update(Buffer.alloc(64)), cipher.final()])
+      const fetchImpl = vi.fn(async () => new Response(new Uint8Array(encrypted), { status: 200 })) as unknown as typeof fetch
+
+      await expect(downloadWechatMediaItem(
+        {
+          type: WeixinItemType.IMAGE,
+          image_item: {
+            media: { full_url: 'https://cdn.example/large', aes_key: key.toString('base64') },
+          },
+        },
+        { fetchImpl, maxBytes: 32 },
+      )).rejects.toThrow('exceeds 32 bytes')
     })
   })
 

--- a/packages/channels/src/types.ts
+++ b/packages/channels/src/types.ts
@@ -29,6 +29,20 @@ export type IncomingMessage = {
   mediaDurationSec?: number
   /** File size in bytes when the webhook payload carries it. Used to refuse files over the channel's download limit before attempting a doomed download. */
   mediaSizeBytes?: number
+  /**
+   * Platform-local durable archive asset. Channel routes set this only after
+   * bytes have been staged and fingerprinted; provider URLs/base64 never enter
+   * the archive outbox.
+   */
+  archiveMediaRef?: {
+    assetId: string
+    sha256: string
+    filename: string
+    mime: string
+    sizeBytes: number
+  }
+  /** Explicit terminal acquisition failure when provider media could not be stored. */
+  archiveMediaAvailability?: 'missing' | 'failed'
   files?: IncomingFile[]
   replyToMessageId?: string
   isEdit?: boolean

--- a/packages/channels/src/wechat/media.ts
+++ b/packages/channels/src/wechat/media.ts
@@ -66,8 +66,9 @@ export type WechatDownloadedMedia = {
 
 /**
  * Find the first downloadable media item on a message's item list (priority:
- * image > video > file > voice-without-STT, mirroring the reference plugin).
- * Voice items that already carry server STT `text` are handled as text.
+ * image > video > file > voice, mirroring the reference plugin). Voice items
+ * with server STT still return their media so the archive keeps durable bytes;
+ * the STT remains the sender-visible message text.
  */
 export function findWechatMediaItem(itemList: WeixinMessageItem[] | undefined): WeixinMessageItem | null {
   if (!itemList?.length) return null
@@ -76,9 +77,7 @@ export function findWechatMediaItem(itemList: WeixinMessageItem[] | undefined): 
     itemList.find((i) => i.type === WeixinItemType.IMAGE && downloadable(i.image_item?.media)) ??
     itemList.find((i) => i.type === WeixinItemType.VIDEO && downloadable(i.video_item?.media)) ??
     itemList.find((i) => i.type === WeixinItemType.FILE && downloadable(i.file_item?.media)) ??
-    itemList.find(
-      (i) => i.type === WeixinItemType.VOICE && downloadable(i.voice_item?.media) && !i.voice_item?.text,
-    ) ??
+    itemList.find((i) => i.type === WeixinItemType.VOICE && downloadable(i.voice_item?.media)) ??
     null
   )
 }
@@ -89,7 +88,7 @@ export function findWechatMediaItem(itemList: WeixinMessageItem[] | undefined): 
  */
 export async function downloadWechatMediaItem(
   item: WeixinMessageItem,
-  options?: { cdnBaseUrl?: string; fetchImpl?: typeof fetch },
+  options?: { cdnBaseUrl?: string; fetchImpl?: typeof fetch; maxBytes?: number },
 ): Promise<WechatDownloadedMedia | null> {
   const cdnBaseUrl = options?.cdnBaseUrl ?? ILINK_CDN_BASE_URL
   const doFetch = options?.fetchImpl ?? fetch
@@ -97,7 +96,31 @@ export async function downloadWechatMediaItem(
   async function fetchBytes(media: IlinkCdnMedia): Promise<Buffer> {
     const res = await doFetch(buildDownloadUrl(media, cdnBaseUrl))
     if (!res.ok) throw new Error(`iLink CDN download failed: ${res.status}`)
-    return Buffer.from(await res.arrayBuffer())
+    const maxBytes = options?.maxBytes ?? Number.POSITIVE_INFINITY
+    const declaredBytes = Number(res.headers.get('content-length'))
+    if (Number.isFinite(declaredBytes) && declaredBytes > maxBytes) {
+      throw new Error(`iLink CDN media exceeds ${maxBytes} bytes`)
+    }
+    if (!res.body) {
+      const data = Buffer.from(await res.arrayBuffer())
+      if (data.length > maxBytes) throw new Error(`iLink CDN media exceeds ${maxBytes} bytes`)
+      return data
+    }
+    const reader = res.body.getReader()
+    const chunks: Buffer[] = []
+    let total = 0
+    while (true) {
+      const part = await reader.read()
+      if (part.done) break
+      const chunk = Buffer.from(part.value)
+      total += chunk.length
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => {})
+        throw new Error(`iLink CDN media exceeds ${maxBytes} bytes`)
+      }
+      chunks.push(chunk)
+    }
+    return Buffer.concat(chunks, total)
   }
 
   async function fetchDecrypted(media: IlinkCdnMedia, aesKeyBase64: string): Promise<Buffer> {

--- a/packages/core/src/media/__tests__/qwen-asr.test.ts
+++ b/packages/core/src/media/__tests__/qwen-asr.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest'
+import { qwenAsrTranscriber, QWEN_ASR_USD_PER_AUDIO_HOUR } from '../qwen-asr.js'
+
+function response(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('[COMP:media/transcriber-qwen] qwenAsrTranscriber', () => {
+  it('submits local bytes as a base64 audio data URL', async () => {
+    const fetchFn = vi.fn(async () => response({
+      choices: [{ message: { content: 'halo halo halo' } }],
+    })) as unknown as typeof fetch
+    const transcriber = qwenAsrTranscriber({ apiKey: 'ds-key', fetchFn })
+
+    const result = await transcriber.transcribe({
+      buffer: Buffer.from('audio-bytes'),
+      mime: 'audio/mp4',
+      durationMs: 2000,
+      language: 'en',
+    })
+
+    expect(transcriber.name).toBe('dashscope:qwen3-asr-flash')
+    expect(fetchFn).toHaveBeenCalledOnce()
+    const [url, init] = (fetchFn as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(url).toBe('https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions')
+    expect(init.headers.Authorization).toBe('Bearer ds-key')
+    const body = JSON.parse(init.body)
+    expect(body.messages[0].content[0].input_audio.data).toBe(
+      `data:audio/mp4;base64,${Buffer.from('audio-bytes').toString('base64')}`,
+    )
+    expect(body.asr_options).toEqual({ enable_itn: false, language: 'en' })
+    expect(result.utterances).toEqual([
+      { startMs: 0, endMs: 2000, speaker: null, text: 'halo halo halo' },
+    ])
+    expect(result.usages[0].costUsd).toBeCloseTo((2 / 3600) * QWEN_ASR_USD_PER_AUDIO_HOUR)
+  })
+
+  it('fails before the network when the audio exceeds five minutes', async () => {
+    const fetchFn = vi.fn() as unknown as typeof fetch
+    const transcriber = qwenAsrTranscriber({ apiKey: 'key', fetchFn })
+
+    await expect(transcriber.transcribe({
+      buffer: Buffer.from('x'),
+      mime: 'audio/mp4',
+      durationMs: 5 * 60_000 + 1,
+    })).rejects.toThrow(/up to 5 minutes/)
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('surfaces provider errors and empty transcripts', async () => {
+    const bad = qwenAsrTranscriber({
+      apiKey: 'key',
+      fetchFn: vi.fn(async () => response({ error: 'bad audio' }, 400)) as unknown as typeof fetch,
+    })
+    await expect(bad.transcribe({
+      buffer: Buffer.from('x'), mime: 'audio/mp4', durationMs: 1000,
+    })).rejects.toThrow(/HTTP 400/)
+
+    const empty = qwenAsrTranscriber({
+      apiKey: 'key',
+      fetchFn: vi.fn(async () => response({ choices: [{ message: { content: '  ' } }] })) as unknown as typeof fetch,
+    })
+    await expect(empty.transcribe({
+      buffer: Buffer.from('x'), mime: 'audio/mp4', durationMs: 1000,
+    })).rejects.toThrow(/empty transcript/)
+  })
+})

--- a/packages/core/src/media/index.ts
+++ b/packages/core/src/media/index.ts
@@ -64,6 +64,11 @@ export {
   type ScribeWord,
 } from './scribe.js'
 export {
+  qwenAsrTranscriber,
+  QWEN_ASR_USD_PER_AUDIO_HOUR,
+  type QwenAsrOptions,
+} from './qwen-asr.js'
+export {
   qwenFiletransTranscriber,
   QWEN_FILETRANS_USD_PER_AUDIO_HOUR,
   type QwenFiletransOptions,

--- a/packages/core/src/media/qwen-asr.ts
+++ b/packages/core/src/media/qwen-asr.ts
@@ -1,0 +1,97 @@
+/**
+ * Qwen3-ASR-Flash buffer transcriber.
+ *
+ * Unlike the asynchronous filetrans model, this endpoint accepts a base64
+ * data URL. That makes it the correct first choice for local/on-prem storage,
+ * where a loopback signed URL is intentionally unreachable from DashScope.
+ */
+
+import type { RecordingTranscriber, RecordingTranscribeRequest } from './recording-transcriber.js'
+
+const DEFAULT_BASE_URL = 'https://dashscope-intl.aliyuncs.com'
+const DEFAULT_MODEL = 'qwen3-asr-flash'
+const MAX_DURATION_MS = 5 * 60_000
+const MAX_DATA_URL_BYTES = 10 * 1024 * 1024
+
+/** Published international rate: US$0.000035 per audio second. */
+export const QWEN_ASR_USD_PER_AUDIO_HOUR = 0.126
+
+export type QwenAsrOptions = {
+  apiKey: string
+  baseUrl?: string
+  model?: string
+  usdPerAudioHour?: number
+  fetchFn?: typeof fetch
+}
+
+type QwenAsrResponse = {
+  choices?: Array<{ message?: { content?: string } }>
+  output?: { choices?: Array<{ message?: { content?: string } }> }
+}
+
+function transcriptText(body: QwenAsrResponse): string {
+  return (
+    body.choices?.[0]?.message?.content ??
+    body.output?.choices?.[0]?.message?.content ??
+    ''
+  ).trim()
+}
+
+export function qwenAsrTranscriber(opts: QwenAsrOptions): RecordingTranscriber {
+  const base = (opts.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '')
+  const model = opts.model ?? DEFAULT_MODEL
+  const name = `dashscope:${model}`
+
+  return {
+    name,
+    async transcribe(req: RecordingTranscribeRequest) {
+      if (req.durationMs > MAX_DURATION_MS) {
+        throw new Error('qwen buffer ASR supports audio up to 5 minutes')
+      }
+      const dataUrl = `data:${req.mime};base64,${req.buffer.toString('base64')}`
+      if (Buffer.byteLength(dataUrl) > MAX_DATA_URL_BYTES) {
+        throw new Error('qwen buffer ASR input exceeds the 10 MB data URL limit')
+      }
+
+      const response = await (opts.fetchFn ?? fetch)(`${base}/compatible-mode/v1/chat/completions`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${opts.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model,
+          messages: [{
+            role: 'user',
+            content: [{ type: 'input_audio', input_audio: { data: dataUrl } }],
+          }],
+          stream: false,
+          asr_options: {
+            enable_itn: false,
+            ...(req.language ? { language: req.language } : {}),
+          },
+        }),
+      })
+      if (!response.ok) {
+        throw new Error(
+          `qwen buffer ASR failed (HTTP ${response.status}): ${(await response.text().catch(() => '')).slice(0, 300)}`,
+        )
+      }
+
+      const text = transcriptText((await response.json()) as QwenAsrResponse)
+      if (!text) throw new Error('qwen buffer ASR returned an empty transcript')
+
+      return {
+        utterances: [{ startMs: 0, endMs: req.durationMs, speaker: null, text }],
+        usages: [{
+          usage: null,
+          model: name,
+          costUsd: (req.durationMs / 3_600_000) * (opts.usdPerAudioHour ?? QWEN_ASR_USD_PER_AUDIO_HOUR),
+        }],
+        windows: 1,
+        truncated: false,
+        degenerateWindows: 0,
+      }
+    },
+  }
+}

--- a/packages/shared/src/__tests__/ingest-append-contract.test.ts
+++ b/packages/shared/src/__tests__/ingest-append-contract.test.ts
@@ -11,10 +11,13 @@
 import { describe, it, expect } from 'vitest'
 import {
   INGEST_APPEND_CONTRACT_V1,
+  INGEST_APPEND_CONTRACT_V2,
   INGEST_APPEND_IDEMPOTENCY_HEADER,
   INGEST_APPEND_SIGNATURE_HEADER,
   canonicalIngestMessageSchema,
+  canonicalIngestMessageV2Schema,
   ingestAppendRequestSchema,
+  ingestAppendRequestV2Schema,
   ingestAppendResponseSchema,
 } from '../ingest-append-contract.js'
 
@@ -58,6 +61,44 @@ describe('[COMP:shared/ingest-append-contract] wire shape', () => {
     expect(
       ingestAppendRequestSchema.safeParse({ ...REQUEST, contract: 'ub.ingest.append.v2' }).success,
     ).toBe(false)
+  })
+
+  it('keeps v1 frozen while v2 admits video with a durable asset', () => {
+    const media = {
+      ...MESSAGE,
+      kind: 'video',
+      body_text: 'Launch walkthrough',
+      media_ref: {
+        asset_id: '4a1e6bd8-0000-4000-8000-000000000004',
+        sha256: 'a'.repeat(64),
+        availability: 'stored',
+        filename: 'walkthrough.mp4',
+        mime: 'video/mp4',
+        size_bytes: 2048,
+      },
+    }
+    expect(canonicalIngestMessageSchema.safeParse(media).success).toBe(false)
+    expect(canonicalIngestMessageV2Schema.safeParse(media).success).toBe(true)
+    expect(ingestAppendRequestV2Schema.safeParse({
+      ...REQUEST,
+      contract: INGEST_APPEND_CONTRACT_V2,
+      messages: [media],
+    }).success).toBe(true)
+  })
+
+  it('requires asset identity and fingerprint for stored v2 media', () => {
+    const media = {
+      ...MESSAGE,
+      kind: 'image',
+      media_ref: {
+        availability: 'stored', filename: 'photo.jpg', mime: 'image/jpeg', size_bytes: 1,
+      },
+    }
+    expect(canonicalIngestMessageV2Schema.safeParse(media).success).toBe(false)
+    expect(canonicalIngestMessageV2Schema.safeParse({
+      ...media,
+      media_ref: { ...media.media_ref, availability: 'missing' },
+    }).success).toBe(true)
   })
 
   it('rejects an empty batch and an unknown message kind', () => {

--- a/packages/shared/src/ingest-append-contract.ts
+++ b/packages/shared/src/ingest-append-contract.ts
@@ -1,6 +1,7 @@
 /**
- * `ub.ingest.append.v1` — the published guidance schema for external ingest
- * sinks (docs/architecture/brain/ingest-external-sink.md → "The append
+ * `ub.ingest.append.v1` and local-media-aware `ub.ingest.append.v2` — the
+ * published guidance schemas for ingest sinks
+ * (docs/architecture/brain/ingest-external-sink.md → "Append
  * contract"; plan docs/plans/ingestion-external-endpoint.md §4).
  *
  * An external service that wants the platform's normalized event stream
@@ -9,8 +10,8 @@
  * (`packages/api/src/ingest/external-sink-relay.ts`) is the only producer;
  * consumers include the wechat-brian / whatsapp-brian archive services.
  *
- * Contract rules (frozen — breaking changes bump the version, never mutate
- * in place, X8):
+ * Contract rules (each version is frozen — breaking changes bump the version,
+ * never mutate in place, X8):
  *
  *   - Idempotency is the CONSUMER's job, keyed `(instance_id,
  *     provider_message_id)` per message (X4). The relay retries freely
@@ -39,6 +40,8 @@ import { z } from 'zod'
 
 /** Contract identifier carried in every request and response body. */
 export const INGEST_APPEND_CONTRACT_V1 = 'ub.ingest.append.v1'
+/** Media-aware contract used by the platform-managed local archive sink. */
+export const INGEST_APPEND_CONTRACT_V2 = 'ub.ingest.append.v2'
 
 /**
  * Whole-batch idempotency key header — the outbox row's `batch_id`, stable
@@ -56,7 +59,7 @@ export const INGEST_APPEND_SIGNATURE_HEADER = 'x-ub-signature'
 /** JSON value passthrough for opaque fields (cursor, raw provider blob). */
 const opaqueJson = z.unknown()
 
-export const canonicalIngestMessageSchema = z.object({
+const canonicalMessageFields = {
   /** Idempotency key together with `instance_id`. */
   provider_message_id: z.string().min(1),
   conversation_id: z.string().min(1),
@@ -79,9 +82,39 @@ export const canonicalIngestMessageSchema = z.object({
   reply_to_provider_id: z.string().nullable(),
   /** Opaque provider payload kept for reparse; never interpreted here. */
   raw_provider_blob: opaqueJson.nullable(),
-})
+}
+
+/** Frozen v1 message shape. */
+export const canonicalIngestMessageSchema = z.object(canonicalMessageFields)
 
 export type CanonicalIngestMessage = z.infer<typeof canonicalIngestMessageSchema>
+
+export const ingestMediaRefV2Schema = z.object({
+  asset_id: z.string().uuid().optional(),
+  sha256: z.string().regex(/^[a-f0-9]{64}$/).optional(),
+  availability: z.enum(['stored', 'missing', 'failed']),
+  filename: z.string(),
+  mime: z.string(),
+  size_bytes: z.number().int().nonnegative(),
+}).superRefine((value, ctx) => {
+  if (value.availability !== 'stored') return
+  if (!value.asset_id) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['asset_id'], message: 'asset_id is required when availability is stored' })
+  }
+  if (!value.sha256) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['sha256'], message: 'sha256 is required when availability is stored' })
+  }
+})
+
+/** V2 retains every v1 field while adding video and a durable media asset. */
+export const canonicalIngestMessageV2Schema = z.object({
+  ...canonicalMessageFields,
+  kind: z.enum(['text', 'image', 'video', 'voice', 'file', 'link']),
+  media_ref: ingestMediaRefV2Schema.nullable(),
+})
+
+export type CanonicalIngestMessageV2 = z.infer<typeof canonicalIngestMessageV2Schema>
+export type AnyCanonicalIngestMessage = CanonicalIngestMessage | CanonicalIngestMessageV2
 
 export const ingestAppendRequestSchema = z.object({
   contract: z.literal(INGEST_APPEND_CONTRACT_V1),
@@ -98,6 +131,19 @@ export const ingestAppendRequestSchema = z.object({
 })
 
 export type IngestAppendRequest = z.infer<typeof ingestAppendRequestSchema>
+
+export const ingestAppendRequestV2Schema = z.object({
+  contract: z.literal(INGEST_APPEND_CONTRACT_V2),
+  instance_id: z.string().uuid(),
+  source: z.string().min(1),
+  workspace_id: z.string().uuid(),
+  owner_user_id: z.string().uuid().nullable(),
+  cursor: opaqueJson.nullable(),
+  messages: z.array(canonicalIngestMessageV2Schema).min(1),
+})
+
+export type IngestAppendRequestV2 = z.infer<typeof ingestAppendRequestV2Schema>
+export type AnyIngestAppendRequest = IngestAppendRequest | IngestAppendRequestV2
 
 /**
  * Per-conversation coverage report (messaging-archive D11) — how an external
@@ -127,3 +173,17 @@ export const ingestAppendResponseSchema = z.object({
 })
 
 export type IngestAppendResponse = z.infer<typeof ingestAppendResponseSchema>
+
+export const ingestAppendResponseV2Schema = z.object({
+  contract: z.literal(INGEST_APPEND_CONTRACT_V2),
+  accepted: z.number().int().nonnegative(),
+  duplicates: z.number().int().nonnegative(),
+  ack_cursor: opaqueJson.optional(),
+  coverage: ingestAppendCoverageSchema.optional(),
+})
+
+export type IngestAppendResponseV2 = z.infer<typeof ingestAppendResponseV2Schema>
+export const anyIngestAppendResponseSchema = z.union([
+  ingestAppendResponseSchema,
+  ingestAppendResponseV2Schema,
+])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -405,8 +405,8 @@ importers:
         specifier: ^7.15.0
         version: 7.21.0(encoding@0.1.13)
       '@whiskeysockets/baileys':
-        specifier: 7.0.0-rc13
-        version: 7.0.0-rc13(sharp@0.34.5)
+        specifier: 7.0.0-rc14
+        version: 7.0.0-rc14(sharp@0.34.5)
       express:
         specifier: ^5
         version: 5.2.1
@@ -3418,8 +3418,8 @@ packages:
   '@vitest/utils@3.2.6':
     resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
 
-  '@whiskeysockets/baileys@7.0.0-rc13':
-    resolution: {integrity: sha512-8JPc8gaaCRykkjW2jxLGQ7/RZGrc7awO7WU+QJocf58eSUI9jAdcuYLynzhAbyU4UWvJJsHImZ+5E/JaZj5ypA==}
+  '@whiskeysockets/baileys@7.0.0-rc14':
+    resolution: {integrity: sha512-WK+X8ju8TPGxvWIsP8hrY6JB6FltYuFe+vsqKfjOYX25JObij9qLf2c3ZGdl1Q+vhFwbnT+AZmWAB5pTvzmSiQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       audio-decode: ^2.1.3
@@ -10631,7 +10631,7 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@whiskeysockets/baileys@7.0.0-rc13(sharp@0.34.5)':
+  '@whiskeysockets/baileys@7.0.0-rc14(sharp@0.34.5)':
     dependencies:
       '@cacheable/node-cache': 1.7.6
       '@hapi/boom': 9.1.4


### PR DESCRIPTION
## Summary

- add loopback-only HMAC media staging, local assets, processing jobs, and cleanup metadata
- normalize and persist live WhatsApp and WeChat image, document, voice, and video attachments
- extract OCR, document text, audio transcripts, and sampled video-frame descriptions
- embed derived segments and include media provenance in Pipeline B enrichment
- extend the single searchChatHistory archive tool with video, extraction state, segment metadata, and media coverage
- preserve v1 for unrelated external sinks and use v2 for the managed local archive

## Verification

- 114 focused archive, contract, WhatsApp, WeChat, and transcription tests passed
- dependency-ordered monorepo build passed all 20 packages
- real-device WhatsApp and WeChat E2E passed for backfill, live append, processing, and search across all four media classes

No cloud deployment changes are included.