### PR TITLE
fix(workflow): recognize connected tools when authoring

### DIFF
--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -2867,6 +2867,14 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     },
     listTriggerJobs: (workflowId) => jobStore.listFiringJobsForWorkflowSystem(workflowId),
     isKnownTool: (name) => allTools.has(name),
+    resolveKnownWorkflowTools: async ({ userId, workspaceId, assistantId, toolNames }) => {
+      const registry = await workflowExecutorDeps.buildToolRegistry({
+        userId,
+        workspaceId,
+        assistantId,
+      })
+      return toolNames.filter((toolName) => registry.has(toolName))
+    },
     jobStore,
     resolvePrimary: resolvePrimaryAssistantForWorkspace,
     resolveDeliveryTarget: createDeliveryTargetResolver(integrationStore ?? undefined),

--- a/packages/core/src/workflow/__tests__/tools.test.ts
+++ b/packages/core/src/workflow/__tests__/tools.test.ts
@@ -262,6 +262,12 @@ function makeJobStore(overrides: Partial<JobStore> = {}): JobStore & { rows: Sch
 
 function makeAllTools(opts?: {
   isKnownTool?: (name: string) => boolean
+  resolveKnownWorkflowTools?: (args: {
+    userId: string
+    workspaceId: string
+    assistantId: string
+    toolNames: string[]
+  }) => Promise<string[]>
   resolvePageAnchor?: (
     userId: string,
     pageId: string,
@@ -310,6 +316,7 @@ function makeAllTools(opts?: {
     onEvent: (e) => events.push(e),
     resolvePageAnchor: opts?.resolvePageAnchor,
     isKnownTool: opts?.isKnownTool,
+    resolveKnownWorkflowTools: opts?.resolveKnownWorkflowTools,
     // Scheduling substrate (scheduling-authoring-unification).
     jobStore,
     resolvePrimary: async () => PRIMARY_ASSISTANT_ID,
@@ -905,6 +912,114 @@ describe('[COMP:workflow/tools] createWorkflowTools', () => {
     const r = await tools.proposeWorkflow.execute({ name: 'X', definition: SIMPLE_DEF }, makeContext())
     const warnings = (r.data as Record<string, unknown>).warnings as string[]
     expect(warnings.some((w) => w.includes('tool_not_found'))).toBe(false)
+  })
+
+  it('proposeWorkflow accepts a connected dynamic CLI tool from the runtime registry', async () => {
+    const resolveKnownWorkflowTools = vi.fn(async ({ toolNames }: { toolNames: string[] }) => (
+      toolNames.filter((toolName) => toolName === 'list_events')
+    ))
+    const { tools } = makeAllTools({
+      isKnownTool: () => false,
+      resolveKnownWorkflowTools,
+      preflightConnectorTool: async () => null,
+    })
+    const r = await tools.proposeWorkflow.execute({
+      name: 'Calendar events',
+      definition: {
+        startStepId: 'events',
+        steps: [{
+          id: 'events',
+          type: 'tool_call',
+          toolName: 'list_events',
+          arguments: {},
+        }],
+      },
+    }, makeContext())
+
+    expect(r.isError).toBeFalsy()
+    const warnings = (r.data as Record<string, unknown>).warnings as string[]
+    expect(warnings.some((w) => w.includes('tool_not_found'))).toBe(false)
+    expect(resolveKnownWorkflowTools).toHaveBeenCalledWith({
+      userId: USER_ID,
+      workspaceId: WORKSPACE_ID,
+      assistantId: PRIMARY_ASSISTANT_ID,
+      toolNames: ['list_events'],
+    })
+  })
+
+  it('batches deterministic tool lookups and does not mix assistant_call scope', async () => {
+    const resolveKnownWorkflowTools = vi.fn(async ({ toolNames }: { toolNames: string[] }) => (
+      toolNames.filter((toolName) => toolName === 'list_events')
+    ))
+    const { tools } = makeAllTools({
+      isKnownTool: () => false,
+      resolveKnownWorkflowTools,
+    })
+    const r = await tools.proposeWorkflow.execute({
+      name: 'Scoped tools',
+      definition: {
+        startStepId: 'events',
+        steps: [
+          { id: 'events', type: 'tool_call', toolName: 'list_events', arguments: {}, nextStepId: 'missing' },
+          { id: 'missing', type: 'tool_call', toolName: 'missing_action', arguments: {}, nextStepId: 'summarize' },
+          {
+            id: 'summarize',
+            type: 'assistant_call',
+            target: { assistantId: '00000000-0000-0000-0000-000000000099' },
+            prompt: 'Summarize.',
+            tools: ['assistant_only'],
+          },
+        ],
+      },
+    }, makeContext())
+
+    expect(r.isError).toBeFalsy()
+    const warnings = (r.data as Record<string, unknown>).warnings as string[]
+    expect(warnings.some((w) => w.includes('list_events') && w.includes('tool_not_found'))).toBe(false)
+    expect(warnings.some((w) => w.includes('missing_action') && w.includes('tool_not_found'))).toBe(true)
+    expect(resolveKnownWorkflowTools).toHaveBeenCalledTimes(1)
+    expect(resolveKnownWorkflowTools).toHaveBeenCalledWith(expect.objectContaining({
+      assistantId: PRIMARY_ASSISTANT_ID,
+      toolNames: ['list_events', 'missing_action'],
+    }))
+  })
+
+  it('keeps the unknown warning when exact runtime lookup fails or disagrees with preflight', async () => {
+    const resolveKnownWorkflowTools = vi.fn(async () => [])
+    const { tools } = makeAllTools({
+      isKnownTool: () => false,
+      resolveKnownWorkflowTools,
+      preflightConnectorTool: async () => ({ ok: true, provider: 'CLI', policy: 'allow' }),
+    })
+    const r = await tools.proposeWorkflow.execute({
+      name: 'Missing dynamic tool',
+      definition: {
+        startStepId: 'missing',
+        steps: [{ id: 'missing', type: 'tool_call', toolName: 'missing_action', arguments: {} }],
+      },
+    }, makeContext())
+
+    expect(r.isError).toBeFalsy()
+    const warnings = (r.data as Record<string, unknown>).warnings as string[]
+    expect(warnings.some((w) => w.includes('missing_action') && w.includes('tool_not_found'))).toBe(true)
+  })
+
+  it('does not build the runtime tool registry during createWorkflow', async () => {
+    const resolveKnownWorkflowTools = vi.fn(async () => ['list_events'])
+    const { tools } = makeAllTools({
+      isKnownTool: () => false,
+      resolveKnownWorkflowTools,
+    })
+    const r = await tools.createWorkflow.execute({
+      name: 'Calendar events',
+      definition: {
+        startStepId: 'events',
+        steps: [{ id: 'events', type: 'tool_call', toolName: 'list_events', arguments: {} }],
+      },
+    }, makeContext())
+
+    expect(r.isError).toBeFalsy()
+    expect(resolveKnownWorkflowTools).not.toHaveBeenCalled()
   })
 
   it('proposeWorkflow rejects malformed definitions', async () => {

--- a/packages/core/src/workflow/tools.ts
+++ b/packages/core/src/workflow/tools.ts
@@ -149,6 +149,17 @@ export type WorkflowToolDeps = {
    */
   isKnownTool?: (toolName: string) => boolean
   /**
+   * Authoring-time exact lookup against the scoped runtime registry. Unlike
+   * `isKnownTool`, this resolves connected custom HTTP/CLI tools for the
+   * workflow's workspace and acting assistant.
+   */
+  resolveKnownWorkflowTools?: (args: {
+    userId: string
+    workspaceId: string
+    assistantId: string
+    toolNames: string[]
+  }) => Promise<string[]>
+  /**
    * Scheduling substrate — lets the authoring tools attach a schedule trigger
    * in one call (scheduling-authoring-unification). `jobStore` + `resolvePrimary`
    * back the workflow-trigger row; the delivery resolvers port the reminder
@@ -392,7 +403,11 @@ function summarize(def: WorkflowDefinition): string {
 
 function warningsFor(
   def: WorkflowDefinition,
-  opts: { phaseBActive: boolean; isKnownTool?: (name: string) => boolean },
+  opts: {
+    phaseBActive: boolean
+    isKnownTool?: (name: string) => boolean
+    runtimeKnownToolNames?: ReadonlySet<string>
+  },
 ): string[] {
   const warnings: string[] = []
   for (const step of def.steps) {
@@ -400,7 +415,12 @@ function warningsFor(
     // `tool_not_found` / hallucinated-tool failure class (prod: `search`).
     // Skipped when the registry check is unavailable. A connector action is
     // not a built-in, so the message stays accurate for that case too.
-    if (step.type === 'tool_call' && opts.isKnownTool && !opts.isKnownTool(step.toolName)) {
+    if (
+      step.type === 'tool_call'
+      && opts.isKnownTool
+      && !opts.isKnownTool(step.toolName)
+      && !opts.runtimeKnownToolNames?.has(step.toolName)
+    ) {
       warnings.push(
         `Step "${step.id}" calls tool "${step.toolName}", which is not a built-in tool. The run fails with \`tool_not_found\` unless it is a connector action whose connector is connected in this workspace. Built-in brain search is \`searchBrain\`; web search / fetch is \`mcp_search\`. Double-check the tool name.`,
       )
@@ -474,6 +494,37 @@ function warningsFor(
     }
   }
   return warnings
+}
+
+async function runtimeKnownToolNames(
+  def: WorkflowDefinition,
+  context: ToolContext,
+  deps: Pick<WorkflowToolDeps, 'isKnownTool' | 'resolveKnownWorkflowTools' | 'resolvePrimary'>,
+): Promise<Set<string>> {
+  if (!context.workspaceId || !deps.resolveKnownWorkflowTools || !deps.resolvePrimary) {
+    return new Set()
+  }
+  const toolNames = [...new Set(def.steps.flatMap((step) => (
+    step.type === 'tool_call'
+    && (!deps.isKnownTool || !deps.isKnownTool(step.toolName))
+      ? [step.toolName]
+      : []
+  )))]
+  if (toolNames.length === 0) return new Set()
+
+  try {
+    const assistantId = await deps.resolvePrimary(context.workspaceId)
+    if (!assistantId) return new Set()
+    return new Set(await deps.resolveKnownWorkflowTools({
+      userId: context.userId,
+      workspaceId: context.workspaceId,
+      assistantId,
+      toolNames,
+    }))
+  } catch (err) {
+    console.warn('[workflow/tools] runtime tool-name lookup threw:', err)
+    return new Set()
+  }
 }
 
 /** "Tag/mention someone" intent in a Slack-delivering step's prompt. */
@@ -1407,6 +1458,8 @@ export function createWorkflowTools(deps: WorkflowToolDeps): {
         }
       }
 
+      const knownRuntimeTools = await runtimeKnownToolNames(definition, context, deps)
+
       return {
         data: {
           ok: true,
@@ -1415,7 +1468,11 @@ export function createWorkflowTools(deps: WorkflowToolDeps): {
           proposedTrigger: trigger ?? null,
           summary: summarize(definition),
           warnings: [
-            ...warningsFor(definition, { phaseBActive, isKnownTool: deps.isKnownTool }),
+            ...warningsFor(definition, {
+              phaseBActive,
+              isKnownTool: deps.isKnownTool,
+              runtimeKnownToolNames: knownRuntimeTools,
+            }),
             ...anchorIssues.warnings,
             ...depIssues.warnings,
             ...skillIssues.warnings,


### PR DESCRIPTION
## Summary
- validate unknown deterministic workflow names against the same primary-assistant runtime registry used for execution
- batch all candidate names into one proposal-only registry build
- recognize connected custom HTTP and CLI actions such as `list_events` without suppressing genuinely missing or ambiguous names
- keep `assistant_call` target scope and create/update paths out of this advisory lookup

## Tests
- `packages/core`: workflow tools suite, 97 passed
- `packages/core`: build and typecheck passed
- `packages/api`: typecheck passed