### PR TITLE
fix(shopify): promote a chat attachment so a product image can reach Shopify

### DIFF
--- a/packages/api/src/mcp/inject.ts
+++ b/packages/api/src/mcp/inject.ts
@@ -18,7 +18,8 @@
  * See docs/architecture/integrations/mcp.md → "Runtime".
  */
 
-import { wrapMcpTools, buildToolIndex, createMcpSearchTools, createGoogleCalendarTools, createGmailTools, createGoogleTasksTools, createGoogleDriveTools, createGoogleDocsTools, createGoogleSheetsTools, createGoogleSlidesTools, createGDriveFilesTools, createGitHubTools, createNotionTools, createFathomTools, createShopifyTools, createMsGraphTools, createKnowledgeTools, createAgentmailTools, createMailboxTools, workspaceFilesCtxFor, workspaceFilesErrorMessage, workspaceFilesGate } from '@use-brian/core'
+import type { AccessContext, CachedFile } from '@use-brian/core'
+import { promoteCachedFile, wrapMcpTools, buildToolIndex, createMcpSearchTools, createGoogleCalendarTools, createGmailTools, createGoogleTasksTools, createGoogleDriveTools, createGoogleDocsTools, createGoogleSheetsTools, createGoogleSlidesTools, createGDriveFilesTools, createGitHubTools, createNotionTools, createFathomTools, createShopifyTools, createMsGraphTools, createKnowledgeTools, createAgentmailTools, createMailboxTools, workspaceFilesCtxFor, workspaceFilesErrorMessage, workspaceFilesGate } from '@use-brian/core'
 import type { Tool, McpSettingsStore, McpServerConfig, KnowledgeStoreInterface, KnowledgeRepoWriter, AuthorizedFile, GDriveFilesStore, GDriveFileKind, LocalSource, RemoteSource, EngineHooks, FilesApi, AgentmailToolApi, MailboxApi, MailboxAccountRouter } from '@use-brian/core'
 import { getGlobalEmailInboxProvider, type EmailInboxProvider } from '../agentmail/provider.js'
 import { renderEmailBody } from '@use-brian/channels'
