### PR TITLE
fix(shopify): give the model a ShopifyQL dictionary and a floor to stop on

### DIFF
--- a/packages/core/src/tools/__tests__/shopify.test.ts
+++ b/packages/core/src/tools/__tests__/shopify.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { createShopifyTools, type ShopifyApi } from '../base/shopify.js'
+import { SHOPIFYQL_SCHEMAS } from '../base/shopify-analytics-catalog.js'
 
 function mockApi(overrides: Partial<ShopifyApi> = {}): ShopifyApi {
   const emptyConn = { edges: [], pageInfo: { hasNextPage: false } }
@@ -480,6 +481,84 @@ describe('[COMP:tools/shopify] Shopify tools', () => {
     expect(String(result.data)).toMatch(/rejected/i)
     // The specific failure must survive to the model so it can fix the query.
     expect(String(result.data)).toMatch(/sesions/)
+  })
+
+  /** Shopify's real rejection wording for an unknown column. */
+  const columnNotFound = (col: string) =>
+    new Error(`ShopifyQL query was rejected: Column Not Found: Column '${col}' not found`)
+
+  it('shopifyAnalyticsQuery says WHERE a column lives when it belongs to another schema', async () => {
+    // The exact 20-minute loop: `new_customers` is a real metric, but of
+    // `sales`, not `customers`. Naming the right schema ends it in one step.
+    const api = mockApi({ runAnalyticsQuery: vi.fn().mockRejectedValue(columnNotFound('new_customers')) })
+    const tool = createShopifyTools(api).find((t) => t.name === 'shopifyAnalyticsQuery')!
+    const result = await tool.execute(
+      { query: 'FROM customers SHOW new_customers SINCE -6m UNTIL today' }, {} as never,
+    )
+    expect(result.isError).toBe(true)
+    expect(String(result.data)).toContain('"sales"')
+    expect(String(result.data)).toContain('new_customer_records')
+  })
+
+  it('shopifyAnalyticsQuery offers the nearest real names for an invented column', async () => {
+    // `customer_type` exists in no schema at all - the model made it up.
+    const api = mockApi({ runAnalyticsQuery: vi.fn().mockRejectedValue(columnNotFound('customer_type')) })
+    const tool = createShopifyTools(api).find((t) => t.name === 'shopifyAnalyticsQuery')!
+    const result = await tool.execute(
+      { query: 'FROM customers SHOW total_amount_spent GROUP BY customer_type SINCE -6m UNTIL today' }, {} as never,
+    )
+    const data = String(result.data)
+    expect(data).toMatch(/closest names/i)
+    // The full metric list is short enough to state outright, and is what SHOW needs.
+    expect(data).toContain('new_customer_records')
+    expect(data).toMatch(/cannot be guessed/i)
+  })
+
+  it('shopifyAnalyticsQuery stops after repeated rejections instead of looping', async () => {
+    // Each rejection reads as "almost right, try again", so nothing about a
+    // single failure tells the model to stop. The cap is what does.
+    const api = mockApi({ runAnalyticsQuery: vi.fn().mockRejectedValue(columnNotFound('nope')) })
+    const tool = createShopifyTools(api).find((t) => t.name === 'shopifyAnalyticsQuery')!
+    const q = { query: 'FROM customers SHOW nope SINCE -6m UNTIL today' }
+    for (let i = 0; i < 3; i++) await tool.execute(q, {} as never)
+    const result = await tool.execute(q, {} as never)
+    expect(result.isError).toBe(true)
+    expect(String(result.data)).toMatch(/stopping/i)
+    expect(String(result.data)).toMatch(/do not try another spelling/i)
+    // The cap must not spend another call on a query it has already refused.
+    expect(api.runAnalyticsQuery).toHaveBeenCalledTimes(3)
+  })
+
+  it('shopifyAnalyticsQuery resets the rejection count after a success', async () => {
+    const runAnalyticsQuery = vi.fn()
+      .mockRejectedValueOnce(columnNotFound('nope'))
+      .mockResolvedValueOnce({ columns: [{ name: 'sessions', dataType: 'INTEGER' }], rows: [{ sessions: '5' }] })
+      .mockRejectedValue(columnNotFound('nope'))
+    const tool = createShopifyTools(mockApi({ runAnalyticsQuery })).find((t) => t.name === 'shopifyAnalyticsQuery')!
+    await tool.execute({ query: 'FROM sessions SHOW nope SINCE -7d UNTIL today' }, {} as never)
+    await tool.execute({ query: 'FROM sessions SHOW sessions SINCE -7d UNTIL today' }, {} as never)
+    // Two more failures must not trip a limit that a success already cleared.
+    await tool.execute({ query: 'FROM sessions SHOW nope SINCE -7d UNTIL today' }, {} as never)
+    const result = await tool.execute({ query: 'FROM sessions SHOW nope SINCE -7d UNTIL today' }, {} as never)
+    expect(String(result.data)).not.toMatch(/stopping/i)
+  })
+
+  it('shopifyAnalyticsQuery refuses a non-existent schema without calling Shopify', async () => {
+    // "orders" and "products" read like obvious schemas and are not - the tool
+    // description used to claim both, which is how the model learned them.
+    const api = mockApi()
+    const tool = createShopifyTools(api).find((t) => t.name === 'shopifyAnalyticsQuery')!
+    const result = await tool.execute({ query: 'FROM orders SHOW orders SINCE -30d UNTIL today' }, {} as never)
+    expect(result.isError).toBe(true)
+    expect(String(result.data)).toContain('"sales"')
+    expect(api.runAnalyticsQuery).not.toHaveBeenCalled()
+  })
+
+  it('shopifyAnalyticsQuery advertises only schemas it can spell for', async () => {
+    const tool = createShopifyTools(mockApi()).find((t) => t.name === 'shopifyAnalyticsQuery')!
+    for (const schema of SHOPIFYQL_SCHEMAS) expect(tool.description).toContain(schema)
+    // The two that never existed must not reappear as advertised schemas.
+    expect(tool.description).toMatch(/no "orders" or "products" schema/i)
   })
 
   it('shopifyGetPayoutsSummary flags non-Shopify-Payments stores honestly', async () => {

--- a/packages/core/src/tools/base/shopify-analytics-catalog.ts
+++ b/packages/core/src/tools/base/shopify-analytics-catalog.ts
@@ -1,0 +1,455 @@
+/**
+ * ShopifyQL field catalog — the dictionary the model cannot get any other way.
+ *
+ * ShopifyQL has **no introspection**: `shopifyqlQuery` is the only root field,
+ * `SHOW COLUMNS` and `SHOW *` are rejected, and a rejection names only the
+ * column that was wrong, never one that would have been right. So a model
+ * handed a free-form query tool has no route to the vocabulary except guessing,
+ * and guessing does not converge — on 2026-08-07 an assistant spent twenty
+ * minutes cycling `new_customers` → `customer_type` → `customer_type` against
+ * the `customers` schema, each rejection telling it only that it was wrong
+ * again. This table is what stops that.
+ *
+ * **Every name here was verified against a live store**, not copied from the
+ * reference: each schema's full candidate list was submitted to the Admin API
+ * and any name Shopify rejected was dropped. All 6 schemas / 78 metrics / 263
+ * dimensions survived on 2026-08-07 against API 2026-04, so the published
+ * reference was accurate — but it had already been wrong once about this field
+ * (rows are keyed objects, not positional arrays), which is why it is checked
+ * rather than trusted. Re-run `scripts/verify-shopifyql-catalog.mjs` when the
+ * API version rolls.
+ *
+ * Scope is deliberate: these are the schemas the connector's use cases need.
+ * A schema absent here is not necessarily invalid ShopifyQL — it is a schema we
+ * cannot help the model spell, which is why the tool says so plainly instead of
+ * letting it try its luck.
+ *
+ * See docs/architecture/integrations/shopify.md → "Storefront analytics".
+ */
+
+export type ShopifyqlSchemaName = keyof typeof SHOPIFYQL_CATALOG
+
+export const SHOPIFYQL_CATALOG = {
+  sessions: {
+    metrics: [
+      'added_to_cart_rate',
+      'average_session_duration',
+      'bounce_rate',
+      'bounces',
+      'checkout_conversion_rate',
+      'completed_checkout_rate',
+      'conversion_rate',
+      'online_store_visitors',
+      'pageviews',
+      'pageviews_per_session',
+      'reached_checkout_rate',
+      'sessions',
+      'sessions_that_completed_checkout',
+      'sessions_that_reached_and_completed_checkout',
+      'sessions_that_reached_checkout',
+      'sessions_with_cart_additions',
+    ],
+    dimensions: [
+      'channel_handle',
+      'customer_account_status',
+      'customer_amount_spent',
+      'customer_cities',
+      'customer_cohort_month',
+      'customer_cohort_quarter',
+      'customer_cohort_week',
+      'customer_countries',
+      'customer_email',
+      'customer_email_domain',
+      'customer_email_subscription_status',
+      'customer_first_order_date',
+      'customer_id',
+      'customer_language',
+      'customer_last_order_date',
+      'customer_name',
+      'customer_number_of_orders',
+      'customer_regions',
+      'customer_sms_subscription_status',
+      'customer_tag',
+      'customer_tags',
+      'day',
+      'day_of_week',
+      'first_order_sales_channel',
+      'hour',
+      'hour_of_day',
+      'human_or_bot_session',
+      'landing_page_path',
+      'landing_page_type',
+      'landing_page_url',
+      'marketing_activity_channel',
+      'marketing_activity_id',
+      'marketing_activity_status',
+      'marketing_activity_title',
+      'marketing_automation_id',
+      'marketing_delivery_channel',
+      'marketing_event_id',
+      'marketing_platform',
+      'minute',
+      'month',
+      'month_of_year',
+      'predicted_spend_tier',
+      'quarter',
+      'referrer_domain',
+      'referrer_name',
+      'referrer_path',
+      'referrer_site',
+      'referrer_source',
+      'referrer_terms',
+      'referrer_url',
+      'referring_channel',
+      'referring_medium',
+      'referring_platform',
+      'rfm_group',
+      'rollout_id',
+      'rollout_ids',
+      'rollout_treatment_id',
+      'rollout_treatment_ids',
+      'second',
+      'session_api_client',
+      'session_bounced',
+      'session_city',
+      'session_country',
+      'session_country_code',
+      'session_device_browser',
+      'session_device_browser_version',
+      'session_device_os',
+      'session_device_os_version',
+      'session_device_type',
+      'session_duration',
+      'session_id',
+      'session_region',
+      'shop_id',
+      'shop_name',
+      'traffic_type',
+      'utm_campaign',
+      'utm_content',
+      'utm_medium',
+      'utm_source',
+      'utm_term',
+      'week',
+      'week_of_year',
+      'year',
+    ],
+  },
+  customers: {
+    metrics: [
+      'days_since_last_order',
+      'new_customer_records',
+      'percent_of_customers',
+      'total_amount_spent',
+      'total_amount_spent_per_order',
+      'total_number_of_orders',
+    ],
+    dimensions: [
+      'abandoned_checkout_date',
+      'customer_account_status',
+      'customer_added_date',
+      'customer_amount_spent',
+      'customer_cities',
+      'customer_city',
+      'customer_cohort_month',
+      'customer_cohort_quarter',
+      'customer_cohort_week',
+      'customer_countries',
+      'customer_country',
+      'customer_created_by_app_id',
+      'customer_email',
+      'customer_email_domain',
+      'customer_email_subscription_status',
+      'customer_first_order_date',
+      'customer_id',
+      'customer_language',
+      'customer_last_order_date',
+      'customer_name',
+      'customer_number_of_orders',
+      'customer_region',
+      'customer_regions',
+      'customer_sms_subscription_status',
+      'customer_tag',
+      'customer_tags',
+      'day',
+      'day_of_week',
+      'hour',
+      'hour_of_day',
+      'minute',
+      'month',
+      'month_of_year',
+      'predicted_spend_tier',
+      'quarter',
+      'rfm_group',
+      'second',
+      'shop_id',
+      'shop_name',
+      'week',
+      'week_of_year',
+      'year',
+    ],
+  },
+  sales: {
+    metrics: [
+      'amount_spent_per_customer',
+      'average_order_value',
+      'cost_of_goods_sold',
+      'customers',
+      'discounts',
+      'duties',
+      'gross_margin',
+      'gross_profit',
+      'gross_returns',
+      'gross_sales',
+      'line_item_discounts',
+      'net_items_sold',
+      'net_returns',
+      'net_sales',
+      'new_customers',
+      'number_of_orders_per_customer',
+      'order_level_discounts',
+      'orders',
+      'orders_first_time',
+      'orders_returning',
+      'quantity_ordered',
+      'quantity_ordered_per_order',
+      'quantity_returned',
+      'returning_customer_rate',
+      'returning_customers',
+      'returns',
+      'shipping_charges',
+      'taxes',
+      'tips',
+      'total_returns',
+      'total_sales',
+      'total_sales_first_time',
+      'total_sales_returning',
+    ],
+    dimensions: [
+      'billing_country',
+      'channel_id',
+      'customer_cohort_month',
+      'customer_email',
+      'customer_id',
+      'customer_name',
+      'day',
+      'day_of_week',
+      'discount_code',
+      'discount_type',
+      'hour',
+      'hour_of_day',
+      'is_discounted_sale',
+      'is_pos_sale',
+      'is_return_related',
+      'market',
+      'month',
+      'month_of_year',
+      'months_since_first_purchase',
+      'new_or_returning_customer',
+      'order_fulfillment_status',
+      'order_id',
+      'order_name',
+      'order_payment_status',
+      'order_referrer_source',
+      'order_risk_level',
+      'order_sales_channel',
+      'order_tag',
+      'order_tags',
+      'order_utm_campaign',
+      'order_utm_medium',
+      'order_utm_source',
+      'product_collection',
+      'product_id',
+      'product_tag',
+      'product_title',
+      'product_type',
+      'product_variant_id',
+      'product_variant_sku',
+      'product_variant_title',
+      'product_vendor',
+      'quarter',
+      'referring_channel',
+      'return_reason',
+      'rfm_group',
+      'sales_channel',
+      'shipping_city',
+      'shipping_country',
+      'shipping_region',
+      'subscription_or_one_time',
+      'traffic_type',
+      'week',
+      'week_of_year',
+      'year',
+    ],
+  },
+  campaign_sessions: {
+    metrics: [
+      'campaign_added_to_cart_rate',
+      'campaign_average_session_duration',
+      'campaign_bounce_rate',
+      'campaign_bounces',
+      'campaign_checkout_conversion_rate',
+      'campaign_completed_checkout_rate',
+      'campaign_conversion_rate',
+      'campaign_online_store_visitors',
+      'campaign_pageviews',
+      'campaign_pageviews_per_session',
+      'campaign_reached_checkout_rate',
+      'campaign_sessions',
+      'campaign_sessions_that_completed_checkout',
+      'campaign_sessions_that_reached_and_completed_checkout',
+      'campaign_sessions_that_reached_checkout',
+      'campaign_sessions_with_cart_additions',
+    ],
+    dimensions: [
+      'campaign_id',
+      'customer_id',
+      'day',
+      'day_of_week',
+      'hour',
+      'hour_of_day',
+      'landing_page_path',
+      'landing_page_type',
+      'landing_page_url',
+      'minute',
+      'month',
+      'month_of_year',
+      'quarter',
+      'referrer_domain',
+      'referrer_name',
+      'referrer_path',
+      'referrer_site',
+      'referrer_source',
+      'referrer_terms',
+      'referrer_url',
+      'referring_channel',
+      'referring_medium',
+      'referring_platform',
+      'second',
+      'session_api_client',
+      'session_bounced',
+      'session_city',
+      'session_country',
+      'session_country_code',
+      'session_device_browser',
+      'session_device_browser_version',
+      'session_device_os',
+      'session_device_os_version',
+      'session_device_type',
+      'session_duration',
+      'session_id',
+      'session_region',
+      'shop_id',
+      'shop_name',
+      'traffic_type',
+      'utm_campaign',
+      'utm_content',
+      'utm_medium',
+      'utm_source',
+      'utm_term',
+      'week',
+      'week_of_year',
+      'year',
+    ],
+  },
+  searches: {
+    metrics: [
+      'searches',
+    ],
+    dimensions: [
+      'day',
+      'day_of_week',
+      'hour',
+      'hour_of_day',
+      'is_article_search_query',
+      'is_page_search_query',
+      'is_product_search_query',
+      'minute',
+      'month',
+      'month_of_year',
+      'quarter',
+      'search_query',
+      'search_query_intent',
+      'search_results_were_returned',
+      'second',
+      'shop_id',
+      'shop_name',
+      'week',
+      'week_of_year',
+      'year',
+    ],
+  },
+  chargebacks: {
+    metrics: [
+      'chargeback_amount',
+      'chargeback_rate',
+      'chargebacks',
+      'fraudulent_chargeback_rate',
+      'fraudulent_chargebacks',
+      'successful_transactions',
+    ],
+    dimensions: [
+      'chargeback_reason',
+      'day',
+      'day_of_week',
+      'hour',
+      'hour_of_day',
+      'is_rapid_dispute_resolution',
+      'minute',
+      'month',
+      'month_of_year',
+      'quarter',
+      'second',
+      'shop_id',
+      'shop_name',
+      'week',
+      'week_of_year',
+      'year',
+    ],
+  },
+} as const satisfies Record<string, { metrics: readonly string[]; dimensions: readonly string[] }>
+
+export const SHOPIFYQL_SCHEMAS = Object.keys(SHOPIFYQL_CATALOG) as ShopifyqlSchemaName[]
+
+/** The schema a query reads, or null when there is no parseable `FROM`. */
+export function schemaOfQuery(query: string): string | null {
+  return query.match(/\bFROM\s+([a-z_][a-z0-9_]*)/i)?.[1]?.toLowerCase() ?? null
+}
+
+/** The column name Shopify rejected, or null when the error is not a column problem. */
+export function rejectedColumn(message: string): string | null {
+  return message.match(/Column '([^']+)' not found/)?.[1] ?? null
+}
+
+/** Every schema in the catalog that does define `column` — the "wrong table" case. */
+export function schemasDefining(column: string): ShopifyqlSchemaName[] {
+  return SHOPIFYQL_SCHEMAS.filter((s) => {
+    const { metrics, dimensions } = SHOPIFYQL_CATALOG[s]
+    return (metrics as readonly string[]).includes(column) || (dimensions as readonly string[]).includes(column)
+  })
+}
+
+/** Levenshtein distance, capped — only used to rank short field names. */
+function editDistance(a: string, b: string): number {
+  const prev = Array.from({ length: b.length + 1 }, (_, i) => i)
+  for (let i = 1; i <= a.length; i++) {
+    let diag = prev[0]
+    prev[0] = i
+    for (let j = 1; j <= b.length; j++) {
+      const tmp = prev[j]
+      prev[j] = Math.min(prev[j] + 1, prev[j - 1] + 1, diag + (a[i - 1] === b[j - 1] ? 0 : 1))
+      diag = tmp
+    }
+  }
+  return prev[b.length]
+}
+
+/** Closest names within one schema, nearest first. */
+export function closestFields(schema: ShopifyqlSchemaName, column: string, limit = 6): string[] {
+  const all = [...SHOPIFYQL_CATALOG[schema].metrics, ...SHOPIFYQL_CATALOG[schema].dimensions] as readonly string[]
+  return [...all]
+    .map((name) => ({ name, d: editDistance(column.toLowerCase(), name.toLowerCase()) }))
+    .sort((a, b) => a.d - b.d || a.name.localeCompare(b.name))
+    .slice(0, limit)
+    .map((x) => x.name)
+}

--- a/packages/core/src/tools/base/shopify.ts
+++ b/packages/core/src/tools/base/shopify.ts
@@ -13,6 +13,15 @@
 import { z } from 'zod'
 import { buildTool, type Tool, type ToolContext } from '../types.js'
 import { type Json, asRows, str, num, bool, obj, projectList } from './_connector-result.js'
+import {
+  SHOPIFYQL_CATALOG,
+  SHOPIFYQL_SCHEMAS,
+  schemaOfQuery,
+  rejectedColumn,
+  schemasDefining,
+  closestFields,
+  type ShopifyqlSchemaName,
+} from './shopify-analytics-catalog.js'
 
 // ── Result projections ─────────────────────────────────────────
 // The GraphQL queries already select only the needed fields, but connection
@@ -250,6 +259,37 @@ function cartDropoff(row: Record<string, unknown>): Record<string, unknown> | un
       ? { reached_checkout_but_never_completed: Math.max(0, reached - completed) }
       : {}),
   }
