### PR TITLE
fix(workflow): select Telegram delivery channels

### DIFF
--- a/apps/app-web/src/app/w/[workspaceId]/workflow/[id]/page.tsx
+++ b/apps/app-web/src/app/w/[workspaceId]/workflow/[id]/page.tsx
@@ -40,11 +40,13 @@ import {
   deleteWorkflow,
   getWorkflowFull,
   listChannelDestinations,
+  listWorkspaceChannelOptions,
   listWorkspaceSlackChannels,
   runWorkflowNow,
   updateWorkflow,
   type ChannelDestination,
   type SlackChannelOption,
+  type WorkspaceChannelOption,
   type WorkflowFull,
   type WorkflowIssue,
   type WorkflowStep,
@@ -87,6 +89,7 @@ export default function WorkflowDetailPage({
   const [draft, setDraft] = useState<WorkflowFull | null>(null);
   const [assistants, setAssistants] = useState<StudioAssistantSummary[]>([]);
   const [destinations, setDestinations] = useState<ChannelDestination[]>([]);
+  const [channelOptions, setChannelOptions] = useState<WorkspaceChannelOption[]>([]);
   const [slackChannels, setSlackChannels] = useState<SlackChannelOption[]>([]);
   const [pages, setPages] = useState<ViewListRow[]>([]);
   const [blueprints, setBlueprints] = useState<CustomPageTemplateSummary[]>([]);
@@ -150,8 +153,14 @@ export default function WorkflowDetailPage({
     if (!activeId) return;
     let cancelled = false;
     void (async () => {
-      const list = await listChannelDestinations(activeId);
-      if (!cancelled) setDestinations(list);
+      const [destinationList, channelList] = await Promise.all([
+        listChannelDestinations(activeId),
+        listWorkspaceChannelOptions(activeId),
+      ]);
+      if (!cancelled) {
+        setDestinations(destinationList);
+        setChannelOptions(channelList);
+      }
     })();
     return () => {
       cancelled = true;
@@ -854,6 +863,7 @@ export default function WorkflowDetailPage({
                 step={selectedStep}
                 assistants={assistants}
                 destinations={destinations}
+                channelOptions={channelOptions}
                 slackChannels={slackChannels}
                 pages={pages}
                 blueprints={blueprints}

--- a/apps/app-web/src/components/workflow/step-editor.tsx
+++ b/apps/app-web/src/components/workflow/step-editor.tsx
@@ -1491,7 +1491,11 @@ function DeliverField({
   const allRelevant = destinations.filter((d) => d.channelType === channelType);
   const telegramChannels = channelOptions.filter((channel) => channel.channelType === "telegram");
   const relevant = channelType === "telegram" && channelIntegrationId
-    ? allRelevant.filter((d) => d.channelIntegrationId === channelIntegrationId)
+    ? allRelevant.filter(
+        (d) =>
+          d.channelIntegrationId === channelIntegrationId ||
+          d.channelIntegrationId == null,
+      )
     : allRelevant;
   const destinationValue = (d: ChannelDestination) =>
     d.channelIntegrationId
@@ -1510,7 +1514,8 @@ function DeliverField({
   const selectedDestination = relevant.find(
     (d) =>
       d.channelId === channelId &&
-      (d.channelIntegrationId ?? undefined) === channelIntegrationId,
+      ((d.channelIntegrationId ?? undefined) === channelIntegrationId ||
+        (channelType === "telegram" && d.channelIntegrationId == null)),
   ) ?? (
     channelIntegrationId === undefined
       ? allRelevant.filter((d) => d.channelId === channelId).length === 1
@@ -1604,17 +1609,19 @@ function DeliverField({
                 onValueChange={(v) => {
                   if (!v) return;
                   const currentIsKnown = allRelevant.some((d) => d.channelId === channelId);
-                  const nextChannelOwnsDestination = allRelevant.some(
-                    (d) => d.channelId === channelId && d.channelIntegrationId === v,
+                  const nextChannelCanUseDestination = allRelevant.some(
+                    (d) =>
+                      d.channelId === channelId &&
+                      (d.channelIntegrationId === v || d.channelIntegrationId == null),
                   );
-                  if (currentIsKnown && !nextChannelOwnsDestination) setStickyCustom(false);
+                  if (currentIsKnown && !nextChannelCanUseDestination) setStickyCustom(false);
                   onChange({
                     ...step,
                     deliver: {
                       ...step.deliver,
                       channelType,
                       channelId:
-                        currentIsKnown && !nextChannelOwnsDestination ? "" : channelId,
+                        currentIsKnown && !nextChannelCanUseDestination ? "" : channelId,
                       channelIntegrationId: v,
                     },
                   });
@@ -1667,7 +1674,8 @@ function DeliverField({
                     ...step.deliver,
                     channelType,
                     channelId: destination?.channelId ?? v,
-                    channelIntegrationId: destination?.channelIntegrationId ?? undefined,
+                    channelIntegrationId:
+                      destination?.channelIntegrationId ?? channelIntegrationId,
                   },
                 });
               }}

--- a/apps/app-web/src/components/workflow/step-editor.tsx
+++ b/apps/app-web/src/components/workflow/step-editor.tsx
@@ -34,6 +34,7 @@ import { buildBlueprintPickerItems } from "@/lib/blueprints";
 import type {
   ChannelDestination,
   SlackChannelOption,
+  WorkspaceChannelOption,
   DeliverChannelType,
   PageAnchor,
   WorkflowModelAlias,
@@ -98,6 +99,8 @@ type Props = {
    * `deliver.channelId` dropdown so users don't paste raw platform IDs.
    */
   destinations: ChannelDestination[];
+  /** Active workspace channel integrations used to pin Telegram delivery. */
+  channelOptions: WorkspaceChannelOption[];
   /**
    * Workspace Slack channels (by name, from `conversations.list`) — backs the
    * deliver picker when the channel type is Slack, so authors pick `#name`
@@ -140,6 +143,7 @@ export function StepEditor({
   step,
   assistants,
   destinations,
+  channelOptions,
   slackChannels,
   pages,
   blueprints,
@@ -272,10 +276,13 @@ export function StepEditor({
                     value={step.target.assistantId}
                     onValueChange={(v) => {
                       if (v)
-                        onChange({
-                          ...step,
-                          target: { ...step.target, assistantId: v },
-                        });
+                    onChange({
+                      ...step,
+                      target: { ...step.target, assistantId: v },
+                      deliver: step.deliver?.channelIntegrationId
+                        ? { ...step.deliver, channelIntegrationId: undefined }
+                        : step.deliver,
+                    });
                     }}
                     disabled={disabled}
                     // Label-map so the trigger shows the name, not a UUID.
@@ -365,6 +372,7 @@ export function StepEditor({
                   <DeliverField
                     step={step}
                     destinations={destinations}
+                    channelOptions={channelOptions}
                     slackChannels={slackChannels}
                     onChange={onChange}
                     disabled={disabled}
@@ -1438,6 +1446,7 @@ function SkillsField({
 function DeliverField({
   step,
   destinations,
+  channelOptions,
   slackChannels,
   onChange,
   disabled,
@@ -1445,6 +1454,7 @@ function DeliverField({
 }: {
   step: Extract<WorkflowStep, { type: "assistant_call" }>;
   destinations: ChannelDestination[];
+  channelOptions: WorkspaceChannelOption[];
   slackChannels: SlackChannelOption[];
   onChange: (s: WorkflowStep) => void;
   disabled?: boolean;
@@ -1453,6 +1463,7 @@ function DeliverField({
   const b = t.workflowPage.builder;
   const channelType = step.deliver?.channelType ?? "telegram";
   const channelId = step.deliver?.channelId ?? "";
+  const channelIntegrationId = step.deliver?.channelIntegrationId;
 
   // Known destinations for the picked channel type. Slack is sourced live from
   // the workspace's real channels by NAME (`#dev-work`), so authors never see
@@ -1463,15 +1474,38 @@ function DeliverField({
   // the chat/person name, so the label is human-readable with the raw id as
   // hint. 'web' has no destination surface — the custom-ID input takes over.
   const isSlack = channelType === "slack";
-  const relevant = destinations.filter((d) => d.channelType === channelType);
+  const allRelevant = destinations.filter((d) => d.channelType === channelType);
+  const telegramChannels = channelOptions.filter((channel) => channel.channelType === "telegram");
+  const relevant = channelType === "telegram" && channelIntegrationId
+    ? allRelevant.filter((d) => d.channelIntegrationId === channelIntegrationId)
+    : allRelevant;
+  const destinationValue = (d: ChannelDestination) =>
+    d.channelIntegrationId
+      ? `${d.channelId}::integration::${d.channelIntegrationId}`
+      : d.channelId;
+  const destinationByValue = new Map(relevant.map((d) => [destinationValue(d), d]));
   const known: SearchableSelectItem[] = isSlack
     ? slackChannels.map((c) => ({ value: c.id, label: `#${c.name}`, hint: c.id }))
     : relevant.map((d) => ({
-        value: d.channelId,
-        label: d.title || d.channelId,
+        value: destinationValue(d),
+        label: d.integrationLabel
+          ? `${d.title || d.channelId} (${d.integrationLabel})`
+          : d.title || d.channelId,
         hint: d.title ? d.channelId : undefined,
       }));
-  const matchesKnown = known.some((k) => k.value === channelId);
+  const selectedDestination = relevant.find(
+    (d) =>
+      d.channelId === channelId &&
+      (d.channelIntegrationId ?? undefined) === channelIntegrationId,
+  ) ?? (
+    channelIntegrationId === undefined
+      ? allRelevant.filter((d) => d.channelId === channelId).length === 1
+        ? allRelevant.find((d) => d.channelId === channelId)
+        : undefined
+      : undefined
+  );
+  const knownValue = isSlack ? channelId : selectedDestination ? destinationValue(selectedDestination) : "";
+  const matchesKnown = known.some((k) => k.value === knownValue);
 
   // Custom-mode is sticky once toggled (so the input stays visible while
   // empty) — derived from data otherwise.
@@ -1487,7 +1521,7 @@ function DeliverField({
   ];
 
   const selectValue = matchesKnown
-    ? channelId
+    ? knownValue
     : showCustom
       ? CUSTOM_DESTINATION_VALUE
       : "";
@@ -1545,6 +1579,51 @@ function DeliverField({
             </SelectContent>
           </Select>
 
+          {channelType === "telegram" && telegramChannels.length > 0 && (
+            <div className="flex flex-col gap-1.5">
+              <FieldLabel
+                label={b.deliverTelegramChannelLabel}
+                hint={b.deliverTelegramChannelHint}
+              />
+              <Select
+                value={channelIntegrationId ?? ""}
+                onValueChange={(v) => {
+                  if (!v) return;
+                  const currentIsKnown = allRelevant.some((d) => d.channelId === channelId);
+                  const nextChannelOwnsDestination = allRelevant.some(
+                    (d) => d.channelId === channelId && d.channelIntegrationId === v,
+                  );
+                  if (currentIsKnown && !nextChannelOwnsDestination) setStickyCustom(false);
+                  onChange({
+                    ...step,
+                    deliver: {
+                      ...step.deliver,
+                      channelType,
+                      channelId:
+                        currentIsKnown && !nextChannelOwnsDestination ? "" : channelId,
+                      channelIntegrationId: v,
+                    },
+                  });
+                }}
+                disabled={disabled}
+                items={Object.fromEntries(
+                  telegramChannels.map((channel) => [channel.id, channel.displayName]),
+                )}
+              >
+                <SelectTrigger size="sm" className="w-full">
+                  <SelectValue placeholder={b.deliverTelegramChannelPlaceholder} />
+                </SelectTrigger>
+                <SelectContent>
+                  {telegramChannels.map((channel) => (
+                    <SelectItem key={channel.id} value={channel.id}>
+                      {channel.displayName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
           <div className="flex flex-col gap-1.5">
             <FieldLabel label={b.deliverDestinationLabel} />
             <SearchableSelect
@@ -1558,14 +1637,24 @@ function DeliverField({
                     // intact across a same-platform destination edit — the
                     // type-change path above deliberately resets it (a thread
                     // parent can't live on another platform).
-                    deliver: { ...step.deliver, channelType, channelId: "" },
+                    deliver: {
+                      ...step.deliver,
+                      channelType,
+                      channelId: "",
+                    },
                   });
                   return;
                 }
                 setStickyCustom(false);
+                const destination = destinationByValue.get(v);
                 onChange({
                   ...step,
-                  deliver: { ...step.deliver, channelType, channelId: v },
+                  deliver: {
+                    ...step.deliver,
+                    channelType,
+                    channelId: destination?.channelId ?? v,
+                    channelIntegrationId: destination?.channelIntegrationId ?? undefined,
+                  },
                 });
               }}
               items={items}
@@ -1603,7 +1692,11 @@ function DeliverField({
                   onChange({
                     ...step,
                     // Same thread-preserving spread as the picker above.
-                    deliver: { ...step.deliver, channelType, channelId: e.target.value },
+                    deliver: {
+                      ...step.deliver,
+                      channelType,
+                      channelId: e.target.value,
+                    },
                   })
                 }
                 disabled={disabled}

--- a/apps/app-web/src/lib/api/workflow.ts
+++ b/apps/app-web/src/lib/api/workflow.ts
@@ -189,7 +189,11 @@ export type AssistantCallStep = {
    */
   blueprintId?: string;
   /** When set, the step's text output is pushed to this channel after the consult. */
-  deliver?: { channelType: DeliverChannelType; channelId: string };
+  deliver?: {
+    channelType: DeliverChannelType;
+    channelId: string;
+    channelIntegrationId?: string;
+  };
   /** `persistent` reuses one callee session across runs; `per_run` (default) is fresh. */
   session?: "per_run" | "persistent";
   /** Per-step model alias. Backfilled from workflow-level on read for legacy rows. */
@@ -840,6 +844,8 @@ export async function listWorkspaceMemberOptions(
 export type ChannelDestination = {
   channelType: "telegram" | "slack" | "whatsapp";
   channelId: string;
+  channelIntegrationId?: string | null;
+  integrationLabel?: string | null;
   title: string | null;
   lastActiveAt: string;
 };
@@ -891,16 +897,26 @@ export async function listWorkspaceChannelOptions(
     displayName: string;
     status: "active" | "revoked" | "invalid";
     integrationId: string | null;
+    integrationStatus: "active" | "revoked" | "invalid" | null;
+    integrationLabel: string | null;
   };
   const data = (await res.json()) as { channels?: Row[] } | null;
   const rows = Array.isArray(data?.channels) ? data!.channels : [];
   // The event dispatcher routes through `channel_integrations.id`, so a
   // channel without an attached integration row is unselectable.
   return rows
-    .filter((r) => r.status === "active" && r.integrationId)
+    .filter(
+      (r) =>
+        r.status === "active" &&
+        r.integrationStatus === "active" &&
+        r.integrationId,
+    )
     .map((r) => ({
       id: r.integrationId!,
       channelType: r.channelType,
-      displayName: r.displayName,
+      displayName:
+        r.channelType === "telegram" && r.integrationLabel
+          ? `${r.displayName} (${r.integrationLabel})`
+          : r.displayName,
     }));
 }

--- a/apps/app-web/src/lib/i18n/dictionaries/en.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/en.ts
@@ -3186,6 +3186,9 @@ export const en = {
       deliverDestinationCustomOption: "Use a custom ID…",
       deliverDestinationCustomLabel: "Channel, chat, or topic ID",
       deliverDestinationCustomHint: "Paste a Telegram chat ID or topic destination (<chat-id>:topic:<topic-id>), or a Slack channel ID.",
+      deliverTelegramChannelLabel: "Telegram channel",
+      deliverTelegramChannelPlaceholder: "Choose a Telegram channel…",
+      deliverTelegramChannelHint: "Select the connected bot that will send this workflow's messages.",
       // ── Manual trigger UI ────────────────────────────────────────────
       manualEndpointLabel: "Run endpoint",
       manualEndpointHint:

--- a/apps/app-web/src/lib/i18n/dictionaries/ja.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/ja.ts
@@ -2936,6 +2936,9 @@ export const ja: Dictionary = {
       deliverChannelIdPlaceholder: "チャンネルまたはチャットID",
       deliverHint:
         "このステップが完了すると、テキスト出力がこのチャンネルに送信されます。配信はベストエフォートで、送信に失敗してもステップは失敗しません。",
+      deliverTelegramChannelLabel: "Telegramチャンネル",
+      deliverTelegramChannelPlaceholder: "Telegramチャンネルを選択…",
+      deliverTelegramChannelHint: "このワークフローのメッセージ送信に使う接続済みBotを選択します。",
       storeOutputAsLabel: "出力を変数として保存（任意）",
       storeOutputAsHint: "後続のステップで {{vars.NAME}} として参照できます。",
       removeStepBtn: "削除",

--- a/apps/app-web/src/lib/i18n/dictionaries/zh.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh.ts
@@ -2912,6 +2912,9 @@ export const zh: Dictionary = {
       deliverChannelIdPlaceholder: "管道或聊天 ID",
       deliverHint:
         "此步驟完成後，會將其文字輸出推送至這個管道。傳送採盡力而為；即使傳送失敗也不會導致步驟失敗。",
+      deliverTelegramChannelLabel: "Telegram 管道",
+      deliverTelegramChannelPlaceholder: "選擇 Telegram 管道…",
+      deliverTelegramChannelHint: "選擇用來傳送此工作流程訊息的已連接機器人。",
       storeOutputAsLabel: "將輸出儲存為（選填）",
       storeOutputAsHint: "後續步驟可透過 {{vars.NAME}} 參照此值。",
       removeStepBtn: "移除",

--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -2356,6 +2356,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
   const consultTransport = createInProcessTransport({
     runConsult: async ({ request }) => {
       const text = await calleeExecutor({
+        workspaceId: request.target.workspaceId,
         callerAssistantId: request.caller.assistantId,
         calleeAssistantId: request.target.assistantId,
         question: request.message.parts

--- a/packages/api/src/db/__tests__/channel-integrations.integration.test.ts
+++ b/packages/api/src/db/__tests__/channel-integrations.integration.test.ts
@@ -234,12 +234,14 @@ describeIf('[COMP:api/channel-integrations-store] getByChannelForWebhook', () =>
     })
 
     const defaultAssistant = await seeded.store.getCredentialsForAssistantIntegrationSystem(
+      seeded.workspaceId,
       seeded.assistantId,
       seeded.integrationId,
       'telegram',
       '-100555:topic:42',
     )
     const surfaceAssistant = await seeded.store.getCredentialsForAssistantIntegrationSystem(
+      seeded.workspaceId,
       surfaceAssistantId,
       seeded.integrationId,
       'telegram',
@@ -259,6 +261,7 @@ describeIf('[COMP:api/channel-integrations-store] getByChannelForWebhook', () =>
     })
 
     const found = await seeded.store.getCredentialsForAssistantIntegrationSystem(
+      seeded.workspaceId,
       seeded.assistantId,
       seeded.integrationId,
       'telegram',
@@ -266,5 +269,56 @@ describeIf('[COMP:api/channel-integrations-store] getByChannelForWebhook', () =>
     )
 
     expect(found?.id).toBe(seeded.integrationId)
+  })
+
+  it('diagnoses when the destination routes to a different assistant', async () => {
+    const seeded = await seedChannelWithIntegration({ channelType: 'telegram' })
+    const client = await pool!.connect()
+    let otherAssistantId: string
+    try {
+      otherAssistantId = await makeAssistant(client, seeded.ownerId, seeded.workspaceId)
+    } finally {
+      client.release()
+    }
+
+    const diagnostic = await seeded.store.diagnoseAssistantIntegrationRoutingSystem(
+      seeded.workspaceId,
+      otherAssistantId,
+      seeded.integrationId,
+      'telegram',
+      '-100555:topic:42',
+    )
+
+    expect(diagnostic).toMatchObject({
+      status: 'assistant_mismatch',
+      requestedAssistantName: 'ci-test-assistant',
+      routedAssistantName: 'ci-test-assistant',
+    })
+  })
+
+  it('hides a valid assistant/integration pair from a foreign workspace', async () => {
+    const seeded = await seedChannelWithIntegration({ channelType: 'telegram' })
+    const foreignWorkspaceId = randomUUID()
+
+    const credentials = await seeded.store.getCredentialsForAssistantIntegrationSystem(
+      foreignWorkspaceId,
+      seeded.assistantId,
+      seeded.integrationId,
+      'telegram',
+      '-100555',
+    )
+    const diagnostic = await seeded.store.diagnoseAssistantIntegrationRoutingSystem(
+      foreignWorkspaceId,
+      seeded.assistantId,
+      seeded.integrationId,
+      'telegram',
+      '-100555',
+    )
+
+    expect(credentials).toBeNull()
+    expect(diagnostic).toEqual({
+      status: 'integration_unavailable',
+      channelLabel: null,
+    })
   })
 })

--- a/packages/api/src/db/__tests__/channel-integrations.integration.test.ts
+++ b/packages/api/src/db/__tests__/channel-integrations.integration.test.ts
@@ -110,6 +110,8 @@ describeIf('[COMP:api/channel-integrations-store] getByChannelForWebhook', () =>
     channelType: 'telegram' | 'slack'
     status?: 'active' | 'revoked'
   }): Promise<{
+    ownerId: string
+    workspaceId: string
     channelId: string
     assistantId: string
     integrationId: string
@@ -169,7 +171,7 @@ describeIf('[COMP:api/channel-integrations-store] getByChannelForWebhook', () =>
       }
     }
 
-    return { channelId, assistantId, integrationId: integration.id, key, store }
+    return { ownerId, workspaceId, channelId, assistantId, integrationId: integration.id, key, store }
   }
 
   it('resolves an active integration by channel_id and decrypts credentials', async () => {
@@ -214,5 +216,37 @@ describeIf('[COMP:api/channel-integrations-store] getByChannelForWebhook', () =>
     })
     const found = await store.getByChannelForWebhook(channelId, 'telegram')
     expect(found).toBeNull()
+  })
+
+  it('uses exact-surface routing precedence over the channel default', async () => {
+    const seeded = await seedChannelWithIntegration({ channelType: 'telegram' })
+    const client = await pool!.connect()
+    let surfaceAssistantId: string
+    try {
+      surfaceAssistantId = await makeAssistant(client, seeded.ownerId, seeded.workspaceId)
+    } finally {
+      client.release()
+    }
+    await channelsStore.attachAssistant(seeded.ownerId, {
+      channelId: seeded.channelId,
+      assistantId: surfaceAssistantId,
+      externalSurfaceId: '-100555:topic:42',
+    })
+
+    const defaultAssistant = await seeded.store.getCredentialsForAssistantIntegrationSystem(
+      seeded.assistantId,
+      seeded.integrationId,
+      'telegram',
+      '-100555:topic:42',
+    )
+    const surfaceAssistant = await seeded.store.getCredentialsForAssistantIntegrationSystem(
+      surfaceAssistantId,
+      seeded.integrationId,
+      'telegram',
+      '-100555:topic:42',
+    )
+
+    expect(defaultAssistant).toBeNull()
+    expect(surfaceAssistant?.id).toBe(seeded.integrationId)
   })
 })

--- a/packages/api/src/db/__tests__/channel-integrations.integration.test.ts
+++ b/packages/api/src/db/__tests__/channel-integrations.integration.test.ts
@@ -249,4 +249,22 @@ describeIf('[COMP:api/channel-integrations-store] getByChannelForWebhook', () =>
     expect(defaultAssistant).toBeNull()
     expect(surfaceAssistant?.id).toBe(seeded.integrationId)
   })
+
+  it('lets a base-chat route authorize delivery to one of its topics', async () => {
+    const seeded = await seedChannelWithIntegration({ channelType: 'telegram' })
+    await channelsStore.attachAssistant(seeded.ownerId, {
+      channelId: seeded.channelId,
+      assistantId: seeded.assistantId,
+      externalSurfaceId: '-100555',
+    })
+
+    const found = await seeded.store.getCredentialsForAssistantIntegrationSystem(
+      seeded.assistantId,
+      seeded.integrationId,
+      'telegram',
+      '-100555:topic:42',
+    )
+
+    expect(found?.id).toBe(seeded.integrationId)
+  })
 })

--- a/packages/api/src/db/__tests__/channels-store.test.ts
+++ b/packages/api/src/db/__tests__/channels-store.test.ts
@@ -8,7 +8,11 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { pickAssistantForSurface, type ChannelAssistant } from '../channels-store.js'
+import {
+  pickAssistantForSurface,
+  pickTelegramRoutingForSurface,
+  type ChannelAssistant,
+} from '../channels-store.js'
 
 function row(assistantId: string, externalSurfaceId: string | null): ChannelAssistant {
   return {
@@ -51,5 +55,21 @@ describe('[COMP:channels/store] pickAssistantForSurface', () => {
   it('routes a mapped surface even when the channel has no default', () => {
     const rows = [row('asst-eng', 'C-ENG'), row('asst-sales', 'C-SALES')]
     expect(pickAssistantForSurface(rows, 'C-SALES')).toBe('asst-sales')
+  })
+
+  it('inherits a Telegram topic from its base-chat route', () => {
+    const rows = [row('asst-default', null), row('asst-forum', '-100555')]
+    expect(pickTelegramRoutingForSurface(rows, '-100555:topic:42')?.assistantId)
+      .toBe('asst-forum')
+  })
+
+  it('prefers an exact Telegram topic route over base-chat and default routes', () => {
+    const rows = [
+      row('asst-default', null),
+      row('asst-forum', '-100555'),
+      row('asst-topic', '-100555:topic:42'),
+    ]
+    expect(pickTelegramRoutingForSurface(rows, '-100555:topic:42')?.assistantId)
+      .toBe('asst-topic')
   })
 })

--- a/packages/api/src/db/channel-integrations.ts
+++ b/packages/api/src/db/channel-integrations.ts
@@ -23,6 +23,7 @@ import {
   encryptCredentials as _encryptCredentials,
   decryptCredentials as _decryptCredentials,
 } from './credential-crypto.js'
+import { parseTopicChannelId } from '@use-brian/channels'
 import { query, queryWithRLS } from './client.js'
 
 // ── Types ──────────────────────────────────────────────────────
@@ -626,6 +627,10 @@ export function createDbChannelIntegrationStore(key: Buffer): ChannelIntegration
       channelType,
       externalSurfaceId,
     ) {
+      const parsedSurface = parseTopicChannelId(externalSurfaceId)
+      const parentSurfaceId = parsedSurface.messageThreadId == null
+        ? externalSurfaceId
+        : parsedSurface.chatId
       const result = await query<CiRow & { credentials: Buffer }>(
         `SELECT ${CI_PUBLIC_COLS}, credentials
          FROM channel_integrations
@@ -642,13 +647,21 @@ export function createDbChannelIntegrationStore(key: Buffer): ChannelIntegration
                SELECT winning.id
                FROM channel_assistants winning
                WHERE winning.channel_id = ci.channel_id
-                 AND (winning.external_surface_id IS NULL OR winning.external_surface_id = $4)
-               ORDER BY (winning.external_surface_id IS NOT NULL) DESC
+                 AND (
+                   winning.external_surface_id IS NULL
+                   OR winning.external_surface_id = $4
+                   OR winning.external_surface_id = $5
+                 )
+               ORDER BY CASE
+                 WHEN winning.external_surface_id = $4 THEN 0
+                 WHEN winning.external_surface_id = $5 THEN 1
+                 ELSE 2
+               END
                LIMIT 1
              )
            LIMIT 1
          )`,
-        [assistantId, integrationId, channelType, externalSurfaceId],
+        [assistantId, integrationId, channelType, externalSurfaceId, parentSurfaceId],
       )
       if (result.rows.length === 0) return null
       const row = result.rows[0]

--- a/packages/api/src/db/channel-integrations.ts
+++ b/packages/api/src/db/channel-integrations.ts
@@ -272,6 +272,22 @@ export type ChannelIntegrationWithCredentials = ChannelIntegration & {
   credentials: ChannelCredentials
 }
 
+export type AssistantIntegrationRoutingDiagnostic =
+  | { status: 'available'; channelLabel: string }
+  | { status: 'integration_unavailable'; channelLabel: string | null }
+  | { status: 'assistant_unavailable'; channelLabel: string }
+  | {
+      status: 'destination_unassigned'
+      channelLabel: string
+      requestedAssistantName: string
+    }
+  | {
+      status: 'assistant_mismatch'
+      channelLabel: string
+      requestedAssistantName: string
+      routedAssistantName: string
+    }
+
 // ── Crypto ─────────────────────────────────────────────────────
 
 
@@ -365,11 +381,21 @@ export type ChannelIntegrationStore = {
 
   /** Resolve one exact integration, proving its routing covers this assistant + surface. */
   getCredentialsForAssistantIntegrationSystem(
+    workspaceId: string,
     assistantId: string,
     integrationId: string,
     channelType: string,
     externalSurfaceId: string,
   ): Promise<ChannelIntegrationWithCredentials | null>
+
+  /** Explain why an exact assistant/integration/surface credential lookup missed. */
+  diagnoseAssistantIntegrationRoutingSystem(
+    workspaceId: string,
+    assistantId: string,
+    integrationId: string,
+    channelType: string,
+    externalSurfaceId: string,
+  ): Promise<AssistantIntegrationRoutingDiagnostic>
 
   /**
    * Lookup by bot username. Used by the Mini App verify route to resolve
@@ -622,6 +648,7 @@ export function createDbChannelIntegrationStore(key: Buffer): ChannelIntegration
     },
 
     async getCredentialsForAssistantIntegrationSystem(
+      workspaceId,
       assistantId,
       integrationId,
       channelType,
@@ -643,6 +670,7 @@ export function createDbChannelIntegrationStore(key: Buffer): ChannelIntegration
              AND ci.channel_type = $3
              AND ci.status = 'active'
              AND c.status = 'active'
+             AND c.workspace_id = $6
              AND ca.id = (
                SELECT winning.id
                FROM channel_assistants winning
@@ -661,7 +689,7 @@ export function createDbChannelIntegrationStore(key: Buffer): ChannelIntegration
              )
            LIMIT 1
          )`,
-        [assistantId, integrationId, channelType, externalSurfaceId, parentSurfaceId],
+        [assistantId, integrationId, channelType, externalSurfaceId, parentSurfaceId, workspaceId],
       )
       if (result.rows.length === 0) return null
       const row = result.rows[0]
@@ -682,6 +710,108 @@ export function createDbChannelIntegrationStore(key: Buffer): ChannelIntegration
         connectorInstanceId: row.connectorInstanceId,
         credentials,
       }
+    },
+
+    async diagnoseAssistantIntegrationRoutingSystem(
+      workspaceId,
+      assistantId,
+      integrationId,
+      channelType,
+      externalSurfaceId,
+    ) {
+      const parsedSurface = parseTopicChannelId(externalSurfaceId)
+      const parentSurfaceId = parsedSurface.messageThreadId == null
+        ? externalSurfaceId
+        : parsedSurface.chatId
+      const result = await query<{
+        integrationStatus: string
+        channelStatus: string
+        channelLabel: string
+        requestedAssistantName: string | null
+        routedAssistantId: string | null
+        routedAssistantName: string | null
+      }>(
+        `WITH selected AS (
+           SELECT
+             ci.channel_id,
+             ci.status AS integration_status,
+             c.status AS channel_status,
+             COALESCE(
+               '@' || NULLIF(ci.bot_username, ''),
+               NULLIF(c.display_name, ''),
+               NULLIF(ci.team_name, ''),
+               'Telegram channel'
+             ) AS channel_label
+           FROM channel_integrations ci
+           JOIN channels c ON c.id = ci.channel_id
+           WHERE ci.id = $2
+             AND ci.channel_type = $3
+             AND c.workspace_id = $6
+           LIMIT 1
+         ), winner AS (
+           SELECT candidate.assistant_id
+           FROM selected s
+           JOIN LATERAL (
+             SELECT ca.assistant_id
+             FROM channel_assistants ca
+             WHERE ca.channel_id = s.channel_id
+               AND (
+                 ca.external_surface_id IS NULL
+                 OR ca.external_surface_id = $4
+                 OR ca.external_surface_id = $5
+               )
+             ORDER BY CASE
+               WHEN ca.external_surface_id = $4 THEN 0
+               WHEN ca.external_surface_id = $5 THEN 1
+               ELSE 2
+             END
+             LIMIT 1
+           ) candidate ON true
+         )
+         SELECT
+           s.integration_status AS "integrationStatus",
+           s.channel_status AS "channelStatus",
+           s.channel_label AS "channelLabel",
+           requested.name AS "requestedAssistantName",
+           winner.assistant_id AS "routedAssistantId",
+           routed.name AS "routedAssistantName"
+         FROM selected s
+         LEFT JOIN winner ON true
+         LEFT JOIN assistants requested
+           ON requested.id = $1 AND requested.workspace_id = $6
+         LEFT JOIN assistants routed ON routed.id = winner.assistant_id`,
+        [assistantId, integrationId, channelType, externalSurfaceId, parentSurfaceId, workspaceId],
+      )
+      const row = result.rows[0]
+      if (!row || row.integrationStatus !== 'active' || row.channelStatus !== 'active') {
+        return {
+          status: 'integration_unavailable',
+          channelLabel: row?.channelLabel ?? null,
+        }
+      }
+      if (!row.requestedAssistantName) {
+        return {
+          status: 'assistant_unavailable',
+          channelLabel: row.channelLabel,
+        }
+      }
+      const requestedAssistantName = row.requestedAssistantName
+      if (!row.routedAssistantId) {
+        return {
+          status: 'destination_unassigned',
+          channelLabel: row.channelLabel,
+          requestedAssistantName,
+        }
+      }
+      if (row.routedAssistantId !== assistantId) {
+        return {
+          status: 'assistant_mismatch',
+          channelLabel: row.channelLabel,
+          requestedAssistantName,
+          routedAssistantName: row.routedAssistantName ?? row.routedAssistantId,
+        }
+      }
+      return { status: 'available', channelLabel: row.channelLabel }
     },
 
     async getByBotUsernameSystem(botUsername, channelType) {

--- a/packages/api/src/db/channel-integrations.ts
+++ b/packages/api/src/db/channel-integrations.ts
@@ -362,6 +362,14 @@ export type ChannelIntegrationStore = {
     channelType: string,
   ): Promise<ChannelIntegrationWithCredentials | null>
 
+  /** Resolve one exact integration, proving its routing covers this assistant + surface. */
+  getCredentialsForAssistantIntegrationSystem(
+    assistantId: string,
+    integrationId: string,
+    channelType: string,
+    externalSurfaceId: string,
+  ): Promise<ChannelIntegrationWithCredentials | null>
+
   /**
    * Lookup by bot username. Used by the Mini App verify route to resolve
    * which BYO bot's token should verify an `initData` HMAC when the
@@ -590,6 +598,57 @@ export function createDbChannelIntegrationStore(key: Buffer): ChannelIntegration
            LIMIT 1
          )`,
         [assistantId, channelType],
+      )
+      if (result.rows.length === 0) return null
+      const row = result.rows[0]
+      const credentials = decryptCredentials(row.credentials, key)
+      return {
+        id: row.id,
+        channelId: row.channelId,
+        channelType: row.channelType,
+        teamId: row.teamId,
+        teamName: row.teamName,
+        botUserId: row.botUserId,
+        botUsername: row.botUsername,
+        config: row.config ?? {},
+        status: row.status,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        lastEventAt: row.lastEventAt,
+        connectorInstanceId: row.connectorInstanceId,
+        credentials,
+      }
+    },
+
+    async getCredentialsForAssistantIntegrationSystem(
+      assistantId,
+      integrationId,
+      channelType,
+      externalSurfaceId,
+    ) {
+      const result = await query<CiRow & { credentials: Buffer }>(
+        `SELECT ${CI_PUBLIC_COLS}, credentials
+         FROM channel_integrations
+         WHERE id = (
+           SELECT ci.id FROM channel_integrations ci
+           JOIN channels c ON c.id = ci.channel_id
+           JOIN channel_assistants ca ON ca.channel_id = ci.channel_id
+           WHERE ca.assistant_id = $1
+             AND ci.id = $2
+             AND ci.channel_type = $3
+             AND ci.status = 'active'
+             AND c.status = 'active'
+             AND ca.id = (
+               SELECT winning.id
+               FROM channel_assistants winning
+               WHERE winning.channel_id = ci.channel_id
+                 AND (winning.external_surface_id IS NULL OR winning.external_surface_id = $4)
+               ORDER BY (winning.external_surface_id IS NOT NULL) DESC
+               LIMIT 1
+             )
+           LIMIT 1
+         )`,
+        [assistantId, integrationId, channelType, externalSurfaceId],
       )
       if (result.rows.length === 0) return null
       const row = result.rows[0]

--- a/packages/api/src/db/channels-store.ts
+++ b/packages/api/src/db/channels-store.ts
@@ -31,6 +31,7 @@
  */
 
 import type { PoolClient } from 'pg'
+import { parseTopicChannelId } from '@use-brian/channels'
 import { getPool, query, queryWithRLS } from './client.js'
 
 // ── Types ──────────────────────────────────────────────────────
@@ -154,10 +155,9 @@ export async function getChannelForWebhook(channelId: string): Promise<Channel |
 /**
  * Resolve which routing row answers on a given external surface.
  *
- * Surface-specific routing wins; the `external_surface_id IS NULL` row is
- * the channel's catch-all default. Returns null when neither a matching
- * surface row nor a default exists — i.e. the channel has no chat routing
- * (a broadcast-only channel, or one not yet configured).
+ * Surface-specific routing wins; the `external_surface_id IS NULL` row is the
+ * catch-all default. Returns null when no candidate exists — i.e. the channel
+ * has no chat routing (a broadcast-only channel, or one not yet configured).
  *
  * Pure so the routing rule can be unit-tested without a database. The
  * `pickAssistantForSurface` shim below preserves the older "just the
@@ -170,6 +170,23 @@ export function pickRoutingForSurface(
   if (externalSurfaceId !== null) {
     const surfaceMatch = rows.find((r) => r.externalSurfaceId === externalSurfaceId)
     if (surfaceMatch) return surfaceMatch
+  }
+  return rows.find((r) => r.externalSurfaceId === null) ?? null
+}
+
+/** Telegram routing adds forum inheritance: exact topic → base chat → default. */
+export function pickTelegramRoutingForSurface(
+  rows: ChannelAssistant[],
+  externalSurfaceId: string | null,
+): ChannelAssistant | null {
+  if (externalSurfaceId !== null) {
+    const surfaceMatch = rows.find((r) => r.externalSurfaceId === externalSurfaceId)
+    if (surfaceMatch) return surfaceMatch
+    const parsed = parseTopicChannelId(externalSurfaceId)
+    if (parsed.messageThreadId != null) {
+      const baseChatMatch = rows.find((r) => r.externalSurfaceId === parsed.chatId)
+      if (baseChatMatch) return baseChatMatch
+    }
   }
   return rows.find((r) => r.externalSurfaceId === null) ?? null
 }
@@ -224,6 +241,34 @@ export async function resolveRoutingForSurface(
     [channelId],
   )
   return pickRoutingForSurface(result.rows, externalSurfaceId)
+}
+
+export async function resolveTelegramRoutingForSurface(
+  channelId: string,
+  externalSurfaceId: string | null,
+): Promise<ChannelAssistant | null> {
+  const result = await query<ChannelAssistant>(
+    `SELECT ${CHANNEL_ASSISTANT_COLS} FROM channel_assistants WHERE channel_id = $1`,
+    [channelId],
+  )
+  return pickTelegramRoutingForSurface(result.rows, externalSurfaceId)
+}
+
+/**
+ * Bootstrap a channel webhook that has surface routes but no catch-all.
+ * Message handling must still resolve the actual external surface before use.
+ */
+export async function resolveAnyRoutingForChannel(
+  channelId: string,
+): Promise<ChannelAssistant | null> {
+  const result = await query<ChannelAssistant>(
+    `SELECT ${CHANNEL_ASSISTANT_COLS} FROM channel_assistants
+     WHERE channel_id = $1
+     ORDER BY external_surface_id NULLS FIRST, created_at ASC
+     LIMIT 1`,
+    [channelId],
+  )
+  return result.rows[0] ?? null
 }
 
 export async function resolveAssistantForSurface(

--- a/packages/api/src/inter-assistant/executor.ts
+++ b/packages/api/src/inter-assistant/executor.ts
@@ -230,6 +230,8 @@ export type CalleeExecutorOptions = {
 }
 
 export type CalleeQueryParams = {
+  /** Originating workflow workspace; authoritative for delivery integration scope. */
+  workspaceId?: string
   callerAssistantId: string
   calleeAssistantId: string
   question: string
@@ -1666,6 +1668,7 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
           if (params.deliverTarget) {
             await sendConfirmationPrompt(
               {
+                workspaceId: params.workspaceId,
                 assistantId: params.calleeAssistantId,
                 channelType: params.deliverTarget.channelType,
                 channelId: params.deliverTarget.channelId,

--- a/packages/api/src/inter-assistant/executor.ts
+++ b/packages/api/src/inter-assistant/executor.ts
@@ -287,7 +287,11 @@ export type CalleeQueryParams = {
    * to this channel and waits in-process (5-min timeout). Absent → ordinary
    * A2A; confirmations are stripped (the approval was already granted).
    */
-  deliverTarget?: { channelType: 'web' | 'telegram' | 'slack' | 'whatsapp' | 'msteams'; channelId: string }
+  deliverTarget?: {
+    channelType: 'web' | 'telegram' | 'slack' | 'whatsapp' | 'msteams'
+    channelId: string
+    channelIntegrationId?: string
+  }
   /**
    * Page anchor — a concrete `saved_views` id resolved by the workflow
    * executor from the step's `page` binding. When set, the callee runs
@@ -1665,6 +1669,7 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
                 assistantId: params.calleeAssistantId,
                 channelType: params.deliverTarget.channelType,
                 channelId: params.deliverTarget.channelId,
+                channelIntegrationId: params.deliverTarget.channelIntegrationId,
               },
               req,
               {

--- a/packages/api/src/routes/__tests__/channels.test.ts
+++ b/packages/api/src/routes/__tests__/channels.test.ts
@@ -286,6 +286,7 @@ describe('[COMP:api/channels-route] channel config', () => {
     )
     expect(res.status).toBe(200)
     expect(res.body.channels[0].integrationId).toBe('int-1')
+    expect(res.body.channels[0].integrationStatus).toBe('active')
     expect(res.body.channels[0].config).toEqual({ requireMention: false })
   })
 
@@ -295,6 +296,7 @@ describe('[COMP:api/channels-route] channel config', () => {
     expect(res.status).toBe(200)
     expect(res.body.channels[0].config).toBeNull()
     expect(res.body.channels[0].integrationId).toBeNull()
+    expect(res.body.channels[0].integrationStatus).toBeNull()
   })
 
   it('PATCH config 503s when no integration store is configured', async () => {
@@ -867,6 +869,7 @@ describe('[COMP:api/channel-destinations-route] GET channel-destinations', () =>
       listForWorkspace: vi.fn().mockResolvedValue([
         makeIntegration({
           channelType: 'telegram',
+          botUsername: 'project_bot',
           config: {
             seenChats: [{
               chatId: '-100555',
@@ -887,8 +890,54 @@ describe('[COMP:api/channel-destinations-route] GET channel-destinations', () =>
     expect(res.body.destinations[0]).toMatchObject({
       channelId: '-100555:topic:42',
       title: 'Project Forum › Standups',
+      channelIntegrationId: 'int-1',
+      integrationLabel: '@project_bot',
     })
     expect(vi.mocked(createTelegramApi)).not.toHaveBeenCalled()
+  })
+
+  it('returns one destination per Telegram channel that can reach the chat', async () => {
+    mockRows([destRow({ channelId: '-100555' })])
+    const seenChat = {
+      chatId: '-100555',
+      chatTitle: 'Project Forum',
+      isForum: false,
+      topics: [],
+      lastSeenAt: '2026-06-29T09:45:15Z',
+    }
+    const integrationStore = {
+      listForWorkspace: vi.fn().mockResolvedValue([
+        makeIntegration({
+          id: 'int-project',
+          channelType: 'telegram',
+          botUsername: 'project_bot',
+          config: { seenChats: [seenChat] },
+        }),
+        makeIntegration({
+          id: 'int-ops',
+          channelType: 'telegram',
+          botUsername: 'ops_bot',
+          config: { seenChats: [seenChat] },
+        }),
+      ]),
+    } as unknown as ChannelIntegrationStore
+
+    const res = await request(buildApp({ integrationStore }))
+      .get('/api/workspaces/ws-1/channel-destinations')
+
+    expect(res.status).toBe(200)
+    expect(res.body.destinations).toEqual([
+      expect.objectContaining({
+        channelId: '-100555',
+        channelIntegrationId: 'int-project',
+        integrationLabel: '@project_bot',
+      }),
+      expect.objectContaining({
+        channelId: '-100555',
+        channelIntegrationId: 'int-ops',
+        integrationLabel: '@ops_bot',
+      }),
+    ])
   })
 
   it('resolves a topic group by its base chat id and falls back to the topic number', async () => {

--- a/packages/api/src/routes/__tests__/channels.test.ts
+++ b/packages/api/src/routes/__tests__/channels.test.ts
@@ -896,6 +896,52 @@ describe('[COMP:api/channel-destinations-route] GET channel-destinations', () =>
     expect(vi.mocked(createTelegramApi)).not.toHaveBeenCalled()
   })
 
+  it('preserves a topic name when a newer bot has only seen the base group', async () => {
+    mockRows([destRow({ channelId: '-100555:topic:42' })])
+    const integrationStore = {
+      listForWorkspace: vi.fn().mockResolvedValue([
+        makeIntegration({
+          id: 'int-project',
+          channelType: 'telegram',
+          botUsername: 'project_bot',
+          config: {
+            seenChats: [{
+              chatId: '-100555',
+              chatTitle: 'Project Forum',
+              isForum: true,
+              topics: [{ topicId: 42, name: 'Standups', lastSeenAt: '2026-06-29T09:45:15Z' }],
+              lastSeenAt: '2026-06-29T09:45:15Z',
+            }],
+          },
+        }),
+        makeIntegration({
+          id: 'int-new',
+          channelType: 'telegram',
+          botUsername: 'new_bot',
+          config: {
+            seenChats: [{
+              chatId: '-100555',
+              chatTitle: 'Project Forum',
+              isForum: true,
+              topics: [],
+              lastSeenAt: '2026-08-16T09:45:15Z',
+            }],
+          },
+        }),
+      ]),
+    } as unknown as ChannelIntegrationStore
+
+    const res = await request(buildApp({ integrationStore }))
+      .get('/api/workspaces/ws-1/channel-destinations')
+
+    expect(res.status).toBe(200)
+    expect(res.body.destinations).toHaveLength(2)
+    expect(res.body.destinations.map((d: { title: string }) => d.title)).toEqual([
+      'Project Forum › Standups',
+      'Project Forum › Standups',
+    ])
+  })
+
   it('returns one destination per Telegram channel that can reach the chat', async () => {
     mockRows([destRow({ channelId: '-100555' })])
     const seenChat = {
@@ -953,7 +999,7 @@ describe('[COMP:api/channel-destinations-route] GET channel-destinations', () =>
     expect(res.body.destinations[0].title).toBe('Project Forum › #42')
   })
 
-  it('resolves a telegram group title via the BYO bot without consulting the default bot', async () => {
+  it('resolves a telegram group title while probing configured bots concurrently', async () => {
     mockRows([destRow({ channelId: '-100555' })])
     const getChat = vi.fn().mockResolvedValue({ id: -100555, type: 'supergroup', title: 'Dev Work' })
     vi.mocked(createTelegramApi).mockReturnValue(telegramApi(getChat))
@@ -962,9 +1008,9 @@ describe('[COMP:api/channel-destinations-route] GET channel-destinations', () =>
     ).get('/api/workspaces/ws-1/channel-destinations')
     expect(res.status).toBe(200)
     expect(res.body.destinations[0]).toMatchObject({ channelId: '-100555', title: 'Dev Work' })
-    // BYO token is tried first; the hit short-circuits the default bot.
+    // Both candidates start together so lookup stays within one timeout window.
     expect(vi.mocked(createTelegramApi).mock.calls[0][0]).toEqual({ token: 'byo-token' })
-    expect(getChat).toHaveBeenCalledTimes(1)
+    expect(getChat).toHaveBeenCalledTimes(2)
   })
 
   it('falls back to the hosted default bot when the BYO bot cannot see the chat', async () => {
@@ -983,6 +1029,29 @@ describe('[COMP:api/channel-destinations-route] GET channel-destinations', () =>
     expect(vi.mocked(createTelegramApi).mock.calls.map((c) => c[0])).toEqual([
       { token: 'byo-token' },
       { token: 'default-token' },
+    ])
+  })
+
+  it('keeps a private DM available when it cannot be attributed through seenChats', async () => {
+    mockRows([destRow({ channelId: '880211324' })])
+    const getChat = vi.fn().mockResolvedValue({
+      id: 880211324,
+      type: 'private',
+      first_name: 'Hinson',
+      last_name: 'Wong',
+    })
+    vi.mocked(createTelegramApi).mockReturnValue(telegramApi(getChat))
+
+    const res = await request(
+      buildApp({ integrationStore: telegramIntegrationStore() }),
+    ).get('/api/workspaces/ws-1/channel-destinations')
+
+    expect(res.body.destinations).toEqual([
+      expect.objectContaining({
+        channelId: '880211324',
+        title: 'Hinson Wong',
+        channelIntegrationId: null,
+      }),
     ])
   })
 

--- a/packages/api/src/routes/__tests__/telegram-byo.test.ts
+++ b/packages/api/src/routes/__tests__/telegram-byo.test.ts
@@ -201,6 +201,22 @@ vi.mock('../../db/channels-store.js', () => ({
     modelAlias: 'standard',
     createdAt: new Date('2026-05-18T00:00:00Z'),
   })),
+  resolveTelegramRoutingForSurface: vi.fn(async () => ({
+    id: 'ca_1',
+    channelId: 'channel_1',
+    assistantId: 'assistant_1',
+    externalSurfaceId: null,
+    modelAlias: 'standard',
+    createdAt: new Date('2026-05-18T00:00:00Z'),
+  })),
+  resolveAnyRoutingForChannel: vi.fn(async () => ({
+    id: 'ca_1',
+    channelId: 'channel_1',
+    assistantId: 'assistant_1',
+    externalSurfaceId: null,
+    modelAlias: 'standard',
+    createdAt: new Date('2026-05-18T00:00:00Z'),
+  })),
 }))
 
 vi.mock('../../db/channel-user-store.js', async () => {
@@ -245,8 +261,14 @@ import {
   shouldUseUniversalTelegramIntake,
 } from '../telegram-byo.js'
 import { findOrCreateSession } from '../../db/sessions.js'
+import {
+  resolveAnyRoutingForChannel,
+  resolveTelegramRoutingForSurface,
+} from '../../db/channels-store.js'
 
 const mockFindOrCreateSession = vi.mocked(findOrCreateSession)
+const mockResolveAnyRouting = vi.mocked(resolveAnyRoutingForChannel)
+const mockResolveTelegramRouting = vi.mocked(resolveTelegramRoutingForSurface)
 
 // ── Test setup ──────────────────────────────────────────────────
 
@@ -697,6 +719,55 @@ describe('[COMP:api/telegram-byo-route] forum-topic routing', () => {
     expect(chatLockCalls).toEqual(['tg-byo:-1001234567890'])
     expect(pipelineCalls).toHaveLength(1)
     expect(pipelineCalls[0]).toMatchObject({ channelId: '-1001234567890', isGroupChat: true })
+  })
+
+  it('boots from a surface route when the channel has no default assistant', async () => {
+    const app = createTestApp(
+      '/webhook/telegram-byo',
+      telegramByoRoutes({
+        provider: {} as never,
+        systemPrompt: '',
+        tools: new Map(),
+        memoryStore: {} as never,
+        integrationStore: makeIntegrationStore() as never,
+        capabilityStore: {} as never,
+        apiUrl: 'http://test',
+      }),
+    )
+    mockResolveTelegramRouting.mockResolvedValueOnce(null)
+
+    await postUpdate(app, buildForumUpdate({ updateId: 51, messageId: 501, threadId: 42 }))
+    await flushMicrotasks()
+    await flushMicrotasks()
+
+    expect(mockResolveAnyRouting).toHaveBeenCalledWith('channel_1')
+    expect(pipelineCalls).toHaveLength(1)
+    expect(pipelineCalls[0]).toMatchObject({ channelId: '-1001234567890:topic:42' })
+  })
+
+  it('drops an unmatched topic when a surface-only channel has no default', async () => {
+    const app = createTestApp(
+      '/webhook/telegram-byo',
+      telegramByoRoutes({
+        provider: {} as never,
+        systemPrompt: '',
+        tools: new Map(),
+        memoryStore: {} as never,
+        integrationStore: makeIntegrationStore() as never,
+        capabilityStore: {} as never,
+        apiUrl: 'http://test',
+      }),
+    )
+    mockResolveTelegramRouting
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+
+    await postUpdate(app, buildForumUpdate({ updateId: 52, messageId: 502, threadId: 99 }))
+    await flushMicrotasks()
+    await flushMicrotasks()
+
+    expect(mockResolveAnyRouting).toHaveBeenCalledWith('channel_1')
+    expect(pipelineCalls).toHaveLength(0)
   })
 })
 

--- a/packages/api/src/routes/channels.ts
+++ b/packages/api/src/routes/channels.ts
@@ -241,6 +241,10 @@ function serializeChannel(
     // Per-integration behavior config. `null` when the channel has no
     // `channel_integrations` row — the UI then renders no config section.
     integrationId: integration?.id ?? null,
+    integrationStatus: integration?.status ?? null,
+    integrationLabel: integration?.botUsername
+      ? `@${integration.botUsername}`
+      : integration?.teamName ?? null,
     config: integration?.config ?? null,
   }
 }
@@ -426,15 +430,41 @@ export function channelsRoutes(opts: ChannelsRouteOptions): Router {
         .map((r) => r.channelId),
     )]
     const telegramNames = await resolveTelegramTitles(userId, workspaceId, telegramIdsToResolve)
+    let telegramIntegrations: ChannelIntegration[] = []
+    if (opts.integrationStore) {
+      try {
+        telegramIntegrations = (await opts.integrationStore.listForWorkspace(userId, workspaceId))
+          .filter((integration) => integration.channelType === 'telegram' && integration.status === 'active')
+      } catch {
+        // Destination discovery stays best-effort; unresolved rows remain usable
+        // through the shared/default bot path.
+      }
+    }
     res.json({
-      destinations: rows.map((r) => ({
-        channelType: r.channelType,
-        channelId: r.channelId,
-        title: parseTelegramDestinationId(r.channelId)?.topicId != null
+      destinations: rows.flatMap((r) => {
+        const title = parseTelegramDestinationId(r.channelId)?.topicId != null
           ? telegramNames.get(r.channelId) ?? r.title
-          : r.title ?? telegramNames.get(r.channelId) ?? null,
-        lastActiveAt: r.lastActiveAt.toISOString(),
-      })),
+          : r.title ?? telegramNames.get(r.channelId) ?? null
+        const base = {
+          channelType: r.channelType,
+          channelId: r.channelId,
+          title,
+          lastActiveAt: r.lastActiveAt.toISOString(),
+        }
+        if (r.channelType !== 'telegram') return [base]
+        const parsed = parseTelegramDestinationId(r.channelId)
+        const owners = parsed
+          ? telegramIntegrations.filter((integration) =>
+              integration.config.seenChats?.some((chat) => chat.chatId === parsed.chatId),
+            )
+          : []
+        if (owners.length === 0) return [{ ...base, channelIntegrationId: null, integrationLabel: null }]
+        return owners.map((integration) => ({
+          ...base,
+          channelIntegrationId: integration.id,
+          integrationLabel: integration.botUsername ? `@${integration.botUsername}` : integration.teamName,
+        }))
+      }),
     })
   })
 

--- a/packages/api/src/routes/channels.ts
+++ b/packages/api/src/routes/channels.ts
@@ -34,7 +34,11 @@ import type { LinkCodeStore } from '../db/link-codes.js'
 import type { DiscordConnectorClient } from '../discord/connector-client.js'
 import type { WhatsappConnectorClient } from '../whatsapp/connector-client.js'
 import type { WechatConnectorClient } from '../wechat/connector-client.js'
-import type { ChannelIntegration, ChannelIntegrationStore } from '../db/channel-integrations.js'
+import type {
+  ChannelIntegration,
+  ChannelIntegrationStore,
+  SeenChat,
+} from '../db/channel-integrations.js'
 import {
   listChannelsForWorkspace,
   getChannelForUser,
@@ -327,12 +331,38 @@ export function channelsRoutes(opts: ChannelsRouteOptions): Router {
       }
     }
 
-    const seenByChatId = new Map(
-      integrations
-        .filter((r) => r.channelType === 'telegram')
-        .flatMap((r) => r.config.seenChats ?? [])
-        .map((chat) => [chat.chatId, chat] as const),
-    )
+    const seenByChatId = new Map<string, SeenChat>()
+    for (const integration of integrations.filter((r) => r.channelType === 'telegram')) {
+      for (const chat of integration.config.seenChats ?? []) {
+        const current = seenByChatId.get(chat.chatId)
+        if (!current) {
+          seenByChatId.set(chat.chatId, chat)
+          continue
+        }
+        const topics = new Map(current.topics.map((topic) => [topic.topicId, topic]))
+        for (const topic of chat.topics) {
+          const existing = topics.get(topic.topicId)
+          if (!existing) {
+            topics.set(topic.topicId, topic)
+            continue
+          }
+          const incomingIsNewer = topic.lastSeenAt >= existing.lastSeenAt
+          topics.set(topic.topicId, incomingIsNewer
+            ? { ...topic, name: topic.name ?? existing.name }
+            : { ...existing, name: existing.name ?? topic.name })
+        }
+        const incomingIsNewer = chat.lastSeenAt >= current.lastSeenAt
+        seenByChatId.set(chat.chatId, {
+          ...current,
+          chatTitle: incomingIsNewer
+            ? chat.chatTitle ?? current.chatTitle
+            : current.chatTitle ?? chat.chatTitle,
+          isForum: current.isForum || chat.isForum,
+          topics: [...topics.values()],
+          lastSeenAt: incomingIsNewer ? chat.lastSeenAt : current.lastSeenAt,
+        })
+      }
+    }
     const unresolvedChatIds = [...new Set(
       parsed
         .filter(({ chatId }) => !seenByChatId.get(chatId)?.chatTitle)
@@ -340,15 +370,20 @@ export function channelsRoutes(opts: ChannelsRouteOptions): Router {
     )]
 
     if (unresolvedChatIds.length > 0 && opts.integrationStore) {
-      const telegram = integrations.find((r) => r.channelType === 'telegram')
-      if (telegram) {
+      const telegramIntegrations = integrations.filter(
+        (r) => r.channelType === 'telegram' && r.status === 'active',
+      )
+      const byoTokens = await Promise.all(telegramIntegrations.map(async (telegram) => {
         try {
-          const withCreds = await opts.integrationStore.getForUserWithCredentials(userId, telegram.id)
-          const byoToken = withCreds && (withCreds.credentials as { bot_token?: string }).bot_token
-          if (byoToken) tokens.push(byoToken)
+          const withCreds = await opts.integrationStore!.getForUserWithCredentials(userId, telegram.id)
+          return withCreds && (withCreds.credentials as { bot_token?: string }).bot_token
         } catch (err) {
           console.warn('[channels/channel-destinations] BYO telegram credential lookup failed:', err instanceof Error ? err.message : err)
+          return undefined
         }
+      }))
+      for (const byoToken of byoTokens) {
+        if (byoToken && !tokens.includes(byoToken)) tokens.push(byoToken)
       }
     }
     if (opts.telegramBotToken && !tokens.includes(opts.telegramBotToken)) tokens.push(opts.telegramBotToken)
@@ -356,15 +391,17 @@ export function channelsRoutes(opts: ChannelsRouteOptions): Router {
     const chatNames = new Map<string, string>()
     const apis = tokens.map((token) => createTelegramApi({ token }))
     await Promise.all(unresolvedChatIds.map(async (chatId) => {
-      for (const api of apis) {
-        try {
+      try {
+        const name = await Promise.any(apis.map(async (api) => {
           const chat = await withTimeout(api.getChat(chatId), TELEGRAM_GETCHAT_TIMEOUT_MS)
           const personal = [chat.first_name, chat.last_name].filter(Boolean).join(' ')
           const name = chat.title ?? (personal || (chat.username ? `@${chat.username}` : ''))
-          if (name) { chatNames.set(chatId, name); return }
-        } catch {
-          // Not this bot's chat (or transient failure) — try the next token.
-        }
+          if (!name) throw new Error('Telegram chat has no display name')
+          return name
+        }))
+        chatNames.set(chatId, name)
+      } catch {
+        // No configured bot could resolve this chat within the shared timeout.
       }
     }))
 

--- a/packages/api/src/routes/telegram-byo.ts
+++ b/packages/api/src/routes/telegram-byo.ts
@@ -33,7 +33,11 @@ import { findAssistantById, findUserById } from '../db/users.js'
 import { getWorkspaceRoleSystem } from '../db/workspace-store.js'
 import { query } from '../db/client.js'
 import { resolveChannelUser, fetchTelegramProfile, type ChannelUserStore } from '../db/channel-user-store.js'
-import { resolveAssistantForSurface, resolveRoutingForSurface, getChannelForWebhook } from '../db/channels-store.js'
+import {
+  resolveAnyRoutingForChannel,
+  resolveTelegramRoutingForSurface,
+  getChannelForWebhook,
+} from '../db/channels-store.js'
 import { mergeShadowUser, type LinkedAccountStore } from '../db/linked-accounts.js'
 import type { LinkCodeStore } from '../db/link-codes.js'
 import { withChatLock } from '../db/chat-lock.js'
@@ -357,12 +361,14 @@ export function telegramByoRoutes(options: TelegramByoRouteOptions): Router {
       console.warn(`[telegram-byo] channel ${integration.channelId} not accepting chat — ignoring inbound`)
       return
     }
-    const defaultRouting = await resolveRoutingForSurface(integration.channelId, null)
-    if (!defaultRouting) {
+    const defaultRouting = await resolveTelegramRoutingForSurface(integration.channelId, null)
+    const bootstrapRouting = defaultRouting
+      ?? await resolveAnyRoutingForChannel(integration.channelId)
+    if (!bootstrapRouting) {
       console.error(`[telegram-byo] channel ${integration.channelId} has no assistant routing — ignoring inbound`)
       return
     }
-    const defaultAssistantId = defaultRouting.assistantId
+    const defaultAssistantId = bootstrapRouting.assistantId
 
     const assistant = await findAssistantById(defaultAssistantId)
     if (!assistant) {
@@ -372,7 +378,7 @@ export function telegramByoRoutes(options: TelegramByoRouteOptions): Router {
     // Per-routing model alias overrides the per-assistant default
     // (migration 197). Re-resolved per-message below if a surface-specific
     // routing row matches.
-    assistant.defaultModelAlias = defaultRouting.modelAlias
+    assistant.defaultModelAlias = bootstrapRouting.modelAlias
     // Post-089 ownership XOR: team assistants have NULL owner_user_id and
     // team access flows through teams.owner_user_id. `billingPartyForAssistant`
     // is the single source of truth for "the authoritative user behind this
@@ -821,10 +827,15 @@ export function telegramByoRoutes(options: TelegramByoRouteOptions): Router {
         console.warn(`[telegram-byo] channel ${chatChannel.id} not accepting chat (status=${chatChannel.status}) — ignoring inbound`)
         return
       }
-      const routedRouting = await resolveRoutingForSurface(
+      const routedRouting = await resolveTelegramRoutingForSurface(
         boundIntegration.channelId,
         incoming.channelId,
       )
+      // `bootstrapRouting` only lets a surface-only channel construct its
+      // adapter. Without a default, every message still needs an exact topic
+      // or base-chat winner; never leak an unmatched surface to the arbitrary
+      // bootstrap assistant.
+      if (!routedRouting && !defaultRouting) return
       if (routedRouting && routedRouting.assistantId !== boundAssistant.id) {
         const found = await findAssistantById(routedRouting.assistantId)
         if (found) routedAssistant = found

--- a/packages/api/src/routes/workflows.ts
+++ b/packages/api/src/routes/workflows.ts
@@ -300,6 +300,7 @@ async function dependencyIssues(
       if (!assistantId) continue
       try {
         const res = await opts.validateDeliveryTarget({
+          workspaceId: ctx.workspaceId,
           assistantId,
           channelType: step.deliver.channelType,
           channelId: step.deliver.channelId,
@@ -307,8 +308,16 @@ async function dependencyIssues(
         })
         if (!res.ok) {
           issues.push({
-            path: ['definition', 'steps', i, 'deliver', 'channelId'],
-            message: `${step.deliver.channelType} channel not reachable: ${res.reason ?? 'channel check failed'}`,
+            path: [
+              'definition',
+              'steps',
+              i,
+              'deliver',
+              step.deliver.channelIntegrationId && !/chat not found/i.test(res.reason ?? '')
+                ? 'channelIntegrationId'
+                : 'channelId',
+            ],
+            message: `${step.deliver.channelType} delivery configuration is invalid: ${res.reason ?? 'channel check failed'}`,
           })
         }
       } catch (err) {

--- a/packages/api/src/routes/workflows.ts
+++ b/packages/api/src/routes/workflows.ts
@@ -303,6 +303,7 @@ async function dependencyIssues(
           assistantId,
           channelType: step.deliver.channelType,
           channelId: step.deliver.channelId,
+          channelIntegrationId: step.deliver.channelIntegrationId,
         })
         if (!res.ok) {
           issues.push({

--- a/packages/api/src/scheduling/__tests__/confirmation-prompt.test.ts
+++ b/packages/api/src/scheduling/__tests__/confirmation-prompt.test.ts
@@ -95,10 +95,12 @@ describe('[COMP:scheduling/confirmation-prompt] resolveTelegramBotToken', () => 
       { integrationStore: store, defaultTelegramBotToken: 'shared-tok' },
       '00000000-0000-4000-8000-000000000001',
       '-100555:topic:42',
+      'ws-1',
     )
 
     expect(token).toBe('selected-tok')
     expect(store.getCredentialsForAssistantIntegrationSystem).toHaveBeenCalledWith(
+      'ws-1',
       'a_1',
       '00000000-0000-4000-8000-000000000001',
       'telegram',
@@ -106,14 +108,17 @@ describe('[COMP:scheduling/confirmation-prompt] resolveTelegramBotToken', () => 
     )
   })
 
-  it('does not fall back when an explicitly selected integration is unavailable', async () => {
+  it('fails closed when an explicit integration has no authoritative workspace scope', async () => {
+    const store = fakeIntegrationStore('foreign-tok')
     const token = await resolveTelegramBotToken(
       'a_1',
-      { integrationStore: fakeIntegrationStore(null), defaultTelegramBotToken: 'shared-tok' },
+      { integrationStore: store, defaultTelegramBotToken: 'shared-tok' },
       '00000000-0000-4000-8000-000000000001',
       '-100555',
     )
     expect(token).toBeUndefined()
+    expect(store.getCredentialsForAssistantSystem).not.toHaveBeenCalled()
+    expect(store.getCredentialsForAssistantIntegrationSystem).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/api/src/scheduling/__tests__/confirmation-prompt.test.ts
+++ b/packages/api/src/scheduling/__tests__/confirmation-prompt.test.ts
@@ -40,6 +40,11 @@ function fakeIntegrationStore(botToken: string | null): ChannelIntegrationStore 
         ? null
         : ({ credentials: { bot_token: botToken }, botUserId: 'U1' } as never),
     ),
+    getCredentialsForAssistantIntegrationSystem: vi.fn(async () =>
+      botToken === null
+        ? null
+        : ({ credentials: { bot_token: botToken }, botUserId: 'U1' } as never),
+    ),
   } as unknown as ChannelIntegrationStore
 }
 
@@ -80,6 +85,34 @@ describe('[COMP:scheduling/confirmation-prompt] resolveTelegramBotToken', () => 
     const token = await resolveTelegramBotToken('a_1', {
       integrationStore: fakeIntegrationStore(null),
     })
+    expect(token).toBeUndefined()
+  })
+
+  it('resolves an explicitly selected integration without shared-bot fallback', async () => {
+    const store = fakeIntegrationStore('selected-tok')
+    const token = await resolveTelegramBotToken(
+      'a_1',
+      { integrationStore: store, defaultTelegramBotToken: 'shared-tok' },
+      '00000000-0000-4000-8000-000000000001',
+      '-100555:topic:42',
+    )
+
+    expect(token).toBe('selected-tok')
+    expect(store.getCredentialsForAssistantIntegrationSystem).toHaveBeenCalledWith(
+      'a_1',
+      '00000000-0000-4000-8000-000000000001',
+      'telegram',
+      '-100555:topic:42',
+    )
+  })
+
+  it('does not fall back when an explicitly selected integration is unavailable', async () => {
+    const token = await resolveTelegramBotToken(
+      'a_1',
+      { integrationStore: fakeIntegrationStore(null), defaultTelegramBotToken: 'shared-tok' },
+      '00000000-0000-4000-8000-000000000001',
+      '-100555',
+    )
     expect(token).toBeUndefined()
   })
 })

--- a/packages/api/src/scheduling/confirmation-prompt.ts
+++ b/packages/api/src/scheduling/confirmation-prompt.ts
@@ -27,6 +27,7 @@ export type ConfirmationPromptTarget = {
   assistantId: string
   channelType: string
   channelId: string
+  channelIntegrationId?: string
 }
 
 export type ConfirmationPromptDeps = {
@@ -44,16 +45,23 @@ export type ConfirmationPromptDeps = {
 export async function resolveTelegramBotToken(
   assistantId: string,
   deps: ConfirmationPromptDeps,
+  channelIntegrationId?: string,
+  channelId?: string,
 ): Promise<string | undefined> {
   if (deps.integrationStore) {
-    const integration = await deps.integrationStore.getCredentialsForAssistantSystem(
-      assistantId,
-      'telegram',
-    )
+    const integration = channelIntegrationId && channelId
+      ? await deps.integrationStore.getCredentialsForAssistantIntegrationSystem(
+          assistantId,
+          channelIntegrationId,
+          'telegram',
+          channelId,
+        )
+      : await deps.integrationStore.getCredentialsForAssistantSystem(assistantId, 'telegram')
     if (integration) {
       return (integration.credentials as { bot_token: string }).bot_token
     }
   }
+  if (channelIntegrationId) return undefined
   return deps.defaultTelegramBotToken
 }
 
@@ -76,7 +84,12 @@ export async function sendConfirmationPrompt(
 
   try {
     if (target.channelType === 'telegram') {
-      const botToken = await resolveTelegramBotToken(target.assistantId, deps)
+      const botToken = await resolveTelegramBotToken(
+        target.assistantId,
+        deps,
+        target.channelIntegrationId,
+        target.channelId,
+      )
       if (botToken) {
         const adapter = createTelegramAdapter({ token: botToken })
         const actions = [

--- a/packages/api/src/scheduling/confirmation-prompt.ts
+++ b/packages/api/src/scheduling/confirmation-prompt.ts
@@ -23,6 +23,7 @@ import { query } from '../db/client.js'
 import type { ChannelIntegrationStore } from '../db/channel-integrations.js'
 
 export type ConfirmationPromptTarget = {
+  workspaceId?: string
   /** Assistant whose channel credentials resolve the outbound adapter. */
   assistantId: string
   channelType: string
@@ -47,21 +48,25 @@ export async function resolveTelegramBotToken(
   deps: ConfirmationPromptDeps,
   channelIntegrationId?: string,
   channelId?: string,
+  workspaceId?: string,
 ): Promise<string | undefined> {
-  if (deps.integrationStore) {
-    const integration = channelIntegrationId && channelId
-      ? await deps.integrationStore.getCredentialsForAssistantIntegrationSystem(
-          assistantId,
-          channelIntegrationId,
-          'telegram',
-          channelId,
-        )
-      : await deps.integrationStore.getCredentialsForAssistantSystem(assistantId, 'telegram')
-    if (integration) {
-      return (integration.credentials as { bot_token: string }).bot_token
-    }
+  if (channelIntegrationId) {
+    if (!deps.integrationStore || !channelId || !workspaceId) return undefined
+    const integration = await deps.integrationStore.getCredentialsForAssistantIntegrationSystem(
+      workspaceId,
+      assistantId,
+      channelIntegrationId,
+      'telegram',
+      channelId,
+    )
+    return integration
+      ? (integration.credentials as { bot_token: string }).bot_token
+      : undefined
   }
-  if (channelIntegrationId) return undefined
+  if (deps.integrationStore) {
+    const integration = await deps.integrationStore.getCredentialsForAssistantSystem(assistantId, 'telegram')
+    if (integration) return (integration.credentials as { bot_token: string }).bot_token
+  }
   return deps.defaultTelegramBotToken
 }
 
@@ -89,6 +94,7 @@ export async function sendConfirmationPrompt(
         deps,
         target.channelIntegrationId,
         target.channelId,
+        target.workspaceId,
       )
       if (botToken) {
         const adapter = createTelegramAdapter({ token: botToken })

--- a/packages/api/src/workflow/__tests__/channel-delivery.test.ts
+++ b/packages/api/src/workflow/__tests__/channel-delivery.test.ts
@@ -153,6 +153,7 @@ describe('[COMP:workflow/channel-delivery] thread-reply pass-through', () => {
       'selected-token',
     ])
     expect(integrationStore.getCredentialsForAssistantIntegrationSystem).toHaveBeenCalledWith(
+      'ws-1',
       'asst-1',
       '00000000-0000-4000-8000-000000000001',
       'telegram',

--- a/packages/api/src/workflow/__tests__/channel-delivery.test.ts
+++ b/packages/api/src/workflow/__tests__/channel-delivery.test.ts
@@ -19,22 +19,28 @@ vi.mock('../../db/client.js', () => ({
   query: vi.fn(async () => ({ rows: [] })),
 }))
 
-const sendMessage = vi.fn(
-  async (_channelId: string, _msg: unknown, _opts?: { threadTs?: string }) => '1751970000.111111',
-)
+const { sendMessage, createTelegramAdapter } = vi.hoisted(() => {
+  const send = vi.fn()
+  return { sendMessage: send, createTelegramAdapter: vi.fn(() => ({ sendMessage: send })) }
+})
 vi.mock('@use-brian/channels', () => ({
   createSlackAdapter: vi.fn(() => ({ sendMessage })),
-  createTelegramAdapter: vi.fn(() => ({ sendMessage })),
+  createTelegramAdapter,
   createWhatsAppAdapter: vi.fn(() => ({ sendMessage })),
 }))
 
 import { createWorkflowChannelDelivery } from '../channel-delivery.js'
+import { createTelegramAdapter as mockedCreateTelegramAdapter } from '@use-brian/channels'
 import type { ChannelIntegrationStore } from '../../db/channel-integrations.js'
 
 const integrationStore = {
   getCredentialsForAssistantSystem: vi.fn(async () => ({
     credentials: { bot_token: 'xoxb-test' },
     botUserId: 'B1',
+  })),
+  getCredentialsForAssistantIntegrationSystem: vi.fn(async () => ({
+    credentials: { bot_token: 'selected-token' },
+    botUserId: 'B2',
   })),
 } as unknown as ChannelIntegrationStore
 
@@ -49,7 +55,11 @@ function baseParams() {
 }
 
 beforeEach(() => {
-  sendMessage.mockClear()
+  sendMessage.mockReset()
+  sendMessage.mockResolvedValue('1751970000.111111')
+  vi.mocked(mockedCreateTelegramAdapter).mockClear()
+  vi.mocked(integrationStore.getCredentialsForAssistantSystem).mockClear()
+  vi.mocked(integrationStore.getCredentialsForAssistantIntegrationSystem).mockClear()
 })
 
 describe('[COMP:workflow/channel-delivery] thread-reply pass-through', () => {
@@ -101,5 +111,53 @@ describe('[COMP:workflow/channel-delivery] thread-reply pass-through', () => {
       { threadTs: '778899' },
     )
     expect(outcome).toMatchObject({ status: 'delivered', messageId: '1751970000.111111' })
+  })
+
+  it('telegram: retries the shared bot when the assistant BYO bot cannot see the chat', async () => {
+    sendMessage
+      .mockRejectedValueOnce(new Error('Telegram API sendMessage: Bad Request: chat not found'))
+      .mockResolvedValueOnce('778900')
+    const deliver = createWorkflowChannelDelivery({
+      integrationStore,
+      defaultTelegramBotToken: 'shared-token',
+    })
+
+    const outcome = await deliver({
+      ...baseParams(),
+      channelType: 'telegram',
+      channelId: '-100555:topic:42',
+    })
+
+    expect(vi.mocked(mockedCreateTelegramAdapter).mock.calls.map(([options]) => options.token)).toEqual([
+      'xoxb-test',
+      'shared-token',
+    ])
+    expect(sendMessage).toHaveBeenCalledTimes(2)
+    expect(outcome).toMatchObject({ status: 'delivered', messageId: '778900' })
+  })
+
+  it('telegram: sends only through the explicitly selected integration', async () => {
+    const deliver = createWorkflowChannelDelivery({
+      integrationStore,
+      defaultTelegramBotToken: 'shared-token',
+    })
+
+    const outcome = await deliver({
+      ...baseParams(),
+      channelType: 'telegram',
+      channelId: '-100555:topic:42',
+      channelIntegrationId: '00000000-0000-4000-8000-000000000001',
+    })
+
+    expect(vi.mocked(mockedCreateTelegramAdapter).mock.calls.map(([options]) => options.token)).toEqual([
+      'selected-token',
+    ])
+    expect(integrationStore.getCredentialsForAssistantIntegrationSystem).toHaveBeenCalledWith(
+      'asst-1',
+      '00000000-0000-4000-8000-000000000001',
+      'telegram',
+      '-100555:topic:42',
+    )
+    expect(outcome).toMatchObject({ status: 'delivered' })
   })
 })

--- a/packages/api/src/workflow/__tests__/dependency-preflight.test.ts
+++ b/packages/api/src/workflow/__tests__/dependency-preflight.test.ts
@@ -15,6 +15,12 @@ function integrationStoreWith(
   return {
     getCredentialsForAssistantSystem: async (_assistantId: string, channelType: string) =>
       creds[channelType] ?? null,
+    getCredentialsForAssistantIntegrationSystem: async (
+      _assistantId: string,
+      _integrationId: string,
+      channelType: string,
+      _channelId: string,
+    ) => creds[channelType] ?? null,
   } as unknown as ChannelIntegrationStore
 }
 
@@ -101,13 +107,101 @@ describe('[COMP:workflow/dependency-preflight] validateDeliveryTarget', () => {
     expect(r.ok).toBe(true)
   })
 
-  it('accepts Telegram with the shared default bot token; rejects when neither BYO nor default exists', async () => {
+  it('accepts Telegram when the shared default bot can see the chat; rejects when no bot exists', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ ok: true, result: { id: 42, type: 'private' } }), { status: 200 })),
+    )
     const withDefault = createWorkflowDependencyPreflight({ defaultTelegramBotToken: 'bot-token' })
     expect((await withDefault.validateDeliveryTarget({ assistantId: ASSISTANT_ID, channelType: 'telegram', channelId: '42' })).ok).toBe(true)
 
     const without = createWorkflowDependencyPreflight({ integrationStore: integrationStoreWith({}) })
     const r = await without.validateDeliveryTarget({ assistantId: ASSISTANT_ID, channelType: 'telegram', channelId: '42' })
     expect(r.ok).toBe(false)
+  })
+
+  it('checks a Telegram topic against its base chat and falls back from BYO to the shared bot', async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input)
+      const body = JSON.parse(String(init?.body)) as { chat_id: string }
+      expect(body.chat_id).toBe('-100555')
+      return url.includes('botbyo-token/')
+        ? new Response(JSON.stringify({ ok: false, error_code: 400, description: 'Bad Request: chat not found' }), { status: 400 })
+        : new Response(JSON.stringify({ ok: true, result: { id: -100555, type: 'supergroup' } }), { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const { validateDeliveryTarget } = createWorkflowDependencyPreflight({
+      integrationStore: integrationStoreWith({ telegram: { credentials: { bot_token: 'byo-token' } } }),
+      defaultTelegramBotToken: 'shared-token',
+    })
+
+    const result = await validateDeliveryTarget({
+      assistantId: ASSISTANT_ID,
+      channelType: 'telegram',
+      channelId: '-100555:topic:42',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects a Telegram target that no configured bot can see', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(
+        JSON.stringify({ ok: false, error_code: 400, description: 'Bad Request: chat not found' }),
+        { status: 400 },
+      )),
+    )
+    const { validateDeliveryTarget } = createWorkflowDependencyPreflight({
+      integrationStore: integrationStoreWith({ telegram: { credentials: { bot_token: 'byo-token' } } }),
+      defaultTelegramBotToken: 'shared-token',
+    })
+
+    const result = await validateDeliveryTarget({
+      assistantId: ASSISTANT_ID,
+      channelType: 'telegram',
+      channelId: '-100555:topic:42',
+    })
+
+    expect(result).toEqual({ ok: false, reason: 'Telegram: chat not found (-100555)' })
+  })
+
+  it('probes only the explicitly selected Telegram integration', async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      expect(String(input)).toContain('botselected-token/getChat')
+      return new Response(JSON.stringify({ ok: true, result: { id: -100555, type: 'supergroup' } }), { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const { validateDeliveryTarget } = createWorkflowDependencyPreflight({
+      integrationStore: integrationStoreWith({ telegram: { credentials: { bot_token: 'selected-token' } } }),
+      defaultTelegramBotToken: 'shared-token',
+    })
+
+    const result = await validateDeliveryTarget({
+      assistantId: ASSISTANT_ID,
+      channelType: 'telegram',
+      channelId: '-100555:topic:42',
+      channelIntegrationId: '00000000-0000-4000-8000-000000000001',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not block Telegram authoring on a transient getChat failure', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network unavailable') }))
+    const { validateDeliveryTarget } = createWorkflowDependencyPreflight({
+      defaultTelegramBotToken: 'shared-token',
+    })
+
+    const result = await validateDeliveryTarget({
+      assistantId: ASSISTANT_ID,
+      channelType: 'telegram',
+      channelId: '-100555:topic:42',
+    })
+
+    expect(result.ok).toBe(true)
   })
 
   it('accepts WhatsApp only when the connector is configured', async () => {

--- a/packages/api/src/workflow/__tests__/dependency-preflight.test.ts
+++ b/packages/api/src/workflow/__tests__/dependency-preflight.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { createWorkflowDependencyPreflight } from '../dependency-preflight.js'
 import type { ChannelIntegrationStore } from '../../db/channel-integrations.js'
+import type { AssistantIntegrationRoutingDiagnostic } from '../../db/channel-integrations.js'
 import type { ConnectorStore } from '../../db/connector-store.js'
 import type { ConnectorInstanceStore } from '../../db/connector-instance-store.js'
 import type { ConnectorGrantStore } from '../../db/connector-grant-store.js'
@@ -16,11 +17,26 @@ function integrationStoreWith(
     getCredentialsForAssistantSystem: async (_assistantId: string, channelType: string) =>
       creds[channelType] ?? null,
     getCredentialsForAssistantIntegrationSystem: async (
+      _workspaceId: string,
       _assistantId: string,
       _integrationId: string,
       channelType: string,
       _channelId: string,
     ) => creds[channelType] ?? null,
+    diagnoseAssistantIntegrationRoutingSystem: async () => ({
+      status: 'integration_unavailable',
+      channelLabel: null,
+    }),
+  } as unknown as ChannelIntegrationStore
+}
+
+function integrationStoreWithDiagnostic(
+  diagnostic: AssistantIntegrationRoutingDiagnostic,
+): ChannelIntegrationStore {
+  return {
+    getCredentialsForAssistantSystem: vi.fn(async () => null),
+    getCredentialsForAssistantIntegrationSystem: vi.fn(async () => null),
+    diagnoseAssistantIntegrationRoutingSystem: vi.fn(async () => diagnostic),
   } as unknown as ChannelIntegrationStore
 }
 
@@ -136,6 +152,7 @@ describe('[COMP:workflow/dependency-preflight] validateDeliveryTarget', () => {
     })
 
     const result = await validateDeliveryTarget({
+      workspaceId: WORKSPACE_ID,
       assistantId: ASSISTANT_ID,
       channelType: 'telegram',
       channelId: '-100555:topic:42',
@@ -159,6 +176,7 @@ describe('[COMP:workflow/dependency-preflight] validateDeliveryTarget', () => {
     })
 
     const result = await validateDeliveryTarget({
+      workspaceId: WORKSPACE_ID,
       assistantId: ASSISTANT_ID,
       channelType: 'telegram',
       channelId: '-100555:topic:42',
@@ -179,6 +197,7 @@ describe('[COMP:workflow/dependency-preflight] validateDeliveryTarget', () => {
     })
 
     const result = await validateDeliveryTarget({
+      workspaceId: WORKSPACE_ID,
       assistantId: ASSISTANT_ID,
       channelType: 'telegram',
       channelId: '-100555:topic:42',
@@ -187,6 +206,96 @@ describe('[COMP:workflow/dependency-preflight] validateDeliveryTarget', () => {
 
     expect(result.ok).toBe(true)
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('explains when the destination is routed to a different assistant', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const store = integrationStoreWithDiagnostic({
+      status: 'assistant_mismatch',
+      channelLabel: '@operations_bot',
+      requestedAssistantName: 'Research Assistant',
+      routedAssistantName: 'Operations Assistant',
+    })
+    const { validateDeliveryTarget } = createWorkflowDependencyPreflight({
+      integrationStore: store,
+      defaultTelegramBotToken: 'shared-token',
+    })
+
+    const result = await validateDeliveryTarget({
+      workspaceId: WORKSPACE_ID,
+      assistantId: ASSISTANT_ID,
+      channelType: 'telegram',
+      channelId: '-100555:topic:42',
+      channelIntegrationId: '00000000-0000-4000-8000-000000000001',
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain('routes this destination to assistant "Operations Assistant"')
+    expect(result.reason).toContain('workflow step uses assistant "Research Assistant"')
+    expect(result.reason).toContain('Studio > Channels')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('explains when the selected channel has no route for the destination', async () => {
+    const { validateDeliveryTarget } = createWorkflowDependencyPreflight({
+      integrationStore: integrationStoreWithDiagnostic({
+        status: 'destination_unassigned',
+        channelLabel: '@project_bot',
+        requestedAssistantName: 'Research Assistant',
+      }),
+    })
+
+    const result = await validateDeliveryTarget({
+      workspaceId: WORKSPACE_ID,
+      assistantId: ASSISTANT_ID,
+      channelType: 'telegram',
+      channelId: '-100555:topic:42',
+      channelIntegrationId: '00000000-0000-4000-8000-000000000001',
+    })
+
+    expect(result.reason).toContain('has no assistant assigned')
+    expect(result.reason).toContain('set "Research Assistant" as the channel default')
+  })
+
+  it('explains when the selected Telegram integration is inactive', async () => {
+    const { validateDeliveryTarget } = createWorkflowDependencyPreflight({
+      integrationStore: integrationStoreWithDiagnostic({
+        status: 'integration_unavailable',
+        channelLabel: '@retired_bot',
+      }),
+    })
+
+    const result = await validateDeliveryTarget({
+      workspaceId: WORKSPACE_ID,
+      assistantId: ASSISTANT_ID,
+      channelType: 'telegram',
+      channelId: '-100555',
+      channelIntegrationId: '00000000-0000-4000-8000-000000000001',
+    })
+
+    expect(result.reason).toContain('"@retired_bot" is disconnected, inactive, or no longer available')
+    expect(result.reason).toContain('Reconnect it in Studio > Channels')
+  })
+
+  it('does not suggest routing a missing or foreign assistant', async () => {
+    const { validateDeliveryTarget } = createWorkflowDependencyPreflight({
+      integrationStore: integrationStoreWithDiagnostic({
+        status: 'assistant_unavailable',
+        channelLabel: '@project_bot',
+      }),
+    })
+
+    const result = await validateDeliveryTarget({
+      workspaceId: WORKSPACE_ID,
+      assistantId: ASSISTANT_ID,
+      channelType: 'telegram',
+      channelId: '-100555',
+      channelIntegrationId: '00000000-0000-4000-8000-000000000001',
+    })
+
+    expect(result.reason).toContain('workflow step assistant is not available in this workspace')
+    expect(result.reason).not.toContain(ASSISTANT_ID)
   })
 
   it('does not block Telegram authoring on a transient getChat failure', async () => {

--- a/packages/api/src/workflow/channel-delivery.ts
+++ b/packages/api/src/workflow/channel-delivery.ts
@@ -50,7 +50,15 @@ export type WorkflowChannelDeliveryOptions = {
 export function createWorkflowChannelDelivery(
   options: WorkflowChannelDeliveryOptions,
 ): DeliverToChannel {
-  return async ({ assistantId, userId, channelType, channelId, text, threadRef }): Promise<DeliveryOutcome> => {
+  return async ({
+    assistantId,
+    userId,
+    channelType,
+    channelId,
+    channelIntegrationId,
+    text,
+    threadRef,
+  }): Promise<DeliveryOutcome> => {
     // Strip any model scaffolding / meta-commentary before it is persisted to
     // the delivery session OR pushed to the channel — a cron-framed turn can
     // echo a "Message body:" planning preamble and a duplicated body (see
@@ -82,24 +90,42 @@ export function createWorkflowChannelDelivery(
     })
 
     if (channelType === 'telegram') {
-      let token = options.defaultTelegramBotToken
+      const tokens: string[] = []
       if (options.integrationStore) {
-        const integ = await options.integrationStore.getCredentialsForAssistantSystem(
-          assistantId,
-          'telegram',
-        )
-        if (integ) token = (integ.credentials as { bot_token: string }).bot_token
+        const integ = channelIntegrationId
+          ? await options.integrationStore.getCredentialsForAssistantIntegrationSystem(
+              assistantId,
+              channelIntegrationId,
+              'telegram',
+              channelId,
+            )
+          : await options.integrationStore.getCredentialsForAssistantSystem(assistantId, 'telegram')
+        const byoToken = integ && (integ.credentials as { bot_token?: string }).bot_token
+        if (byoToken) tokens.push(byoToken)
       }
-      if (!token) return { status: 'skipped', channelType, reason: 'no_integration' }
+      if (!channelIntegrationId && options.defaultTelegramBotToken && !tokens.includes(options.defaultTelegramBotToken)) {
+        tokens.push(options.defaultTelegramBotToken)
+      }
+      if (tokens.length === 0) return { status: 'skipped', channelType, reason: 'no_integration' }
       // `threadRef` (an earlier delivery's message id) posts this one as a
       // reply; the returned message id lets a later `deliver.thread` step
       // reply under THIS message. See workflow.md → deliver `thread`.
-      const tgMessageId = await createTelegramAdapter({ token }).sendMessage(
-        channelId,
-        { text: deliverable, format: 'markdown' },
-        threadRef ? { threadTs: threadRef } : undefined,
-      )
-      return { status: 'delivered', channelType, channelId, messageId: tgMessageId || undefined }
+      for (const [index, token] of tokens.entries()) {
+        try {
+          const tgMessageId = await createTelegramAdapter({ token }).sendMessage(
+            channelId,
+            { text: deliverable, format: 'markdown' },
+            threadRef ? { threadTs: threadRef } : undefined,
+          )
+          return { status: 'delivered', channelType, channelId, messageId: tgMessageId || undefined }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          const canTryNext = index < tokens.length - 1
+            && /Telegram API sendMessage:.*chat not found/i.test(message)
+          if (!canTryNext) throw err
+        }
+      }
+      throw new Error('Telegram delivery exhausted all configured bots')
     }
 
     if (channelType === 'slack') {

--- a/packages/api/src/workflow/channel-delivery.ts
+++ b/packages/api/src/workflow/channel-delivery.ts
@@ -51,6 +51,7 @@ export function createWorkflowChannelDelivery(
   options: WorkflowChannelDeliveryOptions,
 ): DeliverToChannel {
   return async ({
+    workspaceId,
     assistantId,
     userId,
     channelType,
@@ -94,6 +95,7 @@ export function createWorkflowChannelDelivery(
       if (options.integrationStore) {
         const integ = channelIntegrationId
           ? await options.integrationStore.getCredentialsForAssistantIntegrationSystem(
+              workspaceId,
               assistantId,
               channelIntegrationId,
               'telegram',

--- a/packages/api/src/workflow/dependency-preflight.ts
+++ b/packages/api/src/workflow/dependency-preflight.ts
@@ -185,6 +185,7 @@ async function resolveConnectorCredential(
 }
 
 export type ValidateDeliveryTarget = (args: {
+  workspaceId?: string
   assistantId: string
   channelType: 'telegram' | 'slack' | 'whatsapp'
   channelId: string
@@ -259,6 +260,7 @@ export function createWorkflowDependencyPreflight(options: WorkflowDependencyPre
   listSlackMembers: ListSlackMembers
 } {
   const validateDeliveryTarget: ValidateDeliveryTarget = async ({
+    workspaceId,
     assistantId,
     channelType,
     channelId,
@@ -290,12 +292,15 @@ export function createWorkflowDependencyPreflight(options: WorkflowDependencyPre
       const tokens: string[] = []
       if (options.integrationStore) {
         const integ = channelIntegrationId
-          ? await options.integrationStore.getCredentialsForAssistantIntegrationSystem(
+          ? workspaceId
+            ? await options.integrationStore.getCredentialsForAssistantIntegrationSystem(
+              workspaceId,
               assistantId,
               channelIntegrationId,
               'telegram',
               channelId,
             )
+            : null
           : await options.integrationStore.getCredentialsForAssistantSystem(assistantId, 'telegram')
         const byoToken = integ && (integ.credentials as { bot_token?: string }).bot_token
         if (byoToken) tokens.push(byoToken)
@@ -304,6 +309,68 @@ export function createWorkflowDependencyPreflight(options: WorkflowDependencyPre
         tokens.push(options.defaultTelegramBotToken)
       }
       if (tokens.length === 0) {
+        if (workspaceId && channelIntegrationId && options.integrationStore) {
+          try {
+            const diagnostic = await options.integrationStore
+              .diagnoseAssistantIntegrationRoutingSystem(
+                workspaceId,
+                assistantId,
+                channelIntegrationId,
+                'telegram',
+                channelId,
+              )
+            if (diagnostic.status === 'assistant_mismatch') {
+              return {
+                ok: false,
+                reason:
+                  `Selected Telegram channel "${diagnostic.channelLabel}" routes this destination to ` +
+                  `assistant "${diagnostic.routedAssistantName}", but the workflow step uses ` +
+                  `assistant "${diagnostic.requestedAssistantName}". In Studio > Channels, route this ` +
+                  `group/topic to "${diagnostic.requestedAssistantName}"; or select a Telegram channel ` +
+                  `assigned to that assistant; or change the workflow step assistant to ` +
+                  `"${diagnostic.routedAssistantName}".`,
+              }
+            }
+            if (diagnostic.status === 'destination_unassigned') {
+              return {
+                ok: false,
+                reason:
+                  `Selected Telegram channel "${diagnostic.channelLabel}" has no assistant assigned ` +
+                  `for destination "${channelId}". In Studio > Channels, set ` +
+                  `"${diagnostic.requestedAssistantName}" as the channel default or assign this ` +
+                  'group/topic to it.',
+              }
+            }
+            if (diagnostic.status === 'assistant_unavailable') {
+              return {
+                ok: false,
+                reason:
+                  `The workflow step assistant is not available in this workspace for Telegram ` +
+                  `channel "${diagnostic.channelLabel}". Choose an assistant from this workspace, ` +
+                  'then select the Telegram channel again.',
+              }
+            }
+            if (diagnostic.status === 'integration_unavailable') {
+              const label = diagnostic.channelLabel
+                ? ` "${diagnostic.channelLabel}"`
+                : ''
+              return {
+                ok: false,
+                reason:
+                  `The selected Telegram channel${label} is disconnected, inactive, or no longer ` +
+                  'available. Reconnect it in Studio > Channels, then select it again.',
+              }
+            }
+            return {
+              ok: false,
+              reason:
+                `Selected Telegram channel "${diagnostic.channelLabel}" could not load its bot ` +
+                'credentials. Reconnect it in Studio > Channels, then try again.',
+            }
+          } catch (err) {
+            console.warn('[workflow/dependencyIssues] Telegram routing diagnostic failed:', err)
+          }
+        }
         return {
           ok: false,
           reason: channelIntegrationId

--- a/packages/api/src/workflow/dependency-preflight.ts
+++ b/packages/api/src/workflow/dependency-preflight.ts
@@ -23,7 +23,7 @@
  * [COMP:workflow/dependency-preflight]
  */
 
-import { createSlackApi } from '@use-brian/channels'
+import { createSlackApi, createTelegramApi, parseTopicChannelId } from '@use-brian/channels'
 import { APP_LEVEL_ASSISTANT_ID, OFFICIAL_CONNECTOR_TOOLS } from '@use-brian/shared'
 import type { ChannelIntegrationStore } from '../db/channel-integrations.js'
 import type { ConnectorStore } from '../db/connector-store.js'
@@ -188,6 +188,7 @@ export type ValidateDeliveryTarget = (args: {
   assistantId: string
   channelType: 'telegram' | 'slack' | 'whatsapp'
   channelId: string
+  channelIntegrationId?: string
 }) => Promise<{ ok: boolean; reason?: string }>
 
 export type PreflightConnectorTool = (args: {
@@ -257,7 +258,12 @@ export function createWorkflowDependencyPreflight(options: WorkflowDependencyPre
   listSlackChannels: ListSlackChannels
   listSlackMembers: ListSlackMembers
 } {
-  const validateDeliveryTarget: ValidateDeliveryTarget = async ({ assistantId, channelType, channelId }) => {
+  const validateDeliveryTarget: ValidateDeliveryTarget = async ({
+    assistantId,
+    channelType,
+    channelId,
+    channelIntegrationId,
+  }) => {
     if (channelType === 'slack') {
       if (!options.integrationStore) return { ok: true } // can't check → don't block
       const integ = await options.integrationStore.getCredentialsForAssistantSystem(assistantId, 'slack')
@@ -281,12 +287,45 @@ export function createWorkflowDependencyPreflight(options: WorkflowDependencyPre
     }
 
     if (channelType === 'telegram') {
-      let hasToken = !!options.defaultTelegramBotToken
-      if (!hasToken && options.integrationStore) {
-        const integ = await options.integrationStore.getCredentialsForAssistantSystem(assistantId, 'telegram')
-        hasToken = !!integ
+      const tokens: string[] = []
+      if (options.integrationStore) {
+        const integ = channelIntegrationId
+          ? await options.integrationStore.getCredentialsForAssistantIntegrationSystem(
+              assistantId,
+              channelIntegrationId,
+              'telegram',
+              channelId,
+            )
+          : await options.integrationStore.getCredentialsForAssistantSystem(assistantId, 'telegram')
+        const byoToken = integ && (integ.credentials as { bot_token?: string }).bot_token
+        if (byoToken) tokens.push(byoToken)
       }
-      return hasToken ? { ok: true } : { ok: false, reason: 'Telegram is not connected for this assistant' }
+      if (!channelIntegrationId && options.defaultTelegramBotToken && !tokens.includes(options.defaultTelegramBotToken)) {
+        tokens.push(options.defaultTelegramBotToken)
+      }
+      if (tokens.length === 0) {
+        return {
+          ok: false,
+          reason: channelIntegrationId
+            ? 'The selected Telegram channel is not connected to this assistant or destination'
+            : 'Telegram is not connected for this assistant',
+        }
+      }
+
+      const { chatId } = parseTopicChannelId(channelId)
+      for (const token of tokens) {
+        try {
+          await createTelegramApi({ token }).getChat(chatId)
+          return { ok: true }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          if (/Telegram API getChat:.*chat not found/i.test(message)) continue
+          // Network, rate-limit, and other transient failures do not block
+          // authoring. Runtime delivery remains authoritative.
+          return { ok: true }
+        }
+      }
+      return { ok: false, reason: `Telegram: chat not found (${chatId})` }
     }
 
     if (channelType === 'whatsapp') {

--- a/packages/core/src/a2a/types.ts
+++ b/packages/core/src/a2a/types.ts
@@ -242,7 +242,11 @@ export type ConsultRequest = {
    * stripped. See docs/architecture/engine/scheduled-jobs.md →
    * "Deferred confirmations".
    */
-  deliver?: { channelType: 'web' | 'telegram' | 'slack' | 'whatsapp' | 'msteams'; channelId: string }
+  deliver?: {
+    channelType: 'web' | 'telegram' | 'slack' | 'whatsapp' | 'msteams'
+    channelId: string
+    channelIntegrationId?: string
+  }
   /**
    * Optional page anchor for a workflow `assistant_call` step. Always a
    * concrete `saved_views` id by the time it is on the wire — the workflow

--- a/packages/core/src/workflow/__tests__/executor.test.ts
+++ b/packages/core/src/workflow/__tests__/executor.test.ts
@@ -518,6 +518,7 @@ describe('[COMP:workflow/executor] advanceWorkflowRun', () => {
       assistantId: string
       channelType: string
       channelId: string
+      channelIntegrationId?: string
       text: string
     }> = []
     const deps: ExecutorDeps = {
@@ -531,6 +532,7 @@ describe('[COMP:workflow/executor] advanceWorkflowRun', () => {
           assistantId: p.assistantId,
           channelType: p.channelType,
           channelId: p.channelId,
+          channelIntegrationId: p.channelIntegrationId,
           text: p.text,
         })
         return { status: 'delivered' as const, channelType: p.channelType, channelId: p.channelId }
@@ -545,7 +547,11 @@ describe('[COMP:workflow/executor] advanceWorkflowRun', () => {
           type: 'assistant_call',
           target: { assistantId: 'primary' },
           prompt: 'brief me',
-          deliver: { channelType: 'telegram', channelId: 'chat-42' },
+          deliver: {
+            channelType: 'telegram',
+            channelId: 'chat-42',
+            channelIntegrationId: '00000000-0000-4000-8000-000000000001',
+          },
         },
       ],
     }
@@ -560,6 +566,7 @@ describe('[COMP:workflow/executor] advanceWorkflowRun', () => {
         assistantId: PRIMARY_ASSISTANT_ID,
         channelType: 'telegram',
         channelId: 'chat-42',
+        channelIntegrationId: '00000000-0000-4000-8000-000000000001',
         text: 'your morning briefing',
       },
     ])

--- a/packages/core/src/workflow/__tests__/schemas.test.ts
+++ b/packages/core/src/workflow/__tests__/schemas.test.ts
@@ -369,7 +369,12 @@ describe('[COMP:workflow/schemas] WorkflowDefinitionSchema', () => {
 
   function deliverStep(
     id: string,
-    deliver?: { channelType: string; channelId: string; thread?: { fromStep: string } },
+    deliver?: {
+      channelType: string
+      channelId: string
+      channelIntegrationId?: string
+      thread?: { fromStep: string }
+    },
   ) {
     return {
       id,
@@ -400,6 +405,50 @@ describe('[COMP:workflow/schemas] WorkflowDefinitionSchema', () => {
       ],
     }
     expect(WorkflowDefinitionSchema.safeParse(def).success).toBe(true)
+  })
+
+  it('accepts a Telegram destination pinned to one channel integration', () => {
+    const def = {
+      startStepId: 'send',
+      steps: [deliverStep('send', {
+        channelType: 'telegram',
+        channelId: '-100555:topic:42',
+        channelIntegrationId: '00000000-0000-4000-8000-000000000001',
+      })],
+    }
+    expect(WorkflowDefinitionSchema.safeParse(def).success).toBe(true)
+  })
+
+  it('rejects channelIntegrationId on a non-Telegram destination', () => {
+    const def = {
+      startStepId: 'send',
+      steps: [deliverStep('send', {
+        channelType: 'slack',
+        channelId: 'C123',
+        channelIntegrationId: '00000000-0000-4000-8000-000000000001',
+      })],
+    }
+    expect(WorkflowDefinitionSchema.safeParse(def).success).toBe(false)
+  })
+
+  it('rejects a threaded reply pinned to a different channel integration', () => {
+    const def = {
+      startStepId: 'parent',
+      steps: [
+        deliverStep('parent', {
+          channelType: 'telegram',
+          channelId: '-100555:topic:42',
+          channelIntegrationId: '00000000-0000-4000-8000-000000000001',
+        }),
+        deliverStep('reply', {
+          channelType: 'telegram',
+          channelId: '-100555:topic:42',
+          channelIntegrationId: '00000000-0000-4000-8000-000000000002',
+          thread: { fromStep: 'parent' },
+        }),
+      ],
+    }
+    expect(WorkflowDefinitionSchema.safeParse(def).success).toBe(false)
   })
 
   it('rejects deliver.thread on a whatsapp delivery (no threaded replies)', () => {

--- a/packages/core/src/workflow/__tests__/tools.test.ts
+++ b/packages/core/src/workflow/__tests__/tools.test.ts
@@ -1687,6 +1687,7 @@ describe('[COMP:workflow/tools] external-dependency authoring checks', () => {
     expect(data.ok).toBe(false)
     expect(data.errors.join(' ')).toContain('channel_not_found')
     expect(validateDeliveryTarget).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
       assistantId: PRIMARY_ASSISTANT_ID,
       channelType: 'slack',
       channelId: 'web-session-123',
@@ -1702,6 +1703,7 @@ describe('[COMP:workflow/tools] external-dependency authoring checks', () => {
     )
     expect(r.isError).toBeFalsy()
     expect(validateDeliveryTarget).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
       assistantId: DELIVERING_ASSISTANT_ID,
       channelType: 'slack',
       channelId: 'C_TARGET',
@@ -1743,6 +1745,7 @@ describe('[COMP:workflow/tools] external-dependency authoring checks', () => {
     )
     expect(r.isError).toBe(true)
     expect(validateDeliveryTarget).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
       assistantId: PRIMARY_ASSISTANT_ID,
       channelType: 'slack',
       channelId: 'C_STALE',

--- a/packages/core/src/workflow/executor.ts
+++ b/packages/core/src/workflow/executor.ts
@@ -170,6 +170,7 @@ export type DeliverToChannel = (params: {
   userId: string
   channelType: 'web' | 'telegram' | 'slack' | 'whatsapp' | 'msteams'
   channelId: string
+  channelIntegrationId?: string
   text: string
   /**
    * Platform message id to reply under (Slack thread_ts / Telegram
@@ -1303,6 +1304,7 @@ async function dispatchAssistantCall(
               userId: ctx.run.triggeredBy ?? ctx.workflow.createdBy,
               channelType,
               channelId: step.deliver.channelId,
+              channelIntegrationId: step.deliver.channelIntegrationId,
               text: deliveredText,
               threadRef,
             })
@@ -1877,10 +1879,13 @@ async function surfaceConnectorHealth(
         try {
           await deps.deliverToChannel({
             workspaceId: run.workspaceId,
-            assistantId: primaryAssistantId,
+            assistantId: deliverStep.target.assistantId === 'primary'
+              ? primaryAssistantId
+              : deliverStep.target.assistantId,
             userId,
             channelType: deliverStep.deliver.channelType,
             channelId: deliverStep.deliver.channelId,
+            channelIntegrationId: deliverStep.deliver.channelIntegrationId,
             text:
               `Heads up: workflow "${workflow.name}" couldn't use a connector because its ` +
               `credentials stopped working (${dead.map((c) => c.label).join(', ')}). ` +
@@ -1997,10 +2002,13 @@ async function maybeDisableForDeadAnchor(
         try {
           await deps.deliverToChannel({
             workspaceId: run.workspaceId,
-            assistantId: primaryAssistantId,
+            assistantId: deliverStep.target.assistantId === 'primary'
+              ? primaryAssistantId
+              : deliverStep.target.assistantId,
             userId,
             channelType: deliverStep.deliver.channelType,
             channelId: deliverStep.deliver.channelId,
+            channelIntegrationId: deliverStep.deliver.channelIntegrationId,
             text:
               `Workflow "${workflow.name}" was disabled after ${DEAD_ANCHOR_DISABLE_STREAK} runs in a row failed: ` +
               `its page anchor points to a page that no longer exists. ` +

--- a/packages/core/src/workflow/schemas.ts
+++ b/packages/core/src/workflow/schemas.ts
@@ -178,6 +178,7 @@ const assistantCallStepSchema = z.object({
     .object({
       channelType: z.enum(['web', 'telegram', 'slack', 'whatsapp', 'msteams']),
       channelId: z.string().min(1).max(256),
+      channelIntegrationId: z.string().uuid().optional(),
       thread: z.object({ fromStep: stepIdSchema }).strict().optional(),
     })
     .optional(),
@@ -544,6 +545,23 @@ export const WorkflowDefinitionSchema = z
       }
     }
 
+    // Bot integrations are currently an explicit part of Telegram delivery
+    // identity only. Reject inert ids on other channel types instead of
+    // persisting a selection runtime would ignore.
+    for (const [i, step] of def.steps.entries()) {
+      if (
+        step.type === 'assistant_call' &&
+        step.deliver?.channelIntegrationId &&
+        step.deliver.channelType !== 'telegram'
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `step "${step.id}".deliver.channelIntegrationId is only supported for telegram delivery.`,
+          path: ['steps', i, 'deliver', 'channelIntegrationId'],
+        })
+      }
+    }
+
     // `deliver.thread.fromStep` must reference a DIFFERENT assistant_call step
     // that delivers to the SAME channel — the thread parent is the message
     // that step posted this run. Also platform-gated: only Slack (thread_ts)
@@ -553,7 +571,11 @@ export const WorkflowDefinitionSchema = z
     const deliverSteps = new Map(
       def.steps
         .filter((s) => s.type === 'assistant_call' && s.deliver !== undefined)
-        .map((s) => [s.id, (s as { deliver: { channelType: string; channelId: string } }).deliver]),
+        .map((s) => [s.id, (s as { deliver: {
+          channelType: string
+          channelId: string
+          channelIntegrationId?: string
+        } }).deliver]),
     )
     for (const [i, step] of def.steps.entries()) {
       if (step.type !== 'assistant_call' || !step.deliver?.thread) continue
@@ -583,7 +605,8 @@ export const WorkflowDefinitionSchema = z
         })
       } else if (
         parent.channelType !== step.deliver.channelType ||
-        parent.channelId !== step.deliver.channelId
+        parent.channelId !== step.deliver.channelId ||
+        parent.channelIntegrationId !== step.deliver.channelIntegrationId
       ) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,

--- a/packages/core/src/workflow/tools.ts
+++ b/packages/core/src/workflow/tools.ts
@@ -175,6 +175,7 @@ export type WorkflowToolDeps = {
    * docs/architecture/engine/scheduled-jobs.md → "Channel delivery".
    */
   validateDeliveryTarget?: (args: {
+    workspaceId?: string
     assistantId: string
     channelType: 'telegram' | 'slack' | 'whatsapp'
     channelId: string
@@ -775,20 +776,24 @@ async function dependencyIssues(
         const assistantId = t.assistantTarget === 'primary' ? primaryAssistantId : t.assistantTarget
         if (!assistantId) continue
         const res = await deps.validateDeliveryTarget({
+          workspaceId: context.workspaceId ?? undefined,
           assistantId,
           channelType: t.channelType,
           channelId: t.channelId,
           channelIntegrationId: t.channelIntegrationId,
         })
         if (!res.ok) {
+          const guidance = t.channelType === 'slack'
+            ? ' Call `listSlackChannels` to get a real channel id and set it on the terminal step\'s `deliver` as `{ "channelType": "slack", "channelId": "<id>" }` (the internal id from `listChannels` is not a Slack channel id). Or author the workflow from inside the Slack channel you want the result posted to.'
+            : t.channelType === 'telegram'
+              ? /chat not found/i.test(res.reason ?? '')
+                ? ' Author from inside the Telegram chat you want the result delivered to so the correct destination is captured.'
+                : ''
+              : ' Author from inside the chat you want the result delivered to so the correct channel is captured.'
           errors.push(
             `Step "${t.stepId}" delivers to the ${t.channelType} channel "${t.channelId}", which is not reachable: ${
               res.reason ?? 'channel check failed'
-            }. ${
-              t.channelType === 'slack'
-                ? 'Call `listSlackChannels` to get a real channel id and set it on the terminal step\'s `deliver` as `{ "channelType": "slack", "channelId": "<id>" }` (the internal id from `listChannels` is not a Slack channel id). Or author the workflow from inside the Slack channel you want the result posted to.'
-                : 'Author from inside the chat you want the result delivered to so the correct channel is captured.'
-            }`,
+            }.${guidance}`,
           )
         }
       } catch (err) {

--- a/packages/core/src/workflow/tools.ts
+++ b/packages/core/src/workflow/tools.ts
@@ -178,6 +178,7 @@ export type WorkflowToolDeps = {
     assistantId: string
     channelType: 'telegram' | 'slack' | 'whatsapp'
     channelId: string
+    channelIntegrationId?: string
   }) => Promise<{ ok: boolean; reason?: string }>
   /**
    * Authoring-time connector preflight (the GitHub `Bad credentials` incident).
@@ -713,6 +714,7 @@ async function dependencyIssues(
       assistantTarget: AssistantCallStep['target']['assistantId']
       channelType: 'telegram' | 'slack' | 'whatsapp'
       channelId: string
+      channelIntegrationId?: string
     }> = []
     for (const step of def.steps) {
       if (
@@ -729,6 +731,7 @@ async function dependencyIssues(
           assistantTarget: step.target.assistantId,
           channelType: step.deliver.channelType,
           channelId: step.deliver.channelId,
+          channelIntegrationId: step.deliver.channelIntegrationId,
         })
       }
     }
@@ -775,6 +778,7 @@ async function dependencyIssues(
           assistantId,
           channelType: t.channelType,
           channelId: t.channelId,
+          channelIntegrationId: t.channelIntegrationId,
         })
         if (!res.ok) {
           errors.push(

--- a/packages/core/src/workflow/types.ts
+++ b/packages/core/src/workflow/types.ts
@@ -148,6 +148,7 @@ export type AssistantCallStep = WorkflowStepCommon & {
   deliver?: {
     channelType: 'web' | 'telegram' | 'slack' | 'whatsapp' | 'msteams'
     channelId: string
+    channelIntegrationId?: string
     thread?: { fromStep: string }
   }
   /**


### PR DESCRIPTION
## Summary
- persist the selected Telegram channel integration alongside the chat/topic destination
- validate and deliver through that exact bot, including deferred prompts and workflow notifications
- keep private DM destinations visible after selecting a bot without exposing them through `seenChats`
- route Telegram topics with exact topic → base group → channel default precedence
- merge topic inventories across bots so newly added bots do not erase topic names
- report actionable errors when a destination is unassigned, routed to another assistant, or uses an inactive integration
- scope exact integration credential resolution to the workflow workspace
- preserve legacy resolution for existing workflows without a pinned integration

## Verification
- 252 focused Telegram destination, webhook, routing, preflight, confirmation, and workflow tests passed
- API and core type checks passed
- full core suite: 4,919 passed, 20 skipped
- DB integration coverage added; skipped locally because PostgreSQL is unavailable

Follow-up to #199.