### PR TITLE
fix(pipeline-b): constrain the decoder on openai-compat and salvage partial JSON

### DIFF
--- a/packages/core/src/ingest/__tests__/pipeline-b.test.ts
+++ b/packages/core/src/ingest/__tests__/pipeline-b.test.ts
@@ -1263,9 +1263,14 @@ describe('[COMP:brain/pipeline-b] processEpisode', () => {
     // identical column, the fingerprint of end-of-input. Misdiagnosis cost:
     // the 2026-07-16 response was to raise the token cap, which was never the
     // cause (failing calls used 194-2646 of 8192 tokens).
+    //
+    // The payload here stops before ANY nested value closes, so there is no
+    // salvage point and the window is genuinely unrecoverable. Output that
+    // stops after one or more complete records is now recovered instead —
+    // see 'salvages the complete records when the model stops mid-object'.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const truncated =
-      '{"summary":"s","entities":[],"edges":[],"memories":[{"scope":"user","summary":"saved","detail":"d"'
+      '{"summary":"s","entities":[{"kind":"person","display_name":"Priya'
     const episodes = spyEpisodes()
     const deps = makeDeps({
       provider: sequencedProvider([truncated, truncated]),
@@ -1326,6 +1331,65 @@ describe('[COMP:brain/pipeline-b] processEpisode', () => {
     expect(result.extracted).toBe(true)
     expect(memories.created.map((m) => m.summary)).toContain('saved')
     expect(episodes.statusCalls).toEqual([{ id: 'ep-1', next: 'archived' }])
+  })
+
+  it('salvages the complete records when the model stops mid-object', async () => {
+    // Regression: on a provider without constrained decoding the model stops
+    // naturally (stopReason 'end_turn', far below the output cap) leaving the
+    // JSON unclosed. scanBalancedJsonObject demanded a fully balanced object,
+    // so the ENTIRE window was discarded — measured at ~92% of enrichment
+    // windows on qwen3.7-plus, every one of them an episode that stored
+    // nothing while its window was still marked complete.
+    const memories = spyMemories()
+    const episodes = spyEpisodes()
+    const cutOffMidObject =
+      '{"summary":"s","entities":[],"edges":[],"memories":['
+      + '{"scope":"user","summary":"saved","detail":"d","tags":[],"why_not_entity":"n/a","why_not_task":"n/a"},'
+      + '{"scope":"user","summary":"lost","detail":"partial'
+    const classification = JSON.stringify({
+      inferred_sensitivity: 'internal',
+      brief_reason: 'ok',
+    })
+    const deps = makeDeps({
+      provider: sequencedProvider([cutOffMidObject, classification]),
+      memories: memories.store,
+      episodes: episodes.port,
+    })
+
+    const result = await processEpisode(baseEpisode(), 'something', deps)
+
+    expect(result.extracted).toBe(true)
+    // The complete record survives; the half-written one is dropped rather
+    // than taking the whole payload down with it.
+    expect(memories.created.map((m) => m.summary)).toContain('saved')
+    expect(memories.created.map((m) => m.summary)).not.toContain('lost')
+  })
+
+  it('does not close containers opened after the salvage point', async () => {
+    // The open-container stack at EOF is NOT the stack at the cut point: the
+    // model may have opened further containers after the last complete value.
+    // Closing those would append brackets for structures the truncated text
+    // never began, producing valid-looking JSON with invented nesting.
+    const memories = spyMemories()
+    const episodes = spyEpisodes()
+    const reopened =
+      '{"summary":"s","entities":[],"edges":[],"memories":['
+      + '{"scope":"user","summary":"saved","detail":"d","tags":[],"why_not_entity":"n/a","why_not_task":"n/a"}'
+      + '],"tasks":[{"title":"half'
+    const classification = JSON.stringify({
+      inferred_sensitivity: 'internal',
+      brief_reason: 'ok',
+    })
+    const deps = makeDeps({
+      provider: sequencedProvider([reopened, classification]),
+      memories: memories.store,
+      episodes: episodes.port,
+    })
+
+    const result = await processEpisode(baseEpisode(), 'something', deps)
+
+    expect(result.extracted).toBe(true)
+    expect(memories.created.map((m) => m.summary)).toContain('saved')
   })
 
   it('recovers when the LLM emits a trailing comma in an array', async () => {

--- a/packages/core/src/ingest/pipeline-b.ts
+++ b/packages/core/src/ingest/pipeline-b.ts
@@ -1065,7 +1065,7 @@ const JSON_SHORT_ESCAPES: Record<string, string> = {
   '\t': '\\t',
 }
 
-type BalancedScan = { ok: true; json: string } | { ok: false; reason: string }
+type BalancedScan = { ok: true; json: string; salvaged?: boolean } | { ok: false; reason: string }
 
 /**
  * Walk from the first `{` to its MATCHING `}`, escaping raw ASCII control
@@ -1105,6 +1105,15 @@ function scanBalancedJsonObject(text: string): BalancedScan {
   let depth = 0
   let inString = false
   let escaped = false
+  // Salvage state. `stack` is the open containers in order; `safeCut` is the
+  // length of `out` at the last point a nested value CLOSED, which is the last
+  // position where truncating leaves a well-formed prefix.
+  const stack: string[] = []
+  let safeCut = 0
+  // Containers open AT the cut point. The live stack cannot be reused: between
+  // the cut and EOF the model may have opened further containers, and closing
+  // those would append brackets for structures the truncated text never began.
+  let safeStackLen = 0
 
   for (let i = start; i < text.length; i++) {
     const ch = text[i]
@@ -1137,16 +1146,44 @@ function scanBalancedJsonObject(text: string): BalancedScan {
       out += ch
       continue
     }
-    if (ch === '{') depth++
-    else if (ch === '}') {
+    if (ch === '{') {
+      depth++
+      stack.push('}')
+    } else if (ch === '[') {
+      stack.push(']')
+    } else if (ch === ']') {
+      stack.pop()
+      out += ch
+      safeCut = out.length
+      safeStackLen = stack.length
+      continue
+    } else if (ch === '}') {
       depth--
+      stack.pop()
       out += ch
       if (depth === 0) return { ok: true, json: out }
+      safeCut = out.length
+      safeStackLen = stack.length
       continue
     }
     out += ch
   }
 
+  // The object never closed. Rather than discard the whole window — which is
+  // what used to happen, and cost ~92% of extractions on a provider without
+  // constrained decoding — rewind to the last complete nested value and close
+  // the containers that are still open. The trailing partial item is dropped;
+  // every complete one before it survives. Every field on the Zod side is
+  // nullish-with-default, so a payload missing later keys still validates.
+  if (safeCut > 0) {
+    const head = out.slice(0, safeCut).replace(/,\s*$/, '')
+    // `stack` still holds the containers open at the cut point, outermost
+    // first; closing in reverse yields a balanced object.
+    const closers = stack.slice(0, safeStackLen).reverse().join('')
+    if (closers) {
+      return { ok: true, json: head + closers, salvaged: true }
+    }
+  }
   return {
     ok: false,
     reason: `incomplete JSON: model output ended mid-object with ${depth} unclosed brace${depth === 1 ? '' : 's'}${inString ? ' inside an unterminated string' : ''}`,
@@ -1157,6 +1194,13 @@ function parseExtraction(rawText: string): ParseResult {
   const cleaned = rawText.replace(/^```(?:json)?\s*|\s*```$/g, '').trim()
   const scan = scanBalancedJsonObject(cleaned)
   if (!scan.ok) return { ok: false, reason: scan.reason }
+  if (scan.salvaged) {
+    // Worth a line: the window produced records, but the tail of the model's
+    // output was discarded, so this episode is under-extracted rather than
+    // wrong. A rising count here means the output budget or the window size
+    // needs attention.
+    console.warn('[pipeline-b] recovered a truncated extraction payload; trailing items were dropped')
+  }
 
   // Drop trailing commas (`,]` / `,}`) — a common LLM output tic that
   // `JSON.parse` rejects and that carries no semantics.
@@ -1471,6 +1515,12 @@ export async function processEpisode(
     for (let attempt = 1; attempt <= 2 && !windowPayload; attempt++) {
       let rawText = ''
       let truncated = false
+      // Recorded for the failure log: without the stop reason and the token
+      // count, "parse failed" is indistinguishable from "hit the output cap",
+      // and those need opposite fixes. Diagnosing this cost a full round of
+      // instrumentation that the log should have answered directly.
+      let stopReason = 'unset'
+      let outTokens = -1
       try {
         const response = await collectStream(
           deps.provider.stream({
@@ -1502,6 +1552,8 @@ export async function processEpisode(
         // as truncation gets the concision retry instead of the misleading
         // "failed validation" message, which re-runs the same doomed shape.
         truncated = response.stopReason === 'max_tokens' || response.stopReason === 'incomplete'
+        stopReason = String(response.stopReason)
+        outTokens = response.usage?.outputTokens ?? -1
         rawText = response.content
           .filter((b) => b.type === 'text')
           .map((b) => (b.type === 'text' ? b.text : ''))
@@ -1531,7 +1583,9 @@ export async function processEpisode(
         reason = parseRes.reason
       }
       console.warn(
-        `[pipeline-b] extraction ${truncated ? 'truncated' : 'parse failed'} for episode ${episode.id} (window ${wi + 1}/${windows.length}, attempt ${attempt}/2): ${reason}`,
+        `[pipeline-b] extraction ${truncated ? 'truncated' : 'parse failed'} for episode ${episode.id} `
+        + `(window ${wi + 1}/${windows.length}, attempt ${attempt}/2, stop=${stopReason}, `
+        + `out=${outTokens}/${EXTRACTION_MAX_OUTPUT_TOKENS}): ${reason}`,
       )
       if (attempt === 1) {
         // No echo of the bad output — re-anchoring on garbage hurts more than

--- a/packages/core/src/providers/openai-compat.ts
+++ b/packages/core/src/providers/openai-compat.ts
@@ -253,8 +253,11 @@ async function* streamCompat(
     temperature?: number
     thinkingLevel?: ThinkingLevel
     responseFormat?: 'json'
+    responseSchema?: Record<string, unknown>
     signal?: AbortSignal
   },
+  // Set by the fail-open retry below; suppresses the schema on the second try.
+  omitSchema = false,
 ): AsyncGenerator<StreamChunk> {
   const ccMessages: CCMessage[] = [
     ...(systemPrompt ? [{ role: 'system' as const, content: systemPrompt }] : []),
@@ -275,8 +278,22 @@ async function* streamCompat(
       ? { enable_thinking: options.thinkingLevel === 'high' }
       : {}),
     // JSON mode and tools are mutually exclusive (same rule as Gemini).
+    //
+    // `json_object` guarantees only that the output is *syntactically* JSON;
+    // it does not engage constrained decoding, and a model that stops early
+    // still returns an unclosed object. `json_schema` does constrain the
+    // decoder. Callers that supply a schema were previously ignored here —
+    // `responseSchema` never reached the wire for any openai-compat provider,
+    // so Gemini deployments got constrained extraction and Qwen deployments
+    // silently did not. `strict` is deliberately NOT set: the schemas in this
+    // codebase are Gemini's OpenAPI subset and carry `nullable`, which strict
+    // mode rejects outright.
     ...(cfg.supportsJsonMode && options.responseFormat === 'json' && !tools
-      ? { response_format: { type: 'json_object' } }
+      ? {
+        response_format: options.responseSchema && !omitSchema
+          ? { type: 'json_schema', json_schema: { name: 'response', schema: options.responseSchema } }
+          : { type: 'json_object' },
+      }
       : {}),
   }
 
@@ -289,6 +306,18 @@ async function* streamCompat(
     body: JSON.stringify(body),
     signal: options.signal,
   })
+  // Fail open on a rejected schema. "OpenAI-compatible" is a broad church and
+  // json_schema is one of the first things a smaller endpoint drops; degrading
+  // to json_object costs output quality, whereas propagating the 400 would
+  // break every extraction call on that deployment.
+  if (res.status === 400 && options.responseSchema && !omitSchema) {
+    const detail = (await res.text().catch(() => '')).slice(0, 300)
+    console.warn(
+      `[openai-compat:${cfg.label}] endpoint rejected response_format json_schema; retrying with json_object${detail ? `: ${detail}` : ''}`,
+    )
+    yield* streamCompat(cfg, wireModel, recordedModel, systemPrompt, messages, options, true)
+    return
+  }
   if (!res.ok || !res.body) {
     const detail = (await res.text().catch(() => '')).slice(0, 500)
     const suffix = cfg.includeErrorDetail && detail ? `: ${detail}` : ''
@@ -404,6 +433,7 @@ export function createOpenAICompatProvider(options: OpenAICompatProviderOptions)
         temperature: request.temperature,
         thinkingLevel: request.thinkingLevel,
         responseFormat: request.responseFormat,
+        responseSchema: request.responseSchema,
         signal: request.signal,
       })
     },


### PR DESCRIPTION
Extraction failed on **~92% of enrichment windows** against `qwen3.7-plus`. Every failure discarded the whole window while the window was still recorded as complete, so nothing surfaced the loss: **181 windows produced 10 entities.**

Independent of the chat-archive PRs; this is Pipeline B plus the provider adapter.

## Cause 1 — `responseSchema` never reached the wire

`openai-compat.ts` sent `response_format: json_object` and dropped `responseSchema` entirely, for every openai-compat provider.

`json_object` guarantees only that output is *syntactically* JSON. It does not engage constrained decoding, and a model that stops early still returns an unclosed object. So Gemini deployments got the constrained decoding this file's own comment justifies —

> `responseMimeType: 'application/json'` alone is only a hint — the decoder can still emit unparseable output, and did: 56 failed extractions in three days, each one an episode that stored nothing.

— and Qwen deployments silently did not.

DashScope accepts `json_schema`; verified against the live API before wiring it. `strict` is deliberately **not** set: the schemas here are Gemini's OpenAPI subset and carry `nullable`, which strict mode rejects outright. An endpoint that refuses the schema falls back to `json_object` rather than failing the call — "OpenAI-compatible" is a broad church and this is among the first things a smaller endpoint drops.

## Cause 2 — one unclosed brace discarded every complete record

`scanBalancedJsonObject` demanded a fully balanced object. It now rewinds to the last complete nested value and closes what remains open, dropping only the trailing partial item. Every field on the Zod side is `nullish`-with-default, so a payload missing later keys still validates.

The container stack is snapshotted **at the cut point**, not reused from EOF — the model may open further containers after the last complete value, and closing those would invent nesting the truncated text never began. There's a test for exactly that.

## Why diagnosis was slow

The log said `parse failed` and nothing else, which is indistinguishable from hitting the output cap — and those need opposite fixes. It now carries the stop reason and output token count. The measured failures reported `stop=end_turn` with **1,884 of 8,192** tokens used, so the cap was never the cause. (An earlier response to this class of failure was to raise the cap; the comment at `EXTRACTION_MAX_OUTPUT_TOKENS` records that it didn't help, and this explains why.)

## Measured after the change

| | Before | After |
|---|---|---|
| Extraction failures | ~92% of windows | **0** |
| Payloads salvaged | n/a | 4 of 6 |
| Schema rejections | n/a | 0 |
| Entities extracted | 10 across 181 windows | **20 across 6 windows** |

Note the salvage path still fired on 4 of 6 windows — constrained decoding alone did not eliminate early stopping, it just made the output well-formed enough to recover. Both halves are earning their place.

72 tests pass in `pipeline-b.test.ts` (2 new), 112 across the affected suites. `tsc` error count is unchanged from `develop` (8 pre-existing, all in `office/`), and 2 pre-existing `routing.test.ts` failures also reproduce on clean `develop`.

## One behaviour change to review

`reports truncated model output as incomplete JSON` previously asserted that a partially-complete payload yields `extracted: false`. Salvage deliberately changes that. The test is kept — its point about diagnosing truncation as "incomplete JSON" rather than a bogus syntax error still holds — but repointed at a payload that stops before any nested value closes, which remains genuinely unrecoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)