+}
+
+/**
+ * Turn "Column 'X' not found" into something a model can act on in one step.
+ *
+ * Shopify's rejection names only the column that was wrong. It never names one
+ * that would have been right, and ShopifyQL has no introspection to ask - so
+ * the model's only move is another guess, and guesses do not converge. This
+ * appends the answer: where the column actually lives if it exists in another
+ * schema (the single most common mistake, e.g. `new_customers` is real but
+ * belongs to `sales`, not `customers`), the nearest names in the schema that
+ * was queried, and the full metric list, which is short enough to state
+ * outright and is what SHOW needs.
+ *
+ * Returns '' for any error that is not a column-name problem - a syntax error
+ * or a throttle already says what to do.
+ */
+function fieldHelp(schema: string | null, message: string): string {
+  const column = rejectedColumn(message)
+  if (!column || !schema || !(SHOPIFYQL_SCHEMAS as string[]).includes(schema)) return ''
+  const known = schema as ShopifyqlSchemaName
+
+  const elsewhere = schemasDefining(column).filter((s) => s !== known)
+  if (elsewhere.length > 0) {
+    return ` "${column}" is not part of "${schema}" - it belongs to ${elsewhere.map((s) => `"${s}"`).join(' / ')}. ` +
+      `Re-run it against that schema, or pick a "${schema}" field below.` +
+      ` Metrics in "${schema}": ${SHOPIFYQL_CATALOG[known].metrics.join(', ')}.`
+  }
+  return ` Closest names in "${schema}": ${closestFields(known, column).join(', ')}.` +
+    ` All metrics in "${schema}": ${SHOPIFYQL_CATALOG[known].metrics.join(', ')}.` +
+    ` Use one of these verbatim - field names cannot be guessed and there is no way to list them from the API.`
 }
 
 // ── API port ───────────────────────────────────────────────────
