### PR TITLE
fix: bound workflow callee capabilities and prompt context

### DIFF
--- a/packages/api/src/db/__tests__/memories.test.ts
+++ b/packages/api/src/db/__tests__/memories.test.ts
@@ -13,6 +13,8 @@ import {
   searchMemories,
   getIdentityMemories,
   getMemoryIndex,
+  getWorkspaceIdentityMemories,
+  getWorkspaceMemoryIndex,
   listMemoriesWithMetrics,
   updateMemory,
 } from '../memories.js'
@@ -160,6 +162,17 @@ describe('[COMP:memory/bi-temporal-reads] reads filter valid_to IS NULL (SQL sha
   it('getMemoryIndex', async () => {
     await getMemoryIndex(CTX)
     expect(mockQuery.mock.calls[0][0]).toContain('valid_to IS NULL')
+    expect(mockQuery.mock.calls[0][0]).toContain("scope <> 'workspace'")
+  })
+
+  it('workspace prompt reads select only workspace-scoped memories', async () => {
+    await getWorkspaceIdentityMemories(CTX)
+    expect(mockQuery.mock.calls[0][0]).toContain("scope = 'workspace'")
+
+    mockQuery.mockClear()
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 } as never)
+    await getWorkspaceMemoryIndex(CTX)
+    expect(mockQuery.mock.calls[0][0]).toContain("scope = 'workspace'")
   })
 
   it('listMemoriesWithMetrics', async () => {

--- a/packages/api/src/db/memories.ts
+++ b/packages/api/src/db/memories.ts
@@ -658,6 +658,7 @@ export async function getMemoryIndex(
     `SELECT id, summary, tags, app_id as "appId", sensitivity
      FROM memories
      WHERE ${ap.sql}
+       AND scope <> 'workspace'
        AND valid_to IS NULL
        AND confidence > 0
      ORDER BY updated_at DESC`,
@@ -1593,6 +1594,7 @@ export async function getWorkspaceIdentityMemories(ctx: AccessContext): Promise<
   const result = await query<Memory>(
     `SELECT ${MEMORY_SELECT} FROM memories
      WHERE ${ap.sql}
+       AND scope = 'workspace'
        AND 'self-profile' = ANY(tags)
        AND valid_to IS NULL
      ORDER BY confidence DESC, updated_at DESC`,
@@ -1613,6 +1615,7 @@ export async function getWorkspaceMemoryIndex(
     `SELECT id, summary, tags, app_id as "appId", sensitivity
      FROM memories
      WHERE ${ap.sql}
+       AND scope = 'workspace'
        AND valid_to IS NULL
        AND confidence > 0
      ORDER BY updated_at DESC`,

--- a/packages/api/src/inter-assistant/__tests__/executor.test.ts
+++ b/packages/api/src/inter-assistant/__tests__/executor.test.ts
@@ -358,7 +358,7 @@ describe('[COMP:api/inter-assistant-executor] createCalleeExecutor', () => {
     ])
     await executor()(baseParams)
     const systemPrompt = mockQueryLoop.mock.calls[0][0].systemPrompt as string
-    expect(systemPrompt).toContain('## Automated context — tools execute directly')
+    expect(systemPrompt).toContain('## Automated tool policy')
   })
 
   it('omits the direct-execution framing when confirmations are deferred (deliverTarget set)', async () => {
@@ -378,7 +378,7 @@ describe('[COMP:api/inter-assistant-executor] createCalleeExecutor', () => {
       deliverTarget: { channelType: 'telegram', channelId: 'tg-1' },
     })
     const systemPrompt = mockQueryLoop.mock.calls[0][0].systemPrompt as string
-    expect(systemPrompt).not.toContain('## Automated context — tools execute directly')
+    expect(systemPrompt).not.toContain('## Automated tool policy')
   })
 
   it('tells the callee which capabilities are unavailable (2026-07-19/20 GM Bro incident)', async () => {
@@ -392,9 +392,8 @@ describe('[COMP:api/inter-assistant-executor] createCalleeExecutor', () => {
     // hunting for the tool the next. The entry carries the user-actionable fix,
     // so the callee can report something the user can act on.
     const notice =
-      'Google Calendar & Tasks (not connected or disabled for this assistant) — ' +
-      'if the user asks to add/check tasks, calendar events, or reminders, reply: ' +
-      '"I\'ll need Calendar access first. Type /connect gcal to authorize."'
+      'Google Calendar and Google Tasks: not connected for this assistant ' +
+      '(calendar events, tasks, and reminders)'
     mockInjectMcp.mockResolvedValueOnce({
       enrichConfirmation: async (_t: string, i: unknown) => i,
       unavailable: [notice],
@@ -405,10 +404,10 @@ describe('[COMP:api/inter-assistant-executor] createCalleeExecutor', () => {
     await executorWithMcp()(baseParams)
     const systemPrompt = mockQueryLoop.mock.calls[0][0].systemPrompt as string
     expect(systemPrompt).toContain('# Unavailable capabilities')
-    expect(systemPrompt).toContain('Type /connect gcal to authorize')
+    expect(systemPrompt).toContain('Google Calendar and Google Tasks')
     // The directive half matters as much as the list: without it the model
     // treats absence as "keep looking".
-    expect(systemPrompt).toContain('Do not attempt to use them or search for them')
+    expect(systemPrompt).toContain('Do not call, search for, or simulate them')
   })
 
   it('omits the unavailable-capabilities block when everything is reachable', async () => {
@@ -558,7 +557,7 @@ describe('[COMP:api/inter-assistant-executor] createCalleeExecutor', () => {
     expect(passedTools.has('gmailSendMessage')).toBe(false)
     expect(passedTools.has('searchThings')).toBe(true)
     const systemPrompt = call.systemPrompt as string
-    expect(systemPrompt).toContain('## Approval-gated tools are NOT available in this step')
+    expect(systemPrompt).toContain('## Automated tool policy')
     expect(systemPrompt).toContain('gmailSendMessage')
     expect(systemPrompt).toContain('tool_call')
   })
@@ -577,6 +576,34 @@ describe('[COMP:api/inter-assistant-executor] createCalleeExecutor', () => {
     expect(passedTools.has('notionCreatePage')).toBe(false)
   })
 
+  it('drops ask-policy tools added after base and connector injection', async () => {
+    yieldsText()
+    const fillBlueprintFromBrain = {
+      ...plainTool('fillBlueprintFromBrain'),
+      requiresConfirmation: true,
+    }
+    const callee = createCalleeExecutor({
+      provider: {} as never,
+      tools: new Map(),
+      memoryStore: memoryStore() as never,
+      capabilityStore: { listActive: vi.fn().mockResolvedValue([]) } as never,
+      blueprintRecordTools: [fillBlueprintFromBrain] as never,
+    })
+
+    mockFindAssistant.mockImplementation(async (id: string) =>
+      (id === 'callee-1'
+        ? { ...calleeAssistant, workspaceId: 'ws-1' }
+        : id === 'caller-1'
+          ? callerAssistant
+          : null) as never,
+    )
+    await callee({ ...baseParams, callerChannelType: 'workflow' })
+
+    const call = mockQueryLoop.mock.calls[0][0]
+    expect((call.tools as Map<string, unknown>).has('fillBlueprintFromBrain')).toBe(false)
+    expect(call.systemPrompt as string).toContain('fillBlueprintFromBrain')
+  })
+
   it('keeps the legacy strip on ordinary A2A: ask tools stay callable, no drop note', async () => {
     yieldsText()
     const tool = askTool()
@@ -585,9 +612,8 @@ describe('[COMP:api/inter-assistant-executor] createCalleeExecutor', () => {
     const passedTools = call.tools as Map<string, { requiresConfirmation?: boolean }>
     expect(passedTools.has('gmailSendMessage')).toBe(true)
     expect(passedTools.get('gmailSendMessage')?.requiresConfirmation).toBe(false)
-    expect(call.systemPrompt as string).not.toContain(
-      '## Approval-gated tools are NOT available in this step',
-    )
+    expect(call.systemPrompt as string).toContain('## Automated tool policy')
+    expect(call.systemPrompt as string).not.toContain('Removed approval-gated tools')
   })
 
   it('the confirmation strip NEVER mutates the shared tool singletons (chat gates survive consults)', async () => {
@@ -1146,6 +1172,37 @@ describe('[COMP:api/inter-assistant-executor] createCalleeExecutor', () => {
     expect(passedTools.has('search')).toBe(true)
   })
 
+  it('strips workflow orchestration tools from every callee', async () => {
+    yieldsText()
+    const stub = (name: string) => [name, { name }] as const
+    const callee = createCalleeExecutor({
+      provider: {} as never,
+      tools: new Map([
+        stub('proposeWorkflow'),
+        stub('createWorkflow'),
+        stub('updateWorkflow'),
+        stub('runWorkflow'),
+        stub('getWorkflow'),
+      ]) as never,
+      memoryStore: memoryStore() as never,
+      capabilityStore: { listActive: vi.fn().mockResolvedValue([]) } as never,
+    })
+
+    await callee(baseParams)
+
+    const passedTools = mockQueryLoop.mock.calls[0][0].tools as Map<string, unknown>
+    expect(passedTools.has('proposeWorkflow')).toBe(false)
+    expect(passedTools.has('createWorkflow')).toBe(false)
+    expect(passedTools.has('updateWorkflow')).toBe(false)
+    expect(passedTools.has('runWorkflow')).toBe(false)
+    expect(passedTools.has('getWorkflow')).toBe(true)
+
+    await expect(
+      callee({ ...baseParams, allowedTools: ['runWorkflow'] }),
+    ).rejects.toMatchObject({ reason: 'tools_unavailable' })
+    expect(mockQueryLoop).toHaveBeenCalledTimes(1)
+  })
+
   describe('app callees execute end-to-end', () => {
     function asDistributionCallee() {
       mockFindAssistant.mockImplementation(async (id: string) =>
@@ -1486,6 +1543,12 @@ describe('[COMP:api/inter-assistant-executor] workflow research fan-out + memory
 
   it('injects prior-run workflow memories with a save-only-new instruction', async () => {
     const store = wsMemoryStore({
+      getIndex: vi.fn().mockResolvedValue([
+        { id: 'abcd1234-0000-0000-0000-000000000000', summary: 'HK TVP subsidy fact', tags: [] },
+      ]),
+      getWorkspaceIndex: vi.fn().mockResolvedValue([
+        { id: 'abcd1234-0000-0000-0000-000000000000', summary: 'HK TVP subsidy fact', tags: [] },
+      ]),
       getWorkspaceMemoriesByCategory: vi.fn().mockResolvedValue([
         { id: 'abcd1234-0000-0000-0000-000000000000', summary: 'HK TVP subsidy fact' },
       ]),
@@ -1505,6 +1568,7 @@ describe('[COMP:api/inter-assistant-executor] workflow research fan-out + memory
     expect(sp).toContain('Already recorded by this workflow')
     expect(sp).toContain('HK TVP subsidy fact')
     expect(sp).toContain('[id:abcd1234]')
+    expect(sp.match(/HK TVP subsidy fact/g)).toHaveLength(1)
   })
 
   it('does not fetch prior-run memories for an ordinary (non-workflow) consult', async () => {

--- a/packages/api/src/inter-assistant/executor.ts
+++ b/packages/api/src/inter-assistant/executor.ts
@@ -507,11 +507,9 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
         // that were never on its surface (2026-07-20) and, the day before,
         // simply INVENTED their results: a single turn with zero tool calls
         // asserting "No events were found on your Google Calendar" for a
-        // connector it had no grant for. The unavailable entries carry the
-        // user-actionable fix too (e.g. "Type /connect gcal to authorize"), so
-        // the callee can report something the user can act on instead of
-        // improvising. See docs/architecture/integrations/mcp.md →
-        // "Connecting from Telegram" (Nudges + Closed-world wrapper) and
+        // connector it had no grant for. Entries are compact facts; the shared
+        // wrapper supplies the behavioral and remediation guidance once. See
+        // docs/architecture/integrations/mcp.md → "Unavailable capabilities" and
         // docs/architecture/channels/inter-assistant.md → "Unavailable
         // capabilities on the callee path".
         unavailableCapabilities = mcpInjection.unavailable
@@ -575,85 +573,12 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
       })
     }
 
-    // Confirmation lanes — three, by consult origin:
-    //
-    // 1. Scheduled-origin (`deliverTarget` set): `ask`-policy confirmations
-    //    stay LIVE and surface to the user's delivery channel (deferred
-    //    confirmations — see the query loop below).
-    // 2. Workflow-origin, no deliver (`callerChannelType === 'workflow'`):
-    //    `ask`-policy tools are DROPPED from the surface entirely and the
-    //    callee is told which and why (see `askPolicyDropBlock`). There is no
-    //    interactive approver mid-run, and silently auto-allowing them let a
-    //    workflow fire user-approval-gated side-effects with no approval
-    //    anywhere — while the Approve/Deny language in tool descriptions made
-    //    the model refuse anyway (the 2026-07-07 send-step incident). The
-    //    approved path for ask-policy actions in workflows is a `tool_call`
-    //    step, which pauses the run in the unified Approvals queue. `allow`-
-    //    policy tools keep executing directly (the user pre-authorized them).
-    // 3. Ordinary A2A (askAssistant, no deliver): strip confirmations — the
-    //    inter-assistant approval was already granted (free-mode acceptance,
-    //    or the require_approval flow resolving an input_required Task).
-    //    NOTE: this lane still silent-allows ask-policy tools (pre-existing
-    //    semantics, caller's user is interactively present); tracked in
-    //    docs/architecture/channels/inter-assistant.md → "Callee Execution".
+    // Confirmation policy is applied below only after every direct tool source
+    // (base, connectors, docs, memory, retrieval, blueprints) has been merged.
+    // Filtering here would let a later-injected ask tool bypass the workflow
+    // approval gate.
     const deferredConfirmations = params.deliverTarget != null
     const droppedAskTools: string[] = []
-    if (!deferredConfirmations && params.callerChannelType === 'workflow') {
-      // Resolve each tool's effective policy the same way dispatch would
-      // (dynamic resolvers re-read mcp_tool_settings; synthetic ToolContext —
-      // only identity fields are read, mirroring the workflow executor's
-      // tool_call policy gate). Fail-closed: a resolver throw = treat as ask.
-      const policyCtx = {
-        userId: calleeActorUserId,
-        assistantId: params.calleeAssistantId,
-        sessionId: session.id,
-        appId: 'Use Brian',
-        channelType: 'workflow',
-        channelId: session.id,
-        workspaceId: calleeAssistant.workspaceId ?? undefined,
-        abortSignal: new AbortController().signal,
-      }
-      await Promise.all(
-        Array.from(calleeTools.entries()).map(async ([name, tool]) => {
-          let needsConfirmation = !!tool.requiresConfirmation
-          if (tool.resolveConfirmation) {
-            try {
-              needsConfirmation = await tool.resolveConfirmation(
-                policyCtx as Parameters<NonNullable<typeof tool.resolveConfirmation>>[0],
-                undefined,
-              )
-            } catch {
-              needsConfirmation = true
-            }
-          }
-          if (needsConfirmation) {
-            droppedAskTools.push(name)
-            calleeTools.delete(name)
-          } else {
-            // Policy snapshot: the tool resolved `allow` at consult start, so
-            // it executes directly for the whole consult. Clearing the flags
-            // also closes the mid-consult policy-flip edge — this lane has no
-            // confirmation resolver to service a late `ask` event.
-            //
-            // Strip on a SHALLOW CLONE, never the shared object: `options.tools`
-            // holds the boot-time singletons every surface shares, and an
-            // in-place `tool.resolveConfirmation = undefined` here would
-            // permanently disarm the interactive chat's confirmation gates
-            // (browserClick's send gate, saveToWorkspace's ask default, every
-            // policy-'ask' resolver) after the first workflow consult.
-            calleeTools.set(name, { ...tool, requiresConfirmation: false, resolveConfirmation: undefined })
-          }
-        }),
-      )
-      droppedAskTools.sort()
-    } else if (!deferredConfirmations) {
-      // Same clone rule as the workflow lane above: the strip applies to THIS
-      // consult's surface only — mutating the shared singletons would disarm
-      // every other surface's confirmation gates process-wide.
-      for (const [name, tool] of calleeTools) {
-        calleeTools.set(name, { ...tool, requiresConfirmation: false, resolveConfirmation: undefined })
-      }
-    }
 
     // 4. The callee's consult tool surface (full caller-visible set — the
     // destination-side mode filter was retired 2026-07-24).
@@ -739,6 +664,62 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
       }
     }
 
+    // Confirmation lanes — applied to the COMPLETE direct surface:
+    // 1. Scheduled-origin (`deliverTarget` set): ask-policy confirmations stay
+    //    live and surface to the user's delivery channel.
+    // 2. Workflow-origin without delivery: ask-policy tools are removed. There
+    //    is no interactive approver; the approved path is a `tool_call` step.
+    // 3. Ordinary A2A: confirmation metadata is stripped on per-consult clones
+    //    because the interactive caller already approved the delegation.
+    if (!deferredConfirmations && params.callerChannelType === 'workflow') {
+      const policyCtx = {
+        userId: calleeActorUserId,
+        assistantId: params.calleeAssistantId,
+        sessionId: session.id,
+        appId: 'Use Brian',
+        channelType: 'workflow',
+        channelId: session.id,
+        workspaceId: calleeAssistant.workspaceId ?? undefined,
+        abortSignal: new AbortController().signal,
+      }
+      await Promise.all(
+        Array.from(modeTools.entries()).map(async ([name, tool]) => {
+          let needsConfirmation = !!tool.requiresConfirmation
+          if (tool.resolveConfirmation) {
+            try {
+              needsConfirmation = await tool.resolveConfirmation(
+                policyCtx as Parameters<NonNullable<typeof tool.resolveConfirmation>>[0],
+                undefined,
+              )
+            } catch {
+              needsConfirmation = true
+            }
+          }
+          if (needsConfirmation) {
+            droppedAskTools.push(name)
+            modeTools.delete(name)
+          } else {
+            // Clone before clearing policy metadata: boot owns shared tool
+            // singletons used by interactive surfaces.
+            modeTools.set(name, {
+              ...tool,
+              requiresConfirmation: false,
+              resolveConfirmation: undefined,
+            })
+          }
+        }),
+      )
+      droppedAskTools.sort()
+    } else if (!deferredConfirmations) {
+      for (const [name, tool] of modeTools) {
+        modeTools.set(name, {
+          ...tool,
+          requiresConfirmation: false,
+          resolveConfirmation: undefined,
+        })
+      }
+    }
+
     // Blueprint-bound enforcement (half 1 of 2): on a bound consult, wrap the
     // save tool so a successful record write is OBSERVED in-process. The
     // post-consult check below fails the step when a bound consult finishes
@@ -790,35 +771,6 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
         : params.allowedTools
     const finalTools = filterToolsByAllowList(modeTools, effectiveAllowedTools)
 
-    // Fail fast when a pinned allow-list survives as NOTHING — the step's
-    // authored intent (those exact tools) cannot execute, and running the
-    // turn anyway produced a toolless model collapsing into empty responses
-    // (the 2026-07-07 send-step incident, run 0477b50d: allow-list of one
-    // ask-policy tool → zero-tool surface → "did not produce a response"
-    // recorded as a completed step). The typed reason is hoisted into the
-    // step-run error; the message says WHICH pin failed and WHY.
-    if (params.allowedTools?.length && finalTools.size === 0) {
-      const dropped = params.allowedTools.filter((t) => droppedAskTools.includes(t))
-      const unknown = params.allowedTools.filter((t) => !droppedAskTools.includes(t))
-      const parts: string[] = []
-      if (dropped.length) {
-        parts.push(
-          `${dropped.join(', ')}: ask-policy (requires per-use user approval) — not callable inside an automated assistant_call step; use a tool_call step, which pauses the run in the Approvals queue`,
-        )
-      }
-      if (unknown.length) {
-        parts.push(
-          `${unknown.join(', ')}: not available to this assistant (not injected — check the connector is connected and exposed)`,
-        )
-      }
-      throw Object.assign(
-        new Error(
-          `None of the step's pinned tools are available to the callee. ${parts.join('; ')}.`,
-        ),
-        { reason: 'tools_unavailable' },
-      )
-    }
-
     // 4c. Leaf invariant — a delegated callee is a terminal node in the
     // consult tree: strip the inter-assistant delegation tools so it can never
     // initiate a *further* consult. Multi-hop composition is expressed through
@@ -857,6 +809,58 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
     finalTools.delete('spawnWorker')
     finalTools.delete('sendWorkerMessage')
     finalTools.delete('stopWorker')
+
+    // A callee is also terminal with respect to workflow orchestration. An
+    // unpinned assistant_call intentionally keeps the callee's normal effective
+    // tools for compatibility, but it must not author or launch a nested
+    // workflow from inside the current DAG. Read-only workflow inspection can
+    // remain available.
+    finalTools.delete('proposeWorkflow')
+    finalTools.delete('createWorkflow')
+    finalTools.delete('updateWorkflow')
+    finalTools.delete('runWorkflow')
+
+    // Fail fast only after every governance filter, including terminal-node
+    // strips. A pin that names only a forbidden orchestration tool must not run
+    // a tool-less model turn.
+    if (params.allowedTools?.length && finalTools.size === 0) {
+      const orchestrationTools = new Set([
+        'askAssistant',
+        'listConnectedAssistants',
+        'spawnWorker',
+        'sendWorkerMessage',
+        'stopWorker',
+        'proposeWorkflow',
+        'createWorkflow',
+        'updateWorkflow',
+        'runWorkflow',
+      ])
+      const dropped = params.allowedTools.filter((t) => droppedAskTools.includes(t))
+      const forbidden = params.allowedTools.filter((t) => orchestrationTools.has(t))
+      const unknown = params.allowedTools.filter(
+        (t) => !droppedAskTools.includes(t) && !orchestrationTools.has(t),
+      )
+      const parts: string[] = []
+      if (dropped.length) {
+        parts.push(
+          `${dropped.join(', ')}: ask-policy (requires per-use user approval) — use a tool_call step, which pauses the run in the Approvals queue`,
+        )
+      }
+      if (forbidden.length) {
+        parts.push(`${forbidden.join(', ')}: orchestration tools are not available inside a terminal assistant_call`)
+      }
+      if (unknown.length) {
+        parts.push(
+          `${unknown.join(', ')}: not available to this assistant (check connector connection and exposure)`,
+        )
+      }
+      throw Object.assign(
+        new Error(
+          `None of the step's pinned tools are available to the callee. ${parts.join('; ')}.`,
+        ),
+        { reason: 'tools_unavailable' },
+      )
+    }
 
     // 4d. Brain-skill surface. A workflow `assistant_call` step can carry two
     // skill lists: `skills` (DISCOVERY — offered via `useSkill`, the model
@@ -992,20 +996,45 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
 
     let workspaceIdentityMemories: Awaited<ReturnType<typeof options.memoryStore.getWorkspaceIdentity>> = []
     let teamMemoryIndex: Awaited<ReturnType<typeof options.memoryStore.getWorkspaceIndex>> = []
+    let priorRunMemories: Awaited<ReturnType<typeof options.memoryStore.getWorkspaceMemoriesByCategory>> = []
 
     if (includeWorkspaceMemories && calleeAssistant.workspaceId) {
-      ;[workspaceIdentityMemories, teamMemoryIndex] = await Promise.all([
+      ;[workspaceIdentityMemories, teamMemoryIndex, priorRunMemories] = await Promise.all([
         options.memoryStore.getWorkspaceIdentity(calleeCtx),
         options.memoryStore.getWorkspaceIndex(calleeCtx),
+        params.workflowId
+          ? options.memoryStore
+              .getWorkspaceMemoriesByCategory(calleeCtx, `workflow:${params.workflowId}`)
+              .catch((err) => {
+                console.warn('[inter-assistant] prior-run memory fetch failed:', err)
+                return []
+              })
+          : Promise.resolve([]),
       ])
     }
+
+    // The workflow-specific section is the authoritative rendering for its
+    // prior rows. Exclude those ids from the general personal/team indexes so
+    // the same summary is not injected two or three times.
+    const priorRunIds = new Set(priorRunMemories.map((m) => m.id))
+    const priorRunMemoryBlock = priorRunMemories.length > 0
+      ? `\n\n## Already recorded by this workflow\n` +
+        `Previous runs of this workflow saved the facts below. Call \`saveMemory\` ONLY for genuinely new or materially changed facts — do not re-save anything already covered here. If a fact below needs refining, update it by its id rather than creating a duplicate.\n` +
+        priorRunMemories.map((m) => `- [id:${m.id.slice(0, 8)}] ${m.summary}`).join('\n')
+      : ''
 
     const memoryContext = buildMemoryContext({
       soul,
       identityMemories: identityMemories.map((m) => ({ id: m.id, summary: m.summary, detail: m.detail })),
-      memoryIndex: memoryIndex.map((m) => ({ ...m, appId: null })),
-      workspaceIdentityMemories: workspaceIdentityMemories.map((m) => ({ id: m.id, summary: m.summary, detail: m.detail })),
-      teamMemoryIndex: teamMemoryIndex.map((m) => ({ ...m, appId: null })),
+      memoryIndex: memoryIndex
+        .filter((m) => !priorRunIds.has(m.id))
+        .map((m) => ({ ...m, appId: null })),
+      workspaceIdentityMemories: workspaceIdentityMemories
+        .filter((m) => !priorRunIds.has(m.id))
+        .map((m) => ({ id: m.id, summary: m.summary, detail: m.detail })),
+      teamMemoryIndex: teamMemoryIndex
+        .filter((m) => !priorRunIds.has(m.id))
+        .map((m) => ({ ...m, appId: null })),
       assistantName: calleeAssistant.name,
     })
 
@@ -1015,30 +1044,6 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
     const docAnchorBlock = params.pageAnchorId
       ? `\n\n${buildDocSupervisorSkillBlock({ mode: 'page' })}\n## Anchored page\nThis session is anchored to page \`${params.pageAnchorId}\`. Read it with \`getCurrentPage\` when needed, then submit one in-place edit brief through \`delegateDocEdit\`. Do not request a new page unless the request explicitly asks for one.`
       : ''
-
-    // Memory continuity for recurring workflows: surface the facts previous
-    // runs of THIS workflow already saved (tagged `workflow:<id>`) so the step
-    // saves only genuinely new ones instead of re-inserting the same fact every
-    // fire. Visibility-and-judgment, not a hard write-time dedupe. Best-effort:
-    // a fetch failure never fails the consult. See
-    // docs/architecture/features/workflow.md → "assistant_call memory continuity".
-    let priorRunMemoryBlock = ''
-    if (params.workflowId && calleeAssistant.workspaceId) {
-      try {
-        const prior = await options.memoryStore.getWorkspaceMemoriesByCategory(
-          calleeCtx,
-          `workflow:${params.workflowId}`,
-        )
-        if (prior.length > 0) {
-          priorRunMemoryBlock =
-            `\n\n## Already recorded by this workflow\n` +
-            `Previous runs of this workflow saved the facts below. Call \`saveMemory\` ONLY for genuinely new or materially changed facts — do not re-save anything already covered here. If a fact below needs refining, update it by its id rather than creating a duplicate.\n` +
-            prior.map((m) => `- [id:${m.id.slice(0, 8)}] ${m.summary}`).join('\n')
-        }
-      } catch (err) {
-        console.warn('[inter-assistant] prior-run memory fetch failed:', err)
-      }
-    }
 
     // Anti-fabrication guard for workflow-origin callees (fix C). A workflow
     // step runs unattended — if a tool it needs fails (auth error, connector
@@ -1071,7 +1076,7 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
     // clutter). This is the task analog of the `priorRunMemoryBlock` above.
     // Conditioned on "unless the instruction explicitly asks" so action steps
     // (a step whose job IS to create a task) are unaffected, and it never
-    // contradicts `directExecutionBlock` (which forbids REFUSING an asked-for
+    // contradicts `automatedToolPolicyBlock` (which forbids REFUSING an asked-for
     // action). See docs/architecture/features/workflow.md → "assistant_call
     // record-creation restraint".
     const recordCreationGuardBlock =
@@ -1079,29 +1084,17 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
         ? `\n\n## Produce this step's output, do not restate it as a record\nDo NOT create, update, or retract tasks, memories, contacts, deals, or other workspace records unless THIS step's instruction explicitly asks you to create or change one. When the instruction is to summarize, review, list, report on, or give an overview of existing items, the message you write IS the complete deliverable: do not also open a task that merely echoes the instruction. A recurring run that creates such a task mints a near-duplicate every fire.`
         : ''
 
-    // Direct-execution framing for confirmation-stripped consults. The
-    // confirmation strip above sets `requiresConfirmation = false` on every
-    // tool, but base prompts + tool descriptions still describe an
-    // Approve/Deny confirmation UI — in this UI-less context the model has
-    // inferred "manual confirmation is not available here" and REFUSED to
-    // call a tool it was explicitly granted (the 2026-07-07 send-step
-    // incident: callee session with zero tool_use, honest refusal text,
-    // step recorded completed). Tool-agnostic by design (tool-awareness rule).
-    const directExecutionBlock = !deferredConfirmations
-      ? `\n\n## Automated context — tools execute directly\nThere is no Approve/Deny or confirmation interface in this context; any interactive-approval flow described elsewhere does not apply here. Every tool available to you has already been authorized for this consult — calling it executes the action immediately. If the request asks you to perform an action and you have a tool for it, call the tool. Do not decline because manual confirmation is unavailable, and never describe an action as done without having called the tool. If you cannot perform the action (no suitable tool, or the tool errors), state that plainly as your outcome.`
-      : ''
-
-    // Approval-gated tools dropped from this workflow consult (lane 2 above).
-    // Scoped to the step's pinned list when one exists, so the note names only
-    // tools the step could plausibly reach for. Telling the callee exactly
-    // which tools are missing AND why is what turns the 2026-07-07 failure
-    // shape (model guesses, refuses, or narrates a phantom send) into an
-    // honest one-line outcome the step trail surfaces.
+    // One compact policy block carries both sides of the UI-less lane: visible
+    // tools execute directly, while removed ask-policy tools did not execute
+    // and require an approval-gated workflow tool_call step.
     const relevantDroppedAskTools = params.allowedTools?.length
       ? droppedAskTools.filter((t) => params.allowedTools!.includes(t))
       : droppedAskTools
-    const askPolicyDropBlock = relevantDroppedAskTools.length
-      ? `\n\n## Approval-gated tools are NOT available in this step\nThese tools require per-use user approval (ask policy) and are not callable inside an automated workflow step: ${relevantDroppedAskTools.join(', ')}. Do not attempt to call them, do not simulate their effect, and never state or imply their action happened. If the request depends on one of them, state plainly that the action was not performed and that it needs an approval-gated \`tool_call\` workflow step (it pauses the run in the Approvals queue until the user approves).`
+    const automatedToolPolicyBlock = !deferredConfirmations
+      ? `\n\n## Automated tool policy\nThere is no Approve/Deny interface in this consult. Call an available tool directly when the request requires it. If a tool reports that its underlying action still requires approval, treat the action as not performed. Never claim an action without a successful tool result.` +
+        (relevantDroppedAskTools.length
+          ? `\nRemoved approval-gated tools: ${relevantDroppedAskTools.join(', ')}. They are not callable here. If the request depends on one, report that it was not performed and requires an approval-gated \`tool_call\` workflow step.`
+          : '')
       : ''
 
     // Dynamic workspace-blueprints section — chat parity (closed-world; empty
@@ -1154,7 +1147,7 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
       }
     }
 
-    const fullSystemPrompt = `${systemPrompt}${docAnchorBlock}${priorRunMemoryBlock}${workflowGuardBlock}${recordCreationGuardBlock}${directExecutionBlock}${askPolicyDropBlock}${unavailableBlock}${skillPromptFragment}${blueprintPromptFragment}\n\n# Context\nCurrent date and time: ${currentDateTime}\nTimezone: ${calleeOwner.timezone}\n\n${memoryContext}`
+    const fullSystemPrompt = `${systemPrompt}${docAnchorBlock}${priorRunMemoryBlock}${workflowGuardBlock}${recordCreationGuardBlock}${automatedToolPolicyBlock}${unavailableBlock}${skillPromptFragment}${blueprintPromptFragment}\n\n# Context\nCurrent date and time: ${currentDateTime}\nTimezone: ${calleeOwner.timezone}\n\n${memoryContext}`
     const backgroundLlmRuntime = calleeAssistant.workspaceId && options.resolveWorkspaceCustomLlm
       ? await options.resolveWorkspaceCustomLlm({
           workspaceId: calleeAssistant.workspaceId,

--- a/packages/api/src/mcp/__tests__/inject-mailbox.test.ts
+++ b/packages/api/src/mcp/__tests__/inject-mailbox.test.ts
@@ -154,13 +154,12 @@ describe('[COMP:tools/mailbox-imap] imap injection', () => {
     expect(tools.get('imapSendMessage')?.description).toMatch(/ordinary email sending/i)
 
     // Gmail OAuth is absent in this fixture, but email is available through
-    // the injected IMAP/SMTP mailbox. Its notice must not turn a missing
-    // service into a false claim that the broader capability is missing.
+    // the injected IMAP/SMTP mailbox. The connector entry stays a compact fact;
+    // the shared prompt wrapper carries the use-another-available-tool policy.
     const gmailNotice = result.unavailable.find((line) => line.startsWith('Gmail: not connected'))
     expect(gmailNotice).toBeDefined()
-    expect(gmailNotice).toMatch(/another available tool can fulfill/i)
-    expect(gmailNotice).toMatch(/do not mention this missing service/i)
-    expect(gmailNotice).not.toMatch(/so sending and reading email are unavailable/i)
+    expect(gmailNotice).toBe('Gmail: not connected for this assistant (sending and reading email)')
+    expect(gmailNotice).not.toMatch(/unavailable this turn/i)
   })
 
   it('announces the capability as unavailable when no mailbox is connected', async () => {

--- a/packages/api/src/mcp/__tests__/inject.test.ts
+++ b/packages/api/src/mcp/__tests__/inject.test.ts
@@ -1670,7 +1670,7 @@ describe('[COMP:integrations/connector-health] team-native connector health gate
       keepBuiltinsDirect: true,
     })
     expect([...tools.keys()].some((n) => n.startsWith('githubSearchRepositories'))).toBe(false)
-    expect(result.unavailable.some((u) => /stopped working/i.test(u) && /github/i.test(u))).toBe(true)
+    expect(result.unavailable.some((u) => /reconnect required/i.test(u) && /github/i.test(u))).toBe(true)
   })
 })
 
@@ -2027,7 +2027,7 @@ describe('[COMP:api/mcp-inject] msgraph workspace overlays', () => {
     // The reconnect wording specifically — a bare "Microsoft Teams" match also
     // passes on the not-connected notice the suppressed base load emits, which
     // is what this suite exists to distinguish.
-    expect(result.unavailable.join('\n')).toMatch(/Microsoft Teams .*credentials failed/)
+    expect(result.unavailable.join('\n')).toMatch(/Microsoft Teams .*reconnect required/)
   })
 
   it('retracts the base pass\'s not-connected advert once the grant overlay injects', async () => {

--- a/packages/api/src/mcp/__tests__/stale-not-connected.test.ts
+++ b/packages/api/src/mcp/__tests__/stale-not-connected.test.ts
@@ -21,9 +21,7 @@ const tool = (name: string) => [name, { name } as Tool] as const
 
 /** The exact wording `notConnectedNotice` produces. */
 const notice = (displayName: string) =>
-  `${displayName}: not connected for this assistant, so things are unavailable this turn. ` +
-  'If the user asks for one, say so plainly in your own words and point them to Studio then Connectors to connect it. ' +
-  'Do not quote this notice back to them, and do not claim a tool call failed.'
+  `${displayName}: not connected for this assistant (things)`
 
 describe('[COMP:api/mcp-inject] stale not-connected notice retraction', () => {
   it('retracts the notice for a provider whose tools were injected by an overlay', () => {
@@ -50,7 +48,7 @@ describe('[COMP:api/mcp-inject] stale not-connected notice retraction', () => {
   })
 
   it('leaves unrelated notices untouched', () => {
-    const other = 'Company email (IMAP): not connected for this assistant, so mail is unavailable this turn.'
+    const other = 'Company email (IMAP): not connected for this assistant (mail)'
     const tools = new Map([tool('shopifyGetShop')])
     const unavailable = [other]
     clearStaleNotConnectedNotices(tools, unavailable)

--- a/packages/api/src/mcp/connector-health.ts
+++ b/packages/api/src/mcp/connector-health.ts
@@ -186,12 +186,7 @@ export function wrapToolsWithHealthProbe(
 export function connectorReconnectNotice(provider: string, label: string): string {
   const name = providerDisplayName(provider)
   const nick = label && label.toLowerCase() !== provider.toLowerCase() ? ` "${label}"` : ''
-  return (
-    `${name}${nick} (credentials failed - the connector needs reconnecting) - ` +
-    `if the user asks for anything requiring ${name}, tell them: ` +
-    `"The ${name} connector stopped working (its credentials expired or were revoked). ` +
-    `Reconnect it in Studio then Connectors and try again."`
-  )
+  return `${name}${nick}: reconnect required (credentials expired or revoked; Studio → Connectors)`
 }
 
 function providerDisplayName(provider: string): string {

--- a/packages/api/src/mcp/inject.ts
+++ b/packages/api/src/mcp/inject.ts
@@ -2026,13 +2026,7 @@ export function clearStaleNotConnectedNotices(
 }
 
 function notConnectedNotice(displayName: string, capabilities: string): string {
-  return (
-    `${displayName}: not connected for this assistant, so only this connector's ${capabilities} are unavailable this turn. ` +
-    'Another connected service may still provide the broader capability. Use an available tool that matches the requested account and identity; ' +
-    'do not mention this missing service when another available tool can fulfill the task. ' +
-    'If the task truly requires this service and no available tool can fulfill it, say so plainly in your own words and point the user to Studio then Connectors to connect it. ' +
-    'Do not quote this notice back to them, and do not claim a tool call failed.'
-  )
+  return `${displayName}: not connected for this assistant (${capabilities})`
 }
 
 /**
@@ -2063,10 +2057,7 @@ const NOT_CONNECTED_DISPLAY_NAME: Record<string, string> = {
  * reconnecting genuinely is the remedy.
  */
 function expiredCredentialsNotice(displayName: string): string {
-  return (
-    `${displayName}: connected, but its stored credentials expired or were revoked, so its tools are not loaded this turn. ` +
-    'Tell the user it needs reconnecting in Studio then Connectors. Do not offer any other cause.'
-  )
+  return `${displayName}: reconnect required (credentials expired or revoked; Studio → Connectors)`
 }
 
 async function injectGoogleTools(

--- a/packages/api/src/routes/__tests__/route-helpers.test.ts
+++ b/packages/api/src/routes/__tests__/route-helpers.test.ts
@@ -88,7 +88,8 @@ describe('[COMP:api/route-helpers] Route helpers', () => {
       const result = buildUnavailableCapabilitiesPrompt(['Gmail', 'Google Calendar'], noSearch)
       expect(result).toContain('Gmail')
       expect(result).toContain('Google Calendar')
-      expect(result).toContain('NOT available')
+      expect(result).toContain('not available')
+      expect(result.match(/Studio → Connectors/g)).toHaveLength(1)
     })
 
     it('scopes the Settings suggestion to the listed services (closed world)', () => {
@@ -96,8 +97,8 @@ describe('[COMP:api/route-helpers] Route helpers', () => {
       // The template must be scoped to the list, not a general habit the
       // model extends to arbitrary services (the invented-Jira-connector
       // class caught by the WS2 probe battery).
-      expect(result).toContain('listed above')
-      expect(result).toContain('Never point the user to a Settings toggle or connector for a service that is not listed here')
+      expect(result).toContain('For any other service')
+      expect(result).toContain('Do not suggest a connector setting for an unlisted service')
       expect(result).not.toContain('an unavailable service')
     })
 
@@ -112,7 +113,7 @@ describe('[COMP:api/route-helpers] Route helpers', () => {
 
     it('does NOT claim the visible tools are the whole surface when mcp_search is present', () => {
       const result = buildUnavailableCapabilitiesPrompt(['Gmail'], withSearch)
-      expect(result).not.toContain('This list plus your tools is the complete integration surface')
+      expect(result).not.toContain('The list and visible tools are the complete integration surface')
     })
 
     it('orders a search before any denial when mcp_search is present', () => {
@@ -120,7 +121,7 @@ describe('[COMP:api/route-helpers] Route helpers', () => {
       expect(result).toContain('mcp_search')
       expect(result).toMatch(/before .{0,60}unavailable/i)
       // The listed services stay closed-world — searching for them is still banned.
-      expect(result).toContain('Never point the user to a Settings toggle or connector for a service that is not listed here')
+      expect(result).toContain('Do not suggest a connector setting for an unlisted service')
     })
 
     it('emits the search guidance even when nothing is unavailable', () => {
@@ -137,7 +138,7 @@ describe('[COMP:api/route-helpers] Route helpers', () => {
       expect(buildUnavailableCapabilitiesPrompt([], new Map())).toBe('')
       const result = buildUnavailableCapabilitiesPrompt(['Gmail'], new Map())
       expect(result).not.toContain('mcp_search')
-      expect(result).toContain('This list plus your tools is the complete integration surface')
+      expect(result).toContain('The list and visible tools are the complete integration surface')
     })
   })
 

--- a/packages/api/src/routes/route-helpers.ts
+++ b/packages/api/src/routes/route-helpers.ts
@@ -232,7 +232,7 @@ export function isValidDateString(date: string): boolean {
  * hold is the same tool-awareness violation in the opposite direction.
  */
 const SEARCH_BEFORE_DENIAL =
-  'Before you tell the user a capability is unavailable, run `mcp_search` for it.'
+  'For an unlisted capability, run `mcp_search` before denying it.'
 
 /**
  * Deliberately "may be folded", not "is folded": the workflow path runs with
@@ -241,7 +241,7 @@ const SEARCH_BEFORE_DENIAL =
  * hidden" would be a falsehood on that path.
  */
 const FOLDED_SURFACE =
-  'Your visible tools are not the whole integration surface: connector tools may be folded behind `mcp_search` and not appear by name until you search for them.'
+  'Connector tools may be folded behind `mcp_search` and absent by name.'
 
 export function buildUnavailableCapabilitiesPrompt(
   capabilities: string[],
@@ -256,13 +256,13 @@ export function buildUnavailableCapabilitiesPrompt(
     return `\n\n# Connector tools\n\n${FOLDED_SURFACE} ${SEARCH_BEFORE_DENIAL}`
   }
 
-  const head = `\n\n# Unavailable capabilities\n\nThe following services are NOT available. Do not attempt to use them or search for them:\n${capabilities.map((c) => `- ${c}`).join('\n')}\n\nIf the user asks for something that requires one of the services listed above, say it is not connected and suggest enabling it in Settings (when an entry includes its own connect phrase, use that instead).`
+  const head = `\n\n# Unavailable capabilities\n\nThese capabilities are not available in this run. Do not call, search for, or simulate them:\n${capabilities.map((c) => `- ${c}`).join('\n')}\n\nUse another available tool when it serves the requested account and identity. Otherwise report the limitation plainly and use any remediation stated above, or point the user to Studio → Connectors.`
 
   const closedWorld = searchable
-    ? ` This list, your visible tools, and every tool reachable through \`mcp_search\` together are the complete integration surface. ${FOLDED_SURFACE} ${SEARCH_BEFORE_DENIAL} Only a service listed above, or one \`mcp_search\` cannot find, has no integration to enable: say so plainly then and offer the nearest supported alternative.`
-    : ` This list plus your tools is the complete integration surface: for a service in neither, Use Brian has no integration to enable. Say so plainly and offer the nearest supported alternative.`
+    ? ` ${FOLDED_SURFACE} ${SEARCH_BEFORE_DENIAL} A listed capability remains unavailable even if searched.`
+    : ` The list and visible tools are the complete integration surface. For any other service, say Use Brian has no integration and offer the nearest supported alternative.`
 
-  return `${head}${closedWorld} Never point the user to a Settings toggle or connector for a service that is not listed here.`
+  return `${head}${closedWorld} Do not suggest a connector setting for an unlisted service.`
 }
 
 /**


### PR DESCRIPTION
## Summary
- compact unavailable-connector metadata and centralize shared model guidance
- apply workflow approval filtering after all direct tool injection and remove nested orchestration tools
- separate personal and workspace memory indexes and avoid repeating prior-run memories

## Verification
- `corepack pnpm --filter @use-brian/api... build`
- `corepack pnpm exec vitest run src/inter-assistant/__tests__/executor.test.ts src/routes/__tests__/route-helpers.test.ts src/mcp/__tests__/inject.test.ts src/mcp/__tests__/inject-mailbox.test.ts src/mcp/__tests__/stale-not-connected.test.ts src/mcp/__tests__/connector-health.test.ts src/db/__tests__/memories.test.ts` (228 passed)
- `corepack pnpm --filter @use-brian/api typecheck`
- `corepack pnpm --filter @use-brian/core smoke`