### PR TITLE
fix(workflow): execute pinned custom and CLI tools

### DIFF
--- a/packages/api/src/inter-assistant/__tests__/executor.test.ts
+++ b/packages/api/src/inter-assistant/__tests__/executor.test.ts
@@ -51,7 +51,11 @@ vi.mock('../../db/workspace-store.js', () => ({
     .mockResolvedValue({ clearance: 'confidential', compartments: null }),
 }))
 vi.mock('../../mcp/inject.js', () => ({
-  injectMcpTools: vi.fn().mockResolvedValue({ enrichConfirmation: async (_t: string, i: unknown) => i, unavailable: [] }),
+  injectMcpTools: vi.fn().mockResolvedValue({
+    enrichConfirmation: async (_t: string, i: unknown) => i,
+    unavailable: [],
+    restrictedSearchToolNames: [],
+  }),
 }))
 vi.mock('../../routes/proactive-compaction.js', () => ({
   runProactiveCompaction: vi.fn().mockResolvedValue({ messages: [], compacted: false, episodes: [] }),
@@ -796,6 +800,29 @@ describe('[COMP:api/inter-assistant-executor] createCalleeExecutor', () => {
     yieldsText()
     await injectingExecutor(new Map([['searchThings', plainTool()]]))(baseParams)
     expect(mockInjectMcp.mock.calls[0][0].keepBuiltinsDirect).toBe(false)
+  })
+
+  it('keeps a restricted MCP gateway when a custom or CLI tool is pinned', async () => {
+    yieldsText()
+    mockInjectMcp.mockImplementationOnce(async (params) => {
+      params.tools.set('mcp_search', plainTool('mcp_search') as never)
+      params.tools.set('mcp_call', plainTool('mcp_call') as never)
+      return {
+        enrichConfirmation: async (_toolName: string, input: Record<string, unknown>) => input,
+        unavailable: [],
+        restrictedSearchToolNames: ['lookupCustomer'],
+      }
+    })
+
+    await injectingExecutor(new Map())({
+      ...baseParams,
+      callerChannelType: 'workflow',
+      allowedTools: ['lookupCustomer'],
+    })
+
+    expect(mockInjectMcp.mock.calls[0][0].restrictSearchToToolNames).toEqual(['lookupCustomer'])
+    const passed = mockQueryLoop.mock.calls[0][0].tools as Map<string, unknown>
+    expect([...passed.keys()].sort()).toEqual(['mcp_call', 'mcp_search'])
   })
 
   it('persists the assistant turn on turn_complete', async () => {

--- a/packages/api/src/inter-assistant/executor.ts
+++ b/packages/api/src/inter-assistant/executor.ts
@@ -461,6 +461,8 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
     const calleeTools = filterToolsByCapabilities(new Map(options.tools), calleeCapabilities)
     /** Capabilities MCP injection could not provide — see the assignment below. */
     let unavailableCapabilities: string[] = []
+    /** Pinned custom/CLI names retained behind the restricted MCP gateway. */
+    let restrictedSearchToolNames: string[] = []
 
     if (options.connectorStore && options.mcpSettingsStore) {
       try {
@@ -482,6 +484,7 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
           // caller pins tools preserves the token saving on every unpinned callee,
           // which reaches connectors through `mcp_search` exactly as before.
           keepBuiltinsDirect: (params.allowedTools?.length ?? 0) > 0,
+          restrictSearchToToolNames: params.allowedTools,
           connectorStore: options.connectorStore,
           settingsStore: options.mcpSettingsStore,
           assistantConnectorStore: options.assistantConnectorStore,
@@ -513,6 +516,7 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
         // docs/architecture/channels/inter-assistant.md → "Unavailable
         // capabilities on the callee path".
         unavailableCapabilities = mcpInjection.unavailable
+        restrictedSearchToolNames = mcpInjection.restrictedSearchToolNames ?? []
       } catch (err) {
         console.error('[inter-assistant] MCP injection failed for callee:', err)
         // MCP failure is non-fatal; continue with base + capability-filtered tools.
@@ -763,12 +767,18 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
     // (a workflow `assistant_call.tools` restriction), the callee is narrowed
     // to exactly that set — applied last so it overrides the default consult
     // surface and the memory default. Absent → unchanged.
-    const effectiveAllowedTools =
+    const pageAwareAllowedTools =
       params.pageAnchorId
       && params.allowedTools
       && params.allowedTools.some((name) => DOC_MUTATION_TOOLS.has(name))
         ? [...new Set([...params.allowedTools, 'delegateDocEdit'])]
         : params.allowedTools
+    // Custom HTTP and CLI tools remain folded to preserve remote hooks and MCP
+    // policy dispatch. Their index was restricted during injection, so keeping
+    // the two gateways here cannot broaden the workflow's allow-list.
+    const effectiveAllowedTools = restrictedSearchToolNames.length > 0
+      ? [...new Set([...(pageAwareAllowedTools ?? []), 'mcp_search', 'mcp_call'])]
+      : pageAwareAllowedTools
     const finalTools = filterToolsByAllowList(modeTools, effectiveAllowedTools)
 
     // 4c. Leaf invariant — a delegated callee is a terminal node in the

--- a/packages/api/src/mcp/__tests__/inject.test.ts
+++ b/packages/api/src/mcp/__tests__/inject.test.ts
@@ -351,6 +351,50 @@ describe('[COMP:api/mcp-inject] granted custom MCP overlay', () => {
     expect(tools.has('mcp_call')).toBe(true)
   })
 
+  it('restricts a custom MCP search index to pinned workflow tool names', async () => {
+    callRemoteMcpTool.mockResolvedValueOnce('customer found')
+    discoverMcpServer.mockResolvedValueOnce({
+      name: 'CRM MCP',
+      tools: [
+        { name: 'readCustomer', description: 'Read a customer', inputSchema: { type: 'object' } },
+        { name: 'deleteCustomer', description: 'Delete a customer', inputSchema: { type: 'object' } },
+      ],
+    })
+    const tools = new Map()
+    const result = await injectMcpTools({
+      userId: 'owner-1',
+      assistantId: 'a-1',
+      tools,
+      connectorStore: { list: vi.fn().mockResolvedValue([]) } as never,
+      settingsStore: settingsStoreStub() as never,
+      connectorGrantStore: {
+        listForTargetSystem: vi.fn().mockResolvedValue([{
+          grantedByUserId: 'grantor-1',
+          instance: {
+            id: 'ci-crm', provider: 'mcp-crm', label: 'CRM MCP',
+            url: 'http://localhost:8772/mcp', custom: true, connected: true, config: {},
+          },
+        }]),
+      } as never,
+      assistantTeamId: 'ws-shared',
+      restrictSearchToToolNames: ['readCustomer'],
+    })
+
+    expect(result.restrictedSearchToolNames).toEqual(['readCustomer'])
+    const search = tools.get('mcp_search') as { execute: (i: unknown, c: unknown) => Promise<{ data: unknown }> }
+    const hits = await search.execute({ query: 'customer', limit: 8 }, {} as never)
+    expect(JSON.stringify(hits.data)).toContain('readCustomer')
+    expect(JSON.stringify(hits.data)).not.toContain('deleteCustomer')
+    const call = tools.get('mcp_call') as { execute: (i: unknown, c: unknown) => Promise<unknown> }
+    await call.execute({ server: 'CRM MCP', tool: 'readCustomer', args: { id: 'cust-1' } }, {} as never)
+    expect(callRemoteMcpTool).toHaveBeenCalledWith(
+      'http://localhost:8772/mcp',
+      'readCustomer',
+      { id: 'cust-1' },
+      undefined,
+    )
+  })
+
   it('skips a disconnected granted custom MCP', async () => {
     const tools = new Map()
     const connectorGrantStore = {
@@ -415,6 +459,54 @@ describe('[COMP:api/mcp-inject] granted CLI MCP overlay', () => {
     expect(discoverCliServer).toHaveBeenCalledWith(expect.anything(), 'Project Filesystem')
     expect(tools.has('mcp_search')).toBe(true)
     expect(tools.has('mcp_call')).toBe(true)
+  })
+
+  it('matches pinned CLI tools by their canonical MCP names', async () => {
+    callCliMcpTool.mockResolvedValueOnce('local customer found')
+    discoverCliServer.mockResolvedValueOnce({
+      name: 'Local CRM',
+      url: 'stdio://Local CRM',
+      tools: [
+        { name: 'readLocalCustomer', description: 'Read a local customer', inputSchema: { type: 'object' } },
+        { name: 'deleteLocalCustomer', description: 'Delete a local customer', inputSchema: { type: 'object' } },
+      ],
+    })
+    const tools = new Map()
+    const result = await injectMcpTools({
+      userId: 'owner-1', assistantId: 'a-1', tools,
+      connectorStore: { list: vi.fn().mockResolvedValue([]) } as never,
+      settingsStore: settingsStoreStub() as never,
+      connectorGrantStore: {
+        listForTargetSystem: vi.fn().mockResolvedValue([{
+          grantedByUserId: 'grantor-1',
+          instance: {
+            id: 'cli-local', provider: 'cli', label: 'Local CRM',
+            connected: true, config: {}, updatedAt: new Date(0),
+          },
+        }]),
+      } as never,
+      connectorInstanceStore: {
+        listByWorkspaceSystem: vi.fn().mockResolvedValue([]),
+        getAuthCredentialsSystem: vi.fn().mockResolvedValue({
+          type: 'cli', binaryPath: '/usr/bin/node', args: ['/tmp/local-crm.js'],
+        }),
+      } as never,
+      assistantTeamId: 'ws-shared',
+      restrictSearchToToolNames: ['readLocalCustomer'],
+    })
+
+    expect(result.restrictedSearchToolNames).toEqual(['readLocalCustomer'])
+    const search = tools.get('mcp_search') as { execute: (i: unknown, c: unknown) => Promise<{ data: unknown }> }
+    const hits = await search.execute({ query: 'local customer', limit: 8 }, {} as never)
+    expect(JSON.stringify(hits.data)).toContain('readLocalCustomer')
+    expect(JSON.stringify(hits.data)).not.toContain('deleteLocalCustomer')
+    const call = tools.get('mcp_call') as { execute: (i: unknown, c: unknown) => Promise<unknown> }
+    await call.execute({ server: 'Local CRM', tool: 'readLocalCustomer', args: { id: 'cust-2' } }, {} as never)
+    expect(callCliMcpTool).toHaveBeenCalledWith(
+      expect.objectContaining({ binaryPath: '/usr/bin/node' }),
+      'readLocalCustomer',
+      { id: 'cust-2' },
+    )
   })
 
   it('skips only the CLI instance disabled for this assistant', async () => {

--- a/packages/api/src/mcp/inject.ts
+++ b/packages/api/src/mcp/inject.ts
@@ -382,6 +382,8 @@ export type McpInjectionResult = {
   enrichConfirmation: ConfirmationEnricher
   /** Capabilities that are unavailable (not connected, disabled, or blocked). Injected into the system prompt so the model doesn't waste turns searching for them. */
   unavailable: string[]
+  /** Names from `restrictSearchToToolNames` that survived connector discovery and policy scoping. */
+  restrictedSearchToolNames?: string[]
 }
 
 export async function injectMcpTools(params: {
@@ -470,6 +472,12 @@ export async function injectMcpTools(params: {
    */
   keepBuiltinsDirect?: boolean
   /**
+   * Restrict folded custom/CLI sources to these canonical tool names. The
+   * workflow callee uses this with a pinned allow-list so retaining
+   * `mcp_search`/`mcp_call` cannot expose unpinned connector tools.
+   */
+  restrictSearchToToolNames?: readonly string[]
+  /**
    * Tool-use interception port (remote MCP only). Threaded into
    * `createMcpSearchTools` so `preToolUse` can inject/overwrite outbound
    * headers (merged over the connector's stored-credential headers),
@@ -534,7 +542,8 @@ export async function injectMcpTools(params: {
     gdriveFilesStore,
     connectorGrantStore, connectorInstanceStore, workspaceToolPolicyStore, assistantTeamId,
     connectorActionAudit, assistantConnectorGrantsStore, workspaceDomain,
-    keepBuiltinsDirect = false, engineHooks, actorIdentity, filesApi, readCachedFile,
+    keepBuiltinsDirect = false, restrictSearchToToolNames,
+    engineHooks, actorIdentity, filesApi, readCachedFile,
     introspectionTools, emailInboxProvider,
   } = params
 
@@ -889,7 +898,15 @@ export async function injectMcpTools(params: {
               callCliMcpTool(serverParams, toolName, input),
           })
 
-          return { label: inst.name, tools: wrappedTools }
+          // The search gateway already scopes tools by server, so expose the
+          // MCP server's canonical names. `wrapMcpTools` prefixes names for
+          // legacy direct injection, which does not match workflow catalog ids.
+          const searchableTools = wrappedTools.map((tool, index) => ({
+            ...tool,
+            name: server.tools[index]?.name ?? tool.name,
+          }))
+
+          return { label: inst.name, tools: searchableTools }
         }),
       )
 
@@ -1745,8 +1762,28 @@ export async function injectMcpTools(params: {
   // Build + inject the search pair whenever **any** source is present.
   // Direct-injection-only paths (workflow, smoke tests with no custom MCP)
   // still skip when both lists are empty.
-  if (remoteSources.length > 0 || localSources.length > 0) {
-    const index = buildToolIndex([...remoteSources, ...localSources])
+  const restrictedSearchToolNames = new Set<string>()
+  const searchAllowList = restrictSearchToToolNames
+    ? new Set(restrictSearchToToolNames)
+    : null
+  const searchSources = [...remoteSources, ...localSources].flatMap((source) => {
+    if (!searchAllowList) return [source]
+
+    if (source.kind === 'remote') {
+      const matchedTools = source.server.tools.filter((tool) => searchAllowList.has(tool.name))
+      for (const tool of matchedTools) restrictedSearchToolNames.add(tool.name)
+      if (matchedTools.length === 0) return []
+      return [{ ...source, server: { ...source.server, tools: matchedTools } }]
+    }
+
+    const matchedTools = source.tools.filter((tool) => searchAllowList.has(tool.name))
+    for (const tool of matchedTools) restrictedSearchToolNames.add(tool.name)
+    if (matchedTools.length === 0) return []
+    return [{ ...source, tools: matchedTools }]
+  })
+
+  if (searchSources.length > 0) {
+    const index = buildToolIndex(searchSources)
     const searchTools = createMcpSearchTools({
       index,
       settingsStore,
@@ -1766,14 +1803,24 @@ export async function injectMcpTools(params: {
       tools.set(tool.name, tool)
     }
 
-    const remoteCount = remoteSources.reduce((sum, s) => sum + s.server.tools.length, 0)
-    const localCount = localSources.reduce((sum, s) => sum + s.tools.length, 0)
+    const remoteCount = searchSources.reduce(
+      (sum, source) => sum + (source.kind === 'remote' ? source.server.tools.length : 0),
+      0,
+    )
+    const localCount = searchSources.reduce(
+      (sum, source) => sum + (source.kind === 'local' ? source.tools.length : 0),
+      0,
+    )
     console.debug(
-      `[mcp-inject] tool search: ${remoteCount} remote + ${localCount} local across ${remoteSources.length + localSources.length} sources → mcp_search + mcp_call`,
+      `[mcp-inject] tool search: ${remoteCount} remote + ${localCount} local across ${searchSources.length} sources → mcp_search + mcp_call`,
     )
   }
 
-  return { enrichConfirmation: enricher, unavailable }
+  return {
+    enrichConfirmation: enricher,
+    unavailable,
+    restrictedSearchToolNames: [...restrictedSearchToolNames],
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- restrict folded custom HTTP and CLI MCP indexes to the workflow step's pinned canonical tool names
- retain `mcp_search` and `mcp_call` only when a requested dynamic tool survives discovery
- preserve MCP policy and remote engine-hook dispatch without exposing unpinned sibling tools

## Tests
- `corepack pnpm exec vitest run src/mcp/__tests__/inject.test.ts src/inter-assistant/__tests__/executor.test.ts`
- `corepack pnpm typecheck` in `packages/api`
- `corepack pnpm exec vitest run src/lib/__tests__/workflow-tools.test.ts` in `apps/app-web`