@@ -1057,31 +1097,60 @@ export function createShopifyTools(
     },
   })
 
+  // Consecutive rejections of shopifyAnalyticsQuery in this tool set's lifetime
+  // (one injection ~ one turn). ShopifyQL rejections are individually cheap and
+  // each one reads as "almost right, try again", so nothing about a single
+  // failure tells the model to stop - which is how a bad field name turned into
+  // a twenty-minute loop. Reset on any success.
+  let analyticsRejections = 0
+  const ANALYTICS_REJECTION_LIMIT = 3
+
   const analyticsQueryTool = buildTool({
     name: 'shopifyAnalyticsQuery',
     description:
       'Run a raw ShopifyQL query against the store analytics for questions the other tools do not cover ' +
-      '(traffic, marketing campaigns, site-search terms, customer recency and lifetime spend). ' +
-      'Read-only. Prefer shopifyStorefrontFunnel for anything about the conversion funnel - it cannot fail to parse. ' +
-      'Syntax is "FROM <schema> SHOW <metrics> ...", never SELECT. Schemas include sessions, sales, orders, products, ' +
-      'customers, campaign_sessions, searches, search_queries. If the query is rejected, the error names the problem - ' +
-      'fix the field or schema name and retry; never report a rejected query as "no data".',
+      '(traffic, marketing campaigns, site-search terms, customer acquisition and lifetime spend). Read-only. ' +
+      'Prefer shopifyStorefrontFunnel for anything about the conversion funnel - it cannot fail to parse. ' +
+      `Syntax is "FROM <schema> SHOW <metrics> [GROUP BY <dimensions>] [TIMESERIES <grain>] SINCE <start> UNTIL <end>", never SELECT. ` +
+      `Supported schemas: ${SHOPIFYQL_SCHEMAS.join(', ')}. There is no "orders" or "products" schema - order and ` +
+      'product reporting lives in "sales". Field names cannot be guessed and cannot be discovered at runtime; ' +
+      'a rejected query returns the valid field names for that schema, so read them and use one verbatim ' +
+      'rather than trying another spelling. Never report a rejected query as "no data".',
     inputSchema: z.object({
-      query: z.string().describe('The ShopifyQL query, e.g. "FROM customers SHOW new_customer_records TIMESERIES month SINCE -6m".'),
+      query: z.string().describe('The ShopifyQL query, e.g. "FROM customers SHOW new_customer_records TIMESERIES month SINCE -6m UNTIL today".'),
     }),
     isConcurrencySafe: true,
     isReadOnly: true,
     timeoutMs: 60_000,
     async execute(input) {
+      if (analyticsRejections >= ANALYTICS_REJECTION_LIMIT) {
+        return { data:
+          `Stopping: ${analyticsRejections} ShopifyQL queries in a row were rejected. Do not try another spelling. ` +
+          'Tell the user this question could not be expressed against their store analytics, and say which part ' +
+          'of it you could not express.', isError: true }
+      }
+      const schema = schemaOfQuery(input.query)
+      if (schema && !(SHOPIFYQL_SCHEMAS as string[]).includes(schema)) {
+        analyticsRejections++
+        const hint = schema === 'orders' || schema === 'products'
+          ? ` There is no "${schema}" schema - order and product reporting lives in "sales".`
+          : ''
+        return { data:
+          `Shopify error: "${schema}" is not a supported schema.${hint} Supported: ${SHOPIFYQL_SCHEMAS.join(', ')}.`,
+          isError: true }
+      }
       try {
         const table = await api.runAnalyticsQuery(input.query)
+        analyticsRejections = 0
         return { data: {
           rows: tableToObjects(table),
           row_count: table.rows.length,
           columns: table.columns.map((c) => c.name),
         } }
       } catch (err) {
-        return { data: `Shopify error: ${err instanceof Error ? err.message : String(err)}`, isError: true }
+        analyticsRejections++
+        const message = err instanceof Error ? err.message : String(err)
+        return { data: `Shopify error: ${message}${fieldHelp(schema, message)}`, isError: true }
       }
     },
   })

