### PR TITLE
fix(workflow): harden dynamic connector execution

### DIFF
--- a/apps/app-web/src/lib/__tests__/workflow-tools.test.ts
+++ b/apps/app-web/src/lib/__tests__/workflow-tools.test.ts
@@ -259,7 +259,9 @@ describe("[COMP:app-web/workflow-tools] connected connector loading", () => {
     );
     expect(mockAuthFetch).toHaveBeenNthCalledWith(
       3,
-      expect.stringContaining("/api/connectors/11111111-1111-4111-8111-111111111111/tools"),
+      expect.stringContaining(
+        "/api/assistants/assistant-1/connectors/11111111-1111-4111-8111-111111111111%3Acustom-instance/tools",
+      ),
     );
 
     const groups = buildToolCatalog(sources);

--- a/apps/app-web/src/lib/api/workflow.ts
+++ b/apps/app-web/src/lib/api/workflow.ts
@@ -819,11 +819,11 @@ export async function listConnectedWorkflowToolSources(
         };
       }
 
-      // Custom MCP providers are addressed by their generated provider UUID.
-      // CLI catalogs need the assistant-scoped route: unlike the personal
-      // connector endpoint, it resolves workspace-owned and granted instances.
-      const discoveryUrl = instance.provider === "cli" && assistantId
-        ? `${API_URL}/api/assistants/${encodeURIComponent(assistantId)}/connectors/${encodeURIComponent(`cli:${instance.id}`)}/tools`
+      // Dynamic catalogs use the assistant-scoped exact-instance route so
+      // workspace-owned and granted custom HTTP/CLI instances resolve through
+      // the same exposure and assistant-membership boundary as runtime.
+      const discoveryUrl = assistantId
+        ? `${API_URL}/api/assistants/${encodeURIComponent(assistantId)}/connectors/${encodeURIComponent(`${instance.provider}:${instance.id}`)}/tools`
         : `${API_URL}/api/connectors/${encodeURIComponent(instance.provider === "cli" ? instance.id : instance.provider)}/tools`;
       try {
         const toolRes = await authFetch(discoveryUrl);

--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -2312,6 +2312,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     connectorGrantStore,
     connectorInstanceStore,
     workspaceToolPolicyStore,
+    assistantConnectorGrantsStore,
     knowledgeStore,
     gdriveFilesStore,
     capabilityStore,
@@ -2358,6 +2359,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
       const text = await calleeExecutor({
         callerAssistantId: request.caller.assistantId,
         calleeAssistantId: request.target.assistantId,
+        expectedWorkspaceId: request.target.workspaceId,
         question: request.message.parts
           .filter((p): p is { kind: 'text'; text: string } => p.kind === 'text')
           .map((p) => p.text)
@@ -2467,6 +2469,8 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
         // Evaluated per-run (this closure fires post-boot), so the late
         // `filesApi` initialization below is already done.
         filesApi: filesApi ?? undefined,
+        engineHooks: ports.engineHooks,
+        assistantConnectorGrantsStore,
       },
       { workspaceId, assistantId, userId },
     ),
@@ -4520,6 +4524,8 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     connectorInstanceStore,
     connectorGrantStore,
     mcpSettingsStore,
+    workspaceToolPolicyStore,
+    workspaceStore,
     registry: connectorRegistry,
     jobStore,
     skillStore,

--- a/packages/api/src/inter-assistant/__tests__/executor.test.ts
+++ b/packages/api/src/inter-assistant/__tests__/executor.test.ts
@@ -201,6 +201,14 @@ describe('[COMP:api/inter-assistant-executor] createCalleeExecutor', () => {
     await expect(executor()(baseParams)).rejects.toThrow('Callee assistant not found')
   })
 
+  it('rejects a callee outside the transport-authorized workspace', async () => {
+    await expect(executor()({
+      ...baseParams,
+      expectedWorkspaceId: 'ws-expected',
+    })).rejects.toMatchObject({ reason: 'assistant_workspace_mismatch' })
+    expect(mockSession).not.toHaveBeenCalled()
+  })
+
   it('throws when the callee owner cannot be resolved', async () => {
     mockFindUser.mockResolvedValueOnce(null as never)
     await expect(executor()(baseParams)).rejects.toThrow('Callee owner not found')
@@ -1209,6 +1217,8 @@ describe('[COMP:api/inter-assistant-executor] createCalleeExecutor', () => {
         stub('createWorkflow'),
         stub('updateWorkflow'),
         stub('runWorkflow'),
+        stub('scheduleWorkflow'),
+        stub('createScheduledJob'),
         stub('getWorkflow'),
       ]) as never,
       memoryStore: memoryStore() as never,
@@ -1222,10 +1232,12 @@ describe('[COMP:api/inter-assistant-executor] createCalleeExecutor', () => {
     expect(passedTools.has('createWorkflow')).toBe(false)
     expect(passedTools.has('updateWorkflow')).toBe(false)
     expect(passedTools.has('runWorkflow')).toBe(false)
+    expect(passedTools.has('scheduleWorkflow')).toBe(false)
+    expect(passedTools.has('createScheduledJob')).toBe(false)
     expect(passedTools.has('getWorkflow')).toBe(true)
 
     await expect(
-      callee({ ...baseParams, allowedTools: ['runWorkflow'] }),
+      callee({ ...baseParams, allowedTools: ['createScheduledJob'] }),
     ).rejects.toMatchObject({ reason: 'tools_unavailable' })
     expect(mockQueryLoop).toHaveBeenCalledTimes(1)
   })

--- a/packages/api/src/inter-assistant/executor.ts
+++ b/packages/api/src/inter-assistant/executor.ts
@@ -107,6 +107,7 @@ export type CalleeExecutorOptions = {
   /** Stage 5: enables team-native connector_instance consumption. */
   connectorInstanceStore?: import('../db/connector-instance-store.js').ConnectorInstanceStore
   workspaceToolPolicyStore?: import('../db/workspace-tool-policy-store.js').WorkspaceToolPolicyStore
+  assistantConnectorGrantsStore?: import('../db/assistant-connector-grants-store.js').AssistantConnectorGrantsStore
   knowledgeStore?: KnowledgeStoreInterface
   gdriveFilesStore?: GDriveFilesStore
   /**
@@ -232,6 +233,8 @@ export type CalleeExecutorOptions = {
 export type CalleeQueryParams = {
   callerAssistantId: string
   calleeAssistantId: string
+  /** Authoritative workspace expected by the consult transport. */
+  expectedWorkspaceId?: string
   question: string
   callerSessionId: string
   /**
@@ -348,6 +351,15 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
     // 1. Look up callee assistant and its billing/actor user.
     const calleeAssistant = await findAssistantById(params.calleeAssistantId)
     if (!calleeAssistant) throw new Error('Callee assistant not found')
+    if (
+      params.expectedWorkspaceId
+      && calleeAssistant.workspaceId !== params.expectedWorkspaceId
+    ) {
+      throw Object.assign(
+        new Error('Callee assistant does not belong to the requested workspace'),
+        { reason: 'assistant_workspace_mismatch' },
+      )
+    }
 
     const calleeActorUserId = await billingPartyForAssistant({
       id: calleeAssistant.id,
@@ -494,6 +506,7 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
           connectorGrantStore: options.connectorGrantStore,
           connectorInstanceStore: options.connectorInstanceStore,
           workspaceToolPolicyStore: options.workspaceToolPolicyStore,
+          assistantConnectorGrantsStore: options.assistantConnectorGrantsStore,
           assistantTeamId: calleeAssistant.workspaceId ?? null,
           engineHooks: options.engineHooks,
           // KB write tools are chat-only (D2): the A2A callee path strips
@@ -829,6 +842,10 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
     finalTools.delete('createWorkflow')
     finalTools.delete('updateWorkflow')
     finalTools.delete('runWorkflow')
+    finalTools.delete('scheduleWorkflow')
+    finalTools.delete('createScheduledJob')
+    finalTools.delete('updateScheduledJob')
+    finalTools.delete('deleteScheduledJob')
 
     // Fail fast only after every governance filter, including terminal-node
     // strips. A pin that names only a forbidden orchestration tool must not run
@@ -844,6 +861,10 @@ export function createCalleeExecutor(options: CalleeExecutorOptions): CalleeExec
         'createWorkflow',
         'updateWorkflow',
         'runWorkflow',
+        'scheduleWorkflow',
+        'createScheduledJob',
+        'updateScheduledJob',
+        'deleteScheduledJob',
       ])
       const dropped = params.allowedTools.filter((t) => droppedAskTools.includes(t))
       const forbidden = params.allowedTools.filter((t) => orchestrationTools.has(t))

--- a/packages/api/src/mcp/__tests__/inject.test.ts
+++ b/packages/api/src/mcp/__tests__/inject.test.ts
@@ -493,6 +493,7 @@ describe('[COMP:api/mcp-inject] granted CLI MCP overlay', () => {
       } as never,
       assistantTeamId: 'ws-shared',
       restrictSearchToToolNames: ['readLocalCustomer'],
+      keepDynamicToolsDirect: true,
     })
 
     expect(result.restrictedSearchToolNames).toEqual(['readLocalCustomer'])
@@ -500,12 +501,23 @@ describe('[COMP:api/mcp-inject] granted CLI MCP overlay', () => {
     const hits = await search.execute({ query: 'local customer', limit: 8 }, {} as never)
     expect(JSON.stringify(hits.data)).toContain('readLocalCustomer')
     expect(JSON.stringify(hits.data)).not.toContain('deleteLocalCustomer')
+    expect(tools.has('readLocalCustomer')).toBe(true)
+    expect(tools.has('mcp_Local_CRM_readLocalCustomer')).toBe(true)
     const call = tools.get('mcp_call') as { execute: (i: unknown, c: unknown) => Promise<unknown> }
     await call.execute({ server: 'Local CRM', tool: 'readLocalCustomer', args: { id: 'cust-2' } }, {} as never)
     expect(callCliMcpTool).toHaveBeenCalledWith(
       expect.objectContaining({ binaryPath: '/usr/bin/node' }),
       'readLocalCustomer',
       { id: 'cust-2' },
+    )
+    const legacy = tools.get('mcp_Local_CRM_readLocalCustomer') as {
+      execute: (i: unknown, c: unknown) => Promise<unknown>
+    }
+    await legacy.execute({ id: 'cust-3' }, {} as never)
+    expect(callCliMcpTool).toHaveBeenLastCalledWith(
+      expect.objectContaining({ binaryPath: '/usr/bin/node' }),
+      'readLocalCustomer',
+      { id: 'cust-3' },
     )
   })
 

--- a/packages/api/src/mcp/__tests__/inject.test.ts
+++ b/packages/api/src/mcp/__tests__/inject.test.ts
@@ -332,6 +332,7 @@ describe('[COMP:api/mcp-inject] granted custom MCP overlay', () => {
         },
       ]),
     }
+    const isEnabled = vi.fn().mockResolvedValue(true)
 
     await injectMcpTools({
       userId: 'owner-1',
@@ -340,6 +341,7 @@ describe('[COMP:api/mcp-inject] granted custom MCP overlay', () => {
       connectorStore: { list: vi.fn().mockResolvedValue([]) } as never,
       settingsStore: settingsStoreStub() as never,
       connectorGrantStore: connectorGrantStore as never,
+      assistantConnectorStore: { isEnabled } as never,
       assistantTeamId: 'ws-shared',
     })
 
@@ -349,6 +351,7 @@ describe('[COMP:api/mcp-inject] granted custom MCP overlay', () => {
     // the grant were dropped — no other source exists for this workspace.)
     expect(tools.has('mcp_search')).toBe(true)
     expect(tools.has('mcp_call')).toBe(true)
+    expect(isEnabled).toHaveBeenCalledWith('a-1', 'mcp-uuid-123:ci-mcp', 'mcp-uuid-123')
   })
 
   it('restricts a custom MCP search index to pinned workflow tool names', async () => {
@@ -461,7 +464,7 @@ describe('[COMP:api/mcp-inject] granted CLI MCP overlay', () => {
     expect(tools.has('mcp_call')).toBe(true)
   })
 
-  it('matches pinned CLI tools by their canonical MCP names', async () => {
+  it('matches pinned CLI tools by persisted legacy MCP names', async () => {
     callCliMcpTool.mockResolvedValueOnce('local customer found')
     discoverCliServer.mockResolvedValueOnce({
       name: 'Local CRM',
@@ -492,11 +495,11 @@ describe('[COMP:api/mcp-inject] granted CLI MCP overlay', () => {
         }),
       } as never,
       assistantTeamId: 'ws-shared',
-      restrictSearchToToolNames: ['readLocalCustomer'],
+      restrictSearchToToolNames: ['mcp_Local_CRM_readLocalCustomer'],
       keepDynamicToolsDirect: true,
     })
 
-    expect(result.restrictedSearchToolNames).toEqual(['readLocalCustomer'])
+    expect(result.restrictedSearchToolNames).toEqual(['mcp_Local_CRM_readLocalCustomer'])
     const search = tools.get('mcp_search') as { execute: (i: unknown, c: unknown) => Promise<{ data: unknown }> }
     const hits = await search.execute({ query: 'local customer', limit: 8 }, {} as never)
     expect(JSON.stringify(hits.data)).toContain('readLocalCustomer')
@@ -557,6 +560,41 @@ describe('[COMP:api/mcp-inject] granted CLI MCP overlay', () => {
     expect(isEnabled).toHaveBeenCalledWith('a-1', 'cli:cli-enabled-2', 'cli')
     expect(discoverCliServer).toHaveBeenCalledTimes(1)
     expect(discoverCliServer).toHaveBeenCalledWith(expect.anything(), 'Two')
+  })
+
+  it('does not broaden a restricted legacy name across duplicate CLI labels', async () => {
+    discoverCliServer.mockImplementation(async (_params, name) => ({
+      name,
+      url: `stdio://${name}`,
+      tools: [{ name: 'readEvents', description: 'Read events', inputSchema: { type: 'object' } }],
+    }))
+    const instances = ['cli-a', 'cli-b'].map((id) => ({
+      id, provider: 'cli', label: 'Calendar', connected: true, config: {}, updatedAt: new Date(0),
+    }))
+    const tools = new Map()
+    const result = await injectMcpTools({
+      userId: 'owner-1', assistantId: 'a-1', tools,
+      connectorStore: { list: vi.fn().mockResolvedValue([]) } as never,
+      settingsStore: settingsStoreStub() as never,
+      connectorGrantStore: {
+        listForTargetSystem: vi.fn().mockResolvedValue(instances.map((instance) => ({
+          grantedByUserId: 'grantor-1', instance,
+        }))),
+      } as never,
+      connectorInstanceStore: {
+        listByWorkspaceSystem: vi.fn().mockResolvedValue([]),
+        getAuthCredentialsSystem: vi.fn().mockResolvedValue({
+          type: 'cli', binaryPath: '/usr/bin/node', args: ['/tmp/calendar.js'],
+        }),
+      } as never,
+      assistantTeamId: 'ws-shared',
+      keepBuiltinsDirect: true,
+      restrictSearchToToolNames: ['mcp_Calendar_readEvents'],
+    })
+
+    expect(result.restrictedSearchToolNames).toEqual([])
+    expect(tools.has('mcp_search')).toBe(false)
+    expect(tools.has('mcp_call')).toBe(false)
   })
 })
 

--- a/packages/api/src/mcp/inject.ts
+++ b/packages/api/src/mcp/inject.ts
@@ -471,6 +471,8 @@ export async function injectMcpTools(params: {
    * See `docs/architecture/integrations/mcp.md` → "Tool search pattern".
    */
   keepBuiltinsDirect?: boolean
+  /** Emit canonical + legacy dynamic aliases for workflow tool_call lookup. */
+  keepDynamicToolsDirect?: boolean
   /**
    * Restrict folded custom/CLI sources to these canonical tool names. The
    * workflow callee uses this with a pinned allow-list so retaining
@@ -542,7 +544,7 @@ export async function injectMcpTools(params: {
     gdriveFilesStore,
     connectorGrantStore, connectorInstanceStore, workspaceToolPolicyStore, assistantTeamId,
     connectorActionAudit, assistantConnectorGrantsStore, workspaceDomain,
-    keepBuiltinsDirect = false, restrictSearchToToolNames,
+    keepBuiltinsDirect = false, keepDynamicToolsDirect = false, restrictSearchToToolNames,
     engineHooks, actorIdentity, filesApi, readCachedFile,
     introspectionTools, emailInboxProvider,
   } = params
@@ -1798,8 +1800,20 @@ export async function injectMcpTools(params: {
       callMcpTool: (serverUrl, toolName, input, overrides) =>
         callRemoteMcpTool(serverUrl, toolName, input, mergeValidatedHeaders(headersByUrl.get(serverUrl), overrides)),
       hooks: engineHooks,
+      keepDynamicToolsDirect,
     })
     for (const tool of searchTools) {
+      // A dynamic MCP can choose a generic canonical name such as `search`.
+      // Never let that replace an existing first-party registry entry; its
+      // server-prefixed compatibility alias remains available to tool_call.
+      if (
+        keepDynamicToolsDirect
+        && tool.name !== 'mcp_search'
+        && tool.name !== 'mcp_call'
+        && tools.has(tool.name)
+      ) {
+        continue
+      }
       tools.set(tool.name, tool)
     }
 

--- a/packages/api/src/mcp/inject.ts
+++ b/packages/api/src/mcp/inject.ts
@@ -19,7 +19,7 @@
  */
 
 import type { AccessContext, CachedFile } from '@use-brian/core'
-import { promoteCachedFile, wrapMcpTools, buildToolIndex, createMcpSearchTools, createGoogleCalendarTools, createGmailTools, createGoogleTasksTools, createGoogleDriveTools, createGoogleDocsTools, createGoogleSheetsTools, createGoogleSlidesTools, createGDriveFilesTools, createGitHubTools, createNotionTools, createFathomTools, createShopifyTools, createWordPressTools, createMsGraphTools, createKnowledgeTools, createAgentmailTools, createMailboxTools, workspaceFilesCtxFor, workspaceFilesErrorMessage, workspaceFilesGate } from '@use-brian/core'
+import { promoteCachedFile, wrapMcpTools, buildToolIndex, createMcpSearchTools, legacyMcpToolName, createGoogleCalendarTools, createGmailTools, createGoogleTasksTools, createGoogleDriveTools, createGoogleDocsTools, createGoogleSheetsTools, createGoogleSlidesTools, createGDriveFilesTools, createGitHubTools, createNotionTools, createFathomTools, createShopifyTools, createWordPressTools, createMsGraphTools, createKnowledgeTools, createAgentmailTools, createMailboxTools, workspaceFilesCtxFor, workspaceFilesErrorMessage, workspaceFilesGate } from '@use-brian/core'
 import type { Tool, McpSettingsStore, McpServerConfig, KnowledgeStoreInterface, KnowledgeRepoWriter, AuthorizedFile, GDriveFilesStore, GDriveFileKind, LocalSource, RemoteSource, EngineHooks, FilesApi, AgentmailToolApi, MailboxApi, MailboxAccountRouter } from '@use-brian/core'
 import { getGlobalEmailInboxProvider, type EmailInboxProvider } from '../agentmail/provider.js'
 import { renderEmailBody } from '@use-brian/channels'
@@ -591,6 +591,9 @@ export async function injectMcpTools(params: {
     console.error('[mcp-inject] failed to list connectors:', err)
     return { enrichConfirmation: async (_t, input) => input, unavailable }
   }
+  const teamPolicyStore = assistantTeamId && workspaceToolPolicyStore
+    ? workspacePolicyAsSettingsStore(workspaceToolPolicyStore, assistantTeamId)
+    : settingsStore
 
   // Layer 1: connected connectors with a remote URL (custom + directory).
   // Built-in connectors (gcal, gmail) are handled separately below. We
@@ -612,9 +615,13 @@ export async function injectMcpTools(params: {
     sendActorIdentity: boolean
     /** Opt-in: send the acting user's `X-UseBrian-Media-Token` capability to this connector. */
     sendMediaToken: boolean
+    policyStore: McpSettingsStore
+    policyUserId: string
+    policyServerName?: string
+    governanceId: string
   }> = connectors
     .filter((c) => c.connected && c.url)
-    .map((c) => ({ connectorId: c.connectorId, name: c.name, url: c.url!, instanceId: c.id, updatedAt: c.updatedAt, preflightHeaders: preflightHeadersToRecord(c.config), sendActorIdentity: c.config?.sendActorIdentity === true, sendMediaToken: c.config?.sendMediaToken === true }))
+    .map((c) => ({ connectorId: c.connectorId, name: c.name, url: c.url!, instanceId: c.id, updatedAt: c.updatedAt, preflightHeaders: preflightHeadersToRecord(c.config), sendActorIdentity: c.config?.sendActorIdentity === true, sendMediaToken: c.config?.sendMediaToken === true, policyStore: settingsStore, policyUserId: userId, governanceId: c.connectorId }))
 
   // Team-native custom MCP instances live as separate `connector_instance`
   // rows scoped to the team. The `provider` column is a UUID for custom
@@ -635,6 +642,10 @@ export async function injectMcpTools(params: {
           preflightHeaders: preflightHeadersToRecord(inst.config),
           sendActorIdentity: inst.config?.sendActorIdentity === true,
           sendMediaToken: inst.config?.sendMediaToken === true,
+          policyStore: teamPolicyStore,
+          policyUserId: userId,
+          policyServerName: inst.provider,
+          governanceId: connectorInstanceGovernanceId(inst.provider, inst.id),
         })
       }
     } catch (err) {
@@ -648,7 +659,7 @@ export async function injectMcpTools(params: {
     const checks = await Promise.all(
       connectedCustom.map(async (c) => ({
         connector: c,
-        enabled: await assistantConnectorStore.isEnabled(assistantId, c.connectorId),
+        enabled: await assistantConnectorStore.isEnabled(assistantId, c.governanceId, c.connectorId),
       })),
     )
     active = checks.filter((c) => c.enabled).map((c) => c.connector)
@@ -685,6 +696,7 @@ export async function injectMcpTools(params: {
   const discoveredServers: Array<{
     server: McpServerConfig
     connectorUrl: string
+    policy: NonNullable<RemoteSource['policy']>
   }> = []
 
   // Resolve per-connector auth headers up front and register them in the
@@ -737,8 +749,16 @@ export async function injectMcpTools(params: {
       const cached = getCachedDiscovery(cacheKey)
       if (cached) {
         console.debug(`[mcp-inject] ${connector.name}: cache hit (${cached.tools.length} tools)`)
-        discoveredServers.push({ server: cached, connectorUrl: connector.url })
-        return
+        return {
+          server: cached,
+          connectorUrl: connector.url,
+          policy: {
+            settingsStore: connector.policyStore,
+            userId: connector.policyUserId,
+            serverName: connector.policyServerName,
+            appLevelAssistantId: APP_LEVEL_ASSISTANT_ID,
+          },
+        }
       }
 
       // Discover with timeout
@@ -750,16 +770,26 @@ export async function injectMcpTools(params: {
       ])
 
       setCachedDiscovery(cacheKey, server)
-      discoveredServers.push({ server, connectorUrl: connector.url })
-
       console.debug(
         `[mcp-inject] ${connector.name}: discovered ${server.tools.length} tools`,
       )
+      return {
+        server,
+        connectorUrl: connector.url,
+        policy: {
+          settingsStore: connector.policyStore,
+          userId: connector.policyUserId,
+          serverName: connector.policyServerName,
+          appLevelAssistantId: APP_LEVEL_ASSISTANT_ID,
+        },
+      }
     }),
   )
 
   for (const result of discoveries) {
-    if (result.status === 'rejected') {
+    if (result.status === 'fulfilled') {
+      discoveredServers.push(result.value)
+    } else {
       console.error('[mcp-inject] server discovery failed:', result.reason)
     }
   }
@@ -773,12 +803,13 @@ export async function injectMcpTools(params: {
   // (`keepBuiltinsDirect: true`) still gets `mcp_search` / `mcp_call`
   // here for custom MCP only — built-ins stay direct so the workflow
   // executor's per-tool `requiresConfirmation` inspection still works.
-  const remoteSources: RemoteSource[] = discoveredServers.map(({ server, connectorUrl }) => ({
+  const remoteSources: RemoteSource[] = discoveredServers.map(({ server, connectorUrl, policy }) => ({
     kind: 'remote' as const,
     server,
     serverUrl: connectorUrl,
     callMcpTool: (url: string, toolName: string, input: Record<string, unknown>) =>
       callRemoteMcpTool(url, toolName, input, headersByUrl.get(url)),
+    policy,
   }))
 
   // Discover a custom remote MCP shared to this workspace via a grant and add
@@ -793,6 +824,7 @@ export async function injectMcpTools(params: {
     cacheUserId: string,
     instanceId?: string | null,
     updatedAt?: Date | null,
+    policyServerName?: string,
   ): Promise<void> {
     if (remoteSources.some((s) => s.serverUrl === url)) return
     try {
@@ -815,6 +847,12 @@ export async function injectMcpTools(params: {
         serverUrl: url,
         callMcpTool: (u: string, toolName: string, input: Record<string, unknown>) =>
           callRemoteMcpTool(u, toolName, input, headersByUrl.get(u)),
+        policy: {
+          settingsStore,
+          userId: cacheUserId,
+          serverName: policyServerName,
+          appLevelAssistantId: APP_LEVEL_ASSISTANT_ID,
+        },
       })
       console.debug(`[mcp-inject] granted custom MCP ${name}: discovered ${server.tools.length} tools`)
     } catch (err) {
@@ -836,9 +874,19 @@ export async function injectMcpTools(params: {
       name: string
       updatedAt: Date | null
       config?: Record<string, unknown>
+      policyStore: McpSettingsStore
+      policyUserId: string
+      policyServerName?: string
     }> = connectors
       .filter((c) => c.connectorId === 'cli' && c.connected)
-      .map((c) => ({ id: c.id, name: c.name, updatedAt: c.updatedAt, config: c.config }))
+      .map((c) => ({
+        id: c.id,
+        name: c.name,
+        updatedAt: c.updatedAt,
+        config: c.config,
+        policyStore: settingsStore,
+        policyUserId: userId,
+      }))
 
     // Workspace assistants suppress all owner-personal base loading. A CLI
     // reaches them only through an explicit workspace grant or team ownership,
@@ -852,10 +900,31 @@ export async function injectMcpTools(params: {
           : Promise.resolve([]),
       ])
       const seen = new Set(cliInstances.map((inst) => inst.id))
-      for (const inst of [...teamNative, ...grants.map((grant) => grant.instance)]) {
+      for (const inst of teamNative) {
         if (inst.provider !== 'cli' || !inst.connected || seen.has(inst.id)) continue
         seen.add(inst.id)
-        cliInstances.push({ id: inst.id, name: inst.label, updatedAt: inst.updatedAt, config: inst.config })
+        cliInstances.push({
+          id: inst.id,
+          name: inst.label,
+          updatedAt: inst.updatedAt,
+          config: inst.config,
+          policyStore: teamPolicyStore,
+          policyUserId: userId,
+          policyServerName: connectorInstanceGovernanceId('cli', inst.id),
+        })
+      }
+      for (const grant of grants) {
+        const inst = grant.instance
+        if (inst.provider !== 'cli' || !inst.connected || seen.has(inst.id)) continue
+        seen.add(inst.id)
+        cliInstances.push({
+          id: inst.id,
+          name: inst.label,
+          updatedAt: inst.updatedAt,
+          config: inst.config,
+          policyStore: settingsStore,
+          policyUserId: grant.grantedByUserId,
+        })
       }
     }
     if (cliInstances.length > 0 && connectorInstanceStore) {
@@ -893,9 +962,11 @@ export async function injectMcpTools(params: {
 
           const wrappedTools = wrapMcpTools({
             server,
-            settingsStore,
+            settingsStore: inst.policyStore,
             assistantId,
-            userId,
+            userId: inst.policyUserId,
+            appLevelAssistantId: APP_LEVEL_ASSISTANT_ID,
+            policyServerName: inst.policyServerName,
             callMcpTool: (_serverName, toolName, input) =>
               callCliMcpTool(serverParams, toolName, input),
           })
@@ -1222,7 +1293,9 @@ export async function injectMcpTools(params: {
           // (keyed on the provider UUID, like the team-native custom path),
           // then discover it and add it to the search index. Without this the
           // grant is a no-op for workspace assistants — the tools never appear.
-          const enabled = !assistantConnectorStore || await assistantConnectorStore.isEnabled(assistantId, p)
+          const governanceId = connectorInstanceGovernanceId(p, g.instance.id)
+          const enabled = !assistantConnectorStore
+            || await assistantConnectorStore.isEnabled(assistantId, governanceId, p)
           if (enabled) {
             await addGrantedCustomMcp(g.instance.url, g.instance.label ?? p, g.grantedByUserId, g.instance.id, g.instance.updatedAt)
           }
@@ -1265,10 +1338,6 @@ export async function injectMcpTools(params: {
       // workspace-keyed adapter so allow/ask/block resolves from
       // workspace_tool_policy. Falls back to the per-user store when the shared
       // policy store isn't wired (legacy call sites / tests).
-      const teamPolicyStore = workspaceToolPolicyStore
-        ? workspacePolicyAsSettingsStore(workspaceToolPolicyStore, assistantTeamId)
-        : settingsStore
-
       // Synthesize a "connectors" array that looks like the legacy per-user
       // one, so the per-provider injectors' enable checks and discovery
       // logic don't need to change. `credsOverride` / `credsOverridePerConnector`
@@ -1768,18 +1837,42 @@ export async function injectMcpTools(params: {
   const searchAllowList = restrictSearchToToolNames
     ? new Set(restrictSearchToToolNames)
     : null
+  const restrictedNameCounts = new Map<string, number>()
+  if (searchAllowList) {
+    for (const source of [...remoteSources, ...localSources]) {
+      const serverName = source.kind === 'remote' ? source.server.name : source.serverName
+      const sourceTools = source.kind === 'remote' ? source.server.tools : source.tools
+      for (const tool of sourceTools) {
+        for (const name of new Set([tool.name, legacyMcpToolName(serverName, tool.name)])) {
+          restrictedNameCounts.set(name, (restrictedNameCounts.get(name) ?? 0) + 1)
+        }
+      }
+    }
+  }
   const searchSources = [...remoteSources, ...localSources].flatMap((source) => {
     if (!searchAllowList) return [source]
 
     if (source.kind === 'remote') {
-      const matchedTools = source.server.tools.filter((tool) => searchAllowList.has(tool.name))
-      for (const tool of matchedTools) restrictedSearchToolNames.add(tool.name)
+      const matchedTools = source.server.tools.filter((tool) => {
+        const legacyName = legacyMcpToolName(source.server.name, tool.name)
+        const canonicalMatch = searchAllowList.has(tool.name) && restrictedNameCounts.get(tool.name) === 1
+        const legacyMatch = searchAllowList.has(legacyName) && restrictedNameCounts.get(legacyName) === 1
+        if (canonicalMatch) restrictedSearchToolNames.add(tool.name)
+        if (legacyMatch) restrictedSearchToolNames.add(legacyName)
+        return canonicalMatch || legacyMatch
+      })
       if (matchedTools.length === 0) return []
       return [{ ...source, server: { ...source.server, tools: matchedTools } }]
     }
 
-    const matchedTools = source.tools.filter((tool) => searchAllowList.has(tool.name))
-    for (const tool of matchedTools) restrictedSearchToolNames.add(tool.name)
+    const matchedTools = source.tools.filter((tool) => {
+      const legacyName = legacyMcpToolName(source.serverName, tool.name)
+      const canonicalMatch = searchAllowList.has(tool.name) && restrictedNameCounts.get(tool.name) === 1
+      const legacyMatch = searchAllowList.has(legacyName) && restrictedNameCounts.get(legacyName) === 1
+      if (canonicalMatch) restrictedSearchToolNames.add(tool.name)
+      if (legacyMatch) restrictedSearchToolNames.add(legacyName)
+      return canonicalMatch || legacyMatch
+    })
     if (matchedTools.length === 0) return []
     return [{ ...source, tools: matchedTools }]
   })

--- a/packages/api/src/routes/__tests__/assistants-connector-scoping.test.ts
+++ b/packages/api/src/routes/__tests__/assistants-connector-scoping.test.ts
@@ -19,6 +19,10 @@ const mockDiscoverCli = vi.fn()
 vi.mock('../../mcp/cli-transport.js', () => ({
   discoverCliServer: (...args: unknown[]) => mockDiscoverCli(...args),
 }))
+const mockDiscoverMcp = vi.fn()
+vi.mock('../../mcp/client.js', () => ({
+  discoverMcpServer: (...args: unknown[]) => mockDiscoverMcp(...args),
+}))
 
 import { assistantRoutes } from '../assistants.js'
 import { queryWithRLS } from '../../db/client.js'
@@ -40,6 +44,12 @@ const connectorInstanceStore = {
 }
 const connectorGrantStore = { listForTargetSystem: vi.fn() }
 const mcpSettingsStore = { getPolicy: vi.fn(), setPolicy: vi.fn() }
+const workspaceToolPolicyStore = {
+  getPolicy: vi.fn(),
+  setPolicy: vi.fn(),
+  listForWorkspace: vi.fn(),
+}
+const workspaceStore = { getRole: vi.fn() }
 const capabilityStore = { listActive: vi.fn<(id: string) => Promise<string[]>>() }
 
 beforeEach(() => {
@@ -51,9 +61,14 @@ beforeEach(() => {
   connectorInstanceStore.getAuthCredentialsSystem.mockReset().mockResolvedValue(null)
   connectorGrantStore.listForTargetSystem.mockReset().mockResolvedValue([])
   mockDiscoverCli.mockReset().mockResolvedValue({ name: 'CLI', tools: [] })
+  mockDiscoverMcp.mockReset().mockResolvedValue({ name: 'Custom MCP', tools: [] })
   capabilityStore.listActive.mockReset().mockResolvedValue([])
   mcpSettingsStore.getPolicy.mockReset().mockResolvedValue(null)
   mcpSettingsStore.setPolicy.mockReset().mockResolvedValue(undefined)
+  workspaceToolPolicyStore.getPolicy.mockReset().mockResolvedValue(null)
+  workspaceToolPolicyStore.setPolicy.mockReset().mockResolvedValue(undefined)
+  workspaceToolPolicyStore.listForWorkspace.mockReset().mockResolvedValue([])
+  workspaceStore.getRole.mockReset().mockResolvedValue('owner')
 })
 
 function makeApp(userId: string) {
@@ -71,6 +86,8 @@ function makeApp(userId: string) {
       connectorInstanceStore: connectorInstanceStore as never,
       connectorGrantStore: connectorGrantStore as never,
       mcpSettingsStore: mcpSettingsStore as never,
+      workspaceToolPolicyStore: workspaceToolPolicyStore as never,
+      workspaceStore: workspaceStore as never,
       // Built-in primitive rows report `enabled` from the capability grant
       // (docs/architecture/features/builtin-primitives.md), so this handler
       // reads the store — an empty stub object is no longer sufficient.
@@ -115,6 +132,27 @@ describe('[COMP:routes/assistants-connector-scoping] GET /:assistantId/connector
     // (files) are synthesized in every response — asserted separately below.
     expect(connectors.filter((c) => c.scope !== 'builtin').map((c) => c.id)).toEqual(['github'])
     expect(connectors[0].scope).toBe('team-native')
+  })
+
+  it('lists workspace custom connectors under exact instance ids', async () => {
+    queueMembershipAndTeam('admin', 'ws-shared')
+    connectorInstanceStore.listByWorkspaceSystem.mockResolvedValueOnce([{
+      id: 'custom-1', provider: '11111111-1111-4111-8111-111111111111',
+      label: 'Team CRM', url: 'https://crm.example.com/mcp',
+      custom: true, connected: true,
+    }])
+
+    const res = await request(makeApp('u-admin')).get('/api/assistants/a-1/connectors')
+
+    expect(res.status).toBe(200)
+    expect(res.body.connectors).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: '11111111-1111-4111-8111-111111111111:custom-1',
+        providerId: '11111111-1111-4111-8111-111111111111',
+        custom: true,
+        instanceId: 'custom-1',
+      }),
+    ]))
   })
 
   it('does not expose internal WhatsApp channel instances as tool connectors', async () => {
@@ -575,5 +613,104 @@ describe('[COMP:routes/assistants-connector-scoping] CLI instance governance rou
       toolName: 'listEvents',
       policy: 'ask',
     }))
+  })
+})
+
+describe('[COMP:routes/assistants-connector-scoping] custom instance tool discovery', () => {
+  it('discovers an exact custom HTTP instance granted to the workspace', async () => {
+    queueMembershipAndTeam('owner', 'ws-1')
+    const instance = {
+      id: 'mcp-1', scope: 'user', userId: 'u-grantor', workspaceId: null,
+      provider: '11111111-1111-4111-8111-111111111111',
+      label: 'Granted CRM', url: 'https://crm.example.com/mcp',
+      custom: true, connected: true, config: {},
+    }
+    connectorGrantStore.listForTargetSystem.mockResolvedValue([{ grantedByUserId: 'u-grantor', instance }])
+    connectorStore.list.mockResolvedValue([{
+      id: 'mcp-1', connectorId: instance.provider, name: 'Viewer copy',
+      url: 'https://wrong.example.com/mcp', custom: true, connected: true,
+    }])
+    connectorInstanceStore.getAuthCredentialsSystem.mockResolvedValue(null)
+    mockDiscoverMcp.mockResolvedValue({
+      name: 'Granted CRM',
+      tools: [{ name: 'read_customer', description: 'Read a customer record.' }],
+    })
+
+    const res = await request(makeApp('u-owner')).get(
+      '/api/assistants/a-1/connectors/11111111-1111-4111-8111-111111111111%3Amcp-1/tools',
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({
+      serverName: 'Granted CRM',
+      tools: [expect.objectContaining({ name: 'read_customer', classification: 'read' })],
+    })
+    expect(mockDiscoverMcp).toHaveBeenCalledWith(
+      'https://crm.example.com/mcp',
+      'Granted CRM',
+      {},
+    )
+    expect(connectorInstanceStore.getAuthCredentialsSystem).toHaveBeenCalledWith('mcp-1')
+
+    mockAccess.mockResolvedValueOnce({
+      assistant: { id: 'a-1', name: 'A', workspaceId: 'ws-1' },
+      role: 'owner',
+    } as never)
+    const updated = await request(makeApp('u-owner'))
+      .post('/api/assistants/a-1/connectors/11111111-1111-4111-8111-111111111111%3Amcp-1/tools/policy')
+      .send({ serverName: 'Granted CRM', toolName: 'read_customer', policy: 'block' })
+    expect(updated.status).toBe(200)
+    expect(mcpSettingsStore.setPolicy).toHaveBeenCalledWith(expect.objectContaining({
+      assistantId: 'a-1',
+      userId: 'u-grantor',
+      serverName: 'Granted CRM',
+      toolName: 'read_customer',
+      policy: 'block',
+    }))
+  })
+
+  it('writes workspace-owned CLI policy to the exact workspace governance id', async () => {
+    mockAccess.mockResolvedValue({
+      assistant: { id: 'a-1', name: 'A', workspaceId: 'ws-1' },
+      role: 'owner',
+    } as never)
+    connectorInstanceStore.listByWorkspaceSystem.mockResolvedValue([{
+      id: 'cli-team', scope: 'workspace', workspaceId: 'ws-1',
+      provider: 'cli', label: 'Team CLI', connected: true,
+    }])
+
+    const updated = await request(makeApp('u-owner'))
+      .post('/api/assistants/a-1/connectors/cli%3Acli-team/tools/policy')
+      .send({ serverName: 'Team CLI', toolName: 'read_data', policy: 'block' })
+
+    expect(updated.status).toBe(200)
+    expect(workspaceToolPolicyStore.setPolicy).toHaveBeenCalledWith(expect.objectContaining({
+      workspaceId: 'ws-1',
+      serverName: 'cli:cli-team',
+      toolName: 'read_data',
+      policy: 'block',
+      updatedBy: 'u-owner',
+    }))
+    expect(mcpSettingsStore.setPolicy).not.toHaveBeenCalled()
+  })
+
+  it('rejects workspace-wide dynamic policy writes from ordinary members', async () => {
+    mockAccess.mockResolvedValue({
+      assistant: { id: 'a-1', name: 'A', workspaceId: 'ws-1' },
+      role: 'member',
+    } as never)
+    connectorInstanceStore.listByWorkspaceSystem.mockResolvedValue([{
+      id: 'cli-team', scope: 'workspace', workspaceId: 'ws-1',
+      provider: 'cli', label: 'Team CLI', connected: true,
+    }])
+    workspaceStore.getRole.mockResolvedValue('member')
+
+    const updated = await request(makeApp('u-member'))
+      .post('/api/assistants/a-1/connectors/cli%3Acli-team/tools/policy')
+      .send({ serverName: 'Team CLI', toolName: 'read_data', policy: 'allow' })
+
+    expect(updated.status).toBe(403)
+    expect(workspaceToolPolicyStore.setPolicy).not.toHaveBeenCalled()
+    expect(mcpSettingsStore.setPolicy).not.toHaveBeenCalled()
   })
 })

--- a/packages/api/src/routes/assistants.ts
+++ b/packages/api/src/routes/assistants.ts
@@ -29,6 +29,7 @@ import {
   type ConnectorInstanceStore,
 } from '../db/connector-instance-store.js'
 import { buildConnectorAuthHeaders } from '../mcp/auth-headers.js'
+import { workspacePolicyAsSettingsStore } from '../db/workspace-tool-policy-store.js'
 import type { ConnectorGrantStore } from '../db/connector-grant-store.js'
 import type { McpSettingsStore, JobStore, CapabilityStore } from '@use-brian/core'
 import {
@@ -65,6 +66,8 @@ type AssistantRouteOptions = {
   connectorInstanceStore?: ConnectorInstanceStore
   connectorGrantStore?: ConnectorGrantStore
   mcpSettingsStore?: McpSettingsStore
+  workspaceToolPolicyStore?: import('../db/workspace-tool-policy-store.js').WorkspaceToolPolicyStore
+  workspaceStore?: Pick<import('../db/workspace-store.js').WorkspaceStore, 'getRole'>
   registry?: ConnectorEntry[]
   jobStore?: JobStore
   skillStore?: SkillStore
@@ -866,7 +869,7 @@ export function assistantRoutes(options: AssistantRouteOptions): Router {
           // WhatsApp channel infrastructure owns connector_instance rows for
           // credentials and attribution, but it exposes no assistant tools.
           if (inst.provider === 'whatsapp') continue
-          if (ALL_EXACT_INSTANCE_GOVERNANCE_CONNECTOR_IDS.has(inst.provider)) {
+          if (inst.custom || ALL_EXACT_INSTANCE_GOVERNANCE_CONNECTOR_IDS.has(inst.provider)) {
             // Exact-governance account routers expose only usable accounts in
             // Assistant Tools; disconnected/auth-failed rows stay manageable
             // on the workspace connector surface.
@@ -877,7 +880,7 @@ export function assistantRoutes(options: AssistantRouteOptions): Router {
               providerId: inst.provider,
               name: inst.connectedEmail ?? inst.label,
               connectedEmail: inst.connectedEmail ?? undefined,
-              custom: false,
+              custom: inst.custom,
               connected: inst.connected,
               enabled: settingsMap.get(governanceId) ?? settingsMap.get(inst.provider) ?? true,
               icon_url: entry?.icon_url,
@@ -940,7 +943,7 @@ export function assistantRoutes(options: AssistantRouteOptions): Router {
             if (winningGrantor && winningGrantor !== g.grantedByUserId) continue
             if (!winningGrantor) winningGrantorByProvider.set(g.instance.provider, g.grantedByUserId)
           }
-          if (ALL_EXACT_INSTANCE_GOVERNANCE_CONNECTOR_IDS.has(g.instance.provider)) {
+          if (g.instance.custom || ALL_EXACT_INSTANCE_GOVERNANCE_CONNECTOR_IDS.has(g.instance.provider)) {
             if (!g.instance.connected) continue
             if (g.instance.provider !== 'cli' && g.instance.healthStatus === 'auth_failed') continue
             const governanceId = connectorInstanceGovernanceId(g.instance.provider, g.instance.id)
@@ -949,7 +952,7 @@ export function assistantRoutes(options: AssistantRouteOptions): Router {
               providerId: g.instance.provider,
               name: g.instance.connectedEmail ?? g.instance.label,
               connectedEmail: g.instance.connectedEmail ?? undefined,
-              custom: false,
+              custom: g.instance.custom,
               connected: g.instance.connected,
               enabled: settingsMap.get(governanceId) ?? settingsMap.get(g.instance.provider) ?? true,
               icon_url: entry?.icon_url,
@@ -1138,17 +1141,16 @@ export function assistantRoutes(options: AssistantRouteOptions): Router {
 
     const { assistantId, connectorId } = req.params as { assistantId: string; connectorId: string }
     const parsedGovernanceId = parseConnectorInstanceGovernanceId(connectorId)
-    const providerId = parsedGovernanceId && OFFICIAL_CONNECTOR_TOOLS[parsedGovernanceId.provider]
-      ? parsedGovernanceId.provider
-      : connectorId
-    const governanceId = parsedGovernanceId && providerId === parsedGovernanceId.provider
-      ? connectorId
-      : providerId
+    const providerId = parsedGovernanceId?.provider ?? connectorId
+    const governanceId = parsedGovernanceId ? connectorId : providerId
 
     try {
       if (providerId === 'cli' && parsedGovernanceId && options.connectorInstanceStore) {
         const instanceId = parsedGovernanceId.instanceId
         let instance: ConnectorInstance | null = null
+        let policyStore = options.mcpSettingsStore
+        let policyUserId = member.userId
+        let policyServerName: string | null = null
         if (member.workspaceId) {
           const [teamNative, grants] = await Promise.all([
             options.connectorInstanceStore.listByWorkspaceSystem(member.workspaceId),
@@ -1156,10 +1158,19 @@ export function assistantRoutes(options: AssistantRouteOptions): Router {
               ? options.connectorGrantStore.listForTargetSystem('workspace', member.workspaceId)
               : Promise.resolve([]),
           ])
-          instance = [
-            ...teamNative,
-            ...grants.map((grant) => grant.instance),
-          ].find((candidate) => candidate.id === instanceId && candidate.provider === 'cli') ?? null
+          const teamOwned = teamNative.find(
+            (candidate) => candidate.id === instanceId && candidate.provider === 'cli',
+          ) ?? null
+          const grant = grants.find(
+            (candidate) => candidate.instance.id === instanceId && candidate.instance.provider === 'cli',
+          ) ?? null
+          instance = teamOwned ?? grant?.instance ?? null
+          if (teamOwned && options.workspaceToolPolicyStore) {
+            policyStore = workspacePolicyAsSettingsStore(options.workspaceToolPolicyStore, member.workspaceId)
+            policyServerName = connectorId
+          } else if (grant) {
+            policyUserId = grant.grantedByUserId
+          }
         } else {
           instance = await options.connectorInstanceStore.get(member.userId, instanceId)
           if (instance?.provider !== 'cli' || instance.scope !== 'user' || instance.userId !== member.userId) {
@@ -1184,20 +1195,21 @@ export function assistantRoutes(options: AssistantRouteOptions): Router {
           cwd: typeof instance.config?.cwd === 'string' ? instance.config.cwd : undefined,
           timeoutMs: typeof instance.config?.timeoutMs === 'number' ? instance.config.timeoutMs : undefined,
         }, instance.label)
+        policyServerName ??= server.name
 
         const tools = await Promise.all(server.tools.map(async (tool) => {
           const classification = classifyTool(tool.name, tool.description)
           const fallback = defaultPolicy(classification)
-          const appOverride = await options.mcpSettingsStore!.getPolicy({
+          const appOverride = await policyStore!.getPolicy({
             assistantId: APP_LEVEL_ASSISTANT_ID,
-            userId: member.userId,
-            serverName: server.name,
+            userId: policyUserId,
+            serverName: policyServerName,
             toolName: tool.name,
           })
-          const assistantOverride = await options.mcpSettingsStore!.getPolicy({
+          const assistantOverride = await policyStore!.getPolicy({
             assistantId,
-            userId: member.userId,
-            serverName: server.name,
+            userId: policyUserId,
+            serverName: policyServerName,
             toolName: tool.name,
           })
           const appPolicy = appOverride?.policy ?? fallback
@@ -1259,7 +1271,11 @@ export function assistantRoutes(options: AssistantRouteOptions): Router {
       // MCPs use a UUID `provider` (set in connector-instances.ts) so
       // they can never collide with personal `connectorId`s here.
       const connectors = await options.connectorStore!.list(member.userId)
-      const personal = connectors.find((c) => c.connectorId === connectorId)
+      const personal = member.workspaceId
+        ? undefined
+        : connectors.find((c) => parsedGovernanceId
+          ? c.id === parsedGovernanceId.instanceId && c.connectorId === providerId
+          : c.connectorId === providerId)
       let mcpUrl: string | null = personal?.url ?? null
       let mcpName: string = personal?.name ?? connectorId
       // Outbound auth headers (bearer / custom header) for an auth-required
@@ -1267,9 +1283,12 @@ export function assistantRoutes(options: AssistantRouteOptions): Router {
       // isn't rejected (which would 500 this route and blank the L2 policy
       // editor). Mirrors GET /connectors/:id/tools + injectMcpTools.
       let authHeaders: Record<string, string> = {}
+      let policyStore = options.mcpSettingsStore
+      let policyUserId = member.userId
+      let policyServerName: string | null = null
       if (personal?.url) {
         authHeaders = buildConnectorAuthHeaders(
-          await options.connectorStore!.getAuthCredentials(member.userId, connectorId),
+          await options.connectorStore!.getAuthCredentials(member.userId, providerId),
         )
       }
 
@@ -1279,24 +1298,50 @@ export function assistantRoutes(options: AssistantRouteOptions): Router {
           `SELECT workspace_id FROM assistants WHERE id = $1`,
           [assistantId],
         )
-        const assistantTeamId = teamRow.rows[0]?.workspace_id ?? null
+        const assistantTeamId = member.workspaceId ?? teamRow.rows[0]?.workspace_id ?? null
         if (assistantTeamId) {
-          const teamInstances = await options.connectorInstanceStore.listByWorkspaceSystem(assistantTeamId)
-          const teamCustom = teamInstances.find((inst) => inst.provider === connectorId && inst.custom && inst.url)
-          if (teamCustom) {
-            mcpUrl = teamCustom.url
-            mcpName = teamCustom.label
+          const [teamInstances, grants] = await Promise.all([
+            options.connectorInstanceStore.listByWorkspaceSystem(assistantTeamId),
+            options.connectorGrantStore
+              ? options.connectorGrantStore.listForTargetSystem('workspace', assistantTeamId)
+              : Promise.resolve([]),
+          ])
+          const teamOwned = teamInstances.find((inst) => (
+            inst.provider === providerId
+            && (!parsedGovernanceId || inst.id === parsedGovernanceId.instanceId)
+            && inst.custom
+            && inst.connected
+            && inst.url
+          )) ?? null
+          const grant = grants.find(({ instance: inst }) => (
+            inst.provider === providerId
+            && (!parsedGovernanceId || inst.id === parsedGovernanceId.instanceId)
+            && inst.custom
+            && inst.connected
+            && inst.url
+          )) ?? null
+          const workspaceCustom = teamOwned ?? grant?.instance ?? null
+          if (workspaceCustom?.url) {
+            mcpUrl = workspaceCustom.url
+            mcpName = workspaceCustom.label
             authHeaders = buildConnectorAuthHeaders(
-              await options.connectorInstanceStore.getAuthCredentialsSystem(teamCustom.id),
+              await options.connectorInstanceStore.getAuthCredentialsSystem(workspaceCustom.id),
             )
+            if (teamOwned && options.workspaceToolPolicyStore) {
+              policyStore = workspacePolicyAsSettingsStore(options.workspaceToolPolicyStore, assistantTeamId)
+              policyServerName = providerId
+            } else if (grant) {
+              policyUserId = grant.grantedByUserId
+            }
           }
         }
       }
 
-      if (!mcpUrl) { res.json({ tools: [], serverName: connectorId }); return }
+      if (!mcpUrl) { res.json({ tools: [], serverName: providerId }); return }
 
       const { discoverMcpServer } = await import('../mcp/client.js')
       const server = await discoverMcpServer(mcpUrl, mcpName, authHeaders)
+      policyServerName ??= server.name
 
       const tools = await Promise.all(
         server.tools.map(async (t) => {
@@ -1305,17 +1350,17 @@ export function assistantRoutes(options: AssistantRouteOptions): Router {
 
           // L1: app-level (sentinel assistant ID)
           let appPolicy: string = defPolicy
-          const appOverride = await options.mcpSettingsStore!.getPolicy({
-            assistantId: APP_LEVEL_ASSISTANT_ID, userId: member.userId,
-            serverName: server.name, toolName: t.name,
+          const appOverride = await policyStore!.getPolicy({
+            assistantId: APP_LEVEL_ASSISTANT_ID, userId: policyUserId,
+            serverName: policyServerName, toolName: t.name,
           })
           if (appOverride) appPolicy = appOverride.policy
 
           // L2: assistant-level
           let assistantPolicy: string = defPolicy
-          const o = await options.mcpSettingsStore!.getPolicy({
-            assistantId, userId: member.userId,
-            serverName: server.name, toolName: t.name,
+          const o = await policyStore!.getPolicy({
+            assistantId, userId: policyUserId,
+            serverName: policyServerName, toolName: t.name,
           })
           if (o) assistantPolicy = o.policy
 
@@ -1357,9 +1402,53 @@ export function assistantRoutes(options: AssistantRouteOptions): Router {
     try {
       const classification = classifyTool(toolName)
       const parsedGovernanceId = parseConnectorInstanceGovernanceId(connectorId)
-      const providerId = parsedGovernanceId && OFFICIAL_CONNECTOR_TOOLS[parsedGovernanceId.provider]
-        ? parsedGovernanceId.provider
-        : connectorId
+      const providerId = parsedGovernanceId?.provider ?? connectorId
+      const dynamicInstance = !!parsedGovernanceId && (
+        providerId === 'cli' || !OFFICIAL_CONNECTOR_TOOLS[providerId]
+      )
+      let policyUserId = member.userId
+      if (dynamicInstance && member.workspaceId && options.connectorInstanceStore) {
+        const [teamNative, grants] = await Promise.all([
+          options.connectorInstanceStore.listByWorkspaceSystem(member.workspaceId),
+          options.connectorGrantStore
+            ? options.connectorGrantStore.listForTargetSystem('workspace', member.workspaceId)
+            : Promise.resolve([]),
+        ])
+        const teamOwned = teamNative.find((instance) => (
+          instance.id === parsedGovernanceId.instanceId && instance.provider === providerId
+        ))
+        const grant = grants.find(({ instance }) => (
+          instance.id === parsedGovernanceId.instanceId && instance.provider === providerId
+        ))
+        if (teamOwned) {
+          const workspaceRole = options.workspaceStore
+            ? await options.workspaceStore.getRole(member.userId, member.workspaceId)
+            : null
+          if (workspaceRole !== 'owner' && workspaceRole !== 'admin') {
+            res.status(403).json({ error: 'Workspace owner or admin role required' })
+            return
+          }
+          if (!options.workspaceToolPolicyStore) {
+            res.status(500).json({ error: 'Workspace policy store is not configured' })
+            return
+          }
+          await options.workspaceToolPolicyStore.setPolicy({
+            workspaceId: member.workspaceId,
+            serverName: providerId === 'cli' ? connectorId : providerId,
+            toolName,
+            policy: policy as 'allow' | 'ask' | 'block',
+            classification,
+            updatedBy: member.userId,
+          })
+          res.json({ ok: true })
+          return
+        }
+        if (!grant) {
+          res.status(404).json({ error: 'Connector instance not found' })
+          return
+        }
+        policyUserId = grant.grantedByUserId
+      }
       const persistedServerName = providerId === 'cli' && parsedGovernanceId
         ? serverName
         : OFFICIAL_CONNECTOR_TOOLS[providerId]
@@ -1368,7 +1457,7 @@ export function assistantRoutes(options: AssistantRouteOptions): Router {
 
       await options.mcpSettingsStore.setPolicy({
         assistantId,
-        userId: member.userId,
+        userId: policyUserId,
         serverName: persistedServerName,
         toolName,
         policy: policy as 'allow' | 'ask' | 'block',

--- a/packages/api/src/workflow/__tests__/approval.test.ts
+++ b/packages/api/src/workflow/__tests__/approval.test.ts
@@ -415,15 +415,19 @@ describe('[COMP:workflow/approval] Phase C — pause + resume', () => {
       async execute() { postCalled = true; return { data: { ok: true } } },
     })
 
+    const registryUsers: Array<string | null> = []
     const executorDeps: ExecutorDeps = {
       workflowStore: stores.workflowStore,
       runStore: stores.runStore,
       consultTransport: FAKE_TRANSPORT,
       resolvePrimary: async () => PRIMARY_ASSISTANT_ID,
-      buildToolRegistry: async () => new Map([
-        ['gmailSendMessage', askTool],
-        ['noop', followupTool],
-      ]),
+      buildToolRegistry: async ({ userId }) => {
+        registryUsers.push(userId)
+        return new Map([
+          ['gmailSendMessage', askTool],
+          ['noop', followupTool],
+        ])
+      },
     }
     const bridgeDeps: ApprovalBridgeDeps = {
       approvalsStore: approvals, auditStore: audit,
@@ -450,7 +454,7 @@ describe('[COMP:workflow/approval] Phase C — pause + resume', () => {
     })
     const run = await stores.runStore.createRun({
       workflowId: workflow.id, workspaceId: WORKSPACE_ID,
-      triggeredBy: USER_ID, triggerKind: 'manual',
+      triggeredBy: null, triggerKind: 'schedule',
       input: { email: 'frozen@example.com' },
     })
 
@@ -466,6 +470,8 @@ describe('[COMP:workflow/approval] Phase C — pause + resume', () => {
     expect(capturedArgs).toEqual({ to: 'frozen@example.com', body: 'hi' })
     // Follow-up tool ran.
     expect(postCalled).toBe(true)
+    expect(registryUsers).toHaveLength(3)
+    expect(new Set(registryUsers)).toEqual(new Set([USER_ID]))
     // Final run state.
     expect(stores.runs.get(run.id)?.status).toBe('completed')
     // Audit recorded approval_approved.
@@ -511,6 +517,59 @@ describe('[COMP:workflow/approval] Phase C — pause + resume', () => {
     expect(result.status).toBe('failed')
     expect(stores.runs.get(run.id)?.status).toBe('failed')
     expect(audit.events.find((e) => e.eventType === 'workflow.approval_rejected')).toBeTruthy()
+  })
+
+  it('fails the run instead of stranding it when registry rebuild throws after approval', async () => {
+    const stores = makeStores()
+    const approvals = fakeApprovalsStore()
+    const audit = fakeAuditStore()
+    const askTool = askPolicyTool('send_report')
+    let registryBuilds = 0
+    const executorDeps: ExecutorDeps = {
+      workflowStore: stores.workflowStore,
+      runStore: stores.runStore,
+      consultTransport: FAKE_TRANSPORT,
+      resolvePrimary: async () => PRIMARY_ASSISTANT_ID,
+      buildToolRegistry: async () => {
+        registryBuilds += 1
+        if (registryBuilds > 1) throw new Error('connector discovery unavailable')
+        return new Map([['send_report', askTool]])
+      },
+    }
+    const bridgeDeps: ApprovalBridgeDeps = {
+      approvalsStore: approvals,
+      auditStore: audit,
+      workflowStore: stores.workflowStore,
+      runStore: stores.runStore,
+      buildToolRegistry: executorDeps.buildToolRegistry,
+      resolvePrimary: executorDeps.resolvePrimary,
+      deliveries: async () => {},
+      executorDeps,
+    }
+    executorDeps.requestApproval = makeRequestApproval(bridgeDeps)
+    const workflow = await stores.workflowStore.create({
+      userId: USER_ID,
+      workspaceId: WORKSPACE_ID,
+      name: 'registry failure',
+      definition: {
+        startStepId: 'send',
+        steps: [{ id: 'send', type: 'tool_call', toolName: 'send_report', arguments: {} }],
+      },
+    })
+    const run = await stores.runStore.createRun({
+      workflowId: workflow.id,
+      workspaceId: WORKSPACE_ID,
+      triggeredBy: USER_ID,
+      triggerKind: 'manual',
+    })
+    await advanceWorkflowRun(executorDeps, run.id)
+
+    const result = await resumeFromApproval(bridgeDeps, approvals.rows[0].id, 'approved', USER_ID)
+
+    expect(result.status).toBe('failed')
+    expect(stores.runs.get(run.id)?.error).toMatchObject({
+      reason: 'tool_registry_unavailable_after_resume',
+    })
   })
 
   it('resume is idempotent — second approve/reject is a no-op', async () => {

--- a/packages/api/src/workflow/__tests__/mcp-bridge.test.ts
+++ b/packages/api/src/workflow/__tests__/mcp-bridge.test.ts
@@ -65,11 +65,38 @@ describe('[COMP:workflow/mcp-bridge] buildWorkflowToolRegistry', () => {
   })
 
   it('forwards the run scope to injectMcpTools', async () => {
-    await buildWorkflowToolRegistry(makeDeps(new Map<string, Tool>()), scope)
+    const engineHooks = { preToolUse: vi.fn() }
+    const assistantConnectorGrantsStore = { listForAssistant: vi.fn() }
+    await buildWorkflowToolRegistry({
+      ...makeDeps(new Map<string, Tool>()),
+      engineHooks,
+      assistantConnectorGrantsStore,
+    } as never, scope)
     const arg = mockInject.mock.calls[0][0]
     expect(arg.userId).toBe('u-1')
     expect(arg.assistantId).toBe('a-1')
     expect(arg.assistantTeamId).toBe('ws-1')
+    expect(arg.engineHooks).toBe(engineHooks)
+    expect(arg.assistantConnectorGrantsStore).toBe(assistantConnectorGrantsStore)
+  })
+
+  it('strips recursive orchestration tools from the deterministic registry', async () => {
+    mockInject.mockImplementationOnce(async (params) => {
+      params.tools.set('mcp_safe', {} as Tool)
+      return { enrichConfirmation: () => undefined, unavailable: [] } as unknown as McpInjectionResult
+    })
+    const firstParty = new Map<string, Tool>([
+      ['runWorkflow', {} as Tool],
+      ['createWorkflow', {} as Tool],
+      ['askAssistant', {} as Tool],
+      ['createScheduledJob', {} as Tool],
+      ['scheduleWorkflow', {} as Tool],
+      ['listTasks', {} as Tool],
+    ])
+    const out = await buildWorkflowToolRegistry(makeDeps(firstParty), scope)
+
+    expect([...out.keys()].sort()).toEqual(['listTasks', 'mcp_safe'])
+    expect(firstParty.has('runWorkflow')).toBe(true)
   })
 
   it('enables KB writes and forwards the repo writer — the executor approval pause is the gate', async () => {

--- a/packages/api/src/workflow/__tests__/mcp-bridge.test.ts
+++ b/packages/api/src/workflow/__tests__/mcp-bridge.test.ts
@@ -86,6 +86,8 @@ describe('[COMP:workflow/mcp-bridge] buildWorkflowToolRegistry', () => {
     // The executor can only see `requiresConfirmation` on a built-in that was
     // left directly in the map; routing it behind mcp_call would hide it.
     expect(mockInject.mock.calls[0][0].keepBuiltinsDirect).toBe(true)
+    // Deterministic tool_call steps also need exact custom/CLI registry names.
+    expect(mockInject.mock.calls[0][0].keepDynamicToolsDirect).toBe(true)
   })
 
   it('exposes no repo write path when the writer port is absent (open standalone boot)', async () => {

--- a/packages/api/src/workflow/approval.ts
+++ b/packages/api/src/workflow/approval.ts
@@ -211,11 +211,24 @@ export async function resumeFromApproval(
     return { status: 'failed', runId: run.id }
   }
 
-  const registry = await deps.buildToolRegistry({
-    workspaceId: run.workspaceId,
-    assistantId: primaryAssistantId,
-    userId: run.triggeredBy,
-  })
+  let registry: Awaited<ReturnType<ApprovalBridgeDeps['buildToolRegistry']>>
+  try {
+    registry = await deps.buildToolRegistry({
+      workspaceId: run.workspaceId,
+      assistantId: primaryAssistantId,
+      userId: run.triggeredBy ?? workflow.createdBy,
+    })
+  } catch (err) {
+    await failStep(
+      deps,
+      run,
+      workflow,
+      updated,
+      'tool_registry_unavailable_after_resume',
+      err instanceof Error ? err.message : String(err),
+    )
+    return { status: 'failed', runId: run.id }
+  }
 
   const tool = registry.get(updated.toolName)
   if (!tool) {

--- a/packages/api/src/workflow/mcp-bridge.ts
+++ b/packages/api/src/workflow/mcp-bridge.ts
@@ -18,7 +18,7 @@
  * [COMP:workflow/mcp-bridge]
  */
 
-import type { Tool, KnowledgeStoreInterface, KnowledgeRepoWriter, GDriveFilesStore, McpSettingsStore, FilesApi } from '@use-brian/core'
+import type { Tool, KnowledgeStoreInterface, KnowledgeRepoWriter, GDriveFilesStore, McpSettingsStore, FilesApi, EngineHooks } from '@use-brian/core'
 import { injectMcpTools } from '../mcp/inject.js'
 import type { ConnectorStore } from '../db/connector-store.js'
 import type { AssistantConnectorStore } from '../db/assistant-connector-store.js'
@@ -47,6 +47,28 @@ export type WorkflowToolRegistryDeps = {
   /** Workspace-files byte layer — `gmailSendMessage` attachments on workflow
    *  `tool_call` steps (`docs/architecture/integrations/gmail.md`). */
   filesApi?: FilesApi
+  engineHooks?: EngineHooks
+  assistantConnectorGrantsStore?: import('../db/assistant-connector-grants-store.js').AssistantConnectorGrantsStore
+}
+
+const FORBIDDEN_WORKFLOW_REGISTRY_TOOLS = [
+  'askAssistant',
+  'listConnectedAssistants',
+  'spawnWorker',
+  'sendWorkerMessage',
+  'stopWorker',
+  'proposeWorkflow',
+  'createWorkflow',
+  'updateWorkflow',
+  'runWorkflow',
+  'scheduleWorkflow',
+  'createScheduledJob',
+  'updateScheduledJob',
+  'deleteScheduledJob',
+] as const
+
+function stripOrchestrationTools(tools: Map<string, Tool>): void {
+  for (const name of FORBIDDEN_WORKFLOW_REGISTRY_TOOLS) tools.delete(name)
 }
 
 /**
@@ -78,6 +100,7 @@ export async function buildWorkflowToolRegistry(
     // keyed by user). Skip MCP entirely; first-party tools still work.
     // Phase B's scheduled trigger always passes the workflow.created_by
     // here so this branch is a defensive no-op.
+    stripOrchestrationTools(tools)
     return tools
   }
 
@@ -134,7 +157,10 @@ export async function buildWorkflowToolRegistry(
     allowKnowledgeWrites: true,
     knowledgeRepoWriter: deps.knowledgeRepoWriter,
     filesApi: deps.filesApi,
+    engineHooks: deps.engineHooks,
+    assistantConnectorGrantsStore: deps.assistantConnectorGrantsStore,
   })
 
+  stripOrchestrationTools(tools)
   return tools
 }

--- a/packages/api/src/workflow/mcp-bridge.ts
+++ b/packages/api/src/workflow/mcp-bridge.ts
@@ -89,11 +89,14 @@ export async function buildWorkflowToolRegistry(
   // ability to inspect each built-in's `requiresConfirmation` and route
   // ask-policy pauses through the `kind='workflow_step'` unified-approvals
   // surface + per-step permission grants. Routing built-ins through
-  // `mcp_call` would hide those flags from the executor. Custom MCP
-  // still goes through `mcp_search` / `mcp_call` here for the token
-  // win. See docs/architecture/integrations/mcp.md → "Tool search
-  // pattern" and docs/architecture/features/workflow.md → "Unified
-  // approvals".
+  // `mcp_call` would hide those flags from the executor.
+  //
+  // `keepDynamicToolsDirect: true` adds server-side registry adapters for
+  // custom HTTP/CLI tools. A deterministic tool_call cannot perform a model
+  // search/call sequence, and the adapter keeps policy + hooks intact while
+  // exposing the metadata the workflow approval gate needs. See
+  // docs/architecture/integrations/mcp.md → "Tool search pattern" and
+  // docs/architecture/features/workflow.md → "Unified approvals".
   await injectMcpTools({
     userId: scope.userId,
     assistantId: scope.assistantId,
@@ -109,6 +112,7 @@ export async function buildWorkflowToolRegistry(
     workspaceToolPolicyStore: deps.workspaceToolPolicyStore,
     assistantTeamId: scope.workspaceId,
     keepBuiltinsDirect: true,
+    keepDynamicToolsDirect: true,
     // KB writes ARE exposed here, and are governed by the executor's own
     // approval pause rather than a chat Approve/Deny card. Both write tools
     // carry `requiresConfirmation: true`, and `keepBuiltinsDirect` (above) is

--- a/packages/core/src/mcp/__tests__/connector.test.ts
+++ b/packages/core/src/mcp/__tests__/connector.test.ts
@@ -117,6 +117,42 @@ describe('[COMP:mcp/connector] wrapMcpTools', () => {
     expect(callMcpTool).not.toHaveBeenCalled()
   })
 
+  it('applies the strictest app-level and assistant-level policy', async () => {
+    const settingsStore: McpSettingsStore = {
+      async getPolicy(params) {
+        if (params.assistantId !== 'app-level') return null
+        return {
+          id: 'set-app',
+          assistantId: params.assistantId,
+          userId: params.userId,
+          serverName: params.serverName,
+          toolName: params.toolName,
+          policy: 'block',
+          classification: 'read',
+          timesAllowed: 0,
+          timesDenied: 0,
+        }
+      },
+      async setPolicy() {},
+      async recordUsage() {},
+      async recordUsageAndGetCount() { return { timesAllowed: 0, timesDenied: 0 } },
+    }
+    const callMcpTool = vi.fn(async () => ({}))
+    const [tool] = wrapMcpTools({
+      server: readToolServer,
+      settingsStore,
+      assistantId: 'a1',
+      appLevelAssistantId: 'app-level',
+      userId: 'u1',
+      callMcpTool,
+    })
+
+    expect(await tool.resolveConfirmation?.(ctx, {})).toBe(false)
+    const result = await tool.execute({ query: 'foo' }, ctx)
+    expect(result.isError).toBe(true)
+    expect(callMcpTool).not.toHaveBeenCalled()
+  })
+
   it('surfaces MCP client errors as tool errors', async () => {
     const [tool] = wrapMcpTools({
       server: readToolServer,

--- a/packages/core/src/mcp/__tests__/tool-search.test.ts
+++ b/packages/core/src/mcp/__tests__/tool-search.test.ts
@@ -214,6 +214,120 @@ describe('[COMP:mcp/tool-search] createMcpSearchTools', () => {
     expect(callMcpTool).not.toHaveBeenCalled()
   })
 
+  it('uses a remote source policy authority instead of the caller store', async () => {
+    const sourcePolicies = new Map<string, McpToolSetting>()
+    sourcePolicies.set('workspace-custom:search_pages', {
+      id: 'set-workspace',
+      assistantId: 'workspace-policy',
+      userId: 'workspace-user',
+      serverName: 'workspace-custom',
+      toolName: 'search_pages',
+      policy: 'block',
+      classification: 'read',
+      timesAllowed: 0,
+      timesDenied: 0,
+    })
+    const callMcpTool = vi.fn(async () => ({ result: 'should not run' }))
+    const tools = createMcpSearchTools({
+      index: buildToolIndex([{
+        kind: 'remote',
+        server: notionServer,
+        serverUrl: notionServer.url,
+        callMcpTool: async () => ({}),
+        policy: {
+          settingsStore: makeFakeSettingsStore(sourcePolicies),
+          userId: 'workspace-user',
+          serverName: 'workspace-custom',
+          appLevelAssistantId: 'workspace-policy',
+        },
+      }]),
+      settingsStore: makeFakeSettingsStore(),
+      assistantId: 'a1',
+      userId: 'caller-user',
+      callMcpTool,
+      keepDynamicToolsDirect: true,
+    })
+
+    const direct = tools.find((tool) => tool.name === 'search_pages')!
+    const result = await direct.execute({ query: 'private' }, ctx as never)
+    expect(result.isError).toBe(true)
+    expect(String(result.data)).toContain('blocked by policy')
+    expect(callMcpTool).not.toHaveBeenCalled()
+  })
+
+  it('omits an ambiguous canonical alias and keeps unique server-qualified aliases', () => {
+    const makeServer = (name: string): McpServerConfig => ({
+      name,
+      url: `https://${name.toLowerCase()}.example.com/mcp`,
+      tools: [{ name: 'list_events', description: 'List events.', inputSchema: { type: 'object' } }],
+    })
+    const primary = makeServer('Primary calendar')
+    const archive = makeServer('Archive calendar')
+    const tools = createMcpSearchTools({
+      index: buildToolIndex([
+        { kind: 'remote', server: primary, serverUrl: primary.url, callMcpTool: async () => ({}) },
+        { kind: 'remote', server: archive, serverUrl: archive.url, callMcpTool: async () => ({}) },
+      ]),
+      settingsStore: makeFakeSettingsStore(),
+      assistantId: 'a1', userId: 'u1',
+      callMcpTool: vi.fn(async () => ({})),
+      keepDynamicToolsDirect: true,
+    })
+
+    expect(tools.some((tool) => tool.name === 'list_events')).toBe(false)
+    expect(tools.some((tool) => tool.name === 'mcp_Primary_calendar_list_events')).toBe(true)
+    expect(tools.some((tool) => tool.name === 'mcp_Archive_calendar_list_events')).toBe(true)
+  })
+
+  it('removes duplicate full server/tool keys from search and direct dispatch', async () => {
+    const duplicate: McpServerConfig = {
+      name: 'Calendar',
+      url: 'https://calendar.example.com/mcp',
+      tools: [{ name: 'list_events', description: 'List events.', inputSchema: { type: 'object' } }],
+    }
+    const tools = createMcpSearchTools({
+      index: buildToolIndex([
+        { kind: 'remote', server: duplicate, serverUrl: duplicate.url, callMcpTool: async () => ({}) },
+        { kind: 'remote', server: { ...duplicate, url: 'https://other.example.com/mcp' }, serverUrl: 'https://other.example.com/mcp', callMcpTool: async () => ({}) },
+      ]),
+      settingsStore: makeFakeSettingsStore(),
+      assistantId: 'a1', userId: 'u1',
+      callMcpTool: vi.fn(async () => ({})),
+      keepDynamicToolsDirect: true,
+    })
+
+    expect(tools.map((tool) => tool.name)).toEqual(['mcp_search', 'mcp_call'])
+    const search = await tools[0].execute({ query: 'list events' }, ctx as never)
+    expect(String(search.data)).toContain('No tools found')
+    const call = await tools[1].execute({ server: 'Calendar', tool: 'list_events', args: {} }, ctx as never)
+    expect(call.isError).toBe(true)
+    expect(String(call.data)).toContain('unknown tool')
+  })
+
+  it('fails closed when one canonical name collides with another legacy alias', () => {
+    const server = (name: string, toolName: string): McpServerConfig => ({
+      name,
+      url: `https://collision.example.com/${name}`,
+      tools: [{ name: toolName, description: 'Collision probe.', inputSchema: { type: 'object' } }],
+    })
+    const legacyOwner = server('Bar', 'do')
+    const canonicalOwner = server('Other', 'mcp_Bar_do')
+    const tools = createMcpSearchTools({
+      index: buildToolIndex([
+        { kind: 'remote', server: legacyOwner, serverUrl: legacyOwner.url, callMcpTool: async () => ({}) },
+        { kind: 'remote', server: canonicalOwner, serverUrl: canonicalOwner.url, callMcpTool: async () => ({}) },
+      ]),
+      settingsStore: makeFakeSettingsStore(),
+      assistantId: 'a1', userId: 'u1',
+      callMcpTool: vi.fn(async () => ({})),
+      keepDynamicToolsDirect: true,
+    })
+
+    expect(tools.some((tool) => tool.name === 'mcp_Bar_do')).toBe(false)
+    expect(tools.some((tool) => tool.name === 'do')).toBe(true)
+    expect(tools.some((tool) => tool.name === 'mcp_Other_mcp_Bar_do')).toBe(true)
+  })
+
   it('mcp_search description mentions total tool count and connector names', () => {
     const { tools } = makeSearchTools()
     expect(tools[0].description).toContain('11 tools')

--- a/packages/core/src/mcp/__tests__/tool-search.test.ts
+++ b/packages/core/src/mcp/__tests__/tool-search.test.ts
@@ -99,6 +99,121 @@ describe('[COMP:mcp/tool-search] createMcpSearchTools', () => {
     expect(tools[1].name).toBe('mcp_call')
   })
 
+  it('adds canonical and legacy remote aliases for workflow tool_call execution', async () => {
+    const protonServer: McpServerConfig = {
+      name: 'Proton calendar',
+      url: 'https://proton.example.com/mcp',
+      tools: [{
+        name: 'list_events',
+        description: 'List upcoming calendar events.',
+        inputSchema: { type: 'object', properties: { days: { type: 'number' } } },
+      }],
+    }
+    const callMcpTool = vi.fn(async () => ({ events: [] }))
+    const preToolUse = vi.fn(async () => ({
+      action: 'modify' as const,
+      input: { days: 14 },
+    }))
+    const postToolUse = vi.fn(async () => undefined)
+    const tools = createMcpSearchTools({
+      index: buildToolIndex([{
+        kind: 'remote', server: protonServer, serverUrl: protonServer.url,
+        callMcpTool: async () => ({}),
+      }]),
+      settingsStore: makeFakeSettingsStore(),
+      assistantId: 'a1',
+      userId: 'u1',
+      callMcpTool,
+      hooks: { preToolUse, postToolUse },
+      keepDynamicToolsDirect: true,
+    })
+
+    expect(tools.map((tool) => tool.name)).toEqual([
+      'mcp_search',
+      'mcp_call',
+      'list_events',
+      'mcp_Proton_calendar_list_events',
+    ])
+    const legacy = tools.find((tool) => tool.name === 'mcp_Proton_calendar_list_events')!
+    expect(await legacy.resolveConfirmation?.(ctx as never, { days: 7 })).toBe(false)
+    const result = await legacy.execute({ days: 7 }, ctx as never)
+    expect(result.isError).toBeFalsy()
+    expect(callMcpTool).toHaveBeenCalledWith(
+      'https://proton.example.com/mcp',
+      'list_events',
+      { days: 14 },
+    )
+    expect(preToolUse).toHaveBeenCalledWith(expect.objectContaining({
+      serverName: 'Proton calendar',
+      toolName: 'list_events',
+      input: { days: 7 },
+    }))
+    expect(postToolUse).toHaveBeenCalledWith(expect.objectContaining({
+      serverName: 'Proton calendar',
+      toolName: 'list_events',
+      input: { days: 14 },
+    }))
+  })
+
+  it('keeps local workflow aliases schema-bound and skips only the handled outer approval', async () => {
+    const execute = vi.fn(async () => ({ data: { created: true } }))
+    const createEvent = buildTool({
+      name: 'create_event',
+      description: 'Create a calendar event.',
+      inputSchema: z.object({ title: z.string() }),
+      requiresConfirmation: true,
+      execute,
+    })
+    const tools = createMcpSearchTools({
+      index: buildToolIndex([{ kind: 'local', serverName: 'Proton calendar', tools: [createEvent] }]),
+      settingsStore: makeFakeSettingsStore(),
+      assistantId: 'a1',
+      userId: 'u1',
+      callMcpTool: vi.fn(async () => ({})),
+      keepDynamicToolsDirect: true,
+    })
+    const legacy = tools.find((tool) => tool.name === 'mcp_Proton_calendar_create_event')!
+
+    expect(legacy.requiresConfirmation).toBe(true)
+    expect(legacy.inputSchema.safeParse({ title: 'Review' }).success).toBe(true)
+    const result = await legacy.execute({ title: 'Review' }, ctx as never)
+    expect(result.isError).toBeFalsy()
+    expect(execute).toHaveBeenCalledWith({ title: 'Review' }, ctx)
+  })
+
+  it('does not let authorized workflow dispatch bypass a remote block policy', async () => {
+    const overrides = new Map<string, McpToolSetting>()
+    overrides.set('Notion:create_page', {
+      id: 'set-block',
+      assistantId: 'a1',
+      userId: 'u1',
+      serverName: 'Notion',
+      toolName: 'create_page',
+      policy: 'block',
+      classification: 'write',
+      timesAllowed: 0,
+      timesDenied: 0,
+    })
+    const callMcpTool = vi.fn(async () => ({ result: 'should not run' }))
+    const tools = createMcpSearchTools({
+      index: buildToolIndex([{
+        kind: 'remote', server: notionServer, serverUrl: notionServer.url,
+        callMcpTool: async () => ({}),
+      }]),
+      settingsStore: makeFakeSettingsStore(overrides),
+      assistantId: 'a1',
+      userId: 'u1',
+      callMcpTool,
+      keepDynamicToolsDirect: true,
+    })
+    const direct = tools.find((tool) => tool.name === 'create_page')!
+
+    const result = await direct.execute({ title: 'Blocked' }, ctx as never)
+    expect(result.isError).toBe(true)
+    expect(String(result.data)).toContain('blocked by policy')
+    expect(callMcpTool).not.toHaveBeenCalled()
+  })
+
   it('mcp_search description mentions total tool count and connector names', () => {
     const { tools } = makeSearchTools()
     expect(tools[0].description).toContain('11 tools')

--- a/packages/core/src/mcp/connector.ts
+++ b/packages/core/src/mcp/connector.ts
@@ -31,8 +31,30 @@ export function wrapMcpTools(params: {
   assistantId: string
   userId: string
   callMcpTool: (serverName: string, toolName: string, input: Record<string, unknown>) => Promise<unknown>
+  appLevelAssistantId?: string
+  policyServerName?: string
 }): Tool[] {
-  const { server, settingsStore, assistantId, userId, callMcpTool } = params
+  const {
+    server, settingsStore, assistantId, userId, callMcpTool,
+    appLevelAssistantId, policyServerName = server.name,
+  } = params
+
+  async function resolveEffectivePolicy(toolName: string, fallback: 'allow' | 'ask' | 'block') {
+    const assistantSetting = await settingsStore.getPolicy({
+      assistantId, userId, serverName: policyServerName, toolName,
+    })
+    if (!appLevelAssistantId) return assistantSetting?.policy ?? fallback
+
+    const appSetting = await settingsStore.getPolicy({
+      assistantId: appLevelAssistantId, userId, serverName: policyServerName, toolName,
+    })
+    const strictness: Record<string, number> = { allow: 0, ask: 1, block: 2 }
+    const appPolicy = appSetting?.policy ?? fallback
+    const assistantPolicy = assistantSetting?.policy ?? fallback
+    return (strictness[appPolicy] ?? 0) >= (strictness[assistantPolicy] ?? 0)
+      ? appPolicy
+      : assistantPolicy
+  }
 
   return server.tools.map((mcpTool) => {
     const classification = classifyTool(mcpTool.name, mcpTool.description)
@@ -49,24 +71,13 @@ export function wrapMcpTools(params: {
       // Dynamic policy check — the user may have overridden the default
       // policy via the web UI since this tool was wrapped.
       async resolveConfirmation() {
-        const override = await settingsStore.getPolicy({
-          assistantId, userId,
-          serverName: server.name,
-          toolName: mcpTool.name,
-        })
-        const effective = override?.policy ?? policy
+        const effective = await resolveEffectivePolicy(mcpTool.name, policy)
         return effective === 'ask'
       },
 
       async execute(input, context) {
         // Check user's policy override
-        const setting = await settingsStore.getPolicy({
-          assistantId, userId,
-          serverName: server.name,
-          toolName: mcpTool.name,
-        })
-
-        const effectivePolicy = setting?.policy ?? policy
+        const effectivePolicy = await resolveEffectivePolicy(mcpTool.name, policy)
 
         if (effectivePolicy === 'block') {
           return { data: `ERROR: "${mcpTool.name}" is blocked by settings. Capability unavailable.`, isError: true }
@@ -78,7 +89,7 @@ export function wrapMcpTools(params: {
           // Track usage
           settingsStore.recordUsage({
             assistantId, userId,
-            serverName: server.name,
+            serverName: policyServerName,
             toolName: mcpTool.name,
             allowed: true,
           }).catch((err) => console.debug('MCP usage tracking failed:', err))

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -4,5 +4,5 @@ export type { McpToolSetting, McpSettingsStore, McpServerConfig, McpToolInfo, Co
 export { AUTO_PROMOTE_THRESHOLD, createConfirmationResolver } from './types.js'
 export { wrapMcpTools } from './connector.js'
 export { createMcpGateway } from './gateway.js'
-export { buildToolIndex, createMcpSearchTools } from './tool-search.js'
+export { buildToolIndex, createMcpSearchTools, legacyMcpToolName } from './tool-search.js'
 export type { McpToolIndex, ToolSource, RemoteSource, LocalSource } from './tool-search.js'

--- a/packages/core/src/mcp/tool-search.ts
+++ b/packages/core/src/mcp/tool-search.ts
@@ -48,6 +48,13 @@ export type RemoteSource = {
   server: McpServerConfig
   serverUrl: string
   callMcpTool: (serverUrl: string, toolName: string, input: Record<string, unknown>, headerOverrides?: Record<string, string>) => Promise<unknown>
+  /** Source-specific policy authority for workspace-owned/granted connectors. */
+  policy?: {
+    settingsStore: McpSettingsStore
+    userId: string
+    serverName?: string
+    appLevelAssistantId?: string
+  }
 }
 
 /**
@@ -97,6 +104,7 @@ type RemoteIndexedTool = IndexedToolBase & {
   serverUrl: string
   /** Original MCP metadata (kept for any code that legacy-typed on `.tool`). */
   toolInfo: McpToolInfo
+  policy?: RemoteSource['policy']
 }
 
 type LocalIndexedTool = IndexedToolBase & {
@@ -151,6 +159,7 @@ export function buildToolIndex(sources: ToolSource[]): McpToolIndex {
           description: tool.description,
           inputSchema: (tool.inputSchema ?? {}) as Record<string, unknown>,
           toolInfo: tool,
+          policy: source.policy,
           tokens: tokenize(tool.name, tool.description),
         })
       }
@@ -358,8 +367,15 @@ export function createMcpSearchTools(params: {
 
   // ── Lookup: server:toolName → IndexedTool ─────────────────────
   const entryByKey = new Map<string, IndexedTool>()
+  const ambiguousEntryKeys = new Set<string>()
   for (const entry of index.entries) {
-    entryByKey.set(`${entry.server}:${entry.toolName}`, entry)
+    const key = `${entry.server}:${entry.toolName}`
+    if (entryByKey.has(key)) {
+      entryByKey.delete(key)
+      ambiguousEntryKeys.add(key)
+    } else if (!ambiguousEntryKeys.has(key)) {
+      entryByKey.set(key, entry)
+    }
   }
 
   // ── Session-level policy tracking ─────────────────────────────
@@ -402,7 +418,10 @@ export function createMcpSearchTools(params: {
         index,
         query,
         limit,
-        (entry) => !blockedTools.has(`${entry.server}:${entry.toolName}`),
+        (entry) => {
+          const key = `${entry.server}:${entry.toolName}`
+          return !blockedTools.has(key) && !ambiguousEntryKeys.has(key)
+        },
       )
 
       if (results.length === 0) {
@@ -510,11 +529,17 @@ export function createMcpSearchTools(params: {
   // hooks, result conversion, and local capability wrappers remain intact.
   const directTools: Tool[] = []
   const claimedNames = new Set(['mcp_search', 'mcp_call'])
+  const aliasCounts = new Map<string, number>()
   for (const entry of index.entries) {
-    const aliases = [
-      entry.toolName,
-      sanitizeMcpToolName(`mcp_${entry.server}_${entry.toolName}`).slice(0, 128),
-    ]
+    const legacyName = legacyMcpToolName(entry.server, entry.toolName)
+    for (const alias of new Set([entry.toolName, legacyName])) {
+      aliasCounts.set(alias, (aliasCounts.get(alias) ?? 0) + 1)
+    }
+  }
+  for (const entry of index.entries) {
+    const legacyName = legacyMcpToolName(entry.server, entry.toolName)
+    const aliases = [...new Set([entry.toolName, legacyName])]
+      .filter((alias) => aliasCounts.get(alias) === 1)
     for (const name of aliases) {
       if (claimedNames.has(name)) continue
       claimedNames.add(name)
@@ -560,6 +585,7 @@ export function createMcpSearchTools(params: {
             assistantId,
             appLevelAssistantId,
             userId,
+            policy: entry.policy,
           }) === 'ask'
         },
         async execute(input, context) {
@@ -590,8 +616,8 @@ export function createMcpSearchTools(params: {
 
 // ── Dispatch: remote source ───────────────────────────────────
 
-function sanitizeMcpToolName(raw: string): string {
-  return raw.replace(/[^a-zA-Z0-9_.\-:]/g, '_')
+export function legacyMcpToolName(serverName: string, toolName: string): string {
+  return `mcp_${serverName}_${toolName}`.replace(/[^a-zA-Z0-9_.\-:]/g, '_').slice(0, 128)
 }
 
 async function resolveRemoteEffectivePolicy(params: {
@@ -602,19 +628,30 @@ async function resolveRemoteEffectivePolicy(params: {
   assistantId: string
   appLevelAssistantId?: string
   userId: string
+  policy?: RemoteSource['policy']
 }): Promise<'allow' | 'ask' | 'block'> {
   const {
     server, tool, description, settingsStore, assistantId,
-    appLevelAssistantId, userId,
+    appLevelAssistantId, userId, policy,
   } = params
+  const effectiveStore = policy?.settingsStore ?? settingsStore
+  const effectiveUserId = policy?.userId ?? userId
+  const effectiveServer = policy?.serverName ?? server
+  const effectiveAppLevelAssistantId = policy?.appLevelAssistantId ?? appLevelAssistantId
   const fallbackPolicy = defaultPolicy(classifyTool(tool, description))
 
-  if (appLevelAssistantId) {
-    const l1 = await settingsStore.getPolicy({
-      assistantId: appLevelAssistantId, userId, serverName: server, toolName: tool,
+  if (effectiveAppLevelAssistantId) {
+    const l1 = await effectiveStore.getPolicy({
+      assistantId: effectiveAppLevelAssistantId,
+      userId: effectiveUserId,
+      serverName: effectiveServer,
+      toolName: tool,
     })
-    const l2 = await settingsStore.getPolicy({
-      assistantId, userId, serverName: server, toolName: tool,
+    const l2 = await effectiveStore.getPolicy({
+      assistantId,
+      userId: effectiveUserId,
+      serverName: effectiveServer,
+      toolName: tool,
     })
     const appPolicy = l1?.policy ?? fallbackPolicy
     const asstPolicy = l2?.policy ?? fallbackPolicy
@@ -624,8 +661,11 @@ async function resolveRemoteEffectivePolicy(params: {
       : asstPolicy
   }
 
-  const setting = await settingsStore.getPolicy({
-    assistantId, userId, serverName: server, toolName: tool,
+  const setting = await effectiveStore.getPolicy({
+    assistantId,
+    userId: effectiveUserId,
+    serverName: effectiveServer,
+    toolName: tool,
   })
   return setting?.policy ?? fallbackPolicy
 }
@@ -658,8 +698,11 @@ async function dispatchRemote(params: {
   const classification = classifyTool(tool, entry.description)
   const effectivePolicy = await resolveRemoteEffectivePolicy({
     server, tool, description: entry.description, settingsStore,
-    assistantId, appLevelAssistantId, userId,
+    assistantId, appLevelAssistantId, userId, policy: entry.policy,
   })
+  const policyStore = entry.policy?.settingsStore ?? settingsStore
+  const policyUserId = entry.policy?.userId ?? userId
+  const policyServerName = entry.policy?.serverName ?? server
 
   if (effectivePolicy === 'block') {
     blockedTools.add(toolKey)
@@ -711,9 +754,9 @@ async function dispatchRemote(params: {
 
         if (decision === 'always_deny') {
           blockedTools.add(toolKey)
-          settingsStore.setPolicy({
-            assistantId, userId,
-            serverName: server, toolName: tool,
+          policyStore.setPolicy({
+            assistantId, userId: policyUserId,
+            serverName: policyServerName, toolName: tool,
             policy: 'block', classification,
           }).catch((err) => console.debug('Failed to persist always_deny:', err))
           return {
@@ -724,9 +767,9 @@ async function dispatchRemote(params: {
 
         if (decision === 'always_allow') {
           allowedTools.add(toolKey)
-          settingsStore.setPolicy({
-            assistantId, userId,
-            serverName: server, toolName: tool,
+          policyStore.setPolicy({
+            assistantId, userId: policyUserId,
+            serverName: policyServerName, toolName: tool,
             policy: 'allow', classification,
           }).catch((err) => console.debug('Failed to persist always_allow:', err))
           // Fall through to execution
@@ -803,9 +846,9 @@ async function dispatchRemote(params: {
       : await callMcpTool(entry.serverUrl, tool, effInput)
 
     // Track usage
-    settingsStore.recordUsage({
-      assistantId, userId,
-      serverName: server,
+    policyStore.recordUsage({
+      assistantId, userId: policyUserId,
+      serverName: policyServerName,
       toolName: tool,
       allowed: true,
     }).catch((err) => console.debug('MCP usage tracking failed:', err))

--- a/packages/core/src/mcp/tool-search.ts
+++ b/packages/core/src/mcp/tool-search.ts
@@ -345,8 +345,16 @@ export function createMcpSearchTools(params: {
    * See `docs/architecture/engine/tool-hooks.md`.
    */
   hooks?: EngineHooks
+  /**
+   * Add direct aliases for deterministic workflow `tool_call` registry
+   * lookups. Other surfaces keep the token-saving search/call pair only.
+   */
+  keepDynamicToolsDirect?: boolean
 }): Tool[] {
-  const { index, settingsStore, assistantId, appLevelAssistantId, userId, callMcpTool, hooks } = params
+  const {
+    index, settingsStore, assistantId, appLevelAssistantId, userId, callMcpTool,
+    hooks, keepDynamicToolsDirect = false,
+  } = params
 
   // ── Lookup: server:toolName → IndexedTool ─────────────────────
   const entryByKey = new Map<string, IndexedTool>()
@@ -493,10 +501,134 @@ export function createMcpSearchTools(params: {
     },
   })
 
-  return [searchTool, callTool]
+  if (!keepDynamicToolsDirect) return [searchTool, callTool]
+
+  // A workflow tool_call performs one exact registry lookup and cannot run a
+  // model-driven mcp_search -> mcp_call sequence. Expose adapters under both
+  // canonical names and the legacy wrapMcpTools name persisted by older
+  // workflow definitions. The adapters reuse the dispatchers below so policy,
+  // hooks, result conversion, and local capability wrappers remain intact.
+  const directTools: Tool[] = []
+  const claimedNames = new Set(['mcp_search', 'mcp_call'])
+  for (const entry of index.entries) {
+    const aliases = [
+      entry.toolName,
+      sanitizeMcpToolName(`mcp_${entry.server}_${entry.toolName}`).slice(0, 128),
+    ]
+    for (const name of aliases) {
+      if (claimedNames.has(name)) continue
+      claimedNames.add(name)
+      const toolKey = `${entry.server}:${entry.toolName}`
+
+      if (entry.kind === 'local') {
+        directTools.push({
+          ...entry.tool,
+          name,
+          async execute(input, context) {
+            return dispatchLocal({
+              entry,
+              server: entry.server,
+              tool: entry.toolName,
+              toolKey,
+              args: input as Record<string, unknown>,
+              context,
+              blockedTools,
+              allowedTools,
+              skipConfirmation: true,
+            })
+          },
+        })
+        continue
+      }
+
+      const classification = classifyTool(entry.toolName, entry.description)
+      const fallbackPolicy = defaultPolicy(classification)
+      directTools.push(buildTool({
+        name,
+        description: `[${entry.server}] ${entry.description}`,
+        inputSchema: z.record(z.unknown()),
+        isConcurrencySafe: classification === 'read',
+        isReadOnly: classification === 'read',
+        requiresConfirmation: fallbackPolicy === 'ask',
+        allowPersistentApproval: true,
+        async resolveConfirmation() {
+          return await resolveRemoteEffectivePolicy({
+            server: entry.server,
+            tool: entry.toolName,
+            description: entry.description,
+            settingsStore,
+            assistantId,
+            appLevelAssistantId,
+            userId,
+          }) === 'ask'
+        },
+        async execute(input, context) {
+          return dispatchRemote({
+            entry,
+            server: entry.server,
+            tool: entry.toolName,
+            toolKey,
+            args: input as Record<string, unknown>,
+            context,
+            blockedTools,
+            allowedTools,
+            settingsStore,
+            assistantId,
+            appLevelAssistantId,
+            userId,
+            callMcpTool,
+            hooks,
+            skipConfirmation: true,
+          })
+        },
+      }))
+    }
+  }
+
+  return [searchTool, callTool, ...directTools]
 }
 
 // ── Dispatch: remote source ───────────────────────────────────
+
+function sanitizeMcpToolName(raw: string): string {
+  return raw.replace(/[^a-zA-Z0-9_.\-:]/g, '_')
+}
+
+async function resolveRemoteEffectivePolicy(params: {
+  server: string
+  tool: string
+  description: string
+  settingsStore: McpSettingsStore
+  assistantId: string
+  appLevelAssistantId?: string
+  userId: string
+}): Promise<'allow' | 'ask' | 'block'> {
+  const {
+    server, tool, description, settingsStore, assistantId,
+    appLevelAssistantId, userId,
+  } = params
+  const fallbackPolicy = defaultPolicy(classifyTool(tool, description))
+
+  if (appLevelAssistantId) {
+    const l1 = await settingsStore.getPolicy({
+      assistantId: appLevelAssistantId, userId, serverName: server, toolName: tool,
+    })
+    const l2 = await settingsStore.getPolicy({
+      assistantId, userId, serverName: server, toolName: tool,
+    })
+    const appPolicy = l1?.policy ?? fallbackPolicy
+    const asstPolicy = l2?.policy ?? fallbackPolicy
+    const strictness: Record<string, number> = { allow: 0, ask: 1, block: 2 }
+    return (strictness[appPolicy] ?? 0) >= (strictness[asstPolicy] ?? 0)
+      ? appPolicy
+      : asstPolicy
+  }
+
+  const setting = await settingsStore.getPolicy({
+    assistantId, userId, serverName: server, toolName: tool,
+  })
+  return setting?.policy ?? fallbackPolicy
+}
 
 async function dispatchRemote(params: {
   entry: RemoteIndexedTool
@@ -513,39 +645,21 @@ async function dispatchRemote(params: {
   userId: string
   callMcpTool: (serverUrl: string, toolName: string, input: Record<string, unknown>, headerOverrides?: Record<string, string>) => Promise<unknown>
   hooks?: EngineHooks
+  skipConfirmation?: boolean
 }) {
   const {
     entry, server, tool, toolKey, args, context,
     blockedTools, allowedTools,
     settingsStore, assistantId, appLevelAssistantId, userId, callMcpTool, hooks,
+    skipConfirmation = false,
   } = params
 
   // Check classification + policy (strictest of L1 app-level + L2 assistant-level)
   const classification = classifyTool(tool, entry.description)
-  const fallbackPolicy = defaultPolicy(classification)
-
-  let effectivePolicy = fallbackPolicy
-
-  if (appLevelAssistantId) {
-    const l1 = await settingsStore.getPolicy({
-      assistantId: appLevelAssistantId, userId,
-      serverName: server, toolName: tool,
-    })
-    const l2 = await settingsStore.getPolicy({
-      assistantId, userId,
-      serverName: server, toolName: tool,
-    })
-    const appPolicy = l1?.policy ?? fallbackPolicy
-    const asstPolicy = l2?.policy ?? fallbackPolicy
-    const STRICTNESS: Record<string, number> = { allow: 0, ask: 1, block: 2 }
-    effectivePolicy = (STRICTNESS[appPolicy] ?? 0) >= (STRICTNESS[asstPolicy] ?? 0) ? appPolicy : asstPolicy
-  } else {
-    const setting = await settingsStore.getPolicy({
-      assistantId, userId,
-      serverName: server, toolName: tool,
-    })
-    effectivePolicy = setting?.policy ?? fallbackPolicy
-  }
+  const effectivePolicy = await resolveRemoteEffectivePolicy({
+    server, tool, description: entry.description, settingsStore,
+    assistantId, appLevelAssistantId, userId,
+  })
 
   if (effectivePolicy === 'block') {
     blockedTools.add(toolKey)
@@ -561,7 +675,7 @@ async function dispatchRemote(params: {
   // notifyConfirmationRequired from ToolContext (threaded from query
   // loop → tool executor → execute()). Decisions persist for the
   // session (allow/deny) or permanently (always_allow/always_deny).
-  if (effectivePolicy === 'ask' && !allowedTools.has(toolKey)) {
+  if (effectivePolicy === 'ask' && !skipConfirmation && !allowedTools.has(toolKey)) {
     const resolver = context?.confirmationResolver
     const notify = context?.notifyConfirmationRequired
     if (resolver && notify) {
@@ -756,6 +870,7 @@ async function dispatchLocal(params: {
   context: import('../tools/types.js').ToolContext
   blockedTools: Set<string>
   allowedTools: Set<string>
+  skipConfirmation?: boolean
 }) {
   const { entry, server, tool, toolKey, context, blockedTools, allowedTools } = params
   const targetTool = entry.tool
@@ -799,7 +914,7 @@ async function dispatchLocal(params: {
     needsConfirmation = false
   }
 
-  if (needsConfirmation) {
+  if (needsConfirmation && !params.skipConfirmation) {
     const resolver = context?.confirmationResolver
     const notify = context?.notifyConfirmationRequired
 

--- a/packages/core/src/workflow/__tests__/executor.test.ts
+++ b/packages/core/src/workflow/__tests__/executor.test.ts
@@ -1048,21 +1048,21 @@ describe('[COMP:workflow/executor] advanceWorkflowRun', () => {
 
   it('Phase B (simulated): pauses the run on a `wait` step', async () => {
     const stores = makeFakeStores()
-    let pauseCall: { runId: string; stepRunId: string; dueAt: Date } | null = null
+    let pauseCall: { runId: string; stepRunId: string; triggeredBy: string | null; dueAt: Date } | null = null
     const deps: ExecutorDeps = {
       workflowStore: stores.workflowStore,
       runStore: stores.runStore,
       consultTransport: makeConsultTransport(),
       resolvePrimary: async () => PRIMARY_ASSISTANT_ID,
       buildToolRegistry: async () => new Map(),
-      pauseRunForWait: async ({ runId, stepRunId, dueAt }) => {
-        pauseCall = { runId, stepRunId, dueAt }
+      pauseRunForWait: async ({ runId, stepRunId, triggeredBy, dueAt }) => {
+        pauseCall = { runId, stepRunId, triggeredBy, dueAt }
       },
     }
     const { run } = await seedWorkflowAndRun(deps, {
       startStepId: 'sleep',
       steps: [{ id: 'sleep', type: 'wait', until: { duration: { minutes: 5 } } }],
-    })
+    }, 'schedule')
     const outcome = await advanceWorkflowRun(deps, run.id)
     expect(outcome.kind).toBe('paused')
     if (outcome.kind === 'paused') {
@@ -1071,6 +1071,7 @@ describe('[COMP:workflow/executor] advanceWorkflowRun', () => {
     }
     expect(pauseCall).not.toBeNull()
     expect(pauseCall!.runId).toBe(run.id)
+    expect(pauseCall!.triggeredBy).toBe(USER_ID)
     expect(stores.runs.get(run.id)!.status).toBe('awaiting_wait')
   })
 

--- a/packages/core/src/workflow/__tests__/schemas.test.ts
+++ b/packages/core/src/workflow/__tests__/schemas.test.ts
@@ -179,6 +179,19 @@ describe('[COMP:workflow/schemas] WorkflowDefinitionSchema', () => {
     expect(WorkflowDefinitionSchema.safeParse(def).success).toBe(false)
   })
 
+  it('accepts MCP tool names containing dot, dash, and colon', () => {
+    const def = {
+      startStepId: 'a',
+      steps: [{
+        id: 'a',
+        type: 'tool_call',
+        toolName: 'mcp_Proton-calendar_list.events:v2',
+        arguments: {},
+      }],
+    }
+    expect(WorkflowDefinitionSchema.safeParse(def).success).toBe(true)
+  })
+
   it('accepts an assistant_call step with a research-depth config', () => {
     const def = {
       startStepId: 'research',

--- a/packages/core/src/workflow/executor.ts
+++ b/packages/core/src/workflow/executor.ts
@@ -841,7 +841,7 @@ export async function advanceWorkflowRun(
         runId,
         stepRunId,
         workspaceId: run.workspaceId,
-        triggeredBy: run.triggeredBy,
+        triggeredBy: run.triggeredBy ?? workflow.createdBy,
         dueAt: result.dueAt,
       })
       await deps.runStore.updateRun(runId, {

--- a/packages/core/src/workflow/schemas.ts
+++ b/packages/core/src/workflow/schemas.ts
@@ -227,7 +227,7 @@ const toolCallStepSchema = z.object({
     .string()
     .min(1)
     .max(128)
-    .regex(/^[a-zA-Z_][a-zA-Z0-9_]*$/, 'toolName must be a valid identifier.'),
+    .regex(/^[a-zA-Z0-9_.:-]+$/, 'toolName contains unsupported characters.'),
   arguments: z.record(z.unknown()),
   approval: approvalSchema.optional(),
 })


### PR DESCRIPTION
## Summary
- register custom HTTP and CLI tools for deterministic workflow `tool_call` under canonical and persisted legacy aliases
- keep pinned dynamic `assistant_call` catalogs restricted and fail closed on ambiguous names
- reject cross-workspace callee targets before session creation
- carry source-specific workspace/grant/personal policy authority into dynamic dispatch
- align exact-instance Studio discovery, enablement, and policy writes with runtime
- forward remote engine hooks and assistant action grants into workflow connector execution
- strip assistant, worker, workflow, and scheduled-job orchestration rails from terminal workflow surfaces
- preserve scheduled connector approvals/waits with creator-user fallback and fail typed on registry rebuild errors
- accept MCP-safe tool-name characters

## Tests
- core workflow/MCP focused suites: 158 tests
- API workflow/MCP/assistant-route focused suites: 191 tests
- app-web workflow catalog suite: 15 tests
- `corepack pnpm typecheck` in `packages/core`, `packages/api`, and `apps/app-web`