### PR TITLE
test(chat-archive): use renumbered migration

### DIFF
--- a/packages/api/src/chat-archive/__tests__/schema.test.ts
+++ b/packages/api/src/chat-archive/__tests__/schema.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 const migration = readFileSync(
-  new URL('../../../migrations/395_chat_message_archive.sql', import.meta.url),
+  new URL('../../../migrations/405_chat_message_archive.sql', import.meta.url),
   'utf8',
 )
 


### PR DESCRIPTION
## Fix

PR #161 renumbered the chat archive migrations from 395-398 to 405-408, but one existing schema test still opened migration 395. CI therefore failed with ENOENT after 4,768 other tests passed.

This updates the stale fixture path to 405_chat_message_archive.sql.

## Verification

- schema.test.ts
- schema-contract.test.ts
- migration-order.test.ts
- 7/7 tests passed locally.