--- a/scripts/verify-shopifyql-catalog.mjs
+++ b/scripts/verify-shopifyql-catalog.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * Verify the ShopifyQL field catalog against a live store.
+ *
+ * ShopifyQL has no introspection, so `packages/core/src/tools/base/shopify-analytics-catalog.ts`
+ * is a hand-carried dictionary — and a hand-carried dictionary silently rots.
+ * This script re-submits every name in it to the Admin API and reports any that
+ * Shopify no longer accepts. Run it when SHOPIFY_API_VERSION rolls.
+ *
+ *   SHOPIFY_TEST_SHOP_DOMAIN=<shop>.myshopify.com \
+ *   SHOPIFY_TEST_ACCESS_TOKEN=shpat_... \
+ *   node scripts/verify-shopifyql-catalog.mjs
+ *
+ * Needs `read_reports`. Exits non-zero if any catalogued name is rejected.
+ * Batches the whole schema into one query and drops whatever Shopify names as
+ * invalid, so a clean run costs one request per schema rather than one per field.
+ */
+import { SHOPIFYQL_CATALOG } from '../packages/core/dist/tools/base/shopify-analytics-catalog.js'
+
+const shop = process.env.SHOPIFY_TEST_SHOP_DOMAIN
+const token = process.env.SHOPIFY_TEST_ACCESS_TOKEN
+if (!shop || !token) {
+  console.error('Set SHOPIFY_TEST_SHOP_DOMAIN and SHOPIFY_TEST_ACCESS_TOKEN (needs read_reports).')
+  process.exit(2)
+}
+const VERSION = process.env.SHOPIFY_API_VERSION ?? '2026-04'
+
+let calls = 0
+async function ql(query) {
+  calls++
+  const r = await fetch(`https://${shop}/admin/api/${VERSION}/graphql.json`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-Shopify-Access-Token': token },
+    body: JSON.stringify({
+      query: 'query($q:String!){ shopifyqlQuery(query:$q){ parseErrors tableData{columns{name}} } }',
+      variables: { q: query },
+    }),
+  })
+  const j = await r.json()
+  if (j.errors) return JSON.stringify(j.errors).slice(0, 200)
+  return j.data?.shopifyqlQuery?.parseErrors?.[0] ?? null
+}
+
+const rejectedName = (e) => (e ?? '').match(/Column '([^']+)' not found/)?.[1]
+
+/** Submit `names` as one query, dropping any Shopify rejects, until it parses. */
+async function survivors(build, names) {
+  let pool = [...names]
+  const rejected = []
+  for (let guard = 0; guard <= names.length && pool.length; guard++) {
+    const err = await ql(build(pool))
+    if (!err) return { rejected }
+    const bad = rejectedName(err)
+    const idx = bad ? pool.findIndex((n) => n === bad || n.endsWith(bad)) : -1
+    if (idx >= 0) { rejected.push(pool[idx]); pool.splice(idx, 1); continue }
+    if (pool.length === 1) { rejected.push(pool[0]); return { rejected } }
+    const half = Math.ceil(pool.length / 2)
+    const a = await survivors(build, pool.slice(0, half))
+    const b = await survivors(build, pool.slice(half))
+    return { rejected: [...rejected, ...a.rejected, ...b.rejected] }
+  }
+  return { rejected }
+}
+
+const chunk = (a, n) => (a.length <= n ? [a] : [a.slice(0, n), ...chunk(a.slice(n), n)])
+
+let failed = false
+for (const [schema, { metrics, dimensions }] of Object.entries(SHOPIFYQL_CATALOG)) {
+  const m = await survivors((ns) => `FROM ${schema} SHOW ${ns.join(', ')} SINCE -30d UNTIL today`, metrics)
+  const probe = metrics.find((n) => !m.rejected.includes(n))
+  const dimRejected = []
+  if (probe) {
+    for (const part of chunk([...dimensions], 10)) {
+      const d = await survivors(
+        (ns) => `FROM ${schema} SHOW ${probe} GROUP BY ${ns.join(', ')} SINCE -30d UNTIL today`,
+        part,
+      )
+      dimRejected.push(...d.rejected)
+    }
+  }
+  const bad = [...m.rejected, ...dimRejected]
+  if (bad.length) {
+    failed = true
+    console.error(`✗ ${schema}: Shopify rejected ${bad.length} catalogued name(s): ${bad.join(', ')}`)
+  } else {
+    console.log(`✓ ${schema}: ${metrics.length} metrics, ${dimensions.length} dimensions`)
+  }
+}
+console.log(`\n${calls} API calls against ${VERSION}.`)
+if (failed) {
+  console.error('Catalog is stale — remove the rejected names and update the doc.')
+  process.exit(1)
+}


