### PR TITLE
fix: honor configured providers for all LLM work

### DIFF
--- a/packages/api/src/__tests__/billing-external.test.ts
+++ b/packages/api/src/__tests__/billing-external.test.ts
@@ -37,6 +37,7 @@ describe('[COMP:api/billing-external] external tool cost recording', () => {
       cacheWriteTokens: 0,
       source: 'included',
       userMessageId: 'msg-1',
+      triggerKey: 'web_search_external_tool',
     })
     expect(recordUsage.mock.calls[0][0].actualCostUsd).toBeCloseTo(flatSearchCostUsd('brave'))
   })
@@ -71,7 +72,7 @@ describe('[COMP:api/billing-external] external tool cost recording', () => {
     expect(recordUsage.mock.calls[0][0].source).toBe('free')
   })
 
-  it('stamps a trigger key when the caller supplies one, and none otherwise', async () => {
+  it('uses a supplied trigger key and otherwise stamps an explicit background trigger', async () => {
     const recordUsage = vi.fn().mockResolvedValue(undefined)
     await recordExternalCostFromMeta({
       ...base,
@@ -87,7 +88,7 @@ describe('[COMP:api/billing-external] external tool cost recording', () => {
       toolMeta: braveMeta,
       usageStore: { recordUsage } as never,
     })
-    expect(recordUsage.mock.calls[0][0].triggerKey).toBeUndefined()
+    expect(recordUsage.mock.calls[0][0].triggerKey).toBe('web_search_external_tool')
   })
 
   it('no-ops on a tool result that carries no cost meta, and with no store wired', async () => {

--- a/packages/api/src/__tests__/custom-llm-runtime.test.ts
+++ b/packages/api/src/__tests__/custom-llm-runtime.test.ts
@@ -100,6 +100,7 @@ describe('[COMP:api/custom-llm-endpoints] custom endpoint runtime', () => {
       selector: customLlmAlias(endpointId),
       inputTokenLimit: 32768,
       maxTokens: 4096,
+      modelTier: 'standard',
       providerKeySource: 'user',
     })
     expect(store.getRuntimeSystem).toHaveBeenCalledWith({ workspaceId: runtime.workspaceId, profileId: endpointId })
@@ -120,9 +121,11 @@ describe('[COMP:api/custom-llm-endpoints] custom endpoint runtime', () => {
       // Drain the stream so the request body can be inspected below.
     }
     const [, init] = fetchFn.mock.calls[0] as [string, RequestInit]
-    const requestBody = JSON.parse(init.body as string) as { messages: unknown }
+    const requestBody = JSON.parse(init.body as string) as { messages: unknown; stream_options?: unknown; max_tokens?: number }
     expect(JSON.stringify(requestBody.messages)).not.toContain('image_url')
     expect(JSON.stringify(requestBody.messages)).toContain('text-only model cannot inspect it')
+    expect(requestBody.stream_options).toEqual({ include_usage: true })
+    expect(requestBody.max_tokens).toBe(4096)
   })
 
   it('resolves the assigned profile for the already-resolved Brian tier', async () => {
@@ -151,7 +154,63 @@ describe('[COMP:api/custom-llm-endpoints] custom endpoint runtime', () => {
       workspaceId: runtime.workspaceId,
       requestedTier: 'max',
     })
-    expect(resolved).toMatchObject({ selector: customLlmAlias(profileId), maxTokens: 32768 })
+    expect(resolved).toMatchObject({ selector: customLlmAlias(profileId), maxTokens: 32768, modelTier: 'max' })
     expect(store.getTierRuntimeSystem).toHaveBeenCalledWith({ workspaceId: runtime.workspaceId, tier: 'max' })
+  })
+
+  it('retries once without streamed usage for older compatible endpoints', async () => {
+    const profileId = '00000000-0000-4000-8000-000000000004'
+    const runtime = {
+      id: profileId, endpointId: profileId,
+      workspaceId: '00000000-0000-4000-8000-000000000010',
+      name: 'Legacy', endpointName: 'Gateway', baseUrl: 'https://model.example/v1',
+      apiKey: null, modelId: 'legacy-model', contextWindow: 32768, maxOutputTokens: 4096,
+      supportsTools: true, verifiedAt: new Date(), createdAt: new Date(), updatedAt: new Date(),
+    }
+    const store = {
+      getRuntimeSystem: vi.fn().mockResolvedValue(runtime),
+      getTierRuntimeSystem: vi.fn(),
+    } as unknown as WorkspaceCustomLlmEndpointStore
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(new Response('unsupported stream_options', { status: 400 }))
+      .mockResolvedValueOnce(textSse())
+    const resolved = await createWorkspaceCustomLlmResolver(store, { fetchFn })({
+      workspaceId: runtime.workspaceId,
+      requestedModel: customLlmAlias(profileId),
+    })
+    if (!resolved) throw new Error('expected runtime')
+
+    for await (const _chunk of resolved.provider.stream({
+      model: resolved.selector,
+      systemPrompt: '',
+      messages: [{ role: 'user', content: 'hello' }],
+    })) { /* drain */ }
+
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    expect(JSON.parse((fetchFn.mock.calls[0]![1] as RequestInit).body as string)).toHaveProperty('stream_options')
+    expect(JSON.parse((fetchFn.mock.calls[1]![1] as RequestInit).body as string)).not.toHaveProperty('stream_options')
+  })
+
+  it('uses another configured tier default for background work when Standard is unset', async () => {
+    const profileId = '00000000-0000-4000-8000-000000000003'
+    const runtime = {
+      id: profileId,
+      endpointId: profileId,
+      workspaceId: '00000000-0000-4000-8000-000000000010',
+      name: 'Pro gateway', endpointName: 'Gateway', baseUrl: 'https://model.example/v1',
+      apiKey: null, modelId: 'pro-model', contextWindow: 100000, maxOutputTokens: 8192,
+      supportsTools: true, verifiedAt: new Date(), createdAt: new Date(), updatedAt: new Date(),
+    }
+    const getTierRuntimeSystem = vi.fn(async ({ tier }: { tier: string }) => tier === 'pro' ? runtime : null)
+    const store = { getRuntimeSystem: vi.fn(), getTierRuntimeSystem } as unknown as WorkspaceCustomLlmEndpointStore
+
+    const resolved = await createWorkspaceCustomLlmResolver(store)({
+      workspaceId: runtime.workspaceId,
+      requestedTier: 'standard',
+      allowAnyDefault: true,
+    })
+
+    expect(resolved).toMatchObject({ selector: customLlmAlias(profileId), modelTier: 'standard' })
+    expect(getTierRuntimeSystem.mock.calls.map(([arg]) => arg.tier)).toEqual(['standard', 'pro'])
   })
 })

--- a/packages/api/src/billing-external.ts
+++ b/packages/api/src/billing-external.ts
@@ -40,7 +40,8 @@ export type RecordExternalCostParams = {
   userPlan?: string
   /**
    * Stamps the row so callee-lane external spend is separable from chat's in
-   * the cost dashboard. The chat lane leaves it unset, as it always has.
+   * the cost dashboard. Chat defaults to an explicit external-tool trigger so
+   * linked tool-cost rows cannot be mistaken for legacy main responses.
    */
   triggerKey?: string
   /** Channel recorded on the failure analytics event. Defaults to `'web'`. */
@@ -83,7 +84,8 @@ export async function recordExternalCostFromMeta(params: RecordExternalCostParam
       actualCostUsd,
       source: params.userPlan === 'free' ? 'free' : 'included',
       userMessageId: params.userMessageId ?? undefined,
-      ...(params.triggerKey ? { triggerKey: params.triggerKey } : {}),
+      triggerKey: params.triggerKey
+        ?? (params.toolMeta?.searchProvider ? 'web_search_external_tool' : 'external_tool'),
     })
   } catch (err) {
     console.error('External cost tracking failed:', err)

--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -572,7 +572,7 @@ import {
   supportDiagnosticRoutes,
 } from './support-diagnostics/index.js'
 
-import type { ChatEpisodeIngestor, BrainEpisodeIngestor } from './ingest-port.js'
+import type { ChatEpisodeIngestor, BrainEpisodeIngestor, ChatEpisodeInput } from './ingest-port.js'
 import type { BuildConnectorActionAudit } from './connector-action-port.js'
 import type { InjectExtraTools, ResolveAppSoul } from './tool-injection-port.js'
 import type { CreditBudgetGate } from './routes/route-helpers.js'
@@ -731,6 +731,8 @@ export interface OpenApiEnv {
  */
 export interface EpisodeIngestorDeps {
   provider: LLMProvider
+  /** Resolve the workspace-owned Standard lane at episode execution time. */
+  resolveWorkspaceLlm?: (workspaceId: string) => Promise<ChatEpisodeInput['llm'] | null>
   /**
    * The background lane's servable model id, resolved once at boot against the
    * configured providers. Absent = the caller had no boot context (tests, the
@@ -1667,6 +1669,30 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
   const resolveWorkspaceCustomLlm = createWorkspaceCustomLlmResolver(customLlmEndpointStore, {
     networkPolicy: customLlmNetworkPolicy,
   })
+  const resolveBackgroundRuntime = async (workspaceId: string | null | undefined) =>
+    workspaceId
+      ? resolveWorkspaceCustomLlm({
+          workspaceId,
+          requestedTier: 'standard',
+          allowDefault: true,
+          allowAnyDefault: true,
+        })
+      : null
+  const workspaceForAssistant = async (assistantId: string): Promise<string | null> => {
+    if (!assistantId) return null
+    const result = await query<{ workspaceId: string }>(
+      `SELECT workspace_id AS "workspaceId" FROM assistants WHERE id = $1`,
+      [assistantId],
+    )
+    return result.rows[0]?.workspaceId ?? null
+  }
+  const ownerForWorkspace = async (workspaceId: string): Promise<string | null> => {
+    const result = await query<{ ownerUserId: string }>(
+      `SELECT owner_user_id AS "ownerUserId" FROM workspaces WHERE id = $1`,
+      [workspaceId],
+    )
+    return result.rows[0]?.ownerUserId ?? null
+  }
   const compartmentStore = createDbCompartmentStore()
   const oauthClientStore = createDbOAuthClientStore()
   const oauthAuthorizationStore = createDbOAuthAuthorizationStore()
@@ -1857,13 +1883,15 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
                 assistantId: u.assistantId,
                 sessionId: u.sessionId,
                 model: u.model,
+                modelTier: u.modelTier,
                 inputTokens: u.usage.inputTokens,
                 outputTokens: u.usage.outputTokens,
                 cacheReadTokens: u.usage.cacheReadTokens,
                 cacheWriteTokens: u.usage.cacheWriteTokens,
-                actualCostUsd: calculateCost(u.model, u.usage),
+                actualCostUsd: u.providerKeySource === 'user' ? 0 : calculateCost(u.model, u.usage),
                 source: 'included',
                 triggerKey: 'worker_run',
+                providerKeySource: u.providerKeySource,
               })
               .catch((err) => console.error('[workers] usage tracking failed:', err))
           }
@@ -2119,6 +2147,19 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
   //    (open default: no-op chat ingest, undefined brain ingest). ──
   const builtIngestors = ports.buildEpisodeIngestors?.({
     provider, crmStore, entitiesStore, entityLinksStore, memoryStore, taskStore, episodesStore, analytics,
+    resolveWorkspaceLlm: async (workspaceId) => {
+      const runtime = await resolveBackgroundRuntime(workspaceId)
+      return runtime
+        ? {
+            provider: runtime.provider,
+            model: runtime.selector,
+            modelTier: 'standard',
+            providerKeySource: 'user' as const,
+            inputTokenLimit: runtime.inputTokenLimit,
+            maxTokens: runtime.maxTokens,
+          }
+        : null
+    },
     usageStore,
     backgroundModel,
     extractionModel,
@@ -3771,6 +3812,12 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     resolvePolicy: resolveComputerToolPolicy,
     unattendedEnabled: unattendedComputerUse,
     getWorkspacePlan,
+    // Hosted custom fetches enforce public-only DNS/IP checks per request.
+    // E2B cannot reuse that host-side transport, so do not bypass it by
+    // handing a hosted endpoint directly to the sandbox process.
+    resolveLlm: customLlmNetworkPolicy === 'private-network'
+      ? async (workspaceId) => (await resolveBackgroundRuntime(workspaceId))?.browserUse ?? null
+      : undefined,
     onEvent: (evt, ctx) => {
       analytics.logEvent({
         userId: ctx.userId,
@@ -5775,25 +5822,33 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     prompt: string,
     ctx: { assistantId: string; userId: string | null; workspaceId: string | null; phase: string },
   ): Promise<string> => {
-    const response = await collectStream(provider.stream({
-      model: CONSOLIDATION_MODEL,
+    const workspaceId = ctx.workspaceId ?? await workspaceForAssistant(ctx.assistantId)
+    const customRuntime = await resolveBackgroundRuntime(workspaceId)
+    const callProvider = customRuntime?.provider ?? provider
+    const callModel = customRuntime?.selector ?? CONSOLIDATION_MODEL
+    const response = await collectStream(callProvider.stream({
+      model: callModel,
       messages: [{ role: 'user', content: prompt }],
       systemPrompt: 'You are a memory consolidation assistant. Follow the user instructions exactly. Output plain text only.',
       maxTokens: 4096,
     }))
-    if (response.usage && ctx.userId && usageStore) {
-      const cost = calculateCost(CONSOLIDATION_MODEL, response.usage)
+    const attributionUserId = ctx.userId ?? (workspaceId ? await ownerForWorkspace(workspaceId) : null)
+    if (response.usage && attributionUserId && usageStore) {
+      const cost = customRuntime ? 0 : calculateCost(callModel, response.usage)
       usageStore.recordUsage({
-        userId: ctx.userId,
+        userId: attributionUserId,
         assistantId: ctx.assistantId,
+        workspaceId: workspaceId ?? undefined,
         sessionId: null,
-        model: CONSOLIDATION_MODEL,
+        model: response.model || callModel,
+        modelTier: 'standard',
         inputTokens: response.usage.inputTokens,
         outputTokens: response.usage.outputTokens,
         cacheReadTokens: response.usage.cacheReadTokens,
         cacheWriteTokens: response.usage.cacheWriteTokens,
         actualCostUsd: cost,
         source: 'overhead:consolidation',
+        providerKeySource: customRuntime ? 'user' : 'platform',
       }).catch((err) => console.error('[consolidation] usage tracking failed:', err))
     }
     return response.content
@@ -5844,6 +5899,41 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
           candidates: brainCandidateStore,
           provider,
           model: 'gemini-flash',
+          resolveLlm: async (workspaceId: string) => {
+            const runtime = await resolveBackgroundRuntime(workspaceId)
+            return runtime
+              ? {
+                  provider: runtime.provider,
+                  model: runtime.selector,
+                  modelTier: 'standard',
+                  providerKeySource: 'user' as const,
+                }
+              : {
+                  provider,
+                  model: 'gemini-flash',
+                  modelTier: 'pro',
+                  providerKeySource: 'platform' as const,
+                }
+          },
+          onUsage: ({ workspaceId, userId, assistantId, model, modelTier, providerKeySource, usage }) => {
+            if (!usageStore) return
+            void usageStore.recordUsage({
+              workspaceId,
+              userId,
+              assistantId,
+              sessionId: null,
+              model,
+              modelTier,
+              inputTokens: usage.inputTokens,
+              outputTokens: usage.outputTokens,
+              cacheReadTokens: usage.cacheReadTokens,
+              cacheWriteTokens: usage.cacheWriteTokens,
+              actualCostUsd: providerKeySource === 'user' ? 0 : calculateCost(model, usage),
+              source: 'overhead:consolidation',
+              triggerKey: 'memory_reclassification',
+              providerKeySource,
+            }).catch((err) => console.error('[reclassifier] usage tracking failed:', err))
+          },
           resolveWorkspaceId: async (assistantId: string) => {
             const r = await query<{ workspaceId: string }>(
               `SELECT workspace_id AS "workspaceId" FROM assistants WHERE id = $1`,
@@ -5892,25 +5982,31 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
   const SKILL_REVIEW_MODEL = backgroundModel
   const skillReviewLLM = createGeminiSkillReviewLLM(
     async ({ systemPrompt, prompt, maxTokens, attribution }) => {
-      const response = await collectStream(provider.stream({
-        model: SKILL_REVIEW_MODEL,
+      const workspaceId = await workspaceForAssistant(attribution.assistantId)
+      const customRuntime = await resolveBackgroundRuntime(workspaceId)
+      const callProvider = customRuntime?.provider ?? provider
+      const callModel = customRuntime?.selector ?? SKILL_REVIEW_MODEL
+      const response = await collectStream(callProvider.stream({
+        model: callModel,
         messages: [{ role: 'user', content: prompt }],
         systemPrompt,
         maxTokens,
       }))
       if (response.usage && usageStore) {
-        const cost = calculateCost(SKILL_REVIEW_MODEL, response.usage)
+        const cost = customRuntime ? 0 : calculateCost(callModel, response.usage)
         usageStore.recordUsage({
           userId: attribution.userId,
           assistantId: attribution.assistantId,
           sessionId: null,
-          model: SKILL_REVIEW_MODEL,
+          model: response.model || callModel,
+          modelTier: 'standard',
           inputTokens: response.usage.inputTokens,
           outputTokens: response.usage.outputTokens,
           cacheReadTokens: response.usage.cacheReadTokens,
           cacheWriteTokens: response.usage.cacheWriteTokens,
           actualCostUsd: cost,
           source: 'overhead:skill-review',
+          providerKeySource: customRuntime ? 'user' : 'platform',
         }).catch((err) => console.error('[skill-review] usage tracking failed:', err))
       }
       return response.content
@@ -5966,25 +6062,31 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
   // docs/architecture/context-engine/assistant-playbook.md.
   const playbookReflectionWorker = createPlaybookReflectionWorker({
     modelCall: async ({ systemPrompt, prompt, maxTokens, attribution }) => {
-      const response = await collectStream(provider.stream({
-        model: backgroundModel,
+      const workspaceId = await workspaceForAssistant(attribution.assistantId)
+      const customRuntime = await resolveBackgroundRuntime(workspaceId)
+      const callProvider = customRuntime?.provider ?? provider
+      const callModel = customRuntime?.selector ?? backgroundModel
+      const response = await collectStream(callProvider.stream({
+        model: callModel,
         messages: [{ role: 'user', content: prompt }],
         systemPrompt,
         maxTokens,
       }))
       if (response.usage && usageStore) {
-        const cost = calculateCost(backgroundModel, response.usage)
+        const cost = customRuntime ? 0 : calculateCost(callModel, response.usage)
         usageStore.recordUsage({
           userId: attribution.userId,
           assistantId: attribution.assistantId,
           sessionId: null,
-          model: backgroundModel,
+          model: response.model || callModel,
+          modelTier: 'standard',
           inputTokens: response.usage.inputTokens,
           outputTokens: response.usage.outputTokens,
           cacheReadTokens: response.usage.cacheReadTokens,
           cacheWriteTokens: response.usage.cacheWriteTokens,
           actualCostUsd: cost,
           source: 'overhead:playbook-reflection',
+          providerKeySource: customRuntime ? 'user' : 'platform',
         }).catch((err) => console.error('[playbook-reflection] usage tracking failed:', err))
       }
       return response.content

--- a/packages/api/src/build-episode-ingestors.ts
+++ b/packages/api/src/build-episode-ingestors.ts
@@ -29,7 +29,7 @@ import {
 } from '@use-brian/core'
 import type { EpisodeIngestorDeps } from './boot.js'
 import type { EpisodeSensitivity } from './db/episodes-store.js'
-import type { BrainEpisodeIngestor, ChatEpisodeIngestor } from './ingest-port.js'
+import type { BrainEpisodeIngestor, ChatEpisodeIngestor, ChatEpisodeInput } from './ingest-port.js'
 
 // Extraction runs on the Standard tier (model-routing.md Trigger #11); the
 // optional drift/kind classifier on the Background-Standard lite model.
@@ -75,14 +75,18 @@ export function buildEpisodeIngestors(deps: EpisodeIngestorDeps): {
 } {
   // Pipeline B deps are a 1:1 projection of the boot store graph. Built fresh
   // per call so the closure stays stateless (the stores themselves are shared).
-  const pipelineDeps = (): PipelineBDeps => ({
-    provider: deps.provider,
+  const pipelineDeps = (llm?: ChatEpisodeInput['llm']): PipelineBDeps => ({
+    provider: llm?.provider ?? deps.provider,
     // Both fall back to their literals when boot supplied nothing (tests, a
     // platform factory that predates the injection). Boot passes ids it has
     // already checked are servable, so a Google-free deploy extracts instead
     // of throwing on every episode.
-    model: deps.extractionModel ?? EXTRACTION_MODEL,
-    classifierModel: deps.backgroundModel ?? CLASSIFIER_MODEL,
+    model: llm?.model ?? deps.extractionModel ?? EXTRACTION_MODEL,
+    classifierModel: llm?.model ?? deps.backgroundModel ?? CLASSIFIER_MODEL,
+    modelTier: llm?.modelTier,
+    providerKeySource: llm?.providerKeySource,
+    inputTokenLimit: llm?.inputTokenLimit,
+    maxTokens: llm?.maxTokens,
     crm: deps.crmStore,
     entities: deps.entitiesStore,
     entityLinks: deps.entityLinksStore,
@@ -97,6 +101,7 @@ export function buildEpisodeIngestors(deps: EpisodeIngestorDeps): {
   })
 
   const brainEpisodeIngestor: BrainEpisodeIngestor = async (input) => {
+    const llm = input.llm ?? await deps.resolveWorkspaceLlm?.(input.workspaceId) ?? undefined
     const sourceKind = input.sourceKind ?? DEFAULT_BRAIN_SOURCE_KIND
     const sensitivity: EpisodeSensitivity = input.sensitivity ?? 'internal'
 
@@ -138,10 +143,11 @@ export function buildEpisodeIngestors(deps: EpisodeIngestorDeps): {
       createdByUserId: input.userId,
       createdByAssistantId: input.assistantId,
     }
-    return processEpisode(pbEpisode, input.content, pipelineDeps())
+    return processEpisode(pbEpisode, input.content, pipelineDeps(llm))
   }
 
   const chatEpisodeIngestor: ChatEpisodeIngestor = async (input) => {
+    const llm = input.llm ?? await deps.resolveWorkspaceLlm?.(input.workspaceId) ?? undefined
     // A compacted chat window → one `web_chat` Episode carrying the session +
     // message range as its back-edge, then the same extraction pipeline.
     // `contentRef` mirrors the hosted twin (`api-platform` pipeline-b-processor
@@ -181,7 +187,7 @@ export function buildEpisodeIngestors(deps: EpisodeIngestorDeps): {
       createdByUserId: input.userId,
       createdByAssistantId: input.assistantId,
     }
-    await processEpisode(pbEpisode, input.content, pipelineDeps())
+    await processEpisode(pbEpisode, input.content, pipelineDeps(llm))
   }
 
   return { chatEpisodeIngestor, brainEpisodeIngestor }

--- a/packages/api/src/custom-llm-runtime.ts
+++ b/packages/api/src/custom-llm-runtime.ts
@@ -9,7 +9,7 @@ import type {
   WorkspaceCustomLlmProfileRuntime,
   WorkspaceCustomLlmEndpointStore,
 } from './db/workspace-custom-llm-endpoints.js'
-import { isCustomLlmTier } from './db/workspace-custom-llm-endpoints.js'
+import { CUSTOM_LLM_TIERS, isCustomLlmTier } from './db/workspace-custom-llm-endpoints.js'
 import {
   createPublicCustomLlmFetch,
   CustomLlmPublicEndpointError,
@@ -96,6 +96,18 @@ function providerFor(
   fetchFn: typeof fetch = fetch,
 ): LLMProvider {
   const recordedModel = customLlmAlias(profile.profileId)
+  const usageCompatibleFetch: typeof fetch = async (input, init) => {
+    const response = await fetchFn(input, init)
+    if (response.status !== 400 || typeof init?.body !== 'string') return response
+    try {
+      const body = JSON.parse(init.body) as Record<string, unknown>
+      if (!('stream_options' in body)) return response
+      delete body.stream_options
+      return fetchFn(input, { ...init, body: JSON.stringify(body) })
+    } catch {
+      return response
+    }
+  }
   return createOpenAICompatProvider({
     apiKey: profile.apiKey?.trim() || undefined,
     baseURL: profile.baseUrl,
@@ -103,8 +115,8 @@ function providerFor(
     wireModel: profile.modelId,
     recordedModel,
     models: [recordedModel],
-    fetchFn,
-    includeStreamUsage: false,
+    fetchFn: usageCompatibleFetch,
+    includeStreamUsage: true,
     enableThinkingField: false,
     supportsJsonMode: false,
     supportsVision: false,
@@ -198,9 +210,17 @@ export type ResolvedWorkspaceCustomLlm = {
   provider: LLMProvider
   selector: string
   profileId: string
+  modelTier: import('./db/workspace-custom-llm-endpoints.js').CustomLlmTier
   inputTokenLimit: number
   maxTokens: number
   providerKeySource: 'user'
+  /** Per-run connection for the isolated browser-use process. Never serialize. */
+  browserUse: {
+    apiKeyEnvName: 'OPENAI_API_KEY'
+    apiKey: string
+    model: string
+    baseUrl: string
+  }
 }
 
 export type WorkspaceCustomLlmResolver = (params: {
@@ -208,6 +228,7 @@ export type WorkspaceCustomLlmResolver = (params: {
   requestedModel?: string
   requestedTier?: string
   allowDefault?: boolean
+  allowAnyDefault?: boolean
 }) => Promise<ResolvedWorkspaceCustomLlm | null>
 
 export function createWorkspaceCustomLlmResolver(
@@ -218,28 +239,57 @@ export function createWorkspaceCustomLlmResolver(
   },
 ): WorkspaceCustomLlmResolver {
   const networkPolicy = options?.networkPolicy ?? 'private-network'
-  return async ({ workspaceId, requestedModel, requestedTier, allowDefault = true }) => {
+  return async ({ workspaceId, requestedModel, requestedTier, allowDefault = true, allowAnyDefault = false }) => {
     const explicitId = customLlmEndpointIdFromAlias(requestedModel)
-    const profile: WorkspaceCustomLlmProfileRuntime | null = explicitId
+    let profile: WorkspaceCustomLlmProfileRuntime | null = explicitId
       ? await store.getRuntimeSystem({ workspaceId, profileId: explicitId })
       : allowDefault && requestedTier && isCustomLlmTier(requestedTier)
         ? await store.getTierRuntimeSystem({ workspaceId, tier: requestedTier })
         : null
+    if (!profile && allowDefault && allowAnyDefault) {
+      for (const tier of CUSTOM_LLM_TIERS) {
+        if (tier === requestedTier) continue
+        profile = await store.getTierRuntimeSystem({ workspaceId, tier })
+        if (profile) break
+      }
+    }
     if (!profile) return null
+    const modelTier = requestedTier && isCustomLlmTier(requestedTier) ? requestedTier : 'standard'
     const selector = customLlmAlias(profile.id)
     const fetchFn = options?.fetchFn ?? (networkPolicy === 'public-only' ? createPublicCustomLlmFetch() : fetch)
+    const provider = wrapProvider(providerFor({
+      profileId: profile.id,
+      baseUrl: profile.baseUrl,
+      apiKey: profile.apiKey,
+      modelId: profile.modelId,
+    }, fetchFn))
+    const limitedProvider: LLMProvider = {
+      ...provider,
+      stream: (request) => provider.stream({
+        ...request,
+        maxTokens: Math.min(request.maxTokens ?? profile.maxOutputTokens, profile.maxOutputTokens),
+        inputTokenLimit: Math.min(request.inputTokenLimit ?? profile.contextWindow, profile.contextWindow),
+      }),
+      createSession: (sessionOptions) => provider.createSession({
+        ...sessionOptions,
+        maxTokens: Math.min(sessionOptions.maxTokens ?? profile.maxOutputTokens, profile.maxOutputTokens),
+        inputTokenLimit: Math.min(sessionOptions.inputTokenLimit ?? profile.contextWindow, profile.contextWindow),
+      }),
+    }
     return {
-      provider: wrapProvider(providerFor({
-        profileId: profile.id,
-        baseUrl: profile.baseUrl,
-        apiKey: profile.apiKey,
-        modelId: profile.modelId,
-      }, fetchFn)),
+      provider: limitedProvider,
       selector,
       profileId: profile.id,
+      modelTier,
       inputTokenLimit: profile.contextWindow,
       maxTokens: profile.maxOutputTokens,
       providerKeySource: 'user',
+      browserUse: {
+        apiKeyEnvName: 'OPENAI_API_KEY',
+        apiKey: profile.apiKey?.trim() || 'not-required',
+        model: profile.modelId,
+        baseUrl: profile.baseUrl,
+      },
     }
   }
 }

--- a/packages/api/src/ingest-port.ts
+++ b/packages/api/src/ingest-port.ts
@@ -9,7 +9,16 @@
  */
 
 import type { EpisodeSensitivity } from './db/episodes-store.js'
-import type { PipelineBResult, SourceKind } from '@use-brian/core'
+import type { LLMProvider, PipelineBResult, SourceKind } from '@use-brian/core'
+
+export type WorkspaceLlmLane = {
+  provider: LLMProvider
+  model: string
+  modelTier?: string
+  providerKeySource?: 'user' | 'platform'
+  inputTokenLimit?: number
+  maxTokens?: number
+}
 
 export type ChatEpisodeInput = {
   workspaceId: string
@@ -19,6 +28,8 @@ export type ChatEpisodeInput = {
   content: string
   occurredAt: Date
   messageIdRange: [string, string]
+  /** Immutable workspace lane captured by the triggering compaction request. */
+  llm?: WorkspaceLlmLane
 }
 
 /** Materialize a compacted chat window as an Episode + run Pipeline B. */
@@ -65,6 +76,8 @@ export type BrainEpisodeInput = {
    * (`EpisodeFilters.parentEpisodeId`). Omitted for standalone ingests.
    */
   parentEpisodeId?: string
+  /** Immutable workspace lane for Pipeline B extraction. */
+  llm?: WorkspaceLlmLane
 }
 
 /** Ingest an arbitrary text Episode (e.g. an MCP `ingestToBrain` call). */

--- a/packages/api/src/inter-assistant/__tests__/executor.test.ts
+++ b/packages/api/src/inter-assistant/__tests__/executor.test.ts
@@ -816,6 +816,7 @@ describe('[COMP:api/inter-assistant-executor] createCalleeExecutor', () => {
       assistantId: 'callee-1',
       sessionId: 'sess-1',
       model: 'gemini-3-flash-preview',
+      modelTier: 'pro',
       inputTokens: 1000,
       outputTokens: 200,
       cacheReadTokens: 5000,

--- a/packages/api/src/inter-assistant/executor.ts
+++ b/packages/api/src/inter-assistant/executor.ts
@@ -1155,6 +1155,14 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
     }
 
     const fullSystemPrompt = `${systemPrompt}${docAnchorBlock}${priorRunMemoryBlock}${workflowGuardBlock}${recordCreationGuardBlock}${directExecutionBlock}${askPolicyDropBlock}${unavailableBlock}${skillPromptFragment}${blueprintPromptFragment}\n\n# Context\nCurrent date and time: ${currentDateTime}\nTimezone: ${calleeOwner.timezone}\n\n${memoryContext}`
+    const backgroundLlmRuntime = calleeAssistant.workspaceId && options.resolveWorkspaceCustomLlm
+      ? await options.resolveWorkspaceCustomLlm({
+          workspaceId: calleeAssistant.workspaceId,
+          requestedTier: 'standard',
+          allowDefault: true,
+          allowAnyDefault: true,
+        })
+      : null
 
     // 6. Build messages and run the query loop.
     //
@@ -1186,7 +1194,11 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
         channelClass: 'cron',
         profile: 'multi-topic',
         unconditional: true,
-        provider: options.provider,
+        provider: backgroundLlmRuntime?.provider ?? options.provider,
+        model: backgroundLlmRuntime?.selector,
+        inputTokenLimit: backgroundLlmRuntime?.inputTokenLimit,
+        modelTier: 'standard',
+        providerKeySource: backgroundLlmRuntime ? 'user' : 'platform',
         systemPrompt: fullSystemPrompt,
         assistantId: params.calleeAssistantId,
         userId: calleeActorUserId,
@@ -1290,6 +1302,7 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
         })
       : null
     const loopProvider = customLlmRuntime?.provider ?? options.provider
+    const preflightLlmRuntime = customLlmRuntime ?? backgroundLlmRuntime
 
     // Run the parallel research pass before the synthesis loop. Best-effort:
     // a fan-out failure must never fail the step — the synthesis loop still
@@ -1299,8 +1312,8 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
     if (isResearchFanout) {
       try {
         const pre = await runPreflight({
-          provider: options.provider,
-          model,
+          provider: preflightLlmRuntime?.provider ?? options.provider,
+          model: preflightLlmRuntime?.selector ?? model,
           message: params.question,
           tools: finalTools,
           context: {
@@ -1339,13 +1352,15 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
               assistantId: params.calleeAssistantId,
               sessionId: session.id,
               model: pre.model,
+              modelTier: preflightLlmRuntime?.modelTier ?? tierForModel(model),
               inputTokens: pre.usage.inputTokens,
               outputTokens: pre.usage.outputTokens,
               cacheReadTokens: pre.usage.cacheReadTokens,
               cacheWriteTokens: pre.usage.cacheWriteTokens,
-              actualCostUsd: calculateCost(pre.model, pre.usage),
+              actualCostUsd: preflightLlmRuntime ? 0 : calculateCost(pre.model, pre.usage),
               source: 'overhead:splitter',
               triggerKey: 'parallel_split_classifier',
+              providerKeySource: preflightLlmRuntime ? 'user' : 'platform',
             })
             .catch((err) => console.error('[inter-assistant] splitter usage tracking failed:', err))
         }
@@ -1483,6 +1498,16 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
             params.pageAnchorId || includeWorkspaceMemories || retrievalReadCeilings
               ? (calleeAssistant.workspaceId ?? undefined)
               : undefined,
+          workerRuntime: customLlmRuntime
+            ? {
+                provider: customLlmRuntime.provider,
+                model: customLlmRuntime.selector,
+                modelTier: customLlmRuntime.modelTier,
+                providerKeySource: customLlmRuntime.providerKeySource,
+                inputTokenLimit: customLlmRuntime.inputTokenLimit,
+                maxTokens: customLlmRuntime.maxTokens,
+              }
+            : undefined,
           assistantKind: calleeAssistant.kind,
           // Read ceilings for the brain retrieval actor — the `min(member,
           // assistant)` clearance + compartment grant. Set only when retrieval
@@ -1692,6 +1717,7 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
                 assistantId: params.calleeAssistantId,
                 sessionId: session.id,
                 model: event.response.model,
+                modelTier: customLlmRuntime?.modelTier ?? tierForModel(model),
                 inputTokens: usage.inputTokens,
                 outputTokens: usage.outputTokens,
                 cacheReadTokens: usage.cacheReadTokens,

--- a/packages/api/src/routes/__tests__/_overhead-usage.test.ts
+++ b/packages/api/src/routes/__tests__/_overhead-usage.test.ts
@@ -41,6 +41,20 @@ describe('[COMP:api/route-helpers] recordOverheadUsage', () => {
     expect(args.actorUserId).toBe('shadow-visitor-id')
   })
 
+  it('records custom endpoint overhead as user-paid with its logical tier', async () => {
+    await recordOverheadUsage({
+      ...baseParams,
+      model: 'custom:00000000-0000-4000-8000-000000000001',
+      modelTier: 'standard',
+      providerKeySource: 'user',
+    })
+    expect(mockRecord).toHaveBeenCalledWith(expect.objectContaining({
+      modelTier: 'standard',
+      providerKeySource: 'user',
+      actualCostUsd: 0,
+    }))
+  })
+
   it('attributes classifier and voice overhead to the channel actor while billing the owner', () => {
     const source = readFileSync(new URL('../channel-pipeline.ts', import.meta.url), 'utf8')
 

--- a/packages/api/src/routes/_overhead-usage.ts
+++ b/packages/api/src/routes/_overhead-usage.ts
@@ -34,6 +34,10 @@ export type RecordOverheadUsageParams = {
   sessionId: string
   userMessageId?: string | null
   model: string | null
+  /** Logical tier for dynamic custom model aliases. */
+  modelTier?: string
+  /** User-owned providers have zero Brian platform COGS. */
+  providerKeySource?: 'user' | 'platform'
   usage: TokenUsage | null | undefined
   source: string
   /**
@@ -64,14 +68,18 @@ export async function recordOverheadUsage(
       assistantId: params.assistantId,
       sessionId: params.sessionId,
       model: params.model,
+      modelTier: params.modelTier,
       inputTokens: params.usage.inputTokens,
       outputTokens: params.usage.outputTokens,
       cacheReadTokens: params.usage.cacheReadTokens,
       cacheWriteTokens: params.usage.cacheWriteTokens,
-      actualCostUsd: calculateCost(params.model, params.usage),
+      actualCostUsd: params.providerKeySource === 'user'
+        ? 0
+        : calculateCost(params.model, params.usage),
       source: params.source,
       userMessageId: params.userMessageId ?? undefined,
       triggerKey: params.triggerKey,
+      providerKeySource: params.providerKeySource,
       ...(params.audioSeconds !== undefined ? { audioSeconds: params.audioSeconds } : {}),
     })
   } catch (err) {

--- a/packages/api/src/routes/channel-pipeline.ts
+++ b/packages/api/src/routes/channel-pipeline.ts
@@ -695,6 +695,20 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
       await clearDowngradeNotice(session.id)
     }
   }
+  const backgroundLlmRuntime = assistant.workspaceId && params.resolveWorkspaceCustomLlm
+    ? await params.resolveWorkspaceCustomLlm({
+        workspaceId: assistant.workspaceId,
+        requestedTier: 'standard',
+        allowDefault: true,
+        allowAnyDefault: true,
+      })
+    : null
+  const backgroundProvider = backgroundLlmRuntime?.provider ?? provider
+  const backgroundLaneModel = backgroundLlmRuntime?.selector ?? laneModel
+  const backgroundUsageAttribution = {
+    modelTier: 'standard',
+    providerKeySource: backgroundLlmRuntime ? 'user' as const : 'platform' as const,
+  }
   // ── Large-paste promotion (large-content-artifacts §Phase 3.2) ──
   // Runs before the message is classified, persisted, or fed to the model, so
   // a giant paste never reaches the classifier or the query loop as a blob.
@@ -760,9 +774,9 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
     try {
       const { classifyResearchIntent } = await import('@use-brian/core')
       const adaptive = await classifyResearchIntent({
-        provider,
+        provider: backgroundProvider,
         message: messageText,
-        model: laneModel,
+        model: backgroundLaneModel,
         recentConversation: adaptiveRecentConversation,
       })
       if (adaptive.research) {
@@ -837,11 +851,11 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
   let classification: TopicClassification | null = null
   try {
     classification = await classifyTopic({
-      provider,
+      provider: backgroundProvider,
       // Background lane (see the chat.ts counterpart) — Flash Lite per
       // cost-and-pricing.md → "Standard-tier routing", not the Flash 3
       // chat alias this had drifted onto.
-      model: laneModel,
+      model: backgroundLaneModel,
       recentUserTurns,
       replyToText: replyResolved?.text ?? null,
       currentMessage: messageText,
@@ -905,6 +919,7 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
     model: classification?.model ?? null,
     usage: classification?.usage,
     source: 'overhead:classifier',
+    ...backgroundUsageAttribution,
   })
 
   // Voice transcription ran in the channel handler before the pipeline —
@@ -948,7 +963,10 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
     tier: modelToCompactionTier(model),
     channelClass: 'messaging',
     profile: 'multi-topic',
-    provider,
+    provider: backgroundProvider,
+    model: backgroundLaneModel,
+    inputTokenLimit: backgroundLlmRuntime?.inputTokenLimit,
+    ...backgroundUsageAttribution,
     systemPrompt,
     assistantId: assistant.id,
     userId,
@@ -1495,7 +1513,7 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
   if (!externalGuest && messageText.length > 40) {
     try {
       const preflight = await runPreflight({
-        provider, model, message: messageText, tools: allTools,
+        provider: backgroundProvider, model: backgroundLaneModel, message: messageText, tools: allTools,
         context: {
           userId, assistantId: assistant.id, sessionId: session.id,
           appId: 'Use Brian', channelType, channelId,
@@ -1591,6 +1609,16 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
         userId, assistantId: assistant.id, sessionId: session.id,
         appId: 'Use Brian', channelType, channelId,
         workspaceId: assistant.workspaceId ?? undefined,
+        workerRuntime: customLlmRuntime
+          ? {
+              provider: customLlmRuntime.provider,
+              model: customLlmRuntime.selector,
+              modelTier: customLlmRuntime.modelTier,
+              providerKeySource: customLlmRuntime.providerKeySource,
+              inputTokenLimit: customLlmRuntime.inputTokenLimit,
+              maxTokens: customLlmRuntime.maxTokens,
+            }
+          : undefined,
         assistantKind: assistant.kind,
         preferredChannel,
         userTimezone,
@@ -1808,6 +1836,7 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
             usageStore.recordUsage({
               userId: billingUserId, actorUserId: userId, assistantId: assistant.id, sessionId: session.id,
               model: event.response.model,
+              modelTier: customLlmRuntime?.modelTier ?? tierForModel(model),
               inputTokens: usage.inputTokens,
               outputTokens: usage.outputTokens,
               cacheReadTokens: usage.cacheReadTokens,
@@ -1868,10 +1897,10 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
         .listOpenBySession(session.id)
         .then((open: SessionStateRecord[]) =>
           runSessionStateDiff({
-            provider,
+            provider: backgroundProvider,
             // Standard tier per docs/architecture/platform/cost-and-pricing.md
             // → Model routing (extraction / classification / structured-output bucket).
-            model: laneModel,
+            model: backgroundLaneModel,
             sessionId: session.id,
             userId,
             assistantId: assistant.id,
@@ -1901,6 +1930,7 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
             usage: result.usage,
             source: 'overhead:session-state-diff',
             triggerKey: 'session_state_diff',
+            ...backgroundUsageAttribution,
           })
         })
         .catch((err) => console.debug(`[${channelType}] session-state diff failed:`, err))
@@ -1915,8 +1945,8 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
       runMemoryNudge({
         turns: pendingAssistantTurns,
         callModel: async (prompt) => {
-          const resp = await collectStream(provider.stream({
-            model: laneModel,
+          const resp = await collectStream(backgroundProvider.stream({
+            model: backgroundLaneModel,
             messages: [{ role: 'user', content: prompt }],
             systemPrompt: 'You are a memory utility judge. Follow instructions exactly.',
             maxTokens: 256,
@@ -1927,7 +1957,7 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
               .map((b) => b.text)
               .join(''),
             usage: resp.usage,
-            model: laneModel,
+            model: backgroundLaneModel,
           }
         },
         store: memoryStore,
@@ -1942,6 +1972,7 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
           usage: result.usage,
           source: 'overhead:nudge',
           triggerKey: 'memory_nudge',
+          ...backgroundUsageAttribution,
         }))
         .catch((err) => console.debug(`[${channelType}] memory nudge failed:`, err))
     }
@@ -1964,7 +1995,7 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
     // calendar updates, two Threads replies). Falls back to the
     // generic `hooks.sendError` when no tools ran or Flash hiccups.
     const recovered = await composeRecoveryMessage({
-      provider,
+      provider: backgroundProvider,
       pendingAssistantTurns,
       userText: messageText,
       channelType,
@@ -1984,6 +2015,7 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
         usage: recovered.usage,
         source: 'overhead:recovery-message',
         triggerKey: 'recovery_message',
+        ...backgroundUsageAttribution,
       })
       // Surface the recovery text via the same channel-native path the
       // normal turn would have used. Kept on `sendResponse` rather than

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -2186,6 +2186,26 @@ export function chatRoutes(options: WebChatOptions): Router {
         }
       }
 
+      // Resolve workspace-attributable auxiliary work independently from the
+      // final response tier. Background work is logically Standard; if that
+      // tier has no custom default, one configured custom endpoint still stays
+      // authoritative for the workspace.
+      const backgroundLlmRuntime = assistant.workspaceId && options.resolveWorkspaceCustomLlm
+        ? await options.resolveWorkspaceCustomLlm({
+            workspaceId: assistant.workspaceId,
+            requestedTier: 'standard',
+            allowDefault: true,
+            allowAnyDefault: true,
+          })
+        : null
+      const backgroundProvider = backgroundLlmRuntime?.provider ?? options.provider
+      const backgroundModel = backgroundLlmRuntime?.selector
+        ?? backgroundModelFor(options.configuredProviders)
+      const backgroundUsageAttribution = {
+        modelTier: 'standard',
+        providerKeySource: backgroundLlmRuntime ? 'user' as const : 'platform' as const,
+      }
+
       // ── Giant-paste promotion (large-content-artifacts §Phase 3.1) ──
       // An over-threshold paste (8K tokens, CJK-aware) becomes a durable
       // artifact; the turn (and the persisted user row) carries the manifest
@@ -2297,9 +2317,9 @@ export function chatRoutes(options: WebChatOptions): Router {
       ) {
         const { classifyResearchIntent } = await import('@use-brian/core')
         const adaptive = await classifyResearchIntent({
-          provider: options.provider,
+          provider: backgroundProvider,
           message,
-          model: backgroundModelFor(options.configuredProviders),
+          model: backgroundModel,
           recentConversation: adaptiveRecentConversation,
         }).catch(() => ({ research: false, operateSite: false, reason: null, usage: null, model: null }))
         adaptiveResearchOverhead = {
@@ -3230,12 +3250,12 @@ export function chatRoutes(options: WebChatOptions): Router {
       let classification: TopicClassification | null = null
       try {
         classification = await classifyTopic({
-          provider: options.provider,
+          provider: backgroundProvider,
           // Background lane — a per-turn classifier is exactly the invisible
           // work cost-and-pricing.md → "Standard-tier routing" pins to Flash
           // Lite (its sibling classifiers already do). Had drifted onto the
           // Flash 3 chat alias at 2x the rate.
-          model: backgroundModelFor(options.configuredProviders),
+          model: backgroundModel,
           recentUserTurns,
           replyToText: replyResolved?.text ?? null,
           currentMessage: userMessageText,
@@ -3318,6 +3338,7 @@ export function chatRoutes(options: WebChatOptions): Router {
           usage: adaptiveResearchOverhead.usage,
           source: 'overhead:classifier',
           triggerKey: 'adaptive_research_classifier',
+          ...backgroundUsageAttribution,
         })
       }
       // Mirror to the session-event bus so other watchers of a live shared
@@ -3355,6 +3376,7 @@ export function chatRoutes(options: WebChatOptions): Router {
         model: classification?.model ?? null,
         usage: classification?.usage,
         source: 'overhead:classifier',
+        ...backgroundUsageAttribution,
       })
 
       // Attribute voice transcription tokens as overhead. One row per audio
@@ -3489,7 +3511,10 @@ export function chatRoutes(options: WebChatOptions): Router {
         tier: modelToCompactionTier(resolveModel(requestedModel, userPlan, 'ok')),
         channelClass: 'web',
         profile: 'linear',
-        provider: options.provider,
+        provider: backgroundProvider,
+        model: backgroundModel,
+        inputTokenLimit: backgroundLlmRuntime?.inputTokenLimit,
+        ...backgroundUsageAttribution,
         systemPrompt: options.systemPrompt,
         assistantId: assistant.id,
         userId: user.id,
@@ -4655,7 +4680,7 @@ export function chatRoutes(options: WebChatOptions): Router {
           const standardDocEditModel = resolveModel('standard', userPlan, 'ok')
           await injectDocTools({
             tools: allTools,
-            backgroundModel: backgroundModelFor(options.configuredProviders),
+            backgroundModel,
             fallbackModel: options.configuredProviders
               ? ensureServableModel(standardDocEditModel, options.configuredProviders)
               : standardDocEditModel,
@@ -4696,7 +4721,7 @@ export function chatRoutes(options: WebChatOptions): Router {
               typeof requestedActiveThemeId === 'string' && requestedActiveThemeId
                 ? requestedActiveThemeId
                 : null,
-            provider: options.provider,
+            provider: backgroundProvider,
             onEditUsage: ({ model: editModel, usage }) => recordOverheadUsage({
               usageStore: options.usageStore,
               userId: user.id,
@@ -4707,6 +4732,7 @@ export function chatRoutes(options: WebChatOptions): Router {
               usage,
               source: 'overhead:doc-edit',
               triggerKey: 'doc_edit_worker',
+              ...backgroundUsageAttribution,
             }),
             onChildToolResult: (result) => {
               if (result.isError) return
@@ -5240,7 +5266,7 @@ export function chatRoutes(options: WebChatOptions): Router {
           // being true here means the explicit toggle: splitter is moot.
           if (!researchMode && !operateSiteIntent) {
             const { classifySplit } = await import('@use-brian/core')
-            const splitResult = await classifySplit({ provider: options.provider, message, model: backgroundModelFor(options.configuredProviders) })
+            const splitResult = await classifySplit({ provider: backgroundProvider, message, model: backgroundModel })
               .catch(() => ({ tasks: null, usage: null, model: null }))
             // Attribute splitter tokens as overhead. Recorded regardless of
             // whether the classifier chose to split — the Gemini call happened.
@@ -5254,6 +5280,7 @@ export function chatRoutes(options: WebChatOptions): Router {
               usage: splitResult.usage,
               source: 'overhead:splitter',
               triggerKey: 'parallel_split_classifier',
+              ...backgroundUsageAttribution,
             })
             splitterDecidedCoordinator = !!splitResult.tasks
 
@@ -5377,8 +5404,8 @@ export function chatRoutes(options: WebChatOptions): Router {
           // snippets instead of the browse the user asked for.
           try {
             const preflight = await runPreflight({
-              provider: options.provider,
-              model,
+              provider: backgroundProvider,
+              model: backgroundModel,
               message,
               tools: allTools,
               context: {
@@ -5478,6 +5505,7 @@ export function chatRoutes(options: WebChatOptions): Router {
               usage: preflight.usage,
               source: 'overhead:splitter',
               triggerKey: 'parallel_split_classifier',
+              ...backgroundUsageAttribution,
             })
           } catch (err) {
             console.error('[chat] pre-flight failed, continuing without:', err)
@@ -6017,6 +6045,16 @@ export function chatRoutes(options: WebChatOptions): Router {
             channelType: session.channelType,
             channelId: session.channelId,
             workspaceId: assistant.workspaceId ?? undefined,
+            workerRuntime: customLlmRuntime
+              ? {
+                  provider: customLlmRuntime.provider,
+                  model: customLlmRuntime.selector,
+                  modelTier: customLlmRuntime.modelTier,
+                  providerKeySource: customLlmRuntime.providerKeySource,
+                  inputTokenLimit: customLlmRuntime.inputTokenLimit,
+                  maxTokens: customLlmRuntime.maxTokens,
+                }
+              : undefined,
             assistantKind: assistant.kind,
             preferredChannel,
             userTimezone: user.timezone ?? undefined,
@@ -6668,6 +6706,7 @@ export function chatRoutes(options: WebChatOptions): Router {
                 assistantId: assistant.id,
                 sessionId: session.id,
                 model: event.response.model,
+                modelTier: customLlmRuntime?.modelTier ?? tierForModel(model),
                 inputTokens: usage.inputTokens,
                 outputTokens: usage.outputTokens,
                 cacheReadTokens: usage.cacheReadTokens,
@@ -6855,8 +6894,8 @@ export function chatRoutes(options: WebChatOptions): Router {
             .listOpenBySession(session.id)
             .then((open: SessionStateRecord[]) =>
               runSessionStateDiff({
-                provider: options.provider,
-                model: backgroundModelFor(options.configuredProviders),
+                provider: backgroundProvider,
+                model: backgroundModel,
                 sessionId: session.id,
                 userId: user.id,
                 assistantId: assistant.id,
@@ -6886,6 +6925,7 @@ export function chatRoutes(options: WebChatOptions): Router {
                 usage: result.usage,
                 source: 'overhead:session-state-diff',
                 triggerKey: 'session_state_diff',
+                ...backgroundUsageAttribution,
               })
             })
             .catch((err) => console.debug('[chat] session-state diff failed:', err))
@@ -6895,11 +6935,11 @@ export function chatRoutes(options: WebChatOptions): Router {
         // Records usage as `overhead:nudge` once the judge call returns.
         // Standard tier per docs/architecture/platform/cost-and-pricing.md
         // → Model routing (extraction / classification / structured-output bucket).
-        const nudgeModel = backgroundModelFor(options.configuredProviders)
+        const nudgeModel = backgroundModel
         runMemoryNudge({
           turns: pendingAssistantTurns,
           callModel: async (prompt) => {
-            const resp = await collectStream(options.provider.stream({
+            const resp = await collectStream(backgroundProvider.stream({
               model: nudgeModel,
               messages: [{ role: 'user', content: prompt }],
               systemPrompt: 'You are a memory utility judge. Follow instructions exactly.',
@@ -6923,6 +6963,7 @@ export function chatRoutes(options: WebChatOptions): Router {
             usage: result.usage,
             source: 'overhead:nudge',
             triggerKey: 'memory_nudge',
+            ...backgroundUsageAttribution,
           }))
           .catch((err) => console.debug('[chat] memory nudge failed:', err))
 
@@ -6991,7 +7032,7 @@ export function chatRoutes(options: WebChatOptions): Router {
             let synthesised: string | null = null
             try {
               const result = await composeEmptyTurnSynthesis({
-                provider: options.provider,
+                provider: backgroundProvider,
                 pendingAssistantTurns,
                 userText: userMessageText,
                 conversationHistory: messages.slice(0, -1),
@@ -7009,6 +7050,7 @@ export function chatRoutes(options: WebChatOptions): Router {
                   usage: result.usage,
                   source: 'overhead:empty-turn-synthesis',
                   triggerKey: 'empty_turn_synthesis',
+                  ...backgroundUsageAttribution,
                 })
               }
             } catch (synthErr) {
@@ -7068,7 +7110,7 @@ export function chatRoutes(options: WebChatOptions): Router {
         // fall through to the outer catch's generic `error` event.
         try {
           const recovered = await composeRecoveryMessage({
-            provider: options.provider,
+            provider: backgroundProvider,
             pendingAssistantTurns,
             userText: userMessageText,
             channelType: 'web',
@@ -7096,6 +7138,7 @@ export function chatRoutes(options: WebChatOptions): Router {
               model: recovered.model,
               usage: recovered.usage,
               source: 'overhead:recovery-message',
+              ...backgroundUsageAttribution,
             })
             recoveryDelivered = true
           }
@@ -7183,7 +7226,7 @@ export function chatRoutes(options: WebChatOptions): Router {
         // `title_update` event for this turn.
         // Resolved once: the same model drives the call and its latency budget,
         // so a slower serving provider can never be given the Gemini deadline.
-        const autoTitleModel = backgroundModelFor(options.configuredProviders)
+        const autoTitleModel = backgroundModel
         const AUTO_TITLE_TIMEOUT_MS = backgroundLatencyBudgetMs(autoTitleModel)
         const autoTitle = (async () => {
           try {
@@ -7194,7 +7237,7 @@ export function chatRoutes(options: WebChatOptions): Router {
               role: m.role as 'user' | 'assistant' | 'system',
               content: m.content as Message['content'],
             }))
-            const titleResult = await generateTitle(options.provider, freshMessages, autoTitleModel)
+            const titleResult = await generateTitle(backgroundProvider, freshMessages, autoTitleModel)
             // generateTitle returns `title: null` when it can't produce a
             // meaningful title (empty excerpt, model returned blank). Keep the
             // existing title in that case — overwriting with a generic fallback
@@ -7211,6 +7254,7 @@ export function chatRoutes(options: WebChatOptions): Router {
                 usage: titleResult.usage,
                 source: 'overhead:title',
                 triggerKey: 'session_title',
+                ...backgroundUsageAttribution,
               })
               return
             }
@@ -7237,6 +7281,7 @@ export function chatRoutes(options: WebChatOptions): Router {
               usage: titleResult.usage,
               source: 'overhead:title',
               triggerKey: 'session_title',
+              ...backgroundUsageAttribution,
             })
           } catch (err) {
             console.error('Auto-title failed:', err)
@@ -7373,11 +7418,11 @@ export function chatRoutes(options: WebChatOptions): Router {
               const result = await runDocAutoTitle({
                 userId: user.id,
                 pageId,
-                provider: options.provider,
+                provider: backgroundProvider,
                 docPageStore,
                 savedViewStore,
                 minChars: AUTO_TITLE_AI_MIN_CHARS,
-                backgroundModel: backgroundModelFor(options.configuredProviders),
+                backgroundModel,
               })
               if (result.applied && result.title && !res.writableEnded) {
                 // `icon` is the emoji the generator suggested + the commit
@@ -7399,6 +7444,7 @@ export function chatRoutes(options: WebChatOptions): Router {
                 usage: result.usage,
                 source: 'overhead:title',
                 triggerKey: 'doc_page_title',
+                ...backgroundUsageAttribution,
               })
             }
           } catch (err) {

--- a/packages/api/src/routes/connectors.ts
+++ b/packages/api/src/routes/connectors.ts
@@ -49,8 +49,8 @@
  * `./custom-connectors.ts` — the same factory the closed edition mounts, so the
  * feature has one implementation across both editions.
  *
- * Out of scope for the open edition (handled by the closed route): Google Drive
- * authorized-files (`/gdrive/*`).
+ * Google Drive Picker authorization mounts from the open shared
+ * `gdrive-authorized-files.ts` factory; hosted consumes the same router.
  *
  * Component tag: [COMP:api/connectors-route].
  */

--- a/packages/api/src/routes/proactive-compaction.ts
+++ b/packages/api/src/routes/proactive-compaction.ts
@@ -186,6 +186,12 @@ export type ProactiveCompactionParams = {
    */
   unconditional?: boolean
   provider: LLMProvider
+  /** Model selector for both pre-compaction extraction and summarization. */
+  model?: string
+  /** Declared provider context limit; defaults to the selected model registry limit. */
+  inputTokenLimit?: number
+  modelTier?: string
+  providerKeySource?: 'user' | 'platform'
   systemPrompt: string
   assistantId: string
   /** Channel user — owns memory, sessions, episodic rows. */
@@ -313,6 +319,7 @@ export async function runProactiveCompaction(
     workspaceId, chatEpisodeIngestor,
   } = params
   const persistLongTermContext = params.persistLongTermContext !== false
+  const compactionModel = params.model ?? 'gemini-flash'
 
   const breaker = params.circuitBreaker ?? defaultCompactionBreaker
   const sessionId = session.id
@@ -349,7 +356,7 @@ export async function runProactiveCompaction(
   // receives over-limit history, even when the summariser is unavailable.
   // All turn models are Gemini (Anthropic is the outage-only fallback), so the
   // Gemini frontier window is the hard limit that would 400 the next turn.
-  const modelHardLimit = resolveInputTokenLimit('gemini-flash')
+  const modelHardLimit = params.inputTokenLimit ?? resolveInputTokenLimit(compactionModel)
   const fitBudget = Math.floor(modelHardLimit * MODEL_CONTEXT_FIT_RATIO)
   const preTokens = estimateTokens(stampedWithSummary)
   const wasOverLimit = preTokens > modelHardLimit
@@ -435,7 +442,7 @@ export async function runProactiveCompaction(
         const existingSummaries = existingIndex.map((m) => m.summary)
         const extracted = await extractMemoriesBeforeCompaction({
           provider,
-          model: 'gemini-flash',
+          model: compactionModel,
           messages: compactableForLLM,
           existingMemories: existingSummaries,
         })
@@ -468,6 +475,8 @@ export async function runProactiveCompaction(
           model: extracted.model, usage: extracted.usage,
           source: 'overhead:extraction',
           triggerKey: 'pattern_extractor',
+          modelTier: params.modelTier,
+          providerKeySource: params.providerKeySource,
         })
       } catch (err) {
         console.error('[pre-compaction extraction] Failed:', err)
@@ -477,7 +486,7 @@ export async function runProactiveCompaction(
     // 8. Summarize.
     const compactResult = await compactConversation({
       provider,
-      model: 'gemini-flash',
+      model: compactionModel,
       messages: compactableForLLM,
       systemPrompt,
       profile,
@@ -489,6 +498,8 @@ export async function runProactiveCompaction(
       model: compactResult.model, usage: compactResult.usage,
       source: 'overhead:compaction',
       triggerKey: 'compaction_full',
+      modelTier: params.modelTier,
+      providerKeySource: params.providerKeySource,
     })
 
     // Defensive cap: if the summarizer exceeded the budget (unusual for
@@ -560,6 +571,12 @@ export async function runProactiveCompaction(
               compactedRows[0]!.id,
               compactedRows[compactedRows.length - 1]!.id,
             ],
+            llm: {
+              provider,
+              model: compactionModel,
+              modelTier: params.modelTier,
+              providerKeySource: params.providerKeySource,
+            },
           }).catch((err) => {
             console.error('[compaction] chat episode ingest failed:', err)
           })

--- a/packages/api/src/routes/public-turn.ts
+++ b/packages/api/src/routes/public-turn.ts
@@ -650,6 +650,14 @@ export async function executePublicTurn(
         allowDefault: true,
       })
     : null
+  const backgroundLlmRuntime = assistant.workspaceId && deps.resolveWorkspaceCustomLlm
+    ? await deps.resolveWorkspaceCustomLlm({
+        workspaceId: assistant.workspaceId,
+        requestedTier: 'standard',
+        allowDefault: true,
+        allowAnyDefault: true,
+      })
+    : null
   const turnProvider = customLlmRuntime?.provider ?? deps.provider
 
   // ── 7. Persist user message ──────────────────────────────
@@ -1025,7 +1033,11 @@ export async function executePublicTurn(
     tier: modelToCompactionTier(model),
     channelClass: 'web',
     profile: 'linear',
-    provider: deps.provider,
+    provider: backgroundLlmRuntime?.provider ?? deps.provider,
+    model: backgroundLlmRuntime?.selector,
+    inputTokenLimit: backgroundLlmRuntime?.inputTokenLimit,
+    modelTier: 'standard',
+    providerKeySource: backgroundLlmRuntime ? 'user' : 'platform',
     systemPrompt: fullSystemPrompt,
     assistantId: assistant.id,
     userId: user.id,
@@ -1124,6 +1136,16 @@ export async function executePublicTurn(
           accrual.compartments,
         ),
         workspaceId: assistant.workspaceId ?? undefined,
+        workerRuntime: customLlmRuntime
+          ? {
+              provider: customLlmRuntime.provider,
+              model: customLlmRuntime.selector,
+              modelTier: customLlmRuntime.modelTier,
+              providerKeySource: customLlmRuntime.providerKeySource,
+              inputTokenLimit: customLlmRuntime.inputTokenLimit,
+              maxTokens: customLlmRuntime.maxTokens,
+            }
+          : undefined,
         assistantKind: assistant.kind,
         // `assistant-full` runs as a synthetic non-member principal, so member
         // RLS hid every brain row before `clearance` was ever consulted — the
@@ -1217,6 +1239,7 @@ export async function executePublicTurn(
       assistantId: assistant.id,
       sessionId: session.id,
       model: responseModel,
+      modelTier: customLlmRuntime?.modelTier ?? tierForModel(model),
       inputTokens: totalUsage.inputTokens,
       outputTokens: totalUsage.outputTokens,
       cacheReadTokens: totalUsage.cacheReadTokens,
@@ -1224,6 +1247,7 @@ export async function executePublicTurn(
       actualCostUsd: cost,
       source: 'api',
       userMessageId: storedUserMsg.id,
+      triggerKey: 'main_response',
       providerKeySource: customLlmRuntime ? 'user' : 'platform',
     }).catch((err) => {
       // Mirror chat.ts: log AND surface to analytics so the

--- a/packages/core/src/consolidation/__tests__/consolidation.test.ts
+++ b/packages/core/src/consolidation/__tests__/consolidation.test.ts
@@ -211,6 +211,7 @@ describe('[COMP:consolidation/phases] REM phase guards', () => {
     const result = await runREMConsolidation(store, 'a1', 'u1', async () => 'NO_PATTERNS')
     expect(result.summary).toContain('Too few memories')
     expect(store.created).toHaveLength(0)
+    expect(store.logs).toEqual([{ phase: 'rem', memoriesAffected: [] }])
   })
 
   it('skips when fewer than 3 distinct tag clusters', async () => {
@@ -221,6 +222,7 @@ describe('[COMP:consolidation/phases] REM phase guards', () => {
     const result = await runREMConsolidation(store, 'a1', 'u1', async () => 'NO_PATTERNS')
     expect(result.summary).toContain('Too few memory clusters')
     expect(store.created).toHaveLength(0)
+    expect(store.logs).toEqual([{ phase: 'rem', memoriesAffected: [] }])
   })
 
   it('creates at most 3 connection memories', async () => {

--- a/packages/core/src/consolidation/__tests__/worker.test.ts
+++ b/packages/core/src/consolidation/__tests__/worker.test.ts
@@ -10,6 +10,7 @@ function makeFakeStore(opts: {
   users: Array<{ assistantId: string; userId: string }>
   lastPhases: Record<string, { light?: Date; rem?: Date; deep?: Date; reflection?: Date }>
   memories?: MemoryWithMetrics[]
+  now?: () => Date
   /** Per-user activity override. Missing keys default to `true` so existing
    *  tests keep the old (ungated) behaviour. */
   recentActivity?: Record<string, boolean>
@@ -55,6 +56,10 @@ function makeFakeStore(opts: {
     async pruneStaleDomainSummaries() { return 0 },
     async logConsolidation(params) {
       runs.push({ phase: params.phase, userId: params.userId })
+      if (opts.now) {
+        const phases = opts.lastPhases[params.userId] ??= {}
+        phases[params.phase] = opts.now()
+      }
     },
 
     // Unused surface methods
@@ -152,7 +157,7 @@ describe('[COMP:consolidation/worker] createConsolidationWorker — cadence gati
       },
       recentActivity: { ghost: false, active: true },
       memories: [
-        // REM needs >= 5 entries to not early-return via its own guard.
+        // REM needs >= 15 entries and 3 tag clusters to reach its model call.
         { id: 'm1', type: 'fact', summary: 's1', tags: [], sensitivity: 'public' } as never,
         { id: 'm2', type: 'fact', summary: 's2', tags: [], sensitivity: 'public' } as never,
         { id: 'm3', type: 'fact', summary: 's3', tags: [], sensitivity: 'public' } as never,
@@ -173,18 +178,29 @@ describe('[COMP:consolidation/worker] createConsolidationWorker — cadence gati
     expect(store.runs.find((r) => r.phase === 'deep' && r.userId === 'active')).toBeDefined()
   })
 
-  it('skips REM when fewer than 5 memories are present', async () => {
-    const now = new Date('2026-04-10T12:00:00Z')
+  it('records an ineligible REM attempt so it does not repeat every tick', async () => {
+    let now = new Date('2026-04-10T12:00:00Z')
     const store = makeFakeStore({
       users: [{ assistantId: 'a1', userId: 'u1' }],
-      lastPhases: {},
-      // REM has its own early-return guard (< 5 memories). The worker
-      // still calls it because cadence is due, but REM writes no log.
+      lastPhases: {
+        u1: {
+          light: new Date(now.getTime() - HOUR),
+          deep: new Date(now.getTime() - HOUR),
+        },
+      },
+      now: () => now,
     })
     const worker = createConsolidationWorker({ store, callModel, now: () => now })
     await worker.tick()
 
-    expect(store.runs.find((r) => r.phase === 'rem')).toBeUndefined()
+    expect(store.runs.filter((r) => r.phase === 'rem')).toHaveLength(1)
+    expect(calls).toBe(0)
+
+    now = new Date(now.getTime() + 15 * 60 * 1000)
+    await worker.tick()
+
+    expect(store.runs.filter((r) => r.phase === 'rem')).toHaveLength(1)
+    expect(calls).toBe(0)
   })
 
   it('isolates per-user failures so one bad user does not abort the tick', async () => {

--- a/packages/core/src/consolidation/phases.ts
+++ b/packages/core/src/consolidation/phases.ts
@@ -354,8 +354,20 @@ export async function runREMConsolidation(
   const inputMemories = index.filter((m) => !isRemOutput(m))
   const existingPatterns = index.filter((m) => isRemOutput(m))
 
+  const skipIneligibleREM = async (summary: string): Promise<ConsolidationResult> => {
+    const memoriesAffected: string[] = []
+    await store.logConsolidation({
+      assistantId,
+      userId,
+      phase: 'rem',
+      summary,
+      memoriesAffected,
+    })
+    return { phase: 'rem', memoriesAffected, summary }
+  }
+
   if (inputMemories.length < REM_MIN_MEMORIES) {
-    return { phase: 'rem', memoriesAffected: [], summary: 'Too few memories for pattern recognition' }
+    return skipIneligibleREM('Too few memories for pattern recognition')
   }
 
   // Post-Phase-4 (retire-memory-type): the legacy "distinct memory
@@ -367,7 +379,7 @@ export async function runREMConsolidation(
     inputMemories.map((m) => (m.tags.length > 0 ? m.tags[0] : 'untagged')),
   )
   if (distinctTagClusters.size < REM_MIN_TYPES) {
-    return { phase: 'rem', memoriesAffected: [], summary: 'Too few memory clusters for pattern recognition' }
+    return skipIneligibleREM('Too few memory clusters for pattern recognition')
   }
   const memorySummaries = inputMemories.map((m) => {
     const tagPrefix = m.tags.length > 0 ? `${m.tags[0]}: ` : ''

--- a/packages/core/src/consolidation/reclassifier.ts
+++ b/packages/core/src/consolidation/reclassifier.ts
@@ -39,6 +39,7 @@ import type {
 } from '../entities/types.js'
 import type { MemoryRecord, MemoryStore } from '../memory/types.js'
 import type { LLMProvider } from '../providers/types.js'
+import type { TokenUsage } from '../providers/types.js'
 import type { Sensitivity } from '../security/sensitivity.js'
 import type { TaskStore } from '../tasks/types.js'
 import { collectStream } from '../providers/accumulator.js'
@@ -143,6 +144,7 @@ export interface ReclassificationDeps {
   /** LLM. */
   provider: LLMProvider
   model: string
+  onUsage?: (model: string, usage: TokenUsage) => void | Promise<void>
 }
 
 export interface ReclassificationResult {
@@ -198,7 +200,9 @@ export async function runReclassification(
 
   let raw: string
   try {
-    raw = await callLLM(deps.provider, deps.model, prompt)
+    const response = await callLLM(deps.provider, deps.model, prompt)
+    raw = response.text
+    if (response.usage) await deps.onUsage?.(response.model, response.usage)
   } catch (err) {
     console.warn(
       `[reclassifier] LLM call failed for workspace ${deps.workspaceId}: ${
@@ -485,7 +489,7 @@ async function callLLM(
   provider: LLMProvider,
   model: string,
   prompt: string,
-): Promise<string> {
+): Promise<{ text: string; model: string; usage: TokenUsage | null }> {
   const response = await collectStream(
     provider.stream({
       model,
@@ -495,10 +499,14 @@ async function callLLM(
       maxTokens: 4_000,
     }),
   )
-  return response.content
-    .filter((b) => b.type === 'text')
-    .map((b) => (b.type === 'text' ? b.text : ''))
-    .join('')
+  return {
+    text: response.content
+      .filter((b) => b.type === 'text')
+      .map((b) => (b.type === 'text' ? b.text : ''))
+      .join(''),
+    model: response.model || model,
+    usage: response.usage,
+  }
 }
 
 function parseDecisions(raw: string): ReclassificationDecision[] | null {

--- a/packages/core/src/consolidation/worker.ts
+++ b/packages/core/src/consolidation/worker.ts
@@ -160,6 +160,21 @@ export type ReclassificationScope = {
   provider: LLMProvider
   /** Reclassifier model — Flash-class is fine. */
   model: string
+  resolveLlm?: (workspaceId: string) => Promise<{
+    provider: LLMProvider
+    model: string
+    modelTier?: string
+    providerKeySource?: 'user' | 'platform'
+  }>
+  onUsage?: (params: {
+    workspaceId: string
+    userId: string
+    assistantId: string
+    model: string
+    modelTier?: string
+    providerKeySource?: 'user' | 'platform'
+    usage: import('../providers/types.js').TokenUsage
+  }) => void | Promise<void>
   /** Resolve the workspaceId an assistant belongs to. Returns null
    *  when the assistant has no workspace partition (legacy rows). */
   resolveWorkspaceId(assistantId: string): Promise<string | null>
@@ -579,6 +594,9 @@ async function runPostRemReclassification(
     assistantKind: 'primary' as const,
   }
   const entities = await scope.entityStore.listForWorkspace(ctx, { limit: 200 })
+  const llm = scope.resolveLlm
+    ? await scope.resolveLlm(workspaceId)
+    : { provider: scope.provider, model: scope.model }
 
   await runReclassification({
     memories: filtered,
@@ -590,7 +608,16 @@ async function runPostRemReclassification(
     taskStore: scope.tasks,
     entityLinks: scope.entityLinks,
     candidates: scope.candidates,
-    provider: scope.provider,
-    model: scope.model,
+    provider: llm.provider,
+    model: llm.model,
+    onUsage: (model, usage) => scope.onUsage?.({
+      workspaceId,
+      userId,
+      assistantId,
+      model,
+      modelTier: llm.modelTier,
+      providerKeySource: llm.providerKeySource,
+      usage,
+    }),
   })
 }

--- a/packages/core/src/ingest/__tests__/pipeline-b.test.ts
+++ b/packages/core/src/ingest/__tests__/pipeline-b.test.ts
@@ -53,7 +53,7 @@ import type { PlatformEngagementMetrics } from '../types.js'
 
 // ── Mock provider (sequenced responses across multiple stream() calls) ──
 
-function sequencedProvider(responses: string[]): LLMProvider {
+function sequencedProvider(responses: string[], requests?: ProviderRequest[]): LLMProvider {
   let i = 0
   return {
     name: 'mock',
@@ -62,7 +62,8 @@ function sequencedProvider(responses: string[]): LLMProvider {
       return { thoughtSignature: undefined } as never
     },
     // eslint-disable-next-line require-yield
-    async *stream(): AsyncGenerator<StreamChunk> {
+    async *stream(request: ProviderRequest): AsyncGenerator<StreamChunk> {
+      requests?.push(request)
       const text = responses[Math.min(i, responses.length - 1)] ?? ''
       i++
       yield { type: 'text_delta', text } as StreamChunk
@@ -2043,6 +2044,34 @@ describe('[COMP:brain/pipeline-b] extraction usage attribution', () => {
     // Both rows carry the originating episode, so a recording's full cost
     // sums back to it (migration 354).
     for (const r of rows) expect(r.sourceEpisodeId).toBe('ep-1')
+  })
+
+  it('records workspace custom extraction as user-paid Standard overhead', async () => {
+    const usage = usageSpy()
+    const requests: ProviderRequest[] = []
+    const provider = sequencedProvider([
+      JSON.stringify({ summary: 'A note.', entities: [], edges: [], memories: [], tags: [] }),
+      JSON.stringify({ inferred_sensitivity: 'internal', brief_reason: 'routine' }),
+    ], requests)
+    await processEpisode(baseEpisode(), 'note', makeDeps({
+      provider,
+      model: 'custom:00000000-0000-4000-8000-000000000001',
+      classifierModel: 'custom:00000000-0000-4000-8000-000000000001',
+      modelTier: 'standard',
+      providerKeySource: 'user',
+      inputTokenLimit: 1024,
+      maxTokens: 64,
+      usage: usage.store,
+    }))
+
+    for (const [row] of usage.recordUsage.mock.calls) {
+      expect(row).toMatchObject({
+        modelTier: 'standard',
+        providerKeySource: 'user',
+        actualCostUsd: 0,
+      })
+    }
+    expect(requests[0]?.maxTokens).toBe(64)
   })
 
   it('still records when the model output fails to parse — the tokens were spent', async () => {

--- a/packages/core/src/ingest/pipeline-b.ts
+++ b/packages/core/src/ingest/pipeline-b.ts
@@ -158,6 +158,11 @@ export type PipelineBDeps = {
   provider: LLMProvider
   /** Extraction model id (Standard tier per model-routing.md Trigger #11). */
   model: string
+  /** Logical tier and key ownership for dynamic workspace custom models. */
+  modelTier?: string
+  providerKeySource?: 'user' | 'platform'
+  inputTokenLimit?: number
+  maxTokens?: number
   crm: CrmStore
   entities: EntityStore
   entityLinks: EntityLinksStore
@@ -1261,13 +1266,17 @@ async function recordExtractionUsage(
       workspaceId: episode.workspaceId,
       sessionId: null,
       model: over.model ?? deps.model,
+      modelTier: deps.modelTier,
       inputTokens: usage.inputTokens,
       outputTokens: usage.outputTokens,
       cacheReadTokens: usage.cacheReadTokens,
       cacheWriteTokens: usage.cacheWriteTokens,
-      actualCostUsd: calculateCost(over.model ?? deps.model, usage),
+      actualCostUsd: deps.providerKeySource === 'user'
+        ? 0
+        : calculateCost(over.model ?? deps.model, usage),
       source: over.source ?? 'overhead:extraction',
       triggerKey: over.triggerKey ?? 'pipeline_b_extraction',
+      providerKeySource: deps.providerKeySource,
       // The episode itself, NOT its parent. Rolling up to the originating
       // recording is `COALESCE(parent_episode_id, id)` at query time — cheap
       // at the current depth of 1, and it keeps which child drove the spend,
@@ -1319,13 +1328,15 @@ async function recordResolverUsage(
       workspaceId: episode.workspaceId,
       sessionId: null,
       model: usageModel,
+      modelTier: deps.modelTier,
       inputTokens: usage.inputTokens,
       outputTokens: usage.outputTokens,
       cacheReadTokens: usage.cacheReadTokens,
       cacheWriteTokens: usage.cacheWriteTokens,
-      actualCostUsd: calculateCost(usageModel, usage),
+      actualCostUsd: deps.providerKeySource === 'user' ? 0 : calculateCost(usageModel, usage),
       source: 'overhead:extraction',
       triggerKey: 'pipeline_b_entity_resolution',
+      providerKeySource: deps.providerKeySource,
     })
   } catch (err) {
     console.warn(
@@ -1446,7 +1457,11 @@ export async function processEpisode(
       )
     }
   }
-  const windows = splitContentByTokenLimit(extractableContent, EXTRACTION_TOKEN_LIMIT)
+  // Leave prompt/schema headroom inside a custom profile's declared context.
+  const extractionTokenLimit = deps.inputTokenLimit
+    ? Math.max(256, Math.min(EXTRACTION_TOKEN_LIMIT, Math.floor(deps.inputTokenLimit * 0.75)))
+    : EXTRACTION_TOKEN_LIMIT
+  const windows = splitContentByTokenLimit(extractableContent, extractionTokenLimit)
   const windowPayloads: ExtractionOutput[] = []
   for (let wi = 0; wi < windows.length; wi++) {
     const extractionMessages: Message[] = [
@@ -1462,7 +1477,7 @@ export async function processEpisode(
             model: deps.model,
             systemPrompt: SYSTEM_PROMPT,
             messages: extractionMessages,
-            maxTokens: EXTRACTION_MAX_OUTPUT_TOKENS,
+            maxTokens: Math.min(deps.maxTokens ?? EXTRACTION_MAX_OUTPUT_TOKENS, EXTRACTION_MAX_OUTPUT_TOKENS),
             temperature: 0.1,
             responseFormat: 'json',
             // The actual decoder constraint (the mime type alone is only a

--- a/packages/core/src/sandbox/bu-fallback.ts
+++ b/packages/core/src/sandbox/bu-fallback.ts
@@ -32,7 +32,7 @@ import type { SandboxTaskBinding } from './cloud-browser-provider.js'
 import { registrableSiteOf } from './orchestrator.js'
 import { distillTrace, skillNameFromGoal } from './self-heal.js'
 import type { ResolveComputerToolPolicy } from './tools.js'
-import type { SandboxProvider, SessionVault } from './types.js'
+import type { BrowserUseLlmConfig, SandboxProvider, SessionVault } from './types.js'
 
 export type BuFallbackEvent = {
   type: 'browser_explore'
@@ -55,6 +55,7 @@ export type CreateBuFallbackToolOptions = {
   resolvePolicy?: ResolveComputerToolPolicy
   unattendedEnabled?: () => boolean
   getWorkspacePlan?: (workspaceId: string) => Promise<string>
+  resolveLlm?: (workspaceId: string) => Promise<BrowserUseLlmConfig | null>
   onEvent?: (event: BuFallbackEvent, context: ToolContext) => void
   maxSteps?: number
   timeoutMs?: number
@@ -216,10 +217,12 @@ export function createBuFallbackTool(opts: CreateBuFallbackToolOptions): { brows
           { url: input.url, browser: true },
         )
         const goal = `Start at ${input.url}. ${input.goal}`
+        const llm = await opts.resolveLlm?.(context.workspaceId)
         const { trace, output } = await opts.provider.runBrowserUse(sandboxId, {
           goal,
           maxSteps: opts.maxSteps ?? DEFAULT_MAX_STEPS,
           timeoutMs: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          ...(llm ? { llm } : {}),
         })
 
         // Self-heal is ALWAYS automatic (R2-5): distill the watched run into

--- a/packages/core/src/sandbox/providers/e2b/bu-driver.ts
+++ b/packages/core/src/sandbox/providers/e2b/bu-driver.ts
@@ -71,7 +71,10 @@ def _make_llm(model):
             from browser_use import ChatOpenAI
         except ImportError:
             from browser_use.llm import ChatOpenAI
-        return ChatOpenAI(model=model)
+        kwargs = {'model': model}
+        if os.environ.get('OPENAI_BASE_URL'):
+            kwargs['base_url'] = os.environ['OPENAI_BASE_URL']
+        return ChatOpenAI(**kwargs)
     raise RuntimeError('no LLM API key in the driver environment')
 
 

--- a/packages/core/src/sandbox/providers/e2b/index.ts
+++ b/packages/core/src/sandbox/providers/e2b/index.ts
@@ -22,6 +22,7 @@ import {
   BrowserBackendError,
   type BlockRunHandle,
   type BrowserUseRunResult,
+  type BrowserUseLlmConfig,
   type BrowserSnapshot,
   type BuTraceStep,
   type RunPythonRequest,
@@ -82,11 +83,7 @@ export type E2bCloudProviderConfig = {
    * exploration's agentic loop runs inside the VM and must reach its LLM.
    * Absent → `runBrowserUse` refuses with an honest configuration error.
    */
-  browserUse?: {
-    apiKeyEnvName: 'ANTHROPIC_API_KEY' | 'GOOGLE_API_KEY' | 'OPENAI_API_KEY'
-    apiKey: string
-    model: string
-  }
+  browserUse?: BrowserUseLlmConfig
 }
 
 type PerSandbox = {
@@ -489,7 +486,7 @@ export function createE2bCloudProvider(
       // `mapBrowserUseHistory` turns into the distiller's trace. The old
       // one-shot `browser-use run --task-file` CLI never existed in 0.13 —
       // every prod run argparse-died with exit 2 (2026-07-21 incident).
-      const bu = config.browserUse
+      const bu = req.llm ?? config.browserUse
       if (!bu) {
         throw new Error(
           'browser-use is not configured on this deployment: the sandbox provider has no LLM key for the exploration agent, so agentic browsing cannot run. The flat browser tools still work.',
@@ -521,6 +518,7 @@ export function createE2bCloudProvider(
           BU_OUT_PATH: outPath,
           BU_MAX_STEPS: String(req.maxSteps ?? 40),
           BU_MODEL: bu.model,
+          ...(bu.baseUrl ? { OPENAI_BASE_URL: bu.baseUrl } : {}),
           // Per-run key injection — the documented no-ambient-secrets
           // exception (see E2bCloudProviderConfig.browserUse).
           [bu.apiKeyEnvName]: bu.apiKey,

--- a/packages/core/src/sandbox/types.ts
+++ b/packages/core/src/sandbox/types.ts
@@ -450,7 +450,14 @@ export interface SandboxProvider {
    */
   runBrowserUse(
     sandboxId: string,
-    req: { goal: string; maxSteps?: number; timeoutMs?: number },
+    req: { goal: string; maxSteps?: number; timeoutMs?: number; llm?: BrowserUseLlmConfig },
   ): Promise<BrowserUseRunResult>
   bridge: SandboxBridge
+}
+
+export type BrowserUseLlmConfig = {
+  apiKeyEnvName: 'ANTHROPIC_API_KEY' | 'GOOGLE_API_KEY' | 'OPENAI_API_KEY'
+  apiKey: string
+  model: string
+  baseUrl?: string
 }

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -6,6 +6,7 @@ import type { Sensitivity, SensitivityAccumulator } from '../security/sensitivit
 import type { CompartmentAccumulator } from '../security/compartments.js'
 import type { EvidenceAccumulator } from '../security/evidence.js'
 import type { AttachmentCollector } from '../workspace-files/attachments.js'
+import type { LLMProvider } from '../providers/types.js'
 
 // ── Tool context ───────────────────────────────────────────────
 
@@ -18,6 +19,15 @@ export type ToolContext = {
   channelId: string
   /** Team ID when the assistant is team-owned. Used by saveMemory for team scope. */
   workspaceId?: string | null
+  /** Immutable provider lane captured by workers spawned from this turn. */
+  workerRuntime?: {
+    provider: LLMProvider
+    model: string
+    modelTier?: string
+    providerKeySource?: 'user' | 'platform'
+    inputTokenLimit?: number
+    maxTokens?: number
+  }
   /**
    * The calling assistant's kind. When 'app' (team-owned distribution
    * assistants), saveMemory defaults scope to 'team' instead of 'user' so

--- a/packages/core/src/workers/__tests__/worker.test.ts
+++ b/packages/core/src/workers/__tests__/worker.test.ts
@@ -433,6 +433,48 @@ describe('[COMP:workers/manager] createWorkerManager', () => {
     expect(seenModels[4]).toBe('gemini-flash')
   })
 
+  it('captures a custom provider lane from the spawning turn', async () => {
+    const seen: Array<{ provider: string; model: string }> = []
+    const provider = (name: string): LLMProvider => ({
+      name,
+      models: ['model'],
+      async *stream(req) {
+        seen.push({ provider: name, model: req.model })
+        yield { type: 'message_start', model: req.model }
+        yield { type: 'text_delta', text: 'ok' }
+        yield { type: 'message_end', stopReason: 'end_turn', usage: { inputTokens: 2, outputTokens: 1 } }
+      },
+      createSession(): ProviderSession {
+        throw new Error('not used')
+      },
+    })
+    const usage: WorkerUsageEvent[] = []
+    const manager = createWorkerManager({
+      provider: provider('platform'),
+      model: 'gemini-flash',
+      tools: new Map(),
+      onUsage: (event) => usage.push(event),
+    })
+
+    manager.spawn('custom task', {
+      ...ctx,
+      workspaceId: 'ws-1',
+      workerRuntime: {
+        provider: provider('custom'),
+        model: 'custom:00000000-0000-4000-8000-000000000001',
+        modelTier: 'pro',
+        providerKeySource: 'user',
+      },
+    })
+    await manager.waitAll()
+
+    expect(seen).toEqual([{
+      provider: 'custom',
+      model: 'custom:00000000-0000-4000-8000-000000000001',
+    }])
+    expect(usage[0]).toMatchObject({ modelTier: 'pro', providerKeySource: 'user' })
+  })
+
   it('returns a graceful failed (not crashed) result when the provider errors inside the stream', async () => {
     const manager = createWorkerManager({
       provider: makeThrowingProvider(),

--- a/packages/core/src/workers/worker.ts
+++ b/packages/core/src/workers/worker.ts
@@ -157,6 +157,8 @@ export type WorkerUsageEvent = {
   sessionId: string
   workspaceId: string | null
   model: string
+  modelTier?: string
+  providerKeySource?: 'user' | 'platform'
   usage: TokenUsage
 }
 
@@ -462,7 +464,9 @@ export function createWorkerManager(options: WorkerOptions) {
     const userPrompt = isResearch
       ? `${RESEARCH_USER_PROMPT_PREAMBLE}${prompt}`
       : prompt
-    const model = isResearch && researchModel ? researchModel : options.model
+    const model = context.workerRuntime?.model
+      ?? (isResearch && researchModel ? researchModel : options.model)
+    const workerProvider = context.workerRuntime?.provider ?? options.provider
 
     // Capture per-spawn refs from the SPAWNING TURN's `context` (stable per
     // spawn), NOT the shared singleton's mutable persistence*/onEvent fields.
@@ -531,8 +535,10 @@ export function createWorkerManager(options: WorkerOptions) {
         let webSearchCalls = 0
 
         for await (const event of queryLoop({
-          provider: options.provider,
+          provider: workerProvider,
           model,
+          maxTokens: context.workerRuntime?.maxTokens,
+          inputTokenLimit: context.workerRuntime?.inputTokenLimit,
           systemPrompt,
           messages: messagesForLoop,
           tools: workerTools,
@@ -592,6 +598,8 @@ export function createWorkerManager(options: WorkerOptions) {
               sessionId: ownSessionId,
               workspaceId: ownWorkspaceId,
               model: event.response.model,
+              modelTier: context.workerRuntime?.modelTier,
+              providerKeySource: context.workerRuntime?.providerKeySource,
               usage: event.totalUsage,
             })
           }


### PR DESCRIPTION
## Summary
- route every workspace-attributable automatic text/tool LLM call through authoritative workspace custom OpenAI-compatible settings, including standalone skills/docs/Office, goals, A2A doc children, ingestion, synthesis, maintenance, and durable continuations
- honor the live application provider preference for Gemini via Vertex/AI Studio, DashScope, or Codex while preserving logical tiers, budgets, credits, profile limits, and fail-closed behavior
- record the actual serving model and correct provider ownership/COGS after routing or fallback
- keep explicit metered selections platform-routed and fail closed on suspended metered turns; keep embeddings, media/transcription, and hosted E2B on their capability-specific lanes
- classify external-tool spend as background and consume REM cadence on deterministic skips

## Testing
- `corepack pnpm --filter @use-brian/core typecheck`
- `corepack pnpm --filter @use-brian/api typecheck`
- full core suite: 4,899 passed, 20 skipped
- full API suite: 5,374 passed
- `git diff --check`