### PR TITLE
fix(workflow): show connected connector tools

### DIFF
--- a/apps/app-web/src/app/w/[workspaceId]/workflow/[id]/page.tsx
+++ b/apps/app-web/src/app/w/[workspaceId]/workflow/[id]/page.tsx
@@ -40,6 +40,7 @@ import {
   deleteWorkflow,
   getWorkflowFull,
   listChannelDestinations,
+  listConnectedWorkflowToolSources,
   listWorkspaceSlackChannels,
   runWorkflowNow,
   updateWorkflow,
@@ -61,6 +62,7 @@ import type { CustomPageTemplateSummary } from "@use-brian/doc-model";
 import { listWorkspaceSkills, type WorkspaceSkillSummary } from "@/lib/api/skills";
 import { WorkflowBoard } from "@/components/workflow/workflow-board";
 import { pruneLayout } from "@/lib/workflow-canvas";
+import { buildToolCatalog } from "@/lib/workflow-tools";
 import { StepEditor } from "@/components/workflow/step-editor";
 import { TriggerEditor } from "@/components/workflow/trigger-editor";
 import { ButtonBindingsList, TriggerJobsList } from "@/components/workflow/trigger-jobs-list";
@@ -91,6 +93,7 @@ export default function WorkflowDetailPage({
   const [pages, setPages] = useState<ViewListRow[]>([]);
   const [blueprints, setBlueprints] = useState<CustomPageTemplateSummary[]>([]);
   const [skills, setSkills] = useState<WorkspaceSkillSummary[]>([]);
+  const [toolGroups, setToolGroups] = useState(() => buildToolCatalog([]));
   // Origin-aware induction: skills distilled from THIS workflow's runs —
   // derived from the same workspace-skills list the SkillsField uses.
   const learnedSkills = useMemo(
@@ -138,6 +141,31 @@ export default function WorkflowDetailPage({
       const list = await listAssistants(activeId);
       if (!cancelled) {
         setAssistants(list.filter((a) => a.workspaceId === activeId));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeId]);
+
+  // Load only connector tools actually available to this workspace. Official
+  // catalogs are static; custom MCP catalogs are discovered live by the API
+  // helper. Built-in first-party tools remain available if this fetch fails.
+  useEffect(() => {
+    if (!activeId) {
+      setToolGroups(buildToolCatalog([]));
+      return;
+    }
+    // Clear the prior workspace immediately; never flash its connector names
+    // while the next workspace inventory is loading.
+    setToolGroups(buildToolCatalog([]));
+    let cancelled = false;
+    void (async () => {
+      try {
+        const sources = await listConnectedWorkflowToolSources(activeId);
+        if (!cancelled) setToolGroups(buildToolCatalog(sources));
+      } catch {
+        if (!cancelled) setToolGroups(buildToolCatalog([]));
       }
     })();
     return () => {
@@ -858,6 +886,7 @@ export default function WorkflowDetailPage({
                 pages={pages}
                 blueprints={blueprints}
                 skills={skills}
+                toolGroups={toolGroups}
                 steps={draft.definition.steps}
                 onChange={(next) => updateStep(selectedStepIdx, next)}
                 onMoveUp={() => moveStep(selectedStepIdx, -1)}

--- a/apps/app-web/src/components/workflow/step-editor.tsx
+++ b/apps/app-web/src/components/workflow/step-editor.tsx
@@ -62,12 +62,12 @@ import {
   SwitchRow,
 } from "@/components/workflow/field";
 import {
-  buildToolCatalog,
   catalogToolNames,
   filterToolGroups,
   normalizeToolName,
   BUILTIN_GROUP_ID,
   MAX_TOOLS,
+  type ToolGroup,
 } from "@/lib/workflow-tools";
 import {
   fieldUnderlineCls,
@@ -122,6 +122,8 @@ type Props = {
    * hides itself and any already-selected slugs are preserved.
    */
   skills: WorkspaceSkillSummary[];
+  /** Connected workspace connector tools for the Restrict tools picker. */
+  toolGroups: ToolGroup[];
   /**
    * All steps in the draft definition — backs the page-anchor "from
    * earlier step" picker (steps with `page.create` other than this one).
@@ -144,6 +146,7 @@ export function StepEditor({
   pages,
   blueprints,
   skills,
+  toolGroups,
   steps,
   onChange,
   onMoveUp,
@@ -352,6 +355,7 @@ export function StepEditor({
               <RailCard title={b.stepRailExecutionHeading}>
                 <ExecutionFields
                   step={step}
+                  toolGroups={toolGroups}
                   onChange={onChange}
                   disabled={disabled}
                   t={t}
@@ -465,11 +469,13 @@ function InstructionBody({
 
 function ExecutionFields({
   step,
+  toolGroups,
   onChange,
   disabled,
   t,
 }: {
   step: Extract<WorkflowStep, { type: "assistant_call" }>;
+  toolGroups: ToolGroup[];
   onChange: (s: WorkflowStep) => void;
   disabled?: boolean;
   t: Dictionary;
@@ -642,7 +648,13 @@ function ExecutionFields({
 
       <div className="flex flex-col gap-1.5">
         <FieldLabel label={b.toolsFilterLabel} hint={b.toolsFilterHint} />
-        <ToolsField step={step} onChange={onChange} disabled={disabled} t={t} />
+        <ToolsField
+          step={step}
+          toolGroups={toolGroups}
+          onChange={onChange}
+          disabled={disabled}
+          t={t}
+        />
       </div>
     </div>
   );
@@ -664,11 +676,13 @@ function ExecutionFields({
  */
 function ToolsField({
   step,
+  toolGroups,
   onChange,
   disabled,
   t,
 }: {
   step: Extract<WorkflowStep, { type: "assistant_call" }>;
+  toolGroups: ToolGroup[];
   onChange: (s: WorkflowStep) => void;
   disabled?: boolean;
   t: Dictionary;
@@ -679,9 +693,9 @@ function ToolsField({
   const count = selected.length;
   const atMax = count >= MAX_TOOLS;
 
-  // Catalog is static; translate only the Built-in group label (connector
-  // labels are registry data, English — same as the connector-grants surface).
-  const catalog = useMemo(() => buildToolCatalog(), []);
+  // Translate only the Built-in group label. Connector labels come from the
+  // shared registry or the connected custom instance.
+  const catalog = toolGroups;
   const groups = useMemo(
     () =>
       catalog.map((g) =>
@@ -888,7 +902,7 @@ function ToolsField({
 
 /** Initial collapse set: a group is collapsed unless it holds a selected tool. */
 function collapseFor(
-  groups: ReturnType<typeof buildToolCatalog>,
+  groups: ToolGroup[],
   selectedSet: Set<string>,
 ): Set<string> {
   const set = new Set<string>();

--- a/apps/app-web/src/lib/__tests__/workflow-tools.test.ts
+++ b/apps/app-web/src/lib/__tests__/workflow-tools.test.ts
@@ -3,24 +3,49 @@
  * Component tag: [COMP:app-web/workflow-tools].
  */
 
-import { describe, it, expect } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/auth-fetch", () => ({ authFetch: vi.fn() }));
 import {
   OFFICIAL_CONNECTOR_TOOLS,
 } from "@use-brian/shared/builtin-connectors";
-import { OFFICIAL_CONNECTORS } from "@use-brian/shared/connector-registry";
+import { BUILTIN_PRIMITIVE_CONNECTOR_IDS } from "@use-brian/shared/connector-registry";
 import {
   buildToolCatalog,
   catalogToolNames,
   filterToolGroups,
   normalizeToolName,
   BUILTIN_GROUP_ID,
-  BUILTIN_TOOL_CATALOG,
   MAX_TOOL_NAME_LEN,
+  type ConnectedToolSource,
 } from "../workflow-tools";
+import { authFetch } from "@/lib/auth-fetch";
+import { listConnectedWorkflowToolSources } from "../api/workflow";
+
+const mockAuthFetch = vi.mocked(authFetch);
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function source(
+  connectorId: string,
+  overrides: Partial<ConnectedToolSource> = {},
+): ConnectedToolSource {
+  return {
+    id: `instance-${connectorId}`,
+    connectorId,
+    label: connectorId,
+    ...overrides,
+  };
+}
 
 describe("[COMP:app-web/workflow-tools] tool catalog", () => {
   it("puts the Built-in group first with the curated base tools", () => {
-    const groups = buildToolCatalog();
+    const groups = buildToolCatalog([]);
     expect(groups[0].id).toBe(BUILTIN_GROUP_ID);
     const names = groups[0].items.map((i) => i.name);
     // Verified against createBaseTools + the free-mode memory surface.
@@ -33,19 +58,24 @@ describe("[COMP:app-web/workflow-tools] tool catalog", () => {
     expect(names).not.toContain("useSkill");
   });
 
-  it("derives one group per official connector that exposes tools, in registry order", () => {
-    const groups = buildToolCatalog();
-    const connectorGroups = groups.filter((g) => g.id !== BUILTIN_GROUP_ID);
-    const expected = OFFICIAL_CONNECTORS.filter(
-      (c) => (OFFICIAL_CONNECTOR_TOOLS[c.id] ?? []).length > 0,
-    ).map((c) => c.id);
-    expect(connectorGroups.map((g) => g.id)).toEqual(expected);
-    // gcs has no tools — it must be skipped.
-    expect(groups.some((g) => g.id === "gcs")).toBe(false);
+  it("shows connected official connectors and omits disconnected ones", () => {
+    const groups = buildToolCatalog([source("gmail")]);
+    expect(groups.some((g) => g.id === "gmail")).toBe(true);
+    expect(groups.some((g) => g.id === "gcal")).toBe(false);
+    expect(groups.some((g) => g.id === "github")).toBe(false);
   });
 
-  it("labels connector groups from the registry and mirrors their tool lists", () => {
-    const groups = buildToolCatalog();
+  it("keeps always-on workspace primitives without connector instances", () => {
+    const groups = buildToolCatalog([]);
+    for (const id of BUILTIN_PRIMITIVE_CONNECTOR_IDS) {
+      if ((OFFICIAL_CONNECTOR_TOOLS[id] ?? []).length > 0) {
+        expect(groups.some((group) => group.id === id)).toBe(true);
+      }
+    }
+  });
+
+  it("labels connected official groups from the registry and mirrors their tool lists", () => {
+    const groups = buildToolCatalog([source("gmail", { label: "Work inbox" })]);
     const gmail = groups.find((g) => g.id === "gmail");
     expect(gmail?.label).toBe("Gmail");
     expect(gmail?.items.map((i) => i.name)).toEqual(
@@ -53,23 +83,55 @@ describe("[COMP:app-web/workflow-tools] tool catalog", () => {
     );
   });
 
-  it("collects every catalog tool name across all groups", () => {
-    const groups = buildToolCatalog();
+  it("adds live-discovered custom connector tools under the instance label", () => {
+    const groups = buildToolCatalog([
+      source("custom-provider", {
+        id: "custom-instance",
+        label: "Acme MCP",
+        items: [
+          {
+            name: "acmeLookup",
+            description: "Look up an Acme record",
+            classification: "read",
+          },
+        ],
+      }),
+    ]);
+    expect(groups.find((group) => group.id === "custom-instance")).toEqual({
+      id: "custom-instance",
+      label: "Acme MCP",
+      items: [
+        {
+          name: "acmeLookup",
+          description: "Look up an Acme record",
+          classification: "read",
+        },
+      ],
+    });
+  });
+
+  it("omits a dynamic connector when discovery returns no tools", () => {
+    const groups = buildToolCatalog([source("custom-provider", { items: [] })]);
+    expect(groups.some((group) => group.id === "instance-custom-provider")).toBe(false);
+  });
+
+  it("collects catalog tool names across built-in, connected, and custom groups", () => {
+    const groups = buildToolCatalog([
+      source("gmail"),
+      source("custom-provider", {
+        items: [{ name: "customRead", description: "Read custom data", classification: "read" }],
+      }),
+    ]);
     const names = catalogToolNames(groups);
     expect(names.has("webSearch")).toBe(true);
     expect(names.has("gmailSendMessage")).toBe(true);
-    expect(names.has("googleCalendarCreateEvent")).toBe(true);
-    // Size = built-in + every non-empty connector's tools.
-    const connectorTotal = OFFICIAL_CONNECTORS.reduce(
-      (n, c) => n + (OFFICIAL_CONNECTOR_TOOLS[c.id] ?? []).length,
-      0,
-    );
-    expect(names.size).toBe(BUILTIN_TOOL_CATALOG.length + connectorTotal);
+    expect(names.has("customRead")).toBe(true);
+    expect(names.has("googleCalendarCreateEvent")).toBe(false);
   });
 });
 
 describe("[COMP:app-web/workflow-tools] filterToolGroups", () => {
-  const groups = buildToolCatalog();
+  const groups = buildToolCatalog([source("gmail")]);
 
   it("returns every group unchanged for an empty query", () => {
     expect(filterToolGroups(groups, "")).toBe(groups);
@@ -112,5 +174,61 @@ describe("[COMP:app-web/workflow-tools] normalizeToolName", () => {
   it("rejects a name past the schema length cap", () => {
     expect(normalizeToolName("a".repeat(MAX_TOOL_NAME_LEN))).not.toBeNull();
     expect(normalizeToolName("a".repeat(MAX_TOOL_NAME_LEN + 1))).toBeNull();
+  });
+});
+
+describe("[COMP:app-web/workflow-tools] connected connector loading", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("loads custom tools and drops disconnected workspace connectors", async () => {
+    mockAuthFetch
+      .mockResolvedValueOnce(json({
+        teamNative: [
+          { id: "gmail-instance", provider: "gmail", label: "Inbox", connected: true },
+          { id: "gcal-instance", provider: "gcal", label: "Calendar", connected: false },
+        ],
+        granted: [{
+          instance: {
+            id: "custom-instance",
+            provider: "11111111-1111-4111-8111-111111111111",
+            label: "Acme MCP",
+            connected: true,
+          },
+        }],
+      }))
+      .mockResolvedValueOnce(json({
+        serverName: "Acme",
+        tools: [{
+          name: "acmeLookup",
+          description: "Look up an Acme record",
+          classification: "read",
+        }],
+      }));
+
+    const sources = await listConnectedWorkflowToolSources("workspace-1");
+
+    expect(sources).toEqual([
+      {
+        id: "gmail-instance",
+        connectorId: "gmail",
+        label: "Inbox",
+      },
+      {
+        id: "custom-instance",
+        connectorId: "11111111-1111-4111-8111-111111111111",
+        label: "Acme MCP",
+        items: [{
+          name: "acmeLookup",
+          description: "Look up an Acme record",
+          classification: "read",
+        }],
+      },
+    ]);
+    expect(mockAuthFetch).toHaveBeenCalledTimes(2);
+    expect(mockAuthFetch).toHaveBeenLastCalledWith(
+      expect.stringContaining("/api/connectors/11111111-1111-4111-8111-111111111111/tools"),
+    );
   });
 });

--- a/apps/app-web/src/lib/api/workflow.ts
+++ b/apps/app-web/src/lib/api/workflow.ts
@@ -25,6 +25,8 @@
 
 import { authFetch } from "@/lib/auth-fetch";
 import { DISPLAY_API_URL } from "@/lib/display-api-url";
+import { OFFICIAL_CONNECTOR_TOOLS } from "@use-brian/shared/builtin-connectors";
+import type { ConnectedToolSource, ToolCatalogItem } from "@/lib/workflow-tools";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
 
@@ -769,6 +771,78 @@ export async function listWorkspaceConnectorOptions(
     label: r.label || r.provider,
     connected: !!r.connected,
   }));
+}
+
+/**
+ * Connected connector tool sources available to this workspace. The workspace
+ * connector route is the same inventory runtime sharing uses: workspace-owned
+ * instances plus connector grants. Official catalogs stay local and static;
+ * only custom/dynamic providers need the existing live tool-discovery route.
+ */
+export async function listConnectedWorkflowToolSources(
+  workspaceId: string,
+): Promise<ConnectedToolSource[]> {
+  const res = await authFetch(
+    `${API_URL}/api/workspaces/${encodeURIComponent(workspaceId)}/connectors`,
+  );
+  if (!res.ok) return [];
+
+  type Instance = {
+    id: string;
+    provider: string;
+    label: string;
+    connected: boolean;
+  };
+  const data = (await res.json()) as {
+    teamNative?: Instance[];
+    granted?: Array<{ instance?: Instance }>;
+  } | null;
+  const instances = [
+    ...(Array.isArray(data?.teamNative) ? data.teamNative : []),
+    ...(Array.isArray(data?.granted)
+      ? data.granted.flatMap((grant) => (grant.instance ? [grant.instance] : []))
+      : []),
+  ];
+  const connected = [...new Map(
+    instances.filter((instance) => instance.connected).map((instance) => [instance.id, instance]),
+  ).values()];
+
+  return Promise.all(
+    connected.map(async (instance): Promise<ConnectedToolSource> => {
+      const staticTools = OFFICIAL_CONNECTOR_TOOLS[instance.provider];
+      if (staticTools?.length) {
+        return {
+          id: instance.id,
+          connectorId: instance.provider,
+          label: instance.label || instance.provider,
+        };
+      }
+
+      // Custom MCP providers are addressed by their generated provider UUID.
+      // CLI catalogs are instance-specific and use the connector-instance id.
+      const discoveryId = instance.provider === "cli" ? instance.id : instance.provider;
+      try {
+        const toolRes = await authFetch(
+          `${API_URL}/api/connectors/${encodeURIComponent(discoveryId)}/tools`,
+        );
+        if (!toolRes.ok) {
+          return { id: instance.id, connectorId: instance.provider, label: instance.label };
+        }
+        const toolData = (await toolRes.json()) as {
+          serverName?: string;
+          tools?: ToolCatalogItem[];
+        };
+        return {
+          id: instance.id,
+          connectorId: instance.provider,
+          label: instance.label || toolData.serverName || instance.provider,
+          items: Array.isArray(toolData.tools) ? toolData.tools : [],
+        };
+      } catch {
+        return { id: instance.id, connectorId: instance.provider, label: instance.label };
+      }
+    }),
+  );
 }
 
 export type WorkspaceChannelOption = {

--- a/apps/app-web/src/lib/workflow-tools.ts
+++ b/apps/app-web/src/lib/workflow-tools.ts
@@ -17,12 +17,12 @@
  *     runtime contract: the allow-list matches by exact name regardless, and
  *     the field's custom-add escape hatch covers any tool not listed here
  *     (custom MCP tools, env-gated base tools like `xSearch`, brain tools).
- *   - **Connectors** — derived at runtime from the shared connector registry
- *     (`OFFICIAL_CONNECTORS` order × `OFFICIAL_CONNECTOR_TOOLS`), never
- *     hardcoded, so adding a connector surfaces it here for free. Imported via
- *     the `@use-brian/shared/builtin-connectors` subpath (not the barrel) to
- *     keep the server-only `env.js` module out of the client bundle — the same
- *     rule `connector-tool-governance.tsx` follows.
+ *   - **Connectors** — connected workspace sources come from the API. Official
+ *     sources use the shared `OFFICIAL_CONNECTOR_TOOLS` registry; custom MCP
+ *     sources carry their live-discovered tools. Always-on workspace
+ *     primitives are included without an instance because connection state is
+ *     meaningless for them. Imported via shared subpaths (not the barrel) to
+ *     keep the server-only `env.js` module out of the client bundle.
  *
  * Spec: docs/architecture/features/workflow.md → "Web builder UI".
  * [COMP:app-web/workflow-tools]
@@ -32,13 +32,27 @@ import {
   OFFICIAL_CONNECTOR_TOOLS,
   type BuiltinToolClassification,
 } from "@use-brian/shared/builtin-connectors";
-import { OFFICIAL_CONNECTORS } from "@use-brian/shared/connector-registry";
+import {
+  BUILTIN_PRIMITIVE_CONNECTOR_IDS,
+  OFFICIAL_CONNECTORS,
+} from "@use-brian/shared/connector-registry";
 
 /** One selectable tool row. `name` is the exact allow-list match key. */
 export type ToolCatalogItem = {
   name: string;
   description: string;
-  classification: BuiltinToolClassification;
+  classification: BuiltinToolClassification | "unknown";
+};
+
+/** One connected workspace connector returned by the workflow API helper. */
+export type ConnectedToolSource = {
+  /** Stable instance id, used for dynamic/custom group identity. */
+  id: string;
+  /** Provider/connector id (`gmail`, or a custom connector UUID). */
+  connectorId: string;
+  label: string;
+  /** Present for live-discovered custom/CLI connectors. */
+  items?: ToolCatalogItem[];
 };
 
 /** A collapsible group of tools — the Built-in group or one connector. */
@@ -71,7 +85,7 @@ export const MAX_TOOL_NAME_LEN = 128;
  * allow-list), `useSkill` (governed by the step's own Skills picker). `xSearch`
  * is env-gated (`XAI_API_KEY`) so it is left to the custom-add escape hatch.
  */
-export const BUILTIN_TOOL_CATALOG: ToolCatalogItem[] = [
+const BUILTIN_TOOL_CATALOG: ToolCatalogItem[] = [
   { name: "webSearch", description: "Search the web for current information", classification: "read" },
   { name: "urlReader", description: "Read the main content of a web page", classification: "read" },
   { name: "getMemory", description: "Look up saved facts in the brain", classification: "read" },
@@ -82,17 +96,22 @@ export const BUILTIN_TOOL_CATALOG: ToolCatalogItem[] = [
 ];
 
 /**
- * Build the full grouped catalog: the Built-in group first, then one group per
- * official connector that exposes at least one tool, in registry order. The
- * connector groups derive from `OFFICIAL_CONNECTORS` (labels) × the
- * `OFFICIAL_CONNECTOR_TOOLS` table — a connector with no tools (`gcs`) is
- * skipped, and a newly registered connector appears automatically.
+ * Build the available grouped catalog: the Built-in group first, then connected
+ * official connectors in registry order, then live-discovered custom/dynamic
+ * connectors. Official always-on workspace primitives do not need an instance.
+ * A source whose dynamic discovery failed carries no items and is omitted.
  */
-export function buildToolCatalog(): ToolGroup[] {
+export function buildToolCatalog(sources: ConnectedToolSource[]): ToolGroup[] {
   const groups: ToolGroup[] = [
     { id: BUILTIN_GROUP_ID, label: "Built-in", items: BUILTIN_TOOL_CATALOG },
   ];
+
+  const connectedIds = new Set(sources.map((source) => source.connectorId));
   for (const connector of OFFICIAL_CONNECTORS) {
+    if (
+      !connectedIds.has(connector.id) &&
+      !BUILTIN_PRIMITIVE_CONNECTOR_IDS.has(connector.id)
+    ) continue;
     const tools = OFFICIAL_CONNECTOR_TOOLS[connector.id] ?? [];
     if (tools.length === 0) continue;
     groups.push({
@@ -104,6 +123,18 @@ export function buildToolCatalog(): ToolGroup[] {
         classification: t.classification,
       })),
     });
+  }
+
+  const officialIds = new Set(OFFICIAL_CONNECTORS.map((connector) => connector.id));
+  for (const source of sources) {
+    // Official connectors with a static catalog were emitted above. Official
+    // dynamic connectors (currently CLI) fall through with their discovered
+    // items, as do custom MCP providers whose id is not in the registry.
+    if (officialIds.has(source.connectorId) && OFFICIAL_CONNECTOR_TOOLS[source.connectorId]) {
+      continue;
+    }
+    if (!source.items?.length) continue;
+    groups.push({ id: source.id, label: source.label, items: source.items });
   }
   return groups;
 }


### PR DESCRIPTION
## Summary

- build the workflow Restrict tools picker from connected workspace-owned and granted connector instances
- live-discover custom MCP and dynamic connector tools while keeping official catalogs registry-backed
- hide disconnected connector groups while preserving stale saved selections for removal
- keep always-on workspace primitives available without connector instances

## Verification

- `pnpm exec vitest run src/lib/__tests__/workflow-tools.test.ts` (15 tests)
- `pnpm typecheck` in `apps/app-web`
- app-web test suite (3,048 tests)

## Paired Pull Requests

- use-brian/brian-kb#62
- use-brian/brian-platform#321