### PR DESCRIPTION
Reported: an assistant asked a customer-acquisition question spent **twenty minutes** cycling `new_customers` → `customer_type` → `customer_type` against the `customers` schema.

## Three defects, all in what I shipped

**1. The tool description advertised schemas that don't exist.** It listed `orders` and `products`; both return `Invalid dataset in FROM clause`. I copied that list from the GraphQL field's doc blurb and never checked it — so the tool itself taught the model dead ends.

**2. There is no way to discover field names.** Verified: `shopifyqlQuery` is the only root field (no introspection), `SHOW COLUMNS` and `SHOW *` are rejected, and `Column Not Found` names only the column that was *wrong*, never one that would have been *right*. A free-form query tool over a language with no dictionary can only guess, and guessing does not converge.

**3. Nothing bounded the loop.** Each rejection is individually cheap and reads as "almost right, try again".

The parse-error guard from `#160` was correct as far as it went — it stopped the model reporting "no data" for a query that never ran. But it traded a silent wrong answer for an unbounded retry, which is its own failure, and one the user pays for in wall-clock and credits.

## The fix

**A live-verified field catalog** for the six schemas the use cases need (`sessions`, `customers`, `sales`, `campaign_sessions`, `searches`, `chargebacks`). Every name was submitted to the Admin API and kept only if Shopify accepted it. All 78 metrics and 263 dimensions survived, so the reference was accurate here — but it had already been wrong once about this same field (rows are keyed objects, not positional arrays), so it is checked rather than trusted.

