### PR TITLE
fix(shopify): ShopifyQL rows are keyed by column name, not positional

### DIFF
--- a/packages/api/src/shopify/__tests__/client.integration.test.ts
+++ b/packages/api/src/shopify/__tests__/client.integration.test.ts
@@ -263,13 +263,35 @@ describeIf('[COMP:api/shopify-client] Shopify live dev-store', () => {
   }, 60_000)
 
   it('accepts every groupBy dimension the tool offers', async () => {
-    // The enum is a promise to the model that any of these parses. An invented
+    // The enum is a promise to the model that any of these parses; an invented
     // dimension name would only ever surface here.
+    //
+    // Asserted WITHOUT the bot filter on purpose. A store whose traffic is all
+    // bots has no rows once the filter applies, and Shopify then returns an
+    // empty `columns` list as well - so asserting through storefrontFunnel
+    // would test the store's traffic mix rather than the dimension name. The
+    // funnel is still called, to prove it does not throw.
     for (const groupBy of ['referrer_source', 'session_device_type', 'session_country'] as const) {
-      const result = await storefrontFunnel(AUTH, { since: '-7d', groupBy, limit: 5 })
-      expect(result.columns.map((c) => c.name)).toContain(groupBy)
+      const raw = await runShopifyqlQuery(
+        AUTH,
+        `FROM sessions SHOW sessions GROUP BY ${groupBy} SINCE -30d UNTIL today`,
+      )
+      expect(raw.columns.map((c) => c.name)).toContain(groupBy)
+      await expect(storefrontFunnel(AUTH, { since: '-7d', groupBy, limit: 5 })).resolves.toBeDefined()
     }
-  }, 120_000)
+  }, 180_000)
+
+  it('returns rows keyed by column name, not positional arrays', async () => {
+    // The shape this client originally assumed was positional, which silently
+    // produced undefined for every column. Nothing but a live call catches it:
+    // the GraphQL field is opaque JSON and a mock only re-asserts its own
+    // invention. Values also arrive as strings whatever dataType claims.
+    const table = await runShopifyqlQuery(AUTH, 'FROM sessions SHOW sessions SINCE -30d UNTIL today')
+    expect(table.rows.length).toBeGreaterThan(0)
+    const row = table.rows[0]
+    expect(Array.isArray(row)).toBe(false)
+    expect(row).toHaveProperty('sessions')
+  }, 60_000)
 
   it('surfaces a bad field name as a parse error rather than an empty table', async () => {
     // The silent-failure guard, proven against Shopify rather than a mock:

--- a/packages/api/src/shopify/__tests__/client.test.ts
+++ b/packages/api/src/shopify/__tests__/client.test.ts
@@ -1146,19 +1146,21 @@ describe('[COMP:api/shopify-client] Shopify GraphQL client', () => {
       .rejects.toThrow(/neither table data nor a parse error/)
   })
 
-  it('runShopifyqlQuery returns columns and rows on success', async () => {
+  it('runShopifyqlQuery passes through Shopify\'s real row shape untouched', async () => {
+    // Live shape (2026-08-07): rows keyed by column name, values as strings
+    // whatever dataType claims. The client must not reinterpret either.
     mockFetch.mockResolvedValue(jsonResponse({
       data: { shopifyqlQuery: {
         parseErrors: [],
         tableData: {
-          columns: [{ name: 'sessions', dataType: 'number' }],
-          rows: [[42]],
+          columns: [{ name: 'sessions', dataType: 'INTEGER' }],
+          rows: [{ sessions: '42' }],
         },
       } },
     }))
     const table = await runShopifyqlQuery(AUTH, 'FROM sessions SHOW sessions')
-    expect(table.columns).toEqual([{ name: 'sessions', dataType: 'number' }])
-    expect(table.rows).toEqual([[42]])
+    expect(table.columns).toEqual([{ name: 'sessions', dataType: 'INTEGER' }])
+    expect(table.rows).toEqual([{ sessions: '42' }])
   })
 
   it('storefrontFunnel sends the built query and echoes it back', async () => {

--- a/packages/api/src/shopify/client.ts
+++ b/packages/api/src/shopify/client.ts
@@ -903,10 +903,20 @@ export async function fetchOrdersRange(
 
 // ── Storefront analytics (ShopifyQL) ─────────────────────────
 
-/** Tabular result of a ShopifyQL query: column metadata plus positional rows. */
+/**
+ * Tabular result of a ShopifyQL query.
+ *
+ * `rows` are **objects keyed by column name**, not positional arrays, and every
+ * value arrives as a **string** (`"49"`, `"0.0"`) whatever `dataType` claims —
+ * both verified against a live store on 2026-08-07. The GraphQL schema types
+ * the field as opaque JSON, so nothing catches a wrong assumption here at
+ * compile time and a mocked test only re-asserts whatever shape the mock
+ * invented. The row type stays permissive because of that: consumers must
+ * normalize rather than index.
+ */
 export type ShopifyqlTable = {
   columns: Array<{ name: string; dataType: string }>
-  rows: unknown[][]
+  rows: Array<Record<string, unknown> | unknown[]>
 }
 
 /**
@@ -927,7 +937,7 @@ export async function runShopifyqlQuery(auth: ShopifyAuth, query: string): Promi
       parseErrors?: string[]
       tableData?: {
         columns?: Array<{ name?: string; dataType?: string }>
-        rows?: unknown[][]
+        rows?: Array<Record<string, unknown> | unknown[]>
       } | null
     } | null
   }>(auth, `

--- a/packages/core/src/tools/__tests__/shopify.test.ts
+++ b/packages/core/src/tools/__tests__/shopify.test.ts
@@ -122,7 +122,7 @@ const DESTRUCTIVE_TOOLS = [
 ]
 
 describe('[COMP:tools/shopify] Shopify tools', () => {
-  it('creates the full 38-tool catalog', () => {
+  it('creates the full 40-tool catalog', () => {
     const tools = createShopifyTools(mockApi())
     expect(tools).toHaveLength(40)
     expect(tools.map((t) => t.name).sort()).toEqual(
@@ -392,16 +392,26 @@ describe('[COMP:tools/shopify] Shopify tools', () => {
     })
   })
 
-  it('shopifyStorefrontFunnel derives the cart drop-off and keys rows by column name', async () => {
+  const FUNNEL_COLUMNS = [
+    { name: 'sessions', dataType: 'INTEGER' },
+    { name: 'sessions_with_cart_additions', dataType: 'INTEGER' },
+    { name: 'sessions_that_reached_checkout', dataType: 'INTEGER' },
+    { name: 'sessions_that_completed_checkout', dataType: 'INTEGER' },
+  ]
+
+  it('shopifyStorefrontFunnel derives the cart drop-off from Shopify\'s real row shape', async () => {
+    // Rows come back keyed by column name with STRING values - verified live,
+    // and the opposite of what this test originally asserted. Positional
+    // indexing produced undefined for every column and failed silently.
     const api = mockApi({
       storefrontFunnel: vi.fn().mockResolvedValue({
-        columns: [
-          { name: 'sessions', dataType: 'number' },
-          { name: 'sessions_with_cart_additions', dataType: 'number' },
-          { name: 'sessions_that_reached_checkout', dataType: 'number' },
-          { name: 'sessions_that_completed_checkout', dataType: 'number' },
-        ],
-        rows: [[1000, 180, 60, 42]],
+        columns: FUNNEL_COLUMNS,
+        rows: [{
+          sessions: '1000',
+          sessions_with_cart_additions: '180',
+          sessions_that_reached_checkout: '60',
+          sessions_that_completed_checkout: '42',
+        }],
         shopifyql: 'FROM sessions SHOW ...',
       }),
     })
@@ -409,10 +419,44 @@ describe('[COMP:tools/shopify] Shopify tools', () => {
     const result = await tool.execute({ since: '-7d' }, {} as never)
     const data = result.data as Record<string, unknown>
     const rows = data.rows as Array<Record<string, unknown>>
-    expect(rows[0].sessions).toBe(1000)
+    expect(rows[0].sessions).toBe('1000')
     // 180 added to cart, only 60 ever reached checkout.
     expect(rows[0].added_to_cart_but_never_reached_checkout).toBe(120)
     expect(rows[0].reached_checkout_but_never_completed).toBe(18)
+    expect(data.no_human_sessions).toBeUndefined()
+  })
+
+  it('shopifyStorefrontFunnel still handles positional rows', async () => {
+    // Defensive: the GraphQL field is opaque JSON, so the shape is not a
+    // contract. Zipping against columns keeps an array form working.
+    const api = mockApi({
+      storefrontFunnel: vi.fn().mockResolvedValue({
+        columns: FUNNEL_COLUMNS,
+        rows: [[1000, 180, 60, 42]],
+        shopifyql: 'FROM sessions SHOW ...',
+      }),
+    })
+    const tool = createShopifyTools(api).find((t) => t.name === 'shopifyStorefrontFunnel')!
+    const result = await tool.execute({}, {} as never)
+    const rows = (result.data as Record<string, unknown>).rows as Array<Record<string, unknown>>
+    expect(rows[0].sessions).toBe(1000)
+    expect(rows[0].added_to_cart_but_never_reached_checkout).toBe(120)
+  })
+
+  it('shopifyStorefrontFunnel names an all-bot store rather than reporting a bare zero', async () => {
+    // A store whose every visit was a bot returns zero sessions once the bot
+    // filter applies - and Shopify drops the column list too when a filtered
+    // group matches nothing, so the result looks broken unless it is named.
+    const api = mockApi({
+      storefrontFunnel: vi.fn().mockResolvedValue({
+        columns: [{ name: 'sessions', dataType: 'INTEGER' }],
+        rows: [{ sessions: '0' }],
+        shopifyql: 'FROM sessions SHOW ...',
+      }),
+    })
+    const tool = createShopifyTools(api).find((t) => t.name === 'shopifyStorefrontFunnel')!
+    const result = await tool.execute({}, {} as never)
+    expect(String((result.data as Record<string, unknown>).no_human_sessions)).toMatch(/not a failed query/i)
   })
 
   it('shopifyStorefrontFunnel states that cart abandoners cannot be contacted', async () => {
@@ -536,4 +580,44 @@ describe('[COMP:tools/shopify] Shopify tools', () => {
     const result = await tool.execute({ orderId: '404' }, {} as never)
     expect(result.isError).toBe(true)
   })
+  it('shopifyAddProductImage turns a not-found reference into the saveFileToBrain step', async () => {
+    // The failure this replaces: a merchant's assistant was handed a chat
+    // attachment id, got a bare "not found", read that as a wrong reference,
+    // and retried with other references six times without ever promoting the
+    // file. The remedy has to travel with the error.
+    const addProductImage = vi.fn()
+    const readFileBytes = vi.fn().mockResolvedValue({
+      error: 'File f4e9383d-aa37-498b-92c2-3dc10b19ef77 not found in this workspace.',
+      notFound: true,
+    })
+    const tool = createShopifyTools(mockApi({ addProductImage }), { readFileBytes }).find(
+      (t) => t.name === 'shopifyAddProductImage',
+    )!
+    const result = await tool.execute(
+      { productId: '2', file: 'f4e9383d-aa37-498b-92c2-3dc10b19ef77' },
+      {} as never,
+    )
+    expect(result.isError).toBe(true)
+    const msg = String(result.data)
+    expect(msg).toContain('saveFileToBrain')
+    // The id must be echoed, so the next call needs no guessing.
+    expect(msg).toContain('f4e9383d-aa37-498b-92c2-3dc10b19ef77')
+    expect(msg).toMatch(/do not retry this tool with the same id/i)
+    expect(addProductImage).not.toHaveBeenCalled()
+  })
+
+  it('shopifyAddProductImage does not suggest saveFileToBrain for failures that are not a missing file', async () => {
+    // A quota or permission error has nothing to do with promotion; pointing
+    // at saveFileToBrain there would send the model down a dead end of its own.
+    const addProductImage = vi.fn()
+    const readFileBytes = vi.fn().mockResolvedValue({ error: 'Workspace storage quota exceeded.' })
+    const tool = createShopifyTools(mockApi({ addProductImage }), { readFileBytes }).find(
+      (t) => t.name === 'shopifyAddProductImage',
+    )!
+    const result = await tool.execute({ productId: '2', file: '/products/x.jpg' }, {} as never)
+    expect(result.isError).toBe(true)
+    expect(String(result.data)).toBe('Workspace storage quota exceeded.')
+    expect(String(result.data)).not.toContain('saveFileToBrain')
+  })
+
 })

--- a/packages/core/src/tools/base/shopify.ts
+++ b/packages/core/src/tools/base/shopify.ts
@@ -183,10 +183,10 @@ const disputeRow = (d: Json) => ({
 
 // ── Storefront analytics ───────────────────────────────────────
 
-/** Tabular ShopifyQL result: column metadata plus positional rows. */
+/** Tabular ShopifyQL result. See the client's `ShopifyqlTable` for the row-shape caveat. */
 type ShopifyqlTable = {
   columns: Array<{ name: string; dataType: string }>
-  rows: unknown[][]
+  rows: Array<Record<string, unknown> | unknown[]>
 }
 
 /** Mirrors `SESSION_DIMENSIONS` in the API client - names from Shopify's `sessions` schema. */
@@ -200,9 +200,22 @@ const SESSION_DIMENSIONS = [
 ] as const
 type SessionDimension = (typeof SESSION_DIMENSIONS)[number]
 
-/** Positional ShopifyQL rows → objects keyed by column name, which a model reads far better. */
+/**
+ * Normalize ShopifyQL rows to objects keyed by column name.
+ *
+ * Shopify returns rows **already keyed by column name** — verified live on
+ * 2026-08-07, against an earlier assumption here that they were positional
+ * arrays. That assumption produced a row of `undefined` for every column and no
+ * error anywhere, because the GraphQL field is opaque JSON and the mocked tests
+ * asserted the same invented shape. Both forms are handled now: an array is
+ * zipped against `columns`, an object passes through.
+ *
+ * Values arrive as strings whatever `dataType` says (`"49"`, `"0.0"`), so
+ * anything doing arithmetic on them has to coerce — see `numberish`.
+ */
 function tableToObjects(table: ShopifyqlTable): Array<Record<string, unknown>> {
   return table.rows.map((row) => {
+    if (!Array.isArray(row)) return row
     const out: Record<string, unknown> = {}
     table.columns.forEach((col, i) => { out[col.name] = row[i] })
     return out
@@ -370,11 +383,23 @@ export type ShopifyApi = {
  *
  * Chat attachments are NOT a valid source — they live in `file_cache` and
  * expire after 7 days. The model saves the photo to the brain first.
+ *
+ * `notFound` is load-bearing, not decoration. The overwhelmingly common way to
+ * reach this error is handing the tool a chat-attachment id, because that is
+ * what the owner just supplied and the id is right there in the turn. The
+ * files layer answers that with a generic "not found", which reads as *wrong
+ * reference* rather than *missing step* — so the model retries with another
+ * reference and never reaches `saveFileToBrain`. On 2026-08-06 a merchant's
+ * assistant burned six calls that way and shipped a product with no image.
+ * The flag lets the tool name the remedy instead of relaying the dead end.
  */
 export type ShopifyFileBytesReader = (
   context: ToolContext,
   idOrPath: string,
-) => Promise<{ bytes: Uint8Array; fileName: string; mimeType: string } | { error: string }>
+) => Promise<
+  | { bytes: Uint8Array; fileName: string; mimeType: string }
+  | { error: string; notFound?: boolean }
+>
 
 export function createShopifyTools(
   api: ShopifyApi,
@@ -1005,10 +1030,21 @@ export function createShopifyTools(
           const dropoff = cartDropoff(row)
           return dropoff ? { ...row, ...dropoff } : row
         })
+        // No rows, or rows with no sessions at all, after the bot filter. This
+        // is a real finding, not a broken query: the store had traffic that
+        // Shopify classified entirely as bots. Saying so is the difference
+        // between "your storefront got no real visitors" and the merchant
+        // reading a bare zero as a tooling failure. Shopify also drops the
+        // column list when a filtered group matches nothing, so an empty
+        // result genuinely looks malformed unless it is named.
+        const noHumanTraffic = rows.length === 0 || rows.every((r) => numberish(r.sessions) === 0)
         return { data: {
           period: `${input.since ?? '-30d'} to ${input.until ?? 'today'}`,
           rows,
           row_count: rows.length,
+          ...(noHumanTraffic
+            ? { no_human_sessions: 'No human sessions in this window. Bot traffic is excluded, so a store whose visits were all bots reports zero here - that is a real finding about the storefront, not a failed query.' }
+            : {}),
           note:
             'Sessions here are anonymous aggregates. A session that added to cart but never reached checkout ' +
             'cannot be identified or contacted - report it as a count and act on it by fixing the cart or ' +
@@ -1093,15 +1129,14 @@ export function createShopifyTools(
   const addProductImageTool = buildTool({
     name: 'shopifyAddProductImage',
     description:
-      'Add an image to a Shopify product from a file already saved in the workspace brain. ' +
-      'The file must be a workspace file - pass its id or absolute workspace path. ' +
-      'If the user just attached a photo to this chat, save it with saveFileToBrain FIRST, then call this with the saved path: ' +
-      'chat attachments are temporary and cannot be uploaded. ' +
+      'Add an image to a Shopify product. ' +
+      'Pass a workspace file id or absolute workspace path, OR the id from an <attached_file> tag the user just sent - ' +
+      'an attachment is saved to the workspace automatically before it is uploaded, so you do not need to call saveFileToBrain first. ' +
       'Shopify processes the image asynchronously, so it may take a few seconds to appear on the product. ' +
       'Call this tool directly — the user will see an Approve/Deny prompt.',
     inputSchema: z.object({
       productId: z.string().describe('Product id (numeric or GID).'),
-      file: z.string().describe('Workspace file id (UUID) or absolute workspace path of the image.'),
+      file: z.string().describe('Workspace file id (UUID), absolute workspace path, or the id from an <attached_file> tag the user just sent.'),
       alt: z.string().optional().describe('Alt text for accessibility and SEO.'),
     }),
     isConcurrencySafe: false,
@@ -1119,7 +1154,21 @@ export function createShopifyTools(
       }
       try {
         const file = await opts.readFileBytes(context, input.file)
-        if ('error' in file) return { data: file.error, isError: true }
+        if ('error' in file) {
+          // A bare "not found" sends the model hunting for a different
+          // reference. Nine times in ten the reference was fine and the step
+          // was missing, so say which step.
+          if (file.notFound) {
+            return {
+              data:
+                `${file.error} If ${input.file} is a file the user just attached, this surface could not read it from the upload cache ` +
+                `(it may have expired - uploads are kept ~7 days). Try saveFileToBrain with fileId "${input.file}"; if that also fails, ask the user to re-attach. ` +
+                'Do not retry this tool with the same id, and do not guess a different one.',
+              isError: true,
+            }
+          }
+          return { data: file.error, isError: true }
+        }
         if (!file.mimeType.startsWith('image/')) {
           return { data: `That file is ${file.mimeType}, not an image. Shopify product media must be an image file.`, isError: true }
         }


### PR DESCRIPTION
Follow-up to `#160`. `read_reports` was granted, I verified live, and it caught a silent failure the mocked tests could never have.

## The bug

`shopifyqlQuery` returns rows as **objects keyed by column name**, with every value a **string** whatever `dataType` claims:

```json
"rows": [{ "sessions": "49", "sessions_with_cart_additions": "0" }]
```

The client assumed positional arrays and zipped them against `columns` via `row[i]`. On the real shape that yields `undefined` for every column - **no throw, no empty result, just a funnel of blanks presented as data**.

Nothing local could have caught it. The GraphQL field is opaque JSON, so there is no type to violate, and the mocked tests asserted the same invented shape the client used - the mock and the code agreed with each other and both were wrong. The unit tests now encode the real shape; the integration suite asserts it directly against the store.

`tableToObjects` handles both forms - an array is zipped, an object passes through - because an opaque field is not a contract.

## Zero sessions is a finding, not a failure

The test store reports **49 sessions, every one classified `bot`**. So the filtered funnel returns zero, and for a *grouped* query Shopify drops the `columns` list too, leaving a result that looks malformed.

That is the bot filter working exactly as intended. Unfiltered, this merchant reads "49 sessions, 0% conversion" and goes hunting for a broken checkout that nobody ever reached. The tool now names the case (`no_human_sessions`) rather than emitting a bare zero, because a zero the merchant cannot interpret is barely better than a wrong number.

## Test correction

The `groupBy` integration test asserted through the funnel, which on an all-bot store tested the *store's traffic mix* rather than whether the dimension name parses. It now asserts each dimension unfiltered, and separately checks the funnel does not throw.

## Verification

| | |
|---|---|
| **Live integration** | **9/9 green** against `brian-test-k449hs2g` |
| `pnpm typecheck` | 39/39 |
| core / api / shared | 4703 / 4949 / 326 |
| `validate-shopify-graphql.mjs` | 52/52 valid |
| `pnpm smoke` | OK |
| `pnpm check` | shopify invariants green; remaining failures are an unrelated in-flight chat-archive branch |

Also settles the open question from `#160`: the "Level 2 access to Customer data" clause in Shopify's denial is **boilerplate for a custom-distribution app**. Adding `read_reports` and nothing else made the query work immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)