### PR TITLE
feat(browser-relay): support self-hosted bind address

### DIFF
--- a/apps/browser-relay/src/__tests__/env.test.ts
+++ b/apps/browser-relay/src/__tests__/env.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { parseEnv } from '../env.js'
+
+const required = {
+  BROWSER_RELAY_SECRET: 'relay-secret',
+  JWT_SECRET: 'jwt-secret',
+}
+
+describe('[COMP:ext/relay] browser relay environment', () => {
+  it('keeps the container-compatible default bind address and port', () => {
+    const env = parseEnv(required)
+
+    expect(env.HOST).toBe('0.0.0.0')
+    expect(env.PORT).toBe(8080)
+  })
+
+  it('accepts a loopback bind for single-machine self-hosting', () => {
+    const env = parseEnv({ ...required, HOST: '127.0.0.1', PORT: '8092' })
+
+    expect(env.HOST).toBe('127.0.0.1')
+    expect(env.PORT).toBe(8092)
+  })
+})

--- a/apps/browser-relay/src/env.ts
+++ b/apps/browser-relay/src/env.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 const envSchema = z.object({
+  HOST: z.string().min(1).default('0.0.0.0'),
   PORT: z.coerce.number().default(8080),
   /**
    * Shared secret the api presents on `/internal/browser/*` calls
@@ -17,11 +18,15 @@ const envSchema = z.object({
 
 export type Env = z.infer<typeof envSchema>
 
+export function parseEnv(input: NodeJS.ProcessEnv): Env {
+  return envSchema.parse(input)
+}
+
 let _env: Env | null = null
 
 export function getEnv(): Env {
   if (!_env) {
-    _env = envSchema.parse(process.env)
+    _env = parseEnv(process.env)
   }
   return _env
 }

--- a/apps/browser-relay/src/index.ts
+++ b/apps/browser-relay/src/index.ts
@@ -71,8 +71,8 @@ wss.on('connection', (socket: WebSocket) => {
 
 const sweep = setInterval(() => relay.sweepDead(), 30_000)
 
-server.listen(env.PORT, () => {
-  console.log(`browser-relay listening on port ${env.PORT}`)
+server.listen(env.PORT, env.HOST, () => {
+  console.log(`browser-relay listening on ${env.HOST}:${env.PORT}`)
 })
 
 // ── Graceful shutdown ─────────────────────────────────────────


### PR DESCRIPTION
cac94047 feat(browser-relay): support self-hosted bind address