**Errors that end the search in one step.** Live output, from the exact reported queries:

```
FROM customers SHOW new_customers ...
→ "new_customers" is not part of "customers" - it belongs to "sales".
  Re-run it against that schema, or pick a "customers" field below.
  Metrics in "customers": days_since_last_order, new_customer_records, ...

FROM customers SHOW ... GROUP BY customer_type ...
→ Closest names in "customers": customer_name, customer_tag, customer_city, ...
  All metrics in "customers": ...
  Use one of these verbatim - field names cannot be guessed and there is
  no way to list them from the API.

FROM orders SHOW orders ...
→ "orders" is not a supported schema. There is no "orders" schema - order
  and product reporting lives in "sales". Supported: sessions, customers, ...
```

The cross-schema case is the important one: `new_customers` is a **real metric**, just of the wrong table. That is the mistake a model makes most, and the one a bare rejection can never resolve.

**A floor.** Three consecutive rejections stop the tool: it tells the model to report which part of the question it could not express rather than try another spelling. Reset on success, so a later legitimate query is not blocked. The unsupported-schema case is refused *before* any API call.

**`scripts/verify-shopifyql-catalog.mjs`** re-checks the catalog against a live store, because a hand-carried dictionary rots silently. One request per schema on a clean run.

## Verification

| | |
|---|---|
| **Live** | all three real failure modes resolve in one step against `brian-test-k449hs2g` |
| Catalog build | 6 schemas verified, 0 names rejected, 35 API calls |
| core tests | 330 files / 4720 pass (6 new) |
| typecheck | clean |

Built in a worktree off `develop`. Docs + component map follow in the platform repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)