### PR TITLE
fix(workflow): discover workspace CLI tools

### DIFF
--- a/apps/app-web/src/app/w/[workspaceId]/workflow/[id]/page.tsx
+++ b/apps/app-web/src/app/w/[workspaceId]/workflow/[id]/page.tsx
@@ -162,7 +162,7 @@ export default function WorkflowDetailPage({
     let cancelled = false;
     void (async () => {
       try {
-        const sources = await listConnectedWorkflowToolSources(activeId);
+        const sources = await listConnectedWorkflowToolSources(activeId, assistants[0]?.id);
         if (!cancelled) setToolGroups(buildToolCatalog(sources));
       } catch {
         if (!cancelled) setToolGroups(buildToolCatalog([]));
@@ -171,7 +171,7 @@ export default function WorkflowDetailPage({
     return () => {
       cancelled = true;
     };
-  }, [activeId]);
+  }, [activeId, assistants]);
 
   // Load recent chat destinations for the per-step `deliver.channelId` dropdown.
   useEffect(() => {

--- a/apps/app-web/src/lib/__tests__/workflow-tools.test.ts
+++ b/apps/app-web/src/lib/__tests__/workflow-tools.test.ts
@@ -188,6 +188,12 @@ describe("[COMP:app-web/workflow-tools] connected connector loading", () => {
         teamNative: [
           { id: "gmail-instance", provider: "gmail", label: "Inbox", connected: true },
           { id: "gcal-instance", provider: "gcal", label: "Calendar", connected: false },
+          {
+            id: "cli-instance",
+            provider: "cli",
+            label: "Local tools",
+            connected: true,
+          },
         ],
         granted: [{
           instance: {
@@ -199,6 +205,14 @@ describe("[COMP:app-web/workflow-tools] connected connector loading", () => {
         }],
       }))
       .mockResolvedValueOnce(json({
+        serverName: "Local tools",
+        tools: [{
+          name: "localStatus",
+          description: "Read local status",
+          classification: "read",
+        }],
+      }))
+      .mockResolvedValueOnce(json({
         serverName: "Acme",
         tools: [{
           name: "acmeLookup",
@@ -207,13 +221,23 @@ describe("[COMP:app-web/workflow-tools] connected connector loading", () => {
         }],
       }));
 
-    const sources = await listConnectedWorkflowToolSources("workspace-1");
+    const sources = await listConnectedWorkflowToolSources("workspace-1", "assistant-1");
 
     expect(sources).toEqual([
       {
         id: "gmail-instance",
         connectorId: "gmail",
         label: "Inbox",
+      },
+      {
+        id: "cli-instance",
+        connectorId: "cli",
+        label: "Local tools",
+        items: [{
+          name: "localStatus",
+          description: "Read local status",
+          classification: "read",
+        }],
       },
       {
         id: "custom-instance",
@@ -226,8 +250,15 @@ describe("[COMP:app-web/workflow-tools] connected connector loading", () => {
         }],
       },
     ]);
-    expect(mockAuthFetch).toHaveBeenCalledTimes(2);
-    expect(mockAuthFetch).toHaveBeenLastCalledWith(
+    expect(mockAuthFetch).toHaveBeenCalledTimes(3);
+    expect(mockAuthFetch).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining(
+        "/api/assistants/assistant-1/connectors/cli%3Acli-instance/tools",
+      ),
+    );
+    expect(mockAuthFetch).toHaveBeenNthCalledWith(
+      3,
       expect.stringContaining("/api/connectors/11111111-1111-4111-8111-111111111111/tools"),
     );
   });

--- a/apps/app-web/src/lib/__tests__/workflow-tools.test.ts
+++ b/apps/app-web/src/lib/__tests__/workflow-tools.test.ts
@@ -261,5 +261,16 @@ describe("[COMP:app-web/workflow-tools] connected connector loading", () => {
       3,
       expect.stringContaining("/api/connectors/11111111-1111-4111-8111-111111111111/tools"),
     );
+
+    const groups = buildToolCatalog(sources);
+    expect(groups.find((group) => group.id === "cli-instance")).toEqual({
+      id: "cli-instance",
+      label: "Local tools",
+      items: [{
+        name: "localStatus",
+        description: "Read local status",
+        classification: "read",
+      }],
+    });
   });
 });

--- a/apps/app-web/src/lib/api/workflow.ts
+++ b/apps/app-web/src/lib/api/workflow.ts
@@ -781,6 +781,7 @@ export async function listWorkspaceConnectorOptions(
  */
 export async function listConnectedWorkflowToolSources(
   workspaceId: string,
+  assistantId?: string,
 ): Promise<ConnectedToolSource[]> {
   const res = await authFetch(
     `${API_URL}/api/workspaces/${encodeURIComponent(workspaceId)}/connectors`,
@@ -819,12 +820,13 @@ export async function listConnectedWorkflowToolSources(
       }
 
       // Custom MCP providers are addressed by their generated provider UUID.
-      // CLI catalogs are instance-specific and use the connector-instance id.
-      const discoveryId = instance.provider === "cli" ? instance.id : instance.provider;
+      // CLI catalogs need the assistant-scoped route: unlike the personal
+      // connector endpoint, it resolves workspace-owned and granted instances.
+      const discoveryUrl = instance.provider === "cli" && assistantId
+        ? `${API_URL}/api/assistants/${encodeURIComponent(assistantId)}/connectors/${encodeURIComponent(`cli:${instance.id}`)}/tools`
+        : `${API_URL}/api/connectors/${encodeURIComponent(instance.provider === "cli" ? instance.id : instance.provider)}/tools`;
       try {
-        const toolRes = await authFetch(
-          `${API_URL}/api/connectors/${encodeURIComponent(discoveryId)}/tools`,
-        );
+        const toolRes = await authFetch(discoveryUrl);
         if (!toolRes.ok) {
           return { id: instance.id, connectorId: instance.provider, label: instance.label };
         }

--- a/apps/app-web/src/lib/workflow-tools.ts
+++ b/apps/app-web/src/lib/workflow-tools.ts
@@ -130,7 +130,10 @@ export function buildToolCatalog(sources: ConnectedToolSource[]): ToolGroup[] {
     // Official connectors with a static catalog were emitted above. Official
     // dynamic connectors (currently CLI) fall through with their discovered
     // items, as do custom MCP providers whose id is not in the registry.
-    if (officialIds.has(source.connectorId) && OFFICIAL_CONNECTOR_TOOLS[source.connectorId]) {
+    if (
+      officialIds.has(source.connectorId) &&
+      (OFFICIAL_CONNECTOR_TOOLS[source.connectorId]?.length ?? 0) > 0
+    ) {
       continue;
     }
     if (!source.items?.length) continue;


### PR DESCRIPTION
## Summary

- discover CLI connector tools through the assistant-scoped exact-instance route
- resolve workspace-owned and teammate-granted CLI instances instead of using the personal connector lookup
- retain the existing HTTP custom connector discovery path
- add a regression covering connected CLI and HTTP MCP sources together

## Verification

- `pnpm exec vitest run src/lib/__tests__/workflow-tools.test.ts` (15 tests)
- `pnpm typecheck` in `apps/app-web`

## Paired Pull Requests

- use-brian/brian-kb#63
- use-brian/brian-platform#321

This fixes the CLI gap found after use-brian/use-brian#200 merged.