### PR TITLE
fix(doc): paragraph-wrap bare-inline richText before it reaches the Y.Doc

### DIFF
--- a/packages/core/src/doc/__tests__/markdown.test.ts
+++ b/packages/core/src/doc/__tests__/markdown.test.ts
@@ -367,6 +367,91 @@ describe('[COMP:doc/markdown-normalizer] List-item text lift (pre-validation)', 
     })
   })
 
+  // Repair #4 (2026-08-10, page c4b2f11a): the model authors `richText`
+  // itself and puts inline text DIRECTLY under `doc`. That validates
+  // (richText is an opaque `z.record`) and persists, then a browser's
+  // y-prosemirror deletes the block from the shared Y.Doc on first open —
+  // the user sees headings with no content. See `normalizeRichTextContent`.
+  describe('liftListItemText — bare-inline richText', () => {
+    const bareInline = (text: string) => ({
+      type: 'doc',
+      content: [{ type: 'text', text }],
+    })
+
+    for (const kind of [
+      'bulleted_list_item',
+      'numbered_list_item',
+      'to_do',
+      'toggle',
+      'quote',
+      'callout',
+    ]) {
+      it(`paragraph-wraps unwrapped inline text on ${kind}`, () => {
+        const lifted = liftListItemText({
+          kind,
+          id: 'b1',
+          richText: bareInline('Ship the thing'),
+        }) as Record<string, unknown>
+        const doc = lifted.richText as { content: { type: string }[] }
+        expect(doc.content[0].type).toBe('paragraph')
+        expect(richPlain(lifted.richText)).toBe('Ship the thing')
+      })
+    }
+
+    it('groups a run of inline nodes into ONE paragraph, not one each', () => {
+      const lifted = liftListItemText({
+        kind: 'bulleted_list_item',
+        id: 'b1',
+        richText: {
+          type: 'doc',
+          content: [
+            { type: 'text', text: 'bold', marks: [{ type: 'bold' }] },
+            { type: 'text', text: ' tail' },
+          ],
+        },
+      }) as Record<string, unknown>
+      const doc = lifted.richText as { content: { type: string; content: unknown[] }[] }
+      expect(doc.content).toHaveLength(1)
+      expect(doc.content[0].content).toHaveLength(2)
+      expect(richPlain(lifted.richText)).toBe('bold tail')
+    })
+
+    it('leaves an already-canonical richText by reference', () => {
+      const canonical = {
+        kind: 'bulleted_list_item',
+        id: 'b1',
+        richText: {
+          type: 'doc',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: 'ok' }] }],
+        },
+      }
+      expect(liftListItemText(canonical)).toBe(canonical)
+    })
+
+    it('is idempotent — a second pass changes nothing', () => {
+      const once = liftListItemText({
+        kind: 'quote',
+        id: 'q1',
+        richText: bareInline('quoted'),
+      })
+      expect(liftListItemText(once)).toBe(once)
+    })
+
+    it('repairs a container child too (recursion still applies)', () => {
+      const lifted = liftListItemText({
+        kind: 'toggle',
+        id: 'g1',
+        richText: bareInline('summary'),
+        children: [
+          { kind: 'bulleted_list_item', id: 'c1', richText: bareInline('child') },
+        ],
+      }) as Record<string, unknown>
+      const child = (lifted.children as Record<string, unknown>[])[0]
+      const doc = child.richText as { content: { type: string }[] }
+      expect(doc.content[0].type).toBe('paragraph')
+    })
+  })
+
   describe('liftListItemText — mirror slip (richText on a plain kind)', () => {
     for (const kind of ['text', 'heading'] as const) {
       it(`flattens a richText doc into plain text on ${kind}`, () => {

--- a/packages/core/src/doc/__tests__/ops.test.ts
+++ b/packages/core/src/doc/__tests__/ops.test.ts
@@ -359,6 +359,44 @@ describe('[COMP:doc/ops] applyOps — edit', () => {
     expect(cellText(merged.rows[0][0])).toBe('Company Name')
     expect(cellText(merged.rows[0][1])).toBe('Expert Local Consultant')
   })
+
+  it('paragraph-wraps bare-inline richText in an `edit` patch (same open-patch bypass)', () => {
+    // Mirror of the table lift above, for the 2026-08-10 loss (page c4b2f11a):
+    // an `edit` patch replacing `richText` skips `liftedBlockSchema`, so an
+    // unwrapped-inline doc reaches storage and the browser's y-prosemirror
+    // then DELETES the block from the shared Y.Doc on first open.
+    const page: Page = {
+      blocks: [
+        {
+          kind: 'bulleted_list_item',
+          id: 'b1',
+          richText: {
+            type: 'doc',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'old' }] }],
+          },
+        } as Block,
+      ],
+    }
+    const { page: out } = applyOps(
+      page,
+      [
+        {
+          op: 'edit',
+          blockId: 'b1',
+          patch: {
+            richText: { type: 'doc', content: [{ type: 'text', text: 'Ship the thing' }] },
+          } as unknown as Record<string, unknown>,
+        },
+      ],
+      makeIdGen(),
+    )
+    const merged = out.blocks[0] as unknown as {
+      richText: { content: { type: string }[] }
+    }
+    expect(merged.richText.content[0].type).toBe('paragraph')
+    const inline = merged.richText.content[0] as { content?: { text?: string }[] }
+    expect((inline.content ?? []).map((n) => n.text ?? '').join('')).toBe('Ship the thing')
+  })
 })
 
 describe('[COMP:doc/ops] applyOps — delete', () => {

--- a/packages/core/src/doc/markdown.ts
+++ b/packages/core/src/doc/markdown.ts
@@ -46,6 +46,7 @@ import type {
   RichTextContent,
   TextBlock,
 } from './page-types.js'
+import { normalizeRichTextContent } from '../views/blocks.js'
 import { richTextToPlain } from './rich-text.js'
 
 // ── id generator (mirrors ops.ts defaultGenerateId) ───────────────────
@@ -321,6 +322,15 @@ export function liftTableRows(rows: unknown): unknown {
  *
  * A third repair (2026-07-22) lifts stray-shaped `table` cells — see
  * `liftTableRows` above.
+ *
+ * A fourth (2026-08-10) paragraph-wraps a `richText` doc whose top level holds
+ * bare INLINE nodes — `{ type:'doc', content:[{ type:'text', text:'…' }] }`,
+ * the shape the Doc edit agent reaches for when it authors `richText` itself
+ * instead of letting repair #1 build it. `richText` is opaque by design
+ * (`z.record(z.string(), z.unknown())`), so that validates, persists, and reads
+ * back fine server-side — then a browser's y-prosemirror deletes every such
+ * block from the shared doc on first open. See `normalizeRichTextContent`
+ * (`../views/blocks.js`) for the full failure chain and the prod repro.
  */
 export function liftListItemText(raw: unknown): unknown {
   if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return raw
@@ -347,6 +357,20 @@ export function liftListItemText(raw: unknown): unknown {
   ) {
     const { richText, ...rest } = next
     next = { ...rest, text: richTextToPlain(richText as RichTextContent) }
+  }
+
+  // Bare-inline richText (repair #4, 2026-08-10): a rich kind whose `richText`
+  // doc holds inline leaves at its top level instead of paragraphs. Runs after
+  // the two shape swaps above so a richText just minted by repair #1 (already
+  // canonical) is a pure pass-through.
+  if (
+    typeof next.kind === 'string' &&
+    RICHTEXT_KINDS.has(next.kind) &&
+    next.richText !== null &&
+    typeof next.richText === 'object'
+  ) {
+    const richText = normalizeRichTextContent(next.richText as RichTextContent)
+    if (richText !== next.richText) next = { ...next, richText }
   }
 
   // Table cells (repair #3, 2026-07-22): a `table` authored with plain-string

--- a/packages/core/src/doc/ops.ts
+++ b/packages/core/src/doc/ops.ts
@@ -47,10 +47,15 @@ import type {
   Op,
   Ops,
   Page,
+  RichTextContent,
   TmpId,
 } from './page-types.js'
 import { bindingConfigSchema } from '../views/schemas.js'
-import { chartBlockSchema, coerceHeadingLevel } from '../views/blocks.js'
+import {
+  chartBlockSchema,
+  coerceHeadingLevel,
+  normalizeRichTextContent,
+} from '../views/blocks.js'
 import { liftTableRows } from './markdown.js'
 
 // ── id generator default ─────────────────────────────────────────────
@@ -293,6 +298,19 @@ function applyOne(
       if (current.kind === 'table' && 'rows' in op.patch) {
         const tbl = merged as Extract<Block, { kind: 'table' }>
         tbl.rows = liftTableRows(tbl.rows) as typeof tbl.rows
+      }
+      // Mirror the paragraph-wrap for richText: an `edit` patch replacing
+      // `richText` rides the same open `patch` record, so a doc holding bare
+      // inline nodes would persist and then be DELETED from the shared Y.Doc
+      // the next time a browser opens the page (see `normalizeRichTextContent`
+      // in views/blocks.ts — repair #4 in `liftListItemText` covers the `add`
+      // path, this covers `edit`).
+      if ('richText' in op.patch) {
+        const rich = (merged as { richText?: unknown }).richText
+        if (rich !== null && typeof rich === 'object') {
+          ;(merged as { richText?: unknown }).richText =
+            normalizeRichTextContent(rich as RichTextContent)
+        }
       }
       // Mirror the binding guard for headings: a model often patches a
       // heading's level with a Notion/Markdown-flavored value (`"h2"`, `"##"`),

--- a/packages/core/src/views/blocks.ts
+++ b/packages/core/src/views/blocks.ts
@@ -251,9 +251,96 @@ export type ChildPageBlock = {
 // there ahead of the server union. Phase 2.5 promotes them into the
 // canonical `Block` union so `renderPage` / `patchPage` can author + Zod-
 // validate them. `richText` is opaque Tiptap `JSONContent` — the server
-// stores it verbatim and never inspects it.
+// stores it verbatim apart from the one structural repair below.
 
 export type RichTextContent = Record<string, unknown>
+
+/** Loose Tiptap/ProseMirror JSON node. Only `type` / `text` / `content` are
+ *  read here; `attrs` / `marks` and anything else ride through untouched. */
+export type RichNode = {
+  type?: string
+  text?: string
+  content?: RichNode[]
+  [key: string]: unknown
+}
+
+/**
+ * Inline leaf types the doc schema declares — `text` + `hardBreak` from
+ * StarterKit plus the two mention nodes (`packages/doc-model/src/schema.ts`).
+ * Listed literally so this module (and `doc-model`'s deliberately schema-free
+ * block mapping) stay free of a `prosemirror-model` dependency.
+ */
+const INLINE_RICH_NODE_TYPES = new Set([
+  'text',
+  'hardBreak',
+  'personMention',
+  'pageMention',
+])
+
+/** True for an inline leaf. A node carrying a `text` string counts regardless
+ *  of its declared type, so an unrecognised inline leaf still normalizes
+ *  rather than being promoted to a block. */
+function isInlineRichNode(n: RichNode): boolean {
+  return typeof n.text === 'string' || INLINE_RICH_NODE_TYPES.has(n.type ?? '')
+}
+
+/**
+ * Gather runs of bare inline leaves into a `paragraph`; pass block nodes
+ * through. Returns the input array by reference when it is already canonical.
+ *
+ * The editor's `editor.getJSON()` always nests inlines under a paragraph, so
+ * this is a no-op for human-authored richText. A **model**-authored block does
+ * not: the Doc edit agent commonly emits
+ * `richText: { type:'doc', content:[{ type:'text', text:'…' }] }` — inline text
+ * as a direct child of `doc`. That shape validates (the schema is
+ * `z.record(z.string(), z.unknown())` — richText is opaque by design) and
+ * persists, but it builds `listItem > text`, which violates `listItem`'s
+ * `paragraph block*` content spec. Nothing on the write path rejects it:
+ * `Node.fromJSON` does not validate content and the Y.Doc encode is purely
+ * structural, so the page reads back intact server-side. The moment a browser
+ * opens it, y-prosemirror's `createNodeFromYElement` fails `createChecked` and
+ * DELETES the offending element from the shared doc; doc-sync then persists
+ * the mutilation.
+ *
+ * That is how page c4b2f11a lost all 26 of its list items on 2026-08-10 while
+ * its 12 heading/text/divider blocks survived — the user saw headings with no
+ * content, and each repair attempt only re-added plain `text` blocks (the one
+ * kind that round-trips), so the page grew "a little bit more" every time
+ * instead of being fixed.
+ *
+ * Applied at both ends: `liftListItemText` (tool-input boundary, so new
+ * `saved_views.page` JSONB is canonical) and `doc-model`'s `richTextToContent`
+ * (encode path, so already-persisted degenerate pages heal on their next
+ * encode). See `docs/architecture/features/doc.md` → "Markdown normalization".
+ */
+export function normalizeRichTextNodes(content: RichNode[]): RichNode[] {
+  if (!content.some(isInlineRichNode)) return content
+  const out: RichNode[] = []
+  let run: RichNode[] | null = null
+  for (const node of content) {
+    if (isInlineRichNode(node)) {
+      if (!run) {
+        run = []
+        out.push({ type: 'paragraph', content: run })
+      }
+      run.push(node)
+    } else {
+      run = null
+      out.push(node)
+    }
+  }
+  return out
+}
+
+/** `normalizeRichTextNodes` over a whole opaque richText doc. Returns the input
+ *  by reference when nothing changed, so a canonical block stays a pure
+ *  pass-through (`liftListItemText` relies on identity to skip the copy). */
+export function normalizeRichTextContent(rt: RichTextContent): RichTextContent {
+  const content = (rt as { content?: unknown }).content
+  if (!Array.isArray(content) || content.length === 0) return rt
+  const normalized = normalizeRichTextNodes(content as RichNode[])
+  return normalized === content ? rt : { ...rt, content: normalized }
+}
 
 export type CalloutBlock = {
   kind: 'callout'

--- a/packages/doc-model/src/__tests__/block-mapping.test.ts
+++ b/packages/doc-model/src/__tests__/block-mapping.test.ts
@@ -5,6 +5,7 @@ import {
   canonicalizeBlock,
   pageToPlaintext,
 } from '../block-mapping.js'
+import { docSchema } from '../schema.js'
 import type { Block } from '@use-brian/core/dist/views/blocks.js'
 import { ALL_KINDS } from './fixtures.js'
 
@@ -348,5 +349,114 @@ describe('[COMP:doc-model/mapping] nested to-dos (TaskItem nested:true)', () => 
     const out = pmDocToBlocks(doc)
     expect(out).toEqual(blocks.map(canonicalizeBlock))
     expect((out[1] as { indent?: number }).indent).toBe(1)
+  })
+})
+
+describe('[COMP:doc-model/mapping] bare-inline richText (model-authored)', () => {
+  /** The shape the Doc edit agent emits when it authors `richText` itself:
+   *  inline text as a DIRECT child of `doc`, with no paragraph wrapper. */
+  const bareInline = (text: string) =>
+    ({ type: 'doc', content: [{ type: 'text', text }] }) as unknown as Record<
+      string,
+      unknown
+    >
+
+  const bullet = (id: string, text: string, indent?: number): Block =>
+    ({
+      kind: 'bulleted_list_item',
+      id,
+      richText: bareInline(text),
+      ...(indent ? { indent } : {}),
+    }) as Block
+
+  /**
+   * The discriminating assertion for the 2026-08-10 data loss (page
+   * c4b2f11a). A structural round-trip is LOSSLESS on the broken shape —
+   * `Node.fromJSON` never validates content and the Y.Doc encode is purely
+   * structural — so counting blocks proves nothing and would have PASSED
+   * against the bug. Only a schema `check()` separates the two: unwrapped
+   * inline text builds `listItem > text`, which violates `listItem`'s
+   * `paragraph block*` spec, and the browser's y-prosemirror deletes every
+   * such element from the SHARED doc on first open. Assert validity, never
+   * block count.
+   */
+  const expectSchemaValid = (blocks: Block[]) => {
+    expect(() =>
+      docSchema().nodeFromJSON(blocksToPMDoc(blocks)).check(),
+    ).not.toThrow()
+  }
+
+  it('wraps a list item authored with unwrapped inline text', () => {
+    const blocks = [bullet('b1', 'Ship the thing')]
+    expectSchemaValid(blocks)
+    const item = blocksToPMDoc(blocks).content[0].content![0]
+    expect(item.content![0]).toMatchObject({ type: 'paragraph' })
+  })
+
+  it('keeps a whole bare-inline list run schema-valid, nesting included', () => {
+    expectSchemaValid([
+      bullet('b1', 'Parent'),
+      bullet('b2', 'Child', 1),
+      bullet('b3', 'Sibling'),
+    ])
+  })
+
+  it('covers every richText-bearing kind, not just list items', () => {
+    expectSchemaValid([
+      bullet('b1', 'bullet'),
+      { kind: 'numbered_list_item', id: 'n1', richText: bareInline('step') } as Block,
+      { kind: 'to_do', id: 't1', checked: false, richText: bareInline('task') } as Block,
+      { kind: 'quote', id: 'q1', richText: bareInline('quoted') } as Block,
+      { kind: 'callout', id: 'c1', icon: '💡', richText: bareInline('note') } as Block,
+      { kind: 'toggle', id: 'g1', richText: bareInline('summary') } as Block,
+      {
+        kind: 'table',
+        id: 'tb1',
+        hasHeaderRow: true,
+        hasHeaderColumn: false,
+        rows: [[bareInline('Col')], [bareInline('Val')]],
+      } as Block,
+    ])
+  })
+
+  it('recovers the text, so the repair is not a silent blanking', () => {
+    const out = pmDocToBlocks(blocksToPMDoc([bullet('b1', 'Ship the thing')]))
+    expect(pageToPlaintext({ blocks: out })).toBe('Ship the thing')
+  })
+
+  it('still satisfies the canonicalizeBlock round-trip contract', () => {
+    const blocks = [bullet('b1', 'Parent'), bullet('b2', 'Child', 1)]
+    expect(pmDocToBlocks(blocksToPMDoc(blocks))).toEqual(
+      blocks.map(canonicalizeBlock),
+    )
+  })
+
+  it('leaves canonical paragraph-wrapped richText untouched', () => {
+    const blocks: Block[] = [
+      { kind: 'bulleted_list_item', id: 'b1', richText: cell('already fine') } as Block,
+    ]
+    expectSchemaValid(blocks)
+    expect(pmDocToBlocks(blocksToPMDoc(blocks))).toEqual(
+      blocks.map(canonicalizeBlock),
+    )
+  })
+
+  it('keeps a mixed run in order: inline lead, then a real block node', () => {
+    const blocks: Block[] = [
+      {
+        kind: 'quote',
+        id: 'q1',
+        richText: {
+          type: 'doc',
+          content: [
+            { type: 'text', text: 'lead' },
+            { type: 'paragraph', content: [{ type: 'text', text: 'body' }] },
+          ],
+        } as unknown as Record<string, unknown>,
+      } as Block,
+    ]
+    expectSchemaValid(blocks)
+    const quote = blocksToPMDoc(blocks).content[0]
+    expect(quote.content!.map((n) => n.type)).toEqual(['paragraph', 'paragraph'])
   })
 })

--- a/packages/doc-model/src/block-mapping.ts
+++ b/packages/doc-model/src/block-mapping.ts
@@ -23,9 +23,11 @@
  * [COMP:doc-model/mapping]
  */
 
+import { normalizeRichTextNodes } from '@use-brian/core/dist/views/blocks.js'
 import type {
   Block,
   Page,
+  RichNode,
   RichTextContent,
   TableBlock,
 } from '@use-brian/core/dist/views/blocks.js'
@@ -88,10 +90,17 @@ function genId(): string {
 /** richText is opaque Tiptap JSON: the old per-block editors stored
  *  `editor.getJSON()` = `{ type: 'doc', content: [...] }`. Return its inner
  *  block content, or a single empty paragraph when absent/empty. The result
- *  always starts with a paragraph so it satisfies listItem/taskItem content. */
+ *  always starts with a paragraph so it satisfies listItem/taskItem content —
+ *  a guarantee `normalizeRichTextNodes` (core `views/blocks.ts`) has to
+ *  ENFORCE, not assume: a model-authored block routinely puts inline text
+ *  directly under `doc`, and passing that through builds `listItem > text`,
+ *  which a browser's y-prosemirror deletes from the shared doc on first open.
+ *  Read that function's comment before touching this one. */
 function richTextToContent(rt: RichTextContent | undefined): PMNode[] {
   const content = (rt as { content?: PMNode[] } | undefined)?.content
-  if (Array.isArray(content) && content.length > 0) return content
+  if (Array.isArray(content) && content.length > 0) {
+    return normalizeRichTextNodes(content as RichNode[]) as PMNode[]
+  }
   return [emptyParagraph()]
 }
 


### PR DESCRIPTION
## The bug

A user asked their assistant to save a conversation into a Doc page. `renderPage` wrote **38 blocks**; the user saw only headings. Asked again, the page grew "a little bit more" — never the lists.

Prod trace (page `c4b2f11a`, session `e1ab05cf`, 2026-08-10): `saved_views.page` still holds all 38 blocks. The live Y.Doc holds **17** — every heading / divider / text block survived, **all 26 list items were gone**.

## Root cause

The Doc edit agent commonly authors `richText` as `{ type:'doc', content:[{ type:'text', text:'…' }] }` — inline text as a **direct child of `doc`**, no paragraph wrapper. `richText` is opaque by design (`z.record(z.string(), z.unknown())`), so it validates and persists. `richTextToContent` then builds `listItem > text`, which violates `listItem`'s `paragraph block*` content spec.

Nothing on the write path notices:

- `Node.fromJSON` does not validate content
- the Y.Doc encode is purely structural
- a server-side `pageToYDocUpdate` → `yDocToSnapshot` round-trip returns **every block intact**

The failure is deferred to the **browser**: y-prosemirror's `createNodeFromYElement` fails `createChecked`, DELETES the element from the shared Y.Doc, and `apps/doc-sync` persists the mutilated snapshot. The block is gone for everyone, permanently.

That also explains the retry loop: `text` blocks are the one kind that round-trips, so each `delegateDocEdit` retry re-added a single intro paragraph per section and the assistant reported success from a receipt that was structurally true.

## The fix

One normalizer in `packages/core/src/views/blocks.ts` — `normalizeRichTextNodes` / `normalizeRichTextContent` gather runs of bare inline leaves (`text`, `hardBreak`, `personMention`, `pageMention`, or anything carrying a `text` string) into one `paragraph`, pass block nodes through, and return the input **by reference** when already canonical.

Wired at three points so no write path is left open:

| Point | Covers |
|---|---|
| `liftListItemText` repair #4 | `renderPage` / `createSubPage` / `patchPage` `add` |
| `applyOps`'s `edit` merge | the open `patch` record bypasses the lifted schemas — same seam the table-rows lift covers |
| doc-model's `richTextToContent` | the encode path, so a degenerate page never yet opened heals on its first seed instead of needing a migration |

## Verification

Reproduced against the **actual prod page JSON**:

- before: structural round-trip lossless (38 → 38), `docSchema().nodeFromJSON(blocksToPMDoc(page.blocks)).check()` → `Invalid content for node listItem`, **26 invalid blocks** (exactly the 26 lost)
- after: 38 → 38, `check()` **passes**, 0 invalid

Regression tests assert **schema validity**, never block count — a count-based test is lossless on the broken shape and would have passed against this bug. Mutation-verified: 4 of the new doc-model tests fail with the normalizer disabled.

`pnpm test` (39/39 packages), `pnpm typecheck` (42/42), `pnpm smoke`, `pnpm check` all green.

## Blast radius

12 pages / 53 blocks in prod carry the shape — 11 already opened (their Y.Docs are already mutilated; recovery is asking the assistant to re-populate, post-deploy), 1 never opened (self-heals on first open). Lower bound: pages written only through the gateway don't surface in `saved_views.page`.

## Docs

Spec + KB pairing land in `brian-platform` (`docs/architecture/features/doc.md` → "Markdown normalization" repair #4, `features/views.md`, component-map) and `brian-kb` (`2cacb6c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)