### PR TITLE
fix(oss): persist local image uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ pnpm dev                    # choose ChatGPT or an API-key backend; opens your b
 That is it. There is no step three. The store defaults to an embedded PGLite
 database under `~/.usebrian/`; point `DATABASE_URL` at a local Postgres if you
 prefer a container. Self-host overrides live in [`.env.example`](./.env.example).
-Binary data can stay local too: set `LOCAL_FILES_DIR` to a durable directory and
-workspace files, recordings, avatars, and channel media use it. Browser uploads,
+Binary data defaults to the durable `~/.usebrian/files` directory; set
+`LOCAL_FILES_DIR` to override it. Workspace files, recordings, avatars, and
+channel media use this store. Browser uploads,
 public media, and audio/video seeking use short-lived signed API URLs, so GCS is
 optional. The exception is Vertex AI long-recording transcription: because
 Vertex has no Files API, set `GCS_FILES_BUCKET` so temporary audio can be passed

--- a/packages/api/scripts/__tests__/oss-local-storage-composition.test.ts
+++ b/packages/api/scripts/__tests__/oss-local-storage-composition.test.ts
@@ -1,0 +1,21 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = resolve(import.meta.dirname, '../../../..')
+
+describe('[COMP:files/local-client] OSS local storage composition', () => {
+  it('keeps launcher-managed blobs beside the durable embedded database', async () => {
+    const launcher = await readFile(resolve(root, 'scripts/launch.mjs'), 'utf8')
+
+    expect(launcher).toContain("const FILES_DIR = join(CONFIG_DIR, 'files')")
+    expect(launcher).toContain("LOCAL_FILES_DIR: process.env.LOCAL_FILES_DIR?.trim() || FILES_DIR")
+  })
+
+  it('imports the legacy ephemeral blob directory before switching paths', async () => {
+    const launcher = await readFile(resolve(root, 'scripts/launch.mjs'), 'utf8')
+
+    expect(launcher).toContain("join(tmpdir(), 'sidanclaw-files')")
+    expect(launcher).toContain('cpSync(legacyFilesDir, FILES_DIR, { recursive: true })')
+  })
+})

--- a/scripts/launch.mjs
+++ b/scripts/launch.mjs
@@ -25,8 +25,8 @@
  */
 import { spawn } from 'node:child_process'
 import { connect, createServer } from 'node:net'
-import { mkdirSync, readFileSync, writeFileSync, existsSync, renameSync, readdirSync, statSync, rmSync } from 'node:fs'
-import { homedir, platform, arch, userInfo } from 'node:os'
+import { mkdirSync, readFileSync, writeFileSync, existsSync, renameSync, readdirSync, statSync, rmSync, cpSync } from 'node:fs'
+import { homedir, platform, arch, userInfo, tmpdir } from 'node:os'
 import { join, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { randomBytes } from 'node:crypto'
@@ -52,6 +52,7 @@ try {
 }
 const CONFIG_FILE = join(CONFIG_DIR, 'config.json')
 const BRAIN_DIR = join(CONFIG_DIR, 'brain')
+const FILES_DIR = join(CONFIG_DIR, 'files')
 
 // Load use-brian/.env into process.env BEFORE any env read below, so `pnpm
 // start` honors it the same way the standalone migrate + doc-sync paths
@@ -123,6 +124,19 @@ const PORTS = { pglite: 54329, api: 4000, docSync: 8080, appWeb: 3003, discordCo
 
 // ── config (ChatGPT sign-in OR one API credential) ──────────────────
 mkdirSync(CONFIG_DIR, { recursive: true })
+// Older launcher versions persisted blob pointers in PGLite but left the bytes
+// in /tmp. Preserve any blobs that still exist before selecting the durable path.
+if (!process.env.LOCAL_FILES_DIR?.trim() && !process.env.GCS_FILES_BUCKET?.trim()) {
+  const legacyFilesDir = join(tmpdir(), 'sidanclaw-files')
+  if (!existsSync(FILES_DIR) && existsSync(legacyFilesDir)) {
+    try {
+      cpSync(legacyFilesDir, FILES_DIR, { recursive: true })
+      console.log(`[launch] migrated local files ${legacyFilesDir} -> ${FILES_DIR}`)
+    } catch (err) {
+      console.warn(`[launch] could not migrate local files from ${legacyFilesDir}:`, err?.message ?? err)
+    }
+  }
+}
 const config = existsSync(CONFIG_FILE) ? JSON.parse(readFileSync(CONFIG_FILE, 'utf8')) : {}
 
 // `.env` was already merged into process.env by loadDotEnv() above, and
@@ -242,6 +256,7 @@ const env = {
   USEBRIAN_PREFERRED_PROVIDER: preferredProvider,
   JWT_SECRET: jwtSecret,
   DATABASE_URL: databaseUrl,
+  LOCAL_FILES_DIR: process.env.LOCAL_FILES_DIR?.trim() || FILES_DIR,
   USEBRIAN_SINGLE_PROCESS: '1',
   // API <-> doc-sync internal auth + the base URL doc-sync POSTs back to for the
   // auto-on-save brain ingest. 127.0.0.1 (not localhost) avoids the IPv6 ::1


### PR DESCRIPTION
## Summary
- store launcher-managed local blobs under the durable ~/.usebrian/files directory
- migrate any still-present blobs from the legacy temporary directory on first launch
- preserve explicit LOCAL_FILES_DIR and GCS configuration
- document and test the OSS storage composition

## Testing
- focused avatar, workspace icon, and local storage tests (32 passed)
- API typecheck
- node --check scripts/launch.mjs