@@ -466,6 +467,18 @@ export async function injectMcpTools(params: {
    */
   filesApi?: FilesApi
   /**
+   * Reader for the transient upload cache (`file_cache`). Wire to
+   * `fileStore.get` at boot on the paths where a user can attach a file
+   * (chat + channels); workflow and inter-assistant sessions have no
+   * attachments and legitimately pass nothing.
+   *
+   * Without it, a photo the owner just attached cannot reach a Shopify
+   * product: `shopifyAddProductImage` reads workspace files only, and the
+   * model has to call `saveFileToBrain` first — a step it demonstrably skips
+   * (six failed calls in one merchant session on 2026-08-06).
+   */
+  readCachedFile?: (id: string, ctx: AccessContext) => Promise<CachedFile | null>
+  /**
    * The on-demand introspection lane (ability audit §6-c/d): operational-
    * visibility read tools (pending approvals, scheduled jobs, research runs,
    * session history, ...) registered as an `mcp_search` LOCAL SOURCE
@@ -493,7 +506,7 @@ export async function injectMcpTools(params: {
     gdriveFilesStore,
     connectorGrantStore, connectorInstanceStore, workspaceToolPolicyStore, assistantTeamId,
     connectorActionAudit, assistantConnectorGrantsStore, workspaceDomain,
-    keepBuiltinsDirect = false, engineHooks, actorIdentity, filesApi,
+    keepBuiltinsDirect = false, engineHooks, actorIdentity, filesApi, readCachedFile,
     introspectionTools, emailInboxProvider,
   } = params
 
@@ -909,7 +922,7 @@ export async function injectMcpTools(params: {
   await injectGitHubTools(connectors, connectorStore, settingsStore, userId, assistantId, assistantConnectorStore, tools, unavailable, undefined, extrasByProvider.get('github'), resolveInstanceCreds, { report: reportHealth }, assistantConnectorGrantsStore)
   await injectNotionTools(connectors, connectorStore, settingsStore, userId, assistantId, assistantConnectorStore, tools, unavailable, undefined, extrasByProvider.get('notion'), resolveInstanceCreds, { report: reportHealth }, assistantConnectorGrantsStore)
   await injectFathomTools(connectors, connectorStore, settingsStore, userId, assistantId, assistantConnectorStore, tools, unavailable, undefined, undefined, extrasByProvider.get('fathom'), resolveInstanceCreds, persistInstanceCreds)
-  await injectShopifyTools(connectors, connectorStore, settingsStore, userId, assistantId, assistantConnectorStore, tools, unavailable, undefined, undefined, extrasByProvider.get('shopify'), resolveInstanceCreds, persistInstanceCreds, { report: reportHealth }, assistantConnectorGrantsStore, filesApi)
+  await injectShopifyTools(connectors, connectorStore, settingsStore, userId, assistantId, assistantConnectorStore, tools, unavailable, undefined, undefined, extrasByProvider.get('shopify'), resolveInstanceCreds, persistInstanceCreds, { report: reportHealth }, assistantConnectorGrantsStore, filesApi, readCachedFile)
   // No extras argument: `msgraph` is `single_instance` in OFFICIAL_CONNECTORS
   // (one Microsoft identity per user), so it is never in
   // MULTI_INSTANCE_CONNECTOR_IDS and `extrasByProvider` never holds it.
@@ -3389,6 +3402,8 @@ async function injectShopifyTools(
   assistantConnectorGrantsStore?: import('../db/assistant-connector-grants-store.js').AssistantConnectorGrantsStore,
   /** Workspace-file reader for `shopifyAddProductImage`. Absent → the tool reports it honestly. */
   filesApi?: FilesApi,
+  /** Upload-cache reader, so a just-attached photo can be promoted on the fly. */
+  readCachedFile?: (id: string, ctx: AccessContext) => Promise<CachedFile | null>,
 ): Promise<void> {
   const shopify = connectors.find((c) => c.connectorId === 'shopify' && c.connected)
   const shopifyEnabled = shopify && (!assistantConnectorStore || await assistantConnectorStore.isEnabled(assistantId, 'shopify'))
@@ -3488,8 +3503,41 @@ async function injectShopifyTools(
         ? async (context, idOrPath) => {
             const gate = workspaceFilesGate(context.workspaceId)
             if (gate) return { error: gate.data }
-            const res = await filesApi.readBytes(workspaceFilesCtxFor(context), idOrPath)
-            if (!res.ok) return { error: workspaceFilesErrorMessage(res.error) }
+            const ctx = workspaceFilesCtxFor(context)
+            let res = await filesApi.readBytes(ctx, idOrPath)
+
+            // A miss here is almost always a chat-attachment id: the owner
+            // attached the photo and the model passed that id straight through,
+            // because that is the id in front of it. Promote it rather than
+            // bouncing the request back for a bookkeeping step nobody asked
+            // for. `readCachedFile` gates on the same access predicate, so this
+            // cannot reach another workspace's upload.
+            if (!res.ok && res.error.kind === 'not_found' && readCachedFile) {
+              // AccessContext, not FilesContext: the cache read is gated by
+              // the universal access predicate, which requires a concrete
+              // assistant rather than the optional one FilesContext carries.
+              const cached = await readCachedFile(idOrPath, {
+                workspaceId: context.workspaceId!,
+                userId: context.userId,
+                assistantId: context.assistantId,
+                assistantKind: context.assistantKind ?? 'standard',
+                clearance: context.clearance,
+                compartments: context.compartments,
+              })
+              if (cached) {
+                const promoted = await promoteCachedFile(filesApi, ctx, cached)
+                // A failed promotion (quota, most likely) is reported, not
+                // skipped: uploading to Shopify anyway would leave the brain
+                // silently missing a file the owner believes was kept.
+                if (!promoted.ok) return { error: workspaceFilesErrorMessage(promoted.error) }
+                res = await filesApi.readBytes(ctx, promoted.value.id)
+              }
+            }
+
+            // Still missing: say which step is absent rather than relaying a
+            // bare "not found", which reads as a wrong reference and sends the
+            // model hunting for another id.
+            if (!res.ok) return { error: workspaceFilesErrorMessage(res.error), notFound: res.error.kind === 'not_found' }
             return {
               bytes: res.value.bytes,
               fileName: res.value.file.name,

--- a/packages/api/src/routes/channel-pipeline.ts
+++ b/packages/api/src/routes/channel-pipeline.ts
@@ -425,6 +425,9 @@ export type ChannelPipelineParams = {
    *  `turn_complete` for document delivery. Absent (dev without a blob
    *  client) → `sendFile` errors honestly on its missing-collector gate. */
   filesApi?: FilesApi
+  /** Upload-cache reader, so a photo just attached to this turn can be
+   *  promoted on demand (Shopify product images). Chat/channel paths only. */
+  readCachedFile?: (id: string, ctx: import('@use-brian/core').AccessContext) => Promise<import('@use-brian/core').CachedFile | null>
   /**
    * Promotes an over-threshold paste to a durable workspace_files artifact
    * (large-content-artifacts §Phase 3.2, decision D6). Wired once at boot from
@@ -589,7 +592,7 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
     provider, systemPrompt, tools, memoryStore, usageStore,
     analytics, connectorStore, mcpSettingsStore, assistantConnectorStore, connectorGrantStore, connectorInstanceStore, workspaceToolPolicyStore,
     knowledgeStore, gdriveFilesStore, skillStore, workerManager,
-    episodicStore, sessionStateStore, workspaceFilesStore, filesApi,
+    episodicStore, sessionStateStore, workspaceFilesStore, filesApi, readCachedFile,
     replyToMessageId, replyRaw, incomingChannelMessageId,
     voiceTranscriptionUsage,
     senderUserId,
@@ -1170,6 +1173,7 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
         // Workspace-files byte layer — `gmailSendMessage` attachments on
         // channel turns (docs/architecture/integrations/gmail.md).
         filesApi,
+        readCachedFile,
         // Actor identity for opted-in connectors. `actorChannelId` is the
         // channel-native id captured from the inbound webhook by the channel
         // route (Slack user id / Telegram @handle / WhatsApp phone); email +

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -4562,7 +4562,14 @@ export function chatRoutes(options: WebChatOptions): Router {
         assistant,
         userTimezone: user.timezone,
         tools: allTools,
-        stores: options,
+        stores: {
+          ...options,
+          // Promote a just-attached photo on demand, so an image can reach a
+          // Shopify product without the model first calling saveFileToBrain.
+          readCachedFile: options.fileStore
+            ? (id, ctx) => options.fileStore!.get(id, ctx)
+            : undefined,
+        },
         engineHooks: options.engineHooks,
         // In-app actor identity: email is how the signed-in user is known on
         // the web/app surface. Channel turns (WA/TG/Slack) set their native id

--- a/packages/api/src/routes/route-helpers.ts
+++ b/packages/api/src/routes/route-helpers.ts
@@ -320,6 +320,9 @@ export type ChannelMcpStores = {
    * attachments (`docs/architecture/integrations/gmail.md` → "Attachments").
    */
   filesApi?: FilesApi
+  /** Upload-cache reader, so a photo just attached to this turn can be
+   *  promoted on demand (Shopify product images). Chat/channel paths only. */
+  readCachedFile?: (id: string, ctx: import('@use-brian/core').AccessContext) => Promise<import('@use-brian/core').CachedFile | null>
 }
 
 export type ApplyMcpInjectionParams = {
@@ -429,6 +432,7 @@ export async function applyMcpInjection(
       engineHooks: params.engineHooks,
       actorIdentity: params.actorIdentity,
       filesApi: stores.filesApi,
+      readCachedFile: stores.readCachedFile,
       introspectionTools: params.introspectionTools,
     })
   } catch (err) {

--- a/packages/api/src/routes/telegram-byo.ts
+++ b/packages/api/src/routes/telegram-byo.ts
@@ -1438,6 +1438,7 @@ async function processMessage(params: ProcessMessageParams): Promise<void> {
     gdriveFilesStore: params.gdriveFilesStore,
     workspaceFilesStore: params.workspaceFilesStore,
     filesApi: params.filesApi,
+    readCachedFile: params.fileStore ? (id, ctx) => params.fileStore!.get(id, ctx) : undefined,
     artifactPromoter: params.artifactPromoter ?? null,
     skillStore: params.skillStore,
     workerManager: params.workerManager,

--- a/packages/core/src/workspace-files/__tests__/promote.test.ts
+++ b/packages/core/src/workspace-files/__tests__/promote.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest'
+import { promoteCachedFile, cachedFileBytes } from '../promote.js'
+import type { FilesApi, FilesContext } from '../api.js'
+import type { CachedFile } from '../../files/types.js'
+
+// 1x1 transparent PNG.
+const PNG_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+
+const CTX: FilesContext = {
+  workspaceId: 'w_1', userId: 'u_1', assistantId: 'a_1',
+  assistantKind: 'standard', clearance: 'confidential', compartments: [],
+} as unknown as FilesContext
+
+function cached(over: Partial<CachedFile> = {}): CachedFile {
+  return {
+    id: 'f_1', sessionId: 's_1', fileName: 'hojicha.png', mimeType: 'image/png',
+    content: `data:image/png;base64,${PNG_B64}`, summary: 'pouch photo', sizeBytes: 100,
+    ...over,
+  } as CachedFile
+}
+
+function fakeApi() {
+  const writeBytes = vi.fn().mockImplementation(async (_ctx, params) => ({
+    ok: true, value: { id: 'wf_1', path: params.path, name: params.title, mime: params.mime },
+  }))
+  return { api: { writeBytes } as unknown as FilesApi, writeBytes }
+}
+
+describe('[COMP:files/tools] Cached-file promotion', () => {
+  it('decodes a base64 data URL to the ORIGINAL bytes, not the URL text', () => {
+    // Writing the data-URL string as UTF-8 yields a file that uploads happily
+    // and is a corrupt image — the failure this single decoder exists to stop.
+    const bytes = cachedFileBytes(cached())
+    expect(bytes.subarray(0, 8)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+    expect(bytes.length).toBe(Buffer.from(PNG_B64, 'base64').length)
+  })
+
+  it('treats a non-data-URL cache entry as UTF-8 text', () => {
+    const bytes = cachedFileBytes(cached({ content: 'plain notes', mimeType: 'text/plain', fileName: 'n.txt' }))
+    expect(bytes.toString('utf-8')).toBe('plain notes')
+  })
+
+  it('defaults to /uploads/<original filename> and carries the binary mime through', async () => {
+    const { api, writeBytes } = fakeApi()
+    const res = await promoteCachedFile(api, CTX, cached())
+    expect(res.ok).toBe(true)
+    expect(writeBytes).toHaveBeenCalledWith(CTX, expect.objectContaining({
+      path: '/uploads/hojicha.png',
+      mime: 'image/png',
+      title: 'hojicha.png',
+      summary: 'pouch photo',
+    }))
+  })
+
+  it('lets an explicit path and title win over the cached defaults', async () => {
+    const { api, writeBytes } = fakeApi()
+    await promoteCachedFile(api, CTX, cached(), { path: '/products/x.png', title: 'Pouch' })
+    expect(writeBytes).toHaveBeenCalledWith(CTX, expect.objectContaining({
+      path: '/products/x.png', title: 'Pouch',
+    }))
+  })
+})

--- a/packages/core/src/workspace-files/index.ts
+++ b/packages/core/src/workspace-files/index.ts
@@ -55,3 +55,4 @@ export {
 } from './attachments.js'
 
 export { buildWorkspaceFilesContext } from './context-builder.js'
+export { promoteCachedFile, cachedFileBytes } from './promote.js'

--- a/packages/core/src/workspace-files/promote.ts
+++ b/packages/core/src/workspace-files/promote.ts
@@ -1,0 +1,53 @@
+/**
+ * Promote a transient upload (`file_cache`) into the permanent workspace file
+ * primitive.
+ *
+ * Extracted so there is exactly ONE decoder. `saveFileToBrain` is the explicit
+ * "keep this file" path; the Shopify product-image seam promotes implicitly so
+ * a photo the owner just attached can reach a product without a bookkeeping
+ * step they never asked for. Two copies of the data-URL branch would drift, and
+ * the failure would be silent: a base64 payload written as UTF-8 is a corrupt
+ * image that still uploads.
+ */
+import type { FilesApi, FilesContext, FilesResult } from './api.js'
+import type { WorkspaceFile } from './types.js'
+import type { CachedFile } from '../files/types.js'
+
+const DATA_URL_RE = /^data:[^;]+;base64,(.+)$/
+
+/**
+ * Binary attachments (image/PDF/audio) are cached as a base64 data URL;
+ * text-like files are cached as plain UTF-8. Decode either to raw bytes.
+ */
+export function cachedFileBytes(cached: CachedFile): Buffer {
+  const m = DATA_URL_RE.exec(cached.content)
+  return m ? Buffer.from(m[1], 'base64') : Buffer.from(cached.content, 'utf-8')
+}
+
+export type PromoteCachedFileOptions = {
+  path?: string
+  title?: string
+  summary?: string
+  tags?: string[]
+  sensitivity?: FilesWriteSensitivity
+}
+
+type FilesWriteSensitivity = NonNullable<Parameters<FilesApi['writeBytes']>[1]['sensitivity']>
+
+/** Persist the cached bytes verbatim at `/uploads/<original name>` by default. */
+export function promoteCachedFile(
+  api: FilesApi,
+  ctx: FilesContext,
+  cached: CachedFile,
+  opts?: PromoteCachedFileOptions,
+): Promise<FilesResult<WorkspaceFile>> {
+  return api.writeBytes(ctx, {
+    path: opts?.path ?? `/uploads/${cached.fileName}`,
+    bytes: cachedFileBytes(cached),
+    mime: cached.mimeType,
+    title: opts?.title ?? cached.fileName,
+    summary: opts?.summary ?? cached.summary ?? null,
+    tags: opts?.tags,
+    sensitivity: opts?.sensitivity,
+  })
+}

--- a/packages/core/src/workspace-files/tools.ts
+++ b/packages/core/src/workspace-files/tools.ts
@@ -21,6 +21,7 @@ import {
   type WorkspaceFileRowStatus,
 } from './types.js'
 import type { CachedFile } from '../files/types.js'
+import { promoteCachedFile } from './promote.js'
 import type { AccessContext } from '../security/access-context.js'
 import { createSendFileTool } from './send-file.js'
 import {
@@ -506,7 +507,6 @@ export function createFileTools(
   // original bytes from the upload cache (`file_cache`, via `readCachedFile`)
   // and persists them verbatim to `workspace_files` (GCS), so an image/PDF is
   // kept as the real file — not a text summary (that's the bug this fixes).
-  const DATA_URL_RE = /^data:[^;]+;base64,(.+)$/
 
   const saveFileToBrain = buildTool({
     name: 'saveFileToBrain',
@@ -564,18 +564,10 @@ export function createFileTools(
         }
       }
 
-      // Binary attachments (image/PDF/audio) are cached as a base64 data URL;
-      // text-like files are cached as plain UTF-8. Decode either to raw bytes.
-      const m = DATA_URL_RE.exec(cached.content)
-      const bytes = m ? Buffer.from(m[1], 'base64') : Buffer.from(cached.content, 'utf-8')
-      const path = input.path ?? `/uploads/${cached.fileName}`
-
-      const result = await api.writeBytes(ctxFor(context), {
-        path,
-        bytes,
-        mime: cached.mimeType,
-        title: input.title ?? cached.fileName,
-        summary: input.summary ?? cached.summary ?? null,
+      const result = await promoteCachedFile(api, ctxFor(context), cached, {
+        path: input.path,
+        title: input.title,
+        summary: input.summary,
         tags: input.tags,
         sensitivity: input.sensitivity,
       })


### PR DESCRIPTION
## The failure

`shopifyAddProductImage` reads workspace files only. A photo the owner just attached lives in `file_cache`, so passing its `<attached_file>` id — the id directly in front of the model — failed with a bare `File <id> not found in this workspace.`

That reads as a **wrong reference**, not a **missing step**. Production, 2026-08-06, one merchant session: the model retried with the uuid, then the filename, then the uuid again. `loadFromWorkspace` failed 4/4, two more `mcp_call`s failed the same way. `saveFileToBrain` was never called once, and the product shipped with no image.

Naming the step in the tool description was already tried — it was in `buildTool({ description })` the whole time. An instruction the model reads once at injection does not survive a failure path that says something else.

## The fix

**The byte seam promotes on demand.** `injectMcpTools` takes an optional `readCachedFile`; on a miss the seam reads the upload cache, promotes the file, and re-reads.

Wired only where a user can actually attach something — web chat (`chat.ts`) and Telegram (`telegram-byo.ts`) — and in both cases **derived from the `fileStore` those routes already hold**, so there are no new public option fields and no `boot.ts` changes. Workflow and inter-assistant paths pass nothing; they have no attachments to promote.

A failed promotion (quota, realistically) is **reported, not skipped**. Uploading to Shopify anyway would leave the brain silently missing a file the owner believes was kept.

**One decoder, not two.** `promoteCachedFile` / `cachedFileBytes` are extracted to `workspace-files/promote.ts` and shared with `saveFileToBrain`. The data-URL-vs-UTF-8 branch must exist exactly once: two copies would drift, and that failure is silent — a base64 payload written as UTF-8 is a corrupt image that still uploads happily.

## Verification

End to end against a live store, replaying the client's own three steps:

| Step | Result |
|---|---|
| 19,137-byte PNG → base64 data URL (25,538 chars) → `cachedFileBytes` | byte-identical, SHA256 `8a344f8a…` |
| `stagedUploadsCreate` | `userErrors: []` |
| multipart POST to the GCS target | **HTTP 201** |
| `productUpdate(media:)` | `userErrors: []` |
| Shopify media | **`status: READY`**, 512×512 |

Pulled back from `cdn.shopify.com`: valid 512×512 8-bit RGB PNG. It hashes differently (2,542 bytes) because Shopify recompresses on upload — same dimensions, same colour type, not corruption.

Tests: 88 core (Shopify tools + workspace-files, incl. 4 new promotion tests), 69 api client, `pnpm smoke` OK, typecheck clean on every touched file.

## Notes for review

- Paired docs land in the platform repo (`docs/architecture/integrations/shopify.md` + component map) and `brian-kb`.
- The `notFound` half of this work — the typed flag on `ShopifyFileBytesReader` that lets the tool name the step when promotion is unavailable — is already on develop, swept into `cb4b4673` (whose message is about ShopifyQL row shape and says nothing about it). This branch builds on that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)