### PR TITLE
feat(chat-archive): support common workplace documents, and archive streamed WhatsApp media

### DIFF
--- a/apps/wa-connector/src/__tests__/socket-manager.test.ts
+++ b/apps/wa-connector/src/__tests__/socket-manager.test.ts
@@ -510,6 +510,25 @@ describe('[COMP:wa-connector/media-routing] inbound media relay routing', () => 
     return call ? JSON.parse((call[1] as { body: string }).body) : undefined
   }
 
+  /**
+   * Wait until the relay call actually lands.
+   *
+   * The media path now spools the attachment to a temp file before uploading,
+   * and real filesystem work resolves on the threadpool rather than on a fixed
+   * number of microtask turns — so draining N immediates and asserting is a
+   * race. Poll for the call instead, bounded so a genuine failure still fails
+   * fast rather than hanging the suite.
+   */
+  async function waitForInboundBody(fetchMock: ReturnType<typeof vi.fn>, timeoutMs = 2000) {
+    const deadline = Date.now() + timeoutMs
+    for (;;) {
+      const body = inboundBody(fetchMock)
+      if (body) return body
+      if (Date.now() > deadline) return undefined
+      await new Promise((r) => setTimeout(r, 5))
+    }
+  }
+
   /** fetch mock that mints an upload URL, accepts the PUT, and ACKs /inbound. */
   function streamingFetchMock() {
     return vi.fn(async (url: unknown, init?: { method?: string }) => {
@@ -524,6 +543,59 @@ describe('[COMP:wa-connector/media-routing] inbound media relay routing', () => 
     })
   }
 
+  it('uploads straight to the archive when the API issues a signed target', async () => {
+    // On-premise the API mints a per-asset signature instead of a workspace
+    // URL, so the bytes go to the archive directly and never leave a second
+    // copy behind. The digest is inside the signature, so the connector must
+    // hash before it can be issued one — hence the two mint calls.
+    const { downloadMediaMessage } = await import('@whiskeysockets/baileys')
+    const { Readable } = await import('node:stream')
+    vi.mocked(downloadMediaMessage).mockResolvedValue(Readable.from([Buffer.from('vid')]) as never)
+    const mints: unknown[] = []
+    const fetchMock = vi.fn(async (url: unknown, init?: { method?: string; body?: string }) => {
+      if (String(url).endsWith('/internal/whatsapp/media-upload-url')) {
+        const body = JSON.parse(init!.body!)
+        mints.push(body)
+        if (!body.sha256) return { ok: true, json: async () => ({ target: 'archive' }) }
+        return {
+          ok: true,
+          json: async () => ({
+            target: 'archive',
+            uploadUrl: 'http://store.test/media?sha256=' + body.sha256,
+            headers: { 'X-UB-Signature': 'sha256=deadbeef' },
+          }),
+        }
+      }
+      if (String(url).startsWith('http://store.test/')) {
+        return { ok: true, json: async () => ({ asset_id: '4a1e6bd8-0000-4000-8000-000000000009' }) }
+      }
+      return { ok: true }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    await connected()
+
+    await emitMedia({ videoMessage: { mimetype: 'video/mp4', fileLength: 9_000_000 } })
+
+    const body = await waitForInboundBody(fetchMock)
+    expect(body).toBeDefined()
+    // No workspace object exists, so no gcsKey — that is what stops the second copy.
+    expect(body.mediaRef.gcsKey).toBeUndefined()
+    expect(body.mediaRef.archiveAssetId).toBe('4a1e6bd8-0000-4000-8000-000000000009')
+    // sha256 of "vid", computed while spooling.
+    expect(body.mediaRef.sha256).toMatch(/^[a-f0-9]{64}$/)
+    expect(body.mediaBase64).toBeUndefined()
+
+    // First mint asks where to go; only the second carries the digest.
+    expect(mints).toHaveLength(2)
+    expect((mints[0] as { sha256?: string }).sha256).toBeUndefined()
+    expect((mints[1] as { sha256?: string }).sha256).toBe((body.mediaRef as { sha256: string }).sha256)
+
+    const upload = fetchMock.mock.calls.find((c) => String(c[0]).startsWith('http://store.test/'))
+    expect((upload![1] as { method: string }).method).toBe('POST')
+    expect((upload![1] as { headers: Record<string, string> }).headers['X-UB-Signature']).toBe('sha256=deadbeef')
+    vi.unstubAllGlobals()
+  })
+
   it('streams a sub-cap VIDEO to GCS and relays a mediaRef (never mediaBase64)', async () => {
     const { downloadMediaMessage } = await import('@whiskeysockets/baileys')
     const { Readable } = await import('node:stream')
@@ -534,7 +606,7 @@ describe('[COMP:wa-connector/media-routing] inbound media relay routing', () => 
 
     await emitMedia({ videoMessage: { mimetype: 'video/mp4', fileLength: 9_000_000 } })
 
-    const body = inboundBody(fetchMock)
+    const body = await waitForInboundBody(fetchMock)
     expect(body).toBeDefined()
     expect(body.mediaRef).toMatchObject({ gcsKey: 'channel-media/k.bin', mimeType: 'video/mp4' })
     expect(body.mediaBase64).toBeUndefined()
@@ -612,7 +684,7 @@ describe('[COMP:wa-connector/media-routing] inbound media relay routing', () => 
 
     await emitMedia({ audioMessage: { mimetype: 'audio/ogg; codecs=opus', ptt: true, fileLength: 80_000 } })
 
-    const body = inboundBody(fetchMock)
+    const body = await waitForInboundBody(fetchMock)
     expect(body).toBeDefined()
     expect(body.mediaBase64).toBe(Buffer.from('voice-bytes').toString('base64'))
     expect(body.mediaRef).toBeUndefined()
@@ -629,7 +701,7 @@ describe('[COMP:wa-connector/media-routing] inbound media relay routing', () => 
 
     await emitMedia({ audioMessage: { mimetype: 'audio/mpeg', fileLength: 3_000_000 } })
 
-    const body = inboundBody(fetchMock)
+    const body = await waitForInboundBody(fetchMock)
     expect(body).toBeDefined()
     expect(body.mediaRef).toMatchObject({ mimeType: 'audio/mpeg' })
     expect(body.mediaBase64).toBeUndefined()

--- a/apps/wa-connector/src/message-parser.ts
+++ b/apps/wa-connector/src/message-parser.ts
@@ -436,7 +436,16 @@ export type WhatsAppIncomingMessage = {
   mediaRef?: {
     /** Local chat-archive staging asset, completed by the API on inbound. */
     assetId?: string
-    gcsKey: string
+    /**
+     * Set when the bytes went straight into the archive under a per-asset
+     * signature the API minted. There is no workspace object in that case, so
+     * `gcsKey` is absent and the API has nothing to read back.
+     */
+    archiveAssetId?: string
+    /** Digest of the uploaded bytes; the archive's signature commits to it. */
+    sha256?: string
+    /** Workspace storage key. Absent on the archive-direct path. */
+    gcsKey?: string
     /** BYO storage URI (bytes live in the workspace's own bucket); echoed from the mint. */
     storageUri?: string
     mimeType: string

--- a/apps/wa-connector/src/socket-manager.ts
+++ b/apps/wa-connector/src/socket-manager.ts
@@ -24,6 +24,12 @@ import {
   useMultiFileAuthState,
 } from '@whiskeysockets/baileys'
 import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { createHash, randomUUID } from 'node:crypto'
+import { createReadStream, createWriteStream } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { pipeline } from 'node:stream/promises'
+import { Transform } from 'node:stream'
 import pino from 'pino'
 
 /**
@@ -355,52 +361,144 @@ export function createSocketManager(options: SocketManagerOptions): SocketManage
     msg: WAMessage,
     mediaInfo: { mimeType: string; fileName?: string; fileLength?: number },
   ): Promise<NonNullable<WhatsAppIncomingMessage['mediaRef']>> {
-    const res = await fetch(`${apiUrl}/internal/whatsapp/media-upload-url`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'X-Connector-Secret': connectorSecret },
-      body: JSON.stringify({
-        channelId,
-        providerMessageId: msg.key.id,
-        kind: mediaInfo.mimeType.startsWith('image/') ? 'image'
-          : mediaInfo.mimeType.startsWith('video/') ? 'video'
-            : mediaInfo.mimeType.startsWith('audio/') ? 'voice' : 'file',
-        mime: mediaInfo.mimeType,
-        fileName: mediaInfo.fileName ?? null,
-        sizeBytes: mediaInfo.fileLength ?? 0,
-      }),
-    })
-    if (!res.ok) {
-      const detail = (await res.text().catch(() => '')).slice(0, 300)
-      throw new Error(`media-upload-url failed: ${res.status} ${res.statusText}${detail ? `: ${detail}` : ''}`)
-    }
-    const { assetId, alreadyStored, gcsKey, uploadUrl, storageUri, sizeBytes } = (await res.json()) as {
-      assetId?: string; alreadyStored?: boolean; gcsKey: string; uploadUrl: string
-      storageUri?: string; sizeBytes?: number
+    const kind = mediaInfo.mimeType.startsWith('image/') ? 'image'
+      : mediaInfo.mimeType.startsWith('video/') ? 'video'
+        : mediaInfo.mimeType.startsWith('audio/') ? 'voice' : 'file'
+
+    const mint = async (sha256?: string) => {
+      const res = await fetch(`${apiUrl}/internal/whatsapp/media-upload-url`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Connector-Secret': connectorSecret },
+        body: JSON.stringify({
+          channelId,
+          providerMessageId: msg.key.id,
+          kind,
+          mime: mediaInfo.mimeType,
+          fileName: mediaInfo.fileName ?? null,
+          sizeBytes: mediaInfo.fileLength ?? 0,
+          ...(sha256 ? { sha256 } : {}),
+        }),
+      })
+      if (!res.ok) {
+        const detail = (await res.text().catch(() => '')).slice(0, 300)
+        throw new Error(`media-upload-url failed: ${res.status} ${res.statusText}${detail ? `: ${detail}` : ''}`)
+      }
+      return (await res.json()) as {
+        target?: 'archive' | 'workspace'
+        headers?: Record<string, string>
+        assetId?: string; alreadyStored?: boolean; gcsKey?: string; uploadUrl?: string
+        storageUri?: string; sizeBytes?: number
+      }
     }
 
-    if (!alreadyStored) {
+    // Ask before downloading. A destination that already holds these bytes ends
+    // the job here, without pulling the attachment off WhatsApp's CDN again.
+    const first = await mint()
+    if (first.alreadyStored) {
+      return {
+        ...(first.assetId ? { assetId: first.assetId } : {}),
+        ...(first.gcsKey ? { gcsKey: first.gcsKey } : {}),
+        ...(first.storageUri ? { storageUri: first.storageUri } : {}),
+        mimeType: mediaInfo.mimeType,
+        ...(mediaInfo.fileName ? { fileName: mediaInfo.fileName } : {}),
+        ...(first.sizeBytes || mediaInfo.fileLength
+          ? { sizeBytes: first.sizeBytes || mediaInfo.fileLength }
+          : {}),
+      }
+    }
+
+    // Workspace storage takes an unsigned PUT, so the bytes can go straight
+    // from WhatsApp to the destination without ever landing on our disk.
+    if (first.target !== 'archive') {
+      if (!first.uploadUrl) throw new Error('media-upload-url returned no uploadUrl')
       const stream = (await downloadMediaMessage(msg, 'stream', {})) as unknown as import('node:stream').Readable
       const headers: Record<string, string> = { 'Content-Type': mediaInfo.mimeType }
       if (mediaInfo.fileLength) headers['Content-Length'] = String(mediaInfo.fileLength)
-      const put = await fetch(uploadUrl, {
+      const put = await fetch(first.uploadUrl, {
         method: 'PUT',
         headers,
         body: stream as unknown as ReadableStream,
         duplex: 'half', // Node streaming request body requires half-duplex.
       } as RequestInit & { duplex: 'half' })
       if (!put.ok) throw new Error(`media PUT failed: ${put.status} ${put.statusText}`)
+      return {
+        ...(first.assetId ? { assetId: first.assetId } : {}),
+        ...(first.gcsKey ? { gcsKey: first.gcsKey } : {}),
+        // Echo the BYO storage URI back with the bytes so the API stamps the exact
+        // bucket the bytes were PUT to (race-free vs. recomputing at /inbound).
+        ...(first.storageUri ? { storageUri: first.storageUri } : {}),
+        mimeType: mediaInfo.mimeType,
+        ...(mediaInfo.fileName ? { fileName: mediaInfo.fileName } : {}),
+        ...(first.sizeBytes || mediaInfo.fileLength
+          ? { sizeBytes: first.sizeBytes || mediaInfo.fileLength }
+          : {}),
+      }
     }
 
-    return {
-      ...(assetId ? { assetId } : {}),
-      gcsKey,
-      // Echo the BYO storage URI back with the bytes so the API stamps the exact
-      // bucket the bytes were PUT to (race-free vs. recomputing at /inbound).
-      ...(storageUri ? { storageUri } : {}),
-      mimeType: mediaInfo.mimeType,
-      ...(mediaInfo.fileName ? { fileName: mediaInfo.fileName } : {}),
-      ...(sizeBytes || mediaInfo.fileLength ? { sizeBytes: sizeBytes || mediaInfo.fileLength } : {}),
+    // The archive signs an upload over a request URI containing the content
+    // digest, so the digest must exist before a destination can be issued.
+    // Spool to disk on the way through: memory stays flat whatever the size,
+    // at the cost of one transient copy. Only this path pays for it.
+    const spooled = await spoolMediaToDisk(msg, kind)
+    try {
+      const signed = await mint(spooled.sha256)
+      if (!signed.uploadUrl) throw new Error('archive upload target returned no uploadUrl')
+      const put = await fetch(signed.uploadUrl, {
+        method: 'POST', // the archive's /media is single-shot POST, not PUT
+        headers: {
+          'Content-Type': mediaInfo.mimeType,
+          'Content-Length': String(spooled.sizeBytes),
+          ...(signed.headers ?? {}),
+        },
+        body: createReadStream(spooled.path) as unknown as ReadableStream,
+        duplex: 'half',
+      } as RequestInit & { duplex: 'half' })
+      if (!put.ok) throw new Error(`archive upload failed: ${put.status} ${put.statusText}`)
+      const stored = (await put.json().catch(() => ({}))) as { asset_id?: string }
+      if (!stored.asset_id) throw new Error('archive upload returned no asset id')
+      return {
+        archiveAssetId: stored.asset_id,
+        sha256: spooled.sha256,
+        mimeType: mediaInfo.mimeType,
+        ...(mediaInfo.fileName ? { fileName: mediaInfo.fileName } : {}),
+        sizeBytes: spooled.sizeBytes,
+      }
+    } finally {
+      await rm(spooled.path, { force: true }).catch(() => {})
     }
+  }
+
+  /**
+   * Download an attachment to a temp file, returning its digest and size.
+   *
+   * Memory stays flat regardless of attachment size: bytes go from the WhatsApp
+   * stream through the hash and onto disk, never accumulating in a buffer.
+   */
+  async function spoolMediaToDisk(
+    msg: WAMessage,
+    kind: string,
+  ): Promise<{ path: string; sha256: string; sizeBytes: number }> {
+    const stream = (await downloadMediaMessage(msg, 'stream', {})) as unknown as import('node:stream').Readable
+    const path = join(tmpdir(), `wa-${kind}-${randomUUID()}`)
+    const hash = createHash('sha256')
+    let sizeBytes = 0
+    // Hash inside the pipeline rather than on a 'data' listener: attaching one
+    // switches the stream to flowing mode immediately, which can drop chunks
+    // before the pipeline is wired up.
+    const meter = new Transform({
+      transform(chunk: Buffer, _enc, done) {
+        hash.update(chunk)
+        sizeBytes += chunk.length
+        done(null, chunk)
+      },
+    })
+    try {
+      await pipeline(stream, meter, createWriteStream(path))
+    } catch (err) {
+      await rm(path, { force: true }).catch(() => {})
+      throw err
+    }
+    return { path, sha256: hash.digest('hex'), sizeBytes }
   }
 
   // ── Notify the API a channel was logged out ──

--- a/packages/api/src/chat-archive/__tests__/extract-service.test.ts
+++ b/packages/api/src/chat-archive/__tests__/extract-service.test.ts
@@ -1,0 +1,85 @@
+/**
+ * [COMP:integrations/chat-message-store] Document-modality dispatch.
+ *
+ * The store treats `unsupported` as terminal — such assets are excluded from
+ * the extraction claim query forever — so the boundary between "no reader
+ * exists" and "nobody looked" is worth pinning down. These cases exist because
+ * the previous MIME allowlist got that boundary wrong: it rejected formats the
+ * parser could already read, and read `application/octet-stream` as proof of
+ * unreadability when it is really just an unhelpful provider.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { createExtractService, type ExtractServiceDeps } from '../extract-service.js'
+
+function service(deps: ExtractServiceDeps = {}) {
+  return createExtractService(deps)
+}
+
+function doc(buffer: Buffer, mime: string, filename?: string) {
+  return { modality: 'document' as const, mime, filename, buffer }
+}
+
+describe('document extraction dispatch', () => {
+  it('reads a text file that declares a text MIME', async () => {
+    const result = await service().extract(
+      doc(Buffer.from('quarterly numbers are up'), 'text/plain', 'notes.txt'),
+    )
+    expect(result.unsupported).toBeFalsy()
+    expect(result.texts[0]?.text).toContain('quarterly numbers are up')
+  })
+
+  it('reads a text file a provider labelled application/octet-stream', async () => {
+    // WeChat labels every document this way. The old gate rejected it outright.
+    const result = await service().extract(
+      doc(Buffer.from('the door code is 4471'), 'application/octet-stream', 'notes.txt'),
+    )
+    expect(result.unsupported).toBeFalsy()
+    expect(result.texts[0]?.text).toContain('the door code is 4471')
+  })
+
+  it('identifies a registry format by extension when the MIME is generic', async () => {
+    const result = await service().extract(
+      doc(Buffer.from('region,revenue\nAPAC,120\n'), 'application/octet-stream', 'report.csv'),
+    )
+    expect(result.unsupported).toBeFalsy()
+    expect(result.texts[0]?.text).toContain('APAC')
+  })
+
+  it('routes a PDF to the distiller rather than the text parser', async () => {
+    // parseFileContent hands PDFs back as base64 for page rendering, which is
+    // not indexable text — so the vision distiller has to own this branch.
+    const distill = vi.fn().mockResolvedValue('page one text')
+    const result = await service({ distill }).extract(
+      doc(Buffer.from('%PDF-1.4\n%\xE2\xE3\xCF\xD3\n', 'binary'), 'application/pdf', 'a.pdf'),
+    )
+    expect(distill).toHaveBeenCalledOnce()
+    expect(result.texts[0]?.text).toBe('page one text')
+  })
+
+  it('reports a genuinely unreadable binary as unsupported', async () => {
+    // Modelled on iWork: a ZIP container no parser in the stack can read. It
+    // must stay terminal so the store does not retry it forever.
+    const zipish = Buffer.concat([Buffer.from('PK\x03\x04', 'binary'), Buffer.alloc(64, 0)])
+    const result = await service().extract(doc(zipish, 'application/octet-stream', 'deck.pages'))
+    expect(result.unsupported).toBe(true)
+    expect(result.texts).toEqual([])
+  })
+
+  it('does not call unsupported when a readable file simply has no text', async () => {
+    // An empty document is a successful extraction that found nothing. Marking
+    // it unsupported would park it permanently on a verdict about its format.
+    const result = await service().extract(doc(Buffer.from('   \n  '), 'text/plain', 'empty.txt'))
+    expect(result.unsupported).toBeFalsy()
+    expect(result.texts).toEqual([])
+  })
+
+  it('rejects an unknown modality rather than guessing', async () => {
+    const result = await service().extract({
+      modality: 'nonsense' as never,
+      mime: 'text/plain',
+      buffer: Buffer.from('x'),
+    })
+    expect(result.unsupported).toBe(true)
+  })
+})

--- a/packages/api/src/chat-archive/__tests__/extract-service.test.ts
+++ b/packages/api/src/chat-archive/__tests__/extract-service.test.ts
@@ -74,6 +74,26 @@ describe('document extraction dispatch', () => {
     expect(result.texts).toEqual([])
   })
 
+  it('does not index the parser\'s failure notice as if it were the document', async () => {
+    // parseFileContent never throws for an unreadable file: it returns a short
+    // bracketed sentence for a human to read. That text is non-empty, so
+    // indexing it verbatim would embed the apology and rank "could not parse"
+    // against every question about a document.
+    //
+    // Drives the real parser, not a stub — a legacy .doc that the library
+    // cannot read — so if those notices are ever reworded upstream this fails
+    // rather than silently filling the index.
+    const notAWordFile = Buffer.concat([
+      Buffer.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]), // OLE magic
+      Buffer.alloc(512, 0x42),
+    ])
+    const result = await service().extract(
+      doc(notAWordFile, 'application/octet-stream', 'legacy.doc'),
+    )
+    expect(result.unsupported).toBe(true)
+    expect(result.texts).toEqual([])
+  })
+
   it('rejects an unknown modality rather than guessing', async () => {
     const result = await service().extract({
       modality: 'nonsense' as never,

--- a/packages/api/src/chat-archive/extract-service.ts
+++ b/packages/api/src/chat-archive/extract-service.ts
@@ -56,6 +56,27 @@ function looksLikeText(buffer: Buffer): boolean {
   return !new TextDecoder('utf-8', { fatal: false }).decode(head).includes('\uFFFD')
 }
 
+/**
+ * Is this `parseFileContent` output a failure notice rather than the document?
+ *
+ * The parser never throws for an unreadable file; it returns a short bracketed
+ * sentence meant for a human reading a chat — "[Document: x.doc. Could not parse
+ * this document.]" or "[File: x, type: y. Content type not supported for text
+ * extraction.]". That text is non-empty, so indexing it verbatim would embed the
+ * apology and rank it against real queries: an archive full of "could not parse"
+ * segments matching every question about a document. Exactly the failure the
+ * media-stub segments had, where placeholder text displaced real content.
+ *
+ * Matched on both shape and phrase. `TestUnparseableDocument` drives the real
+ * parser rather than a stub, so rewording these notices upstream fails loudly
+ * here instead of silently filling the index again.
+ */
+function isParserFailureNotice(text: string): boolean {
+  const trimmed = text.trim()
+  if (!trimmed.startsWith('[') || !trimmed.endsWith(']') || trimmed.includes('\n')) return false
+  return /could not parse|not supported for text extraction/i.test(trimmed)
+}
+
 export type ExtractModality = 'ocr' | 'transcript' | 'document' | 'video_frames'
 
 export type ExtractedText = {
@@ -362,6 +383,12 @@ export function createExtractService(deps: ExtractServiceDeps): ExtractService {
     // A registry hit, or a text-ish MIME, means `parseFileContent` has a lane.
     if (format !== undefined || request.mime.startsWith('text/') || request.mime === 'application/json') {
       const parsed = await parseFileContent(request.buffer, request.mime, filename)
+      // A reader exists but could not read this one — a corrupt file, an
+      // encrypted one, or a format the library only partly supports. Report it
+      // as unsupported rather than indexing the notice: the text is not the
+      // document, and the verdict leaves the asset re-queueable if the parser
+      // later gains the ability.
+      if (isParserFailureNotice(parsed.text)) return { texts: [], unsupported: true }
       return { texts: parsed.text.trim() ? [{ text: parsed.text, metadata: { modality: 'document' } }] : [] }
     }
 

--- a/packages/api/src/chat-archive/extract-service.ts
+++ b/packages/api/src/chat-archive/extract-service.ts
@@ -25,7 +25,7 @@ import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 import { promisify } from 'node:util'
 import type { RecordingTranscriber } from '@use-brian/core'
-import { parseFileContent } from '@use-brian/core'
+import { detectDocumentFormat, parseFileContent } from '@use-brian/core'
 import { extractRecordingAudio, probeRecordingDuration } from '../recordings/ffmpeg.js'
 
 const execFileAsync = promisify(execFile)
@@ -33,21 +33,28 @@ const execFileAsync = promisify(execFile)
 const MAX_VIDEO_FRAMES = 120
 const MAX_MEDIA_DURATION_MS = 180 * 60 * 1000
 
-const PARSEABLE_DOCUMENT_MIMES = new Set([
-  'application/json',
-  'application/xml',
-  'application/yaml',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-])
+/**
+ * Bytes we are willing to read as plain text when nothing else identifies them.
+ *
+ * A NUL byte is the classic binary tell, and a run of C0 control characters
+ * means the same thing. Sampling the head is enough: a text file that opens
+ * with 8KB of clean text and turns binary later is not a case worth serving.
+ */
+const TEXT_SNIFF_BYTES = 8192
 
-const LEGACY_OR_UNKNOWN_MIMES = new Set([
-  'application/msword',
-  'application/vnd.ms-excel',
-  'application/vnd.ms-powerpoint',
-  'application/octet-stream',
-])
+function looksLikeText(buffer: Buffer): boolean {
+  const head = buffer.subarray(0, TEXT_SNIFF_BYTES)
+  if (head.length === 0) return false
+  let suspicious = 0
+  for (const byte of head) {
+    if (byte === 0) return false
+    // Tab, LF, CR and FF are ordinary in text; the rest of C0 is not.
+    if (byte < 0x20 && byte !== 0x09 && byte !== 0x0a && byte !== 0x0c && byte !== 0x0d) suspicious++
+  }
+  if (suspicious / head.length > 0.01) return false
+  // Reject lone surrogates / invalid sequences rather than indexing U+FFFD soup.
+  return !new TextDecoder('utf-8', { fatal: false }).decode(head).includes('\uFFFD')
+}
 
 export type ExtractModality = 'ocr' | 'transcript' | 'document' | 'video_frames'
 
@@ -315,22 +322,60 @@ export function createExtractService(deps: ExtractServiceDeps): ExtractService {
     return texts
   }
 
+  /**
+   * Decide what a document IS before deciding whether we can read it.
+   *
+   * This used to gate on the declared MIME against a hand-written allowlist,
+   * which failed twice over: it rejected formats `parseFileContent` can already
+   * read (ODF, RTF, EPUB, the legacy Office binaries), and it treated
+   * `application/octet-stream` as proof of unreadability — when in practice it
+   * is what a provider sends whenever it cannot be bothered to classify. WeChat
+   * labels every document that way, so real `.docx` files were parked as
+   * unsupported without a parser ever seeing them.
+   *
+   * So identify by evidence, strongest first: the bytes themselves, then the
+   * filename extension, then the declared MIME (see `detectDocumentFormat`).
+   * `unsupported` is reserved for the case where all three come up empty — it
+   * is a terminal verdict in the store, excluded from the extraction claim
+   * query, so it must mean "no reader exists" and never "nobody looked".
+   */
   async function extractDocument(request: ExtractRequest): Promise<ExtractResult> {
-    if (LEGACY_OR_UNKNOWN_MIMES.has(request.mime)) return { texts: [], unsupported: true }
+    const filename = request.filename ?? ''
 
-    if (request.mime === 'application/pdf') {
-      if (!deps.distill) throw new Error('chat archive PDF distillation prerequisite missing')
-      const text = await deps.distill({ buffer: request.buffer, mime: request.mime })
-      return { texts: text.trim() ? [{ text, metadata: { modality: 'document' } }] : [] }
-    }
+    // XML and YAML are text on the wire and have no registry entry; passing
+    // them through the parser would only round-trip them.
     if (request.mime === 'application/xml' || request.mime === 'application/yaml') {
       return { texts: [{ text: request.buffer.toString('utf8'), metadata: { modality: 'document' } }] }
     }
-    if (!request.mime.startsWith('text/') && !PARSEABLE_DOCUMENT_MIMES.has(request.mime)) {
-      return { texts: [], unsupported: true }
+
+    const format = await detectDocumentFormat(request.buffer, request.mime, filename)
+
+    // PDFs go to the vision distiller rather than the text parser:
+    // `parseFileContent` deliberately hands PDFs back as base64 so callers can
+    // render scanned pages, which is not text we can index.
+    if (format === 'pdf') {
+      if (!deps.distill) throw new Error('chat archive PDF distillation prerequisite missing')
+      const text = await deps.distill({ buffer: request.buffer, mime: 'application/pdf' })
+      return { texts: text.trim() ? [{ text, metadata: { modality: 'document' } }] : [] }
     }
-    const parsed = await parseFileContent(request.buffer, request.mime, request.filename ?? '')
-    return { texts: parsed.text.trim() ? [{ text: parsed.text, metadata: { modality: 'document' } }] : [] }
+
+    // A registry hit, or a text-ish MIME, means `parseFileContent` has a lane.
+    if (format !== undefined || request.mime.startsWith('text/') || request.mime === 'application/json') {
+      const parsed = await parseFileContent(request.buffer, request.mime, filename)
+      return { texts: parsed.text.trim() ? [{ text: parsed.text, metadata: { modality: 'document' } }] : [] }
+    }
+
+    // Nothing identified it, but it reads as text — e.g. .txt/.md/.log under a
+    // generic MIME, the same blind spot that lost the Office formats. Decode it
+    // here rather than calling `parseFileContent`, which has no lane for this
+    // and would hand back its "type not supported" placeholder: non-empty
+    // filler that would be embedded and ranked as if it were the document.
+    if (looksLikeText(request.buffer)) {
+      const text = request.buffer.toString('utf8')
+      return { texts: text.trim() ? [{ text, metadata: { modality: 'document' } }] : [] }
+    }
+
+    return { texts: [], unsupported: true }
   }
 
   return {

--- a/packages/api/src/chat-archive/live-media.ts
+++ b/packages/api/src/chat-archive/live-media.ts
@@ -9,7 +9,12 @@
  */
 
 import type { CanonicalIngestMessageV2 } from '@use-brian/shared'
-import type { MessageStoreClient, UploadMediaInput } from './message-store-client.js'
+import type {
+  MediaUploadTarget,
+  MediaUploadTargetInput,
+  MessageStoreClient,
+  UploadMediaInput,
+} from './message-store-client.js'
 
 export type ChatArchiveMediaKind = 'image' | 'video' | 'voice' | 'file'
 
@@ -49,6 +54,16 @@ export function archiveMediaRef(
 
 export type ChatArchiveLiveMedia = {
   storeBuffer(input: Omit<UploadMediaInput, 'bytes'> & { bytes: Buffer }): Promise<StagedArchiveMedia>
+  /**
+   * Pre-sign an upload so a connector can send bytes to the store directly.
+   *
+   * The alternative is for the connector to upload elsewhere and for this
+   * process to fetch the object back and forward it, which keeps a second copy
+   * of every attachment in workspace storage — on-premise, on the operator's
+   * own disk, with nothing consuming it. Handing out a per-asset signature
+   * avoids that without the connector ever holding the archive's secret.
+   */
+  uploadTarget(input: MediaUploadTargetInput): MediaUploadTarget
 }
 
 export function createChatArchiveLiveMedia(client: MessageStoreClient): ChatArchiveLiveMedia {
@@ -66,6 +81,9 @@ export function createChatArchiveLiveMedia(client: MessageStoreClient): ChatArch
         mime: input.mime,
         sizeBytes: uploaded.size_bytes,
       }
+    },
+    uploadTarget(input) {
+      return client.mediaUploadTarget(input)
     },
   }
 }

--- a/packages/api/src/chat-archive/message-store-client.ts
+++ b/packages/api/src/chat-archive/message-store-client.ts
@@ -100,6 +100,15 @@ export type UploadMediaInput = {
   bytes: Buffer
 }
 
+/** What a caller needs to hand an uploader that holds the bytes but not the secret. */
+export type MediaUploadTargetInput = Omit<UploadMediaInput, 'bytes'> & { sha256: string }
+
+/** A one-asset, pre-signed destination for an uploader outside this process. */
+export type MediaUploadTarget = {
+  url: string
+  headers: Record<string, string>
+}
+
 export type UploadedMedia = {
   asset_id: string
   sha256: string
@@ -203,6 +212,43 @@ export class MessageStoreClient {
       'X-UB-Signature': signRequest('POST', requestUri, this.secret),
     }, input.bytes)
     return (await response.json()) as UploadedMedia
+  }
+
+  /**
+   * Pre-sign a `/media` upload so a process that holds the bytes — but must
+   * never hold this secret — can send them straight to the store.
+   *
+   * Safe to hand out because the signature covers the whole request URI, and
+   * every authorization-relevant field lives there: owner, workspace, instance,
+   * provider message id, and the content digest. So it authorizes storing
+   * exactly these bytes, for exactly this owner, against exactly this message —
+   * it cannot be replayed to write different content or to write into anyone
+   * else's archive. The store re-hashes the body as it writes and rejects a
+   * mismatch, so a tampered payload cannot land at the signed address either.
+   *
+   * The digest must therefore be known before the upload starts, which is why
+   * the caller hashes first and asks for a target second.
+   */
+  mediaUploadTarget(input: MediaUploadTargetInput): MediaUploadTarget {
+    const params = new URLSearchParams({
+      workspace_id: input.workspaceId,
+      instance_id: input.instanceId,
+      owner_user_id: input.ownerUserId,
+      source: input.source,
+      provider_message_id: input.providerMessageId,
+      kind: input.kind,
+      filename: input.filename,
+      mime: input.mime,
+      sha256: input.sha256.toLowerCase(),
+    })
+    const requestUri = `/media?${params.toString()}`
+    return {
+      url: `${this.baseUrl}${requestUri}`,
+      headers: {
+        'Content-Type': input.mime || 'application/octet-stream',
+        'X-UB-Signature': signRequest('POST', requestUri, this.secret),
+      },
+    }
   }
 
   /**

--- a/packages/api/src/routes/__tests__/whatsapp-byon.test.ts
+++ b/packages/api/src/routes/__tests__/whatsapp-byon.test.ts
@@ -173,6 +173,110 @@ describe('[COMP:api/whatsapp-byon-route] internal routing', () => {
     },
   }
 
+  it('records an attachment the connector already uploaded to the archive', async () => {
+    // On-premise the connector uploads straight to the store under a signature
+    // this process minted, so the bytes are stored before /inbound is called.
+    // Re-fetching or re-uploading them would be pure waste.
+    const { app, captured, storeBuffer, readBlob } = streamedApp()
+
+    const response = await request(app)
+      .post('/internal/whatsapp/inbound')
+      .set('X-Connector-Secret', 'secret')
+      .send({
+        ...payload,
+        text: '<media:video>',
+        mediaMimeType: 'video/mp4',
+        mediaRef: {
+          archiveAssetId: '4a1e6bd8-0000-4000-8000-000000000009',
+          sha256: 'b'.repeat(64),
+          mimeType: 'video/mp4',
+          sizeBytes: 9,
+        },
+      })
+
+    expect(response.status).toBe(200)
+    expect(readBlob).not.toHaveBeenCalled()
+    expect(storeBuffer).not.toHaveBeenCalled()
+    expect(captured[0]!.archiveMediaRef).toMatchObject({
+      assetId: '4a1e6bd8-0000-4000-8000-000000000009',
+      sha256: 'b'.repeat(64),
+    })
+    expect(captured[0]).toMatchObject({ archiveMediaType: 'video' })
+  })
+
+  it('mints a signed archive upload target once the digest is known', async () => {
+    const uploadTarget = vi.fn(() => ({
+      url: 'http://store.test/media?sha256=' + 'c'.repeat(64),
+      headers: { 'X-UB-Signature': 'sha256=abc' },
+    }))
+    const app = express()
+    app.use(express.json())
+    app.use('/internal/whatsapp', whatsappByonRoutes({
+      connectorSecret: 'secret',
+      integrationStore: {
+        getByChannelForWebhook: vi.fn(async () => ({ connectorInstanceId: 'instance-1' })),
+      } as never,
+      ingestor: {} as never,
+      bot: {} as never,
+      archiveMedia: { storeBuffer: vi.fn(), uploadTarget } as never,
+      filesResolver: { forWorkspace: vi.fn() } as never,
+      getChannel: vi.fn(async () => ({ workspaceId: 'ws-1' })) as never,
+      getWorkspaceOwnerUserId: vi.fn(async () => 'owner-1'),
+    }))
+
+    const response = await request(app)
+      .post('/internal/whatsapp/media-upload-url')
+      .set('X-Connector-Secret', 'secret')
+      .send({
+        channelId: 'byon-channel',
+        providerMessageId: 'm1',
+        kind: 'video',
+        mime: 'video/mp4',
+        sha256: 'c'.repeat(64),
+      })
+
+    expect(response.status).toBe(200)
+    expect(response.body.target).toBe('archive')
+    expect(response.body.headers['X-UB-Signature']).toBe('sha256=abc')
+    // No workspace object is minted at all on this path.
+    expect(response.body.gcsKey).toBeUndefined()
+    // The signature commits to the owner and the digest, which is what makes it
+    // safe to hand to a process that must not hold the archive's secret.
+    expect(uploadTarget).toHaveBeenCalledWith(
+      expect.objectContaining({ ownerUserId: 'owner-1', sha256: 'c'.repeat(64), kind: 'video' }),
+    )
+  })
+
+  it('falls back to workspace storage when no digest is offered', async () => {
+    // Without a digest no archive signature can be produced, so the older
+    // upload-then-read-back path must still work rather than failing the send.
+    const signedWriteUrl = vi.fn(async () => 'http://localhost:4000/api/local-files?signed=1')
+    const app = express()
+    app.use(express.json())
+    app.use('/internal/whatsapp', whatsappByonRoutes({
+      connectorSecret: 'secret',
+      integrationStore: {} as never,
+      ingestor: {} as never,
+      bot: {} as never,
+      archiveMedia: { storeBuffer: vi.fn(), uploadTarget: vi.fn() } as never,
+      filesResolver: {
+        forWorkspace: vi.fn(async () => ({
+          gcs: { signedWriteUrl }, bucket: '/data/files', uriScheme: 'file' as const,
+        })),
+      } as never,
+      getChannel: vi.fn(async () => ({ workspaceId: 'ws-1' })) as never,
+    }))
+
+    const response = await request(app)
+      .post('/internal/whatsapp/media-upload-url')
+      .set('X-Connector-Secret', 'secret')
+      .send({ channelId: 'byon-channel', mime: 'video/mp4' })
+
+    expect(response.status).toBe(200)
+    expect(response.body.target).toBe('workspace')
+    expect(response.body.gcsKey).toMatch(/^ws-1\/channel-media\//)
+  })
+
   it('archives a streamed attachment by reading the uploaded bytes back', async () => {
     const { app, captured, storeBuffer } = streamedApp()
 

--- a/packages/api/src/routes/__tests__/whatsapp-byon.test.ts
+++ b/packages/api/src/routes/__tests__/whatsapp-byon.test.ts
@@ -247,15 +247,57 @@ describe('[COMP:api/whatsapp-byon-route] internal routing', () => {
     )
   })
 
-  it('falls back to workspace storage when no digest is offered', async () => {
-    // Without a digest no archive signature can be produced, so the older
-    // upload-then-read-back path must still work rather than failing the send.
+  it('names the archive before a digest exists, without issuing a URL yet', async () => {
+    // The connector's first call asks only where the bytes belong; it cannot
+    // know the digest until it has read the attachment. Answering with a
+    // workspace URL here would silently send it down the read-back path and
+    // keep the duplicate copy — which is exactly what happened in testing.
+    const uploadTarget = vi.fn()
+    const signedWriteUrl = vi.fn()
+    const app = express()
+    app.use(express.json())
+    app.use('/internal/whatsapp', whatsappByonRoutes({
+      connectorSecret: 'secret',
+      integrationStore: {
+        getByChannelForWebhook: vi.fn(async () => ({ connectorInstanceId: 'instance-1' })),
+      } as never,
+      ingestor: {} as never,
+      bot: {} as never,
+      archiveMedia: { storeBuffer: vi.fn(), uploadTarget } as never,
+      filesResolver: {
+        forWorkspace: vi.fn(async () => ({
+          gcs: { signedWriteUrl }, bucket: '/data/files', uriScheme: 'file' as const,
+        })),
+      } as never,
+      getChannel: vi.fn(async () => ({ workspaceId: 'ws-1' })) as never,
+      getWorkspaceOwnerUserId: vi.fn(async () => 'owner-1'),
+    }))
+
+    const response = await request(app)
+      .post('/internal/whatsapp/media-upload-url')
+      .set('X-Connector-Secret', 'secret')
+      .send({ channelId: 'byon-channel', providerMessageId: 'm1', kind: 'video', mime: 'video/mp4' })
+
+    expect(response.status).toBe(200)
+    expect(response.body.target).toBe('archive')
+    expect(response.body.uploadUrl).toBeUndefined()
+    expect(uploadTarget).not.toHaveBeenCalled()
+    // No workspace object is minted, so nothing is left behind if the connector
+    // never comes back with a digest.
+    expect(signedWriteUrl).not.toHaveBeenCalled()
+  })
+
+  it('falls back to workspace storage when the archive owner cannot be resolved', async () => {
+    // Without an owner there is nothing to scope a signature to, so the older
+    // upload-then-read-back path must still carry the attachment.
     const signedWriteUrl = vi.fn(async () => 'http://localhost:4000/api/local-files?signed=1')
     const app = express()
     app.use(express.json())
     app.use('/internal/whatsapp', whatsappByonRoutes({
       connectorSecret: 'secret',
-      integrationStore: {} as never,
+      integrationStore: {
+        getByChannelForWebhook: vi.fn(async () => ({ connectorInstanceId: 'instance-1' })),
+      } as never,
       ingestor: {} as never,
       bot: {} as never,
       archiveMedia: { storeBuffer: vi.fn(), uploadTarget: vi.fn() } as never,
@@ -265,12 +307,13 @@ describe('[COMP:api/whatsapp-byon-route] internal routing', () => {
         })),
       } as never,
       getChannel: vi.fn(async () => ({ workspaceId: 'ws-1' })) as never,
+      getWorkspaceOwnerUserId: vi.fn(async () => null),
     }))
 
     const response = await request(app)
       .post('/internal/whatsapp/media-upload-url')
       .set('X-Connector-Secret', 'secret')
-      .send({ channelId: 'byon-channel', mime: 'video/mp4' })
+      .send({ channelId: 'byon-channel', providerMessageId: 'm1', mime: 'video/mp4' })
 
     expect(response.status).toBe(200)
     expect(response.body.target).toBe('workspace')

--- a/packages/api/src/routes/__tests__/whatsapp-byon.test.ts
+++ b/packages/api/src/routes/__tests__/whatsapp-byon.test.ts
@@ -97,9 +97,33 @@ describe('[COMP:api/whatsapp-byon-route] internal routing', () => {
     expect(response.body).toEqual({ ok: true })
   })
 
-  it('does not archive a directly-uploaded asset, but still dispatches the message', async () => {
-    const captured: Array<Record<string, unknown>> = []
-    const archiveIncoming = vi.fn(async () => {})
+  /**
+   * A streamed attachment must reach the archive.
+   *
+   * The connector streams video and audio files straight to workspace storage
+   * regardless of size and relays only a reference, so for a long time these
+   * were archived as a message row with no asset and no segments — a video was
+   * recorded as having happened but nothing about its contents was searchable.
+   * The bytes are durably written by the time /inbound runs, so the platform
+   * reads them back and forwards them under its own signature.
+   */
+  function streamedApp(overrides: {
+    statBytes?: number
+    fallback?: boolean
+    captured?: Array<Record<string, unknown>>
+    storeBuffer?: ReturnType<typeof vi.fn>
+    readBlob?: ReturnType<typeof vi.fn>
+  } = {}) {
+    const captured = overrides.captured ?? []
+    const readBlob = overrides.readBlob
+      ?? vi.fn(async () => ({ bytes: Buffer.from('mp4 bytes'), mime: 'video/mp4', metadata: {} }))
+    const storeBuffer = overrides.storeBuffer ?? vi.fn(async () => ({
+      assetId: '4a1e6bd8-0000-4000-8000-000000000001',
+      sha256: 'a'.repeat(64),
+      filename: 'clip.mp4',
+      mime: 'video/mp4',
+      sizeBytes: 9,
+    }))
     const app = express()
     app.use(express.json())
     app.use('/internal/whatsapp', whatsappByonRoutes({
@@ -114,69 +138,89 @@ describe('[COMP:api/whatsapp-byon-route] internal routing', () => {
           return { kind: 'bot' as const, handle: vi.fn(async () => {}) }
         }),
       },
-      archiveMedia: {
-        resolveBinding: vi.fn(async () => 'instance-1'),
-        complete: vi.fn(async () => ({
-          id: '4a1e6bd8-0000-4000-8000-000000000001',
-          workspaceId: 'workspace-1',
-          instanceId: 'instance-1',
-          ownerUserId: 'owner-1',
-          messageId: null,
-          source: 'whatsapp',
-          providerMessageId: 'm1',
-          kind: 'video',
-          filename: 'clip.mp4',
-          mime: 'video/mp4',
-          sizeBytes: 123,
-          expectedSha256: null,
-          sha256: 'a'.repeat(64),
-          storageKey: 'workspace-1/chat-archive-asset',
-          storageUri: 'file://workspace-1/chat-archive-asset',
-          uploadStatus: 'stored',
-          extractionStatus: 'pending',
-          lastError: null,
-          createdAt: new Date(),
-          updatedAt: new Date(),
+      filesResolver: {
+        forWorkspace: vi.fn(async () => ({
+          gcs: {
+            statBlob: vi.fn(async () => ({
+              sizeBytes: overrides.statBytes ?? 9,
+              mime: 'video/mp4',
+              updatedAt: null,
+            })),
+            readBlob,
+          },
+          bucket: '/data/files',
+          uriScheme: 'file' as const,
         })),
       } as never,
-      archiveIncoming,
+      archiveMedia: { storeBuffer } as never,
+      archiveIncoming: vi.fn(async () => {}),
       getChannel: vi.fn(async () => ({ workspaceId: 'workspace-1' })) as never,
       getWorkspaceOwnerUserId: vi.fn(async () => 'owner-1'),
+      passUnknownToFallback: overrides.fallback ?? false,
     }))
+    app.post('/internal/whatsapp/inbound', (_req, res) => res.status(418).json({ official: true }))
+    return { app, captured, storeBuffer, readBlob }
+  }
+
+  const streamedBody = {
+    ...payload,
+    text: '<media:video>',
+    mediaMimeType: 'video/mp4',
+    mediaRef: {
+      gcsKey: 'workspace-1/channel-media/abc',
+      mimeType: 'video/mp4',
+      sizeBytes: 9,
+    },
+  }
+
+  it('archives a streamed attachment by reading the uploaded bytes back', async () => {
+    const { app, captured, storeBuffer } = streamedApp()
 
     const response = await request(app)
       .post('/internal/whatsapp/inbound')
       .set('X-Connector-Secret', 'secret')
-      .send({
-        ...payload,
-        text: '<media:video>',
-        mediaMimeType: 'video/mp4',
-        mediaRef: {
-          assetId: '4a1e6bd8-0000-4000-8000-000000000001',
-          gcsKey: 'workspace-1/chat-archive-asset',
-          mimeType: 'video/mp4',
-          fileName: 'clip.mp4',
-          sizeBytes: 123,
-        },
-      })
+      .send(streamedBody)
 
     expect(response.status).toBe(200)
-    expect(archiveIncoming).toHaveBeenCalledOnce()
+    expect(storeBuffer).toHaveBeenCalledOnce()
+    expect(captured[0]).toMatchObject({ archiveMediaType: 'video', archiveInboundPersisted: true })
+    expect(captured[0]!.archiveMediaRef).toMatchObject({ sha256: 'a'.repeat(64) })
+    // Baileys reports no filename for video, so one is synthesized rather than
+    // archiving the attachment under '' — which would leave it with no
+    // segment 0 and unfindable until extraction produced frame text.
+    expect(storeBuffer.mock.calls[0]![0].filename).toBe('video-m1.mp4')
+  })
 
-    // KNOWN GAP, asserted deliberately. The BYON connector uploads bytes
-    // straight to storage through a pre-signed URL, in a two-phase
-    // init-then-upload flow. The archive's contract is single-shot — metadata
-    // and bytes together, signed with a secret the connector does not hold —
-    // so there is nothing to complete against and no archive reference is
-    // produced.
-    //
-    // What must NOT regress is message delivery: the inbound still dispatches
-    // and is still persisted, it simply carries no archived attachment. Media
-    // that passes through the platform (mediaBase64) is unaffected.
-    expect(captured[0]).toMatchObject({
-      archiveInboundPersisted: true,
-      archiveMediaType: 'video',
-    })
-    expect(captured[0]!.archiveMediaRef).toBeUndefined()
+  it('still hands a streamed reference to the hosted intake after archiving', async () => {
+    // Archiving must not consume the reference: the closed router still owns
+    // turning it into a recording episode.
+    const { app, storeBuffer } = streamedApp({ fallback: true })
+
+    const response = await request(app)
+      .post('/internal/whatsapp/inbound')
+      .set('X-Connector-Secret', 'secret')
+      .send(streamedBody)
+
+    expect(storeBuffer).toHaveBeenCalledOnce()
+    expect(response.status).toBe(418)
+    expect(response.body).toEqual({ official: true })
+  })
+
+  it('skips an oversized streamed attachment rather than buffering it', async () => {
+    // storeBuffer takes a Buffer, so the size is checked with statBlob first —
+    // reading before looking would let one attachment set the memory ceiling.
+    const { app, captured, storeBuffer, readBlob } = streamedApp({ statBytes: 5 * 1024 * 1024 * 1024 })
+
+    const response = await request(app)
+      .post('/internal/whatsapp/inbound')
+      .set('X-Connector-Secret', 'secret')
+      .send(streamedBody)
+
+    expect(response.status).toBe(200)
+    expect(readBlob).not.toHaveBeenCalled()
+    expect(storeBuffer).not.toHaveBeenCalled()
+    // The message itself is still archived and dispatched; only its attachment
+    // is unavailable.
+    expect(captured[0]).toMatchObject({ archiveMediaAvailability: 'failed' })
   })
 })

--- a/packages/api/src/routes/__tests__/whatsapp-byon.test.ts
+++ b/packages/api/src/routes/__tests__/whatsapp-byon.test.ts
@@ -245,6 +245,12 @@ describe('[COMP:api/whatsapp-byon-route] internal routing', () => {
     expect(uploadTarget).toHaveBeenCalledWith(
       expect.objectContaining({ ownerUserId: 'owner-1', sha256: 'c'.repeat(64), kind: 'video' }),
     )
+    // The connector's upload is what creates the asset row, so the name has to
+    // be decided here. Baileys sends none for video; leaving it blank would
+    // strip the extension the extractor falls back on when a MIME is generic.
+    expect(uploadTarget).toHaveBeenCalledWith(
+      expect.objectContaining({ filename: 'video-m1.mp4' }),
+    )
   })
 
   it('names the archive before a digest exists, without issuing a URL yet', async () => {

--- a/packages/api/src/routes/whatsapp-byon.ts
+++ b/packages/api/src/routes/whatsapp-byon.ts
@@ -2,6 +2,7 @@ import { randomUUID, timingSafeEqual } from 'node:crypto'
 import { Router } from 'express'
 import type { ChatArchiveLiveMedia } from '../chat-archive/live-media.js'
 import { archiveMediaRef, mediaByteLimit } from '../chat-archive/live-media.js'
+import type { StagedArchiveMedia } from '../chat-archive/live-media.js'
 import { resolveChatArchiveInstanceId } from '../chat-archive/live-writer.js'
 import { z } from 'zod'
 import type { ChannelIntegrationStore } from '../db/channel-integrations.js'
@@ -30,7 +31,12 @@ const inboundSchema = z.object({
   mediaFileName: z.string().optional(),
   mediaRef: z.object({
     assetId: z.string().uuid().optional(),
-    gcsKey: z.string(),
+    // Set when the connector uploaded straight to the archive; the bytes are
+    // already stored under this asset and there is nothing to fetch back.
+    archiveAssetId: z.string().uuid().optional(),
+    sha256: z.string().regex(/^[a-f0-9]{64}$/i).optional(),
+    // Absent on the archive-direct path — there is no workspace object.
+    gcsKey: z.string().optional(),
     storageUri: z.string().optional(),
     mimeType: z.string(),
     fileName: z.string().optional(),
@@ -151,6 +157,9 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
       mime: z.string().min(1),
       fileName: z.string().nullable().optional(),
       sizeBytes: z.number().int().nonnegative().optional(),
+      // Present once the connector has hashed the file. The archive's signature
+      // covers the digest, so a target cannot be minted without it.
+      sha256: z.string().regex(/^[a-f0-9]{64}$/i).optional(),
     }).safeParse(req.body)
     if (!parsed.success) {
       res.status(400).json({ error: 'channelId and mime required' })
@@ -168,23 +177,71 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
       return
     }
 
-    // The connector uploads bytes here through a pre-signed URL, so they never
-    // pass through this process. The archive's contract is single-shot —
-    // metadata and bytes together, signed with a secret the connector must
-    // never hold — which for a while meant streamed media was simply not
-    // archived: a video landed as a message row with `availability: 'missing'`,
-    // no asset and no segments.
+    // Where should these bytes go?
     //
-    // Resolved by the platform reading the object back at /inbound and
-    // forwarding it under its own signature, rather than by issuing the
-    // connector an upload URL into the store. The secret stays here, and the
-    // upload path below is unchanged.
+    // With an archive configured, straight into it. The connector cannot hold
+    // the archive's secret, but it does not need to: the signature covers the
+    // whole request URI, and owner, workspace, instance, provider message id
+    // and content digest all live there. So a minted target authorizes storing
+    // exactly these bytes for exactly this owner against exactly this message,
+    // and nothing else. That is why the digest is required here.
+    //
+    // The alternative — upload to workspace storage, then have this process
+    // read the object back and forward it — works, and is still the path for
+    // inline media, but it leaves a second copy of every attachment on the
+    // operator's disk with nothing to consume it. The archive is on-premise
+    // only, so hosted keeps the workspace path below untouched: it has no
+    // archive to send bytes to.
+    if (opts.archiveMedia && parsed.data.sha256 && parsed.data.providerMessageId) {
+      try {
+        const integration = await opts.integrationStore.getByChannelForWebhook(parsed.data.channelId, 'whatsapp')
+        const ownerUserId = await (opts.getWorkspaceOwnerUserId ?? resolveWorkspaceOwnerUserId)(channel.workspaceId)
+        if (ownerUserId) {
+          const mime = parsed.data.mime
+          const kind = parsed.data.kind ?? (mime.startsWith('image/') ? 'image'
+            : mime.startsWith('video/') ? 'video'
+              : mime.startsWith('audio/') ? 'voice' : 'file')
+          // Same lazily-minted instance the append path uses; assets key on
+          // `(instance_id, provider_message_id)`, so a different id here would
+          // orphan the bytes from their message.
+          const instanceId = integration?.connectorInstanceId
+            ?? await resolveChatArchiveInstanceId({
+              source: 'whatsapp',
+              ownerUserId,
+              workspaceId: channel.workspaceId,
+              assistantId: '',
+              assistantName: '',
+              conversationId: parsed.data.channelId,
+            })
+          if (instanceId) {
+            const target = opts.archiveMedia.uploadTarget({
+              workspaceId: channel.workspaceId,
+              instanceId,
+              ownerUserId,
+              source: 'whatsapp',
+              providerMessageId: parsed.data.providerMessageId,
+              kind,
+              filename: parsed.data.fileName ?? '',
+              mime,
+              sha256: parsed.data.sha256,
+            })
+            res.json({ target: 'archive', uploadUrl: target.url, headers: target.headers })
+            return
+          }
+        }
+      } catch (err) {
+        // Fall through to workspace storage rather than dropping the
+        // attachment: /inbound still reads it back from there.
+        console.error('[whatsapp] archive upload target failed, falling back to workspace storage:', err)
+      }
+    }
 
     const fileId = `channel-media/${randomUUID()}`
     const key = buildStorageKey(channel.workspaceId, fileId)
     const resolved = await opts.filesResolver.forWorkspace(channel.workspaceId)
     const uploadUrl = await resolved.gcs.signedWriteUrl(key, { contentType: parsed.data.mime, ttlSec: 3600 })
     res.json({
+      target: 'workspace',
       gcsKey: key,
       uploadUrl,
       storageUri: buildStorageUri(resolved.bucket, channel.workspaceId, fileId, resolved.uriScheme),
@@ -277,22 +334,43 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
               conversationId: input.chatJid ?? input.channelId,
             })
           if (!instanceId) throw new Error('whatsapp archive instance could not be resolved')
-          const bytes = input.mediaBase64
-            ? Buffer.from(input.mediaBase64, 'base64')
-            : await readStreamedMedia(channel.workspaceId, input.mediaRef!, kind)
-          if (!bytes) throw new Error('streamed media could not be read back for the archive')
-          const asset = await opts.archiveMedia.storeBuffer({
-            workspaceId: channel.workspaceId,
-            instanceId,
-            ownerUserId,
-            source: 'whatsapp',
-            providerMessageId: input.messageId,
-            kind,
-            filename: archiveFilename(input, kind, mime),
-            mime,
-            bytes,
-          })
-          const ref = archiveMediaRef(asset)
+          // Two ways the bytes get here. The connector may have uploaded them
+          // straight to the archive under a per-asset signature this process
+          // minted, in which case they are already stored and there is nothing
+          // to fetch or re-send. Otherwise we hold them (inline base64) or can
+          // read them back from workspace storage.
+          const staged: StagedArchiveMedia = input.mediaRef?.archiveAssetId && input.mediaRef.sha256
+            ? {
+                assetId: input.mediaRef.archiveAssetId,
+                sha256: input.mediaRef.sha256.toLowerCase(),
+                filename: archiveFilename(input, kind, mime),
+                mime,
+                sizeBytes: input.mediaRef.sizeBytes ?? 0,
+              }
+            : await (async () => {
+                const bytes = input.mediaBase64
+                  ? Buffer.from(input.mediaBase64, 'base64')
+                  : input.mediaRef?.gcsKey
+                    ? await readStreamedMedia(
+                        channel.workspaceId,
+                        input.mediaRef as { gcsKey: string; storageUri?: string },
+                        kind,
+                      )
+                    : null
+                if (!bytes) throw new Error('streamed media could not be read back for the archive')
+                return opts.archiveMedia!.storeBuffer({
+                  workspaceId: channel.workspaceId,
+                  instanceId,
+                  ownerUserId,
+                  source: 'whatsapp',
+                  providerMessageId: input.messageId,
+                  kind,
+                  filename: archiveFilename(input, kind, mime),
+                  mime,
+                  bytes,
+                })
+              })()
+          const ref = archiveMediaRef(staged)
           input.archiveMediaRef = {
             assetId: ref.asset_id!, sha256: ref.sha256!, filename: ref.filename,
             mime: ref.mime, sizeBytes: ref.size_bytes,
@@ -313,7 +391,7 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
     // streamed references; otherwise this BYON router ACKs first and the bytes
     // are uploaded successfully but never become a recording/document artifact.
     // Staging above has already run, so the archive keeps its copy either way.
-    if (input.mediaRef && !input.mediaRef.assetId && opts.passUnknownToFallback) {
+    if (input.mediaRef?.gcsKey && !input.mediaRef.assetId && opts.passUnknownToFallback) {
       next()
       return
     }

--- a/packages/api/src/routes/whatsapp-byon.ts
+++ b/packages/api/src/routes/whatsapp-byon.ts
@@ -133,16 +133,24 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
    * once extraction produces frame text. Synthesizing from the provider message
    * id keeps it identifiable in the meantime.
    */
+  function synthesizeFilename(
+    given: string | undefined | null,
+    kind: string,
+    providerMessageId: string,
+    mime: string,
+  ): string {
+    if (given && given.trim()) return given.trim()
+    const subtype = mime.split('/')[1]?.split(';')[0]?.trim()
+    const extension = subtype && /^[a-z0-9]{1,8}$/i.test(subtype) ? `.${subtype}` : ''
+    return `${kind}-${providerMessageId}${extension}`
+  }
+
   function archiveFilename(
     input: { mediaFileName?: string; mediaRef?: { fileName?: string }; messageId: string },
     kind: string,
     mime: string,
   ): string {
-    const given = input.mediaFileName ?? input.mediaRef?.fileName
-    if (given && given.trim()) return given.trim()
-    const subtype = mime.split('/')[1]?.split(';')[0]?.trim()
-    const extension = subtype && /^[a-z0-9]{1,8}$/i.test(subtype) ? `.${subtype}` : ''
-    return `${kind}-${input.messageId}${extension}`
+    return synthesizeFilename(input.mediaFileName ?? input.mediaRef?.fileName, kind, input.messageId, mime)
   }
 
   router.post('/media-upload-url', async (req, res, next) => {
@@ -230,7 +238,16 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
               source: 'whatsapp',
               providerMessageId: parsed.data.providerMessageId,
               kind,
-              filename: parsed.data.fileName ?? '',
+              // Named here because the connector's upload is what creates the
+              // asset row. Leaving it blank strips the extension the extractor
+              // uses to identify a format when the MIME is generic — the very
+              // signal that rescues documents sent as application/octet-stream.
+              filename: synthesizeFilename(
+                parsed.data.fileName,
+                kind,
+                parsed.data.providerMessageId!,
+                mime,
+              ),
               mime,
               sha256: parsed.data.sha256!,
             })

--- a/packages/api/src/routes/whatsapp-byon.ts
+++ b/packages/api/src/routes/whatsapp-byon.ts
@@ -1,7 +1,7 @@
 import { randomUUID, timingSafeEqual } from 'node:crypto'
 import { Router } from 'express'
 import type { ChatArchiveLiveMedia } from '../chat-archive/live-media.js'
-import { archiveMediaRef } from '../chat-archive/live-media.js'
+import { archiveMediaRef, mediaByteLimit } from '../chat-archive/live-media.js'
 import { resolveChatArchiveInstanceId } from '../chat-archive/live-writer.js'
 import { z } from 'zod'
 import type { ChannelIntegrationStore } from '../db/channel-integrations.js'
@@ -80,6 +80,65 @@ export type WhatsappByonRoutesOptions = {
 export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
   const router = Router()
 
+  /**
+   * Read back media the connector streamed straight to workspace storage.
+   *
+   * Size is checked with `statBlob` first, which does not download: the archive
+   * accepts video up to 512MB and `storeBuffer` takes a Buffer, so reading
+   * before looking would let one oversized attachment decide the process's
+   * memory ceiling. WhatsApp caps sent video far below this in practice, so the
+   * skip is a guard rather than a routine path — but it is the difference
+   * between declining an attachment and losing the API.
+   *
+   * Returns null when the object is missing or too large; the caller records
+   * the media as unavailable and the message itself is archived regardless.
+   */
+  async function readStreamedMedia(
+    workspaceId: string,
+    ref: { gcsKey: string; storageUri?: string },
+    kind: 'image' | 'video' | 'voice' | 'file',
+  ): Promise<Buffer | null> {
+    if (!opts.filesResolver) return null
+    // Prefer the URI the connector echoed back with the bytes: it names the
+    // exact bucket they were PUT to, where recomputing the workspace default
+    // could resolve elsewhere. `forUri` hands back the client itself;
+    // `forWorkspace` wraps it.
+    const client = ref.storageUri
+      ? await opts.filesResolver.forUri(workspaceId, ref.storageUri)
+      : (await opts.filesResolver.forWorkspace(workspaceId)).gcs
+    const limit = mediaByteLimit(kind)
+    const stat = await client.statBlob(ref.gcsKey)
+    if (stat && stat.sizeBytes > limit) {
+      console.warn(
+        `[whatsapp] streamed ${kind} is ${stat.sizeBytes} bytes, over the ${limit} archive limit — not archived`,
+      )
+      return null
+    }
+    const blob = await client.readBlob(ref.gcsKey)
+    return blob?.bytes ?? null
+  }
+
+  /**
+   * A name for the archived attachment.
+   *
+   * Baileys reports no filename for video or audio messages, so a streamed
+   * video would otherwise be archived as `''` — and an attachment with neither
+   * caption nor filename gets no segment 0 at all, leaving it findable only
+   * once extraction produces frame text. Synthesizing from the provider message
+   * id keeps it identifiable in the meantime.
+   */
+  function archiveFilename(
+    input: { mediaFileName?: string; mediaRef?: { fileName?: string }; messageId: string },
+    kind: string,
+    mime: string,
+  ): string {
+    const given = input.mediaFileName ?? input.mediaRef?.fileName
+    if (given && given.trim()) return given.trim()
+    const subtype = mime.split('/')[1]?.split(';')[0]?.trim()
+    const extension = subtype && /^[a-z0-9]{1,8}$/i.test(subtype) ? `.${subtype}` : ''
+    return `${kind}-${input.messageId}${extension}`
+  }
+
   router.post('/media-upload-url', async (req, res, next) => {
     if (!secretMatches(req.headers['x-connector-secret'], opts.connectorSecret)) {
       res.status(401).end()
@@ -109,21 +168,17 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
       return
     }
 
-    // KNOWN GAP — live BYON WhatsApp media no longer reaches the archive.
+    // The connector uploads bytes here through a pre-signed URL, so they never
+    // pass through this process. The archive's contract is single-shot —
+    // metadata and bytes together, signed with a secret the connector must
+    // never hold — which for a while meant streamed media was simply not
+    // archived: a video landed as a message row with `availability: 'missing'`,
+    // no asset and no segments.
     //
-    // This route handed the external connector a pre-signed URL so it could
-    // upload bytes directly, in a two-phase init-then-upload flow. The archive's
-    // contract is single-shot: metadata and bytes arrive together, signed with a
-    // secret the connector does not hold and should not be given.
-    //
-    // Bridging the two needs a decision rather than a guess — either the store
-    // issues its own signed upload URLs, or the platform proxies the bytes on
-    // the connector's behalf. Until then BYON media falls through to generic
-    // workspace storage below: messages and attachments are unaffected, but the
-    // attachment is not archived and so is not searchable by its contents.
-    //
-    // Media on the managed WhatsApp and WeChat paths is unaffected; those
-    // proxy bytes through the platform and go straight to the archive.
+    // Resolved by the platform reading the object back at /inbound and
+    // forwarding it under its own signature, rather than by issuing the
+    // connector an upload URL into the store. The secret stays here, and the
+    // upload path below is unchanged.
 
     const fileId = `channel-media/${randomUUID()}`
     const key = buildStorageKey(channel.workspaceId, fileId)
@@ -179,18 +234,24 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
       input.archiveMediaSizeBytes = input.mediaRef?.sizeBytes ?? 0
       input.archiveMediaAvailability = input.mediaBase64 || input.mediaRef ? 'missing' : 'failed'
     }
-    // Hosted media intake is mounted as the later closed router. Let it own
-    // streamed references; otherwise this BYON router ACKs first and the bytes
-    // are uploaded successfully but never become a recording/document artifact.
-    if (input.mediaRef && !input.mediaRef.assetId && opts.passUnknownToFallback) {
-      next()
-      return
-    }
-
-    // Bytes that pass through the platform still reach the archive. Only the
-    // pre-signed direct-upload path above lost that, because the connector
-    // cannot hold the archive's secret.
-    if (opts.archiveMedia && input.mediaBase64) {
+    // Stage attachment bytes into the archive.
+    //
+    // Two ways bytes arrive. Small media with a live-turn consumer is inlined as
+    // base64 and is simply in hand. Everything else — video and audio files
+    // always, anything over the connector's 10MB inline cap — is streamed
+    // straight to workspace storage, and only a reference reaches us.
+    //
+    // The streamed half used to be dropped: the archive's contract is
+    // single-shot (metadata and bytes together, signed with a secret the
+    // connector must never hold), so a reference had nothing to stage and video
+    // was archived as a message row with `availability: 'missing'`, no asset and
+    // no segments. The platform can simply read the object back — the connector
+    // awaits its PUT before relaying, so the bytes are durably written by the
+    // time we run — and forward them under its own signature.
+    //
+    // This must happen BEFORE the hosted-intake handoff below: that returns from
+    // the handler, and anything staged after it never runs.
+    if (opts.archiveMedia && (input.mediaBase64 || input.mediaRef)) {
       try {
         const integration = await opts.integrationStore.getByChannelForWebhook(input.channelId, 'whatsapp')
         const channel = await (opts.getChannel ?? getChannelForWebhook)(input.channelId)
@@ -216,6 +277,10 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
               conversationId: input.chatJid ?? input.channelId,
             })
           if (!instanceId) throw new Error('whatsapp archive instance could not be resolved')
+          const bytes = input.mediaBase64
+            ? Buffer.from(input.mediaBase64, 'base64')
+            : await readStreamedMedia(channel.workspaceId, input.mediaRef!, kind)
+          if (!bytes) throw new Error('streamed media could not be read back for the archive')
           const asset = await opts.archiveMedia.storeBuffer({
             workspaceId: channel.workspaceId,
             instanceId,
@@ -223,9 +288,9 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
             source: 'whatsapp',
             providerMessageId: input.messageId,
             kind,
-            filename: input.mediaFileName ?? '',
+            filename: archiveFilename(input, kind, mime),
             mime,
-            bytes: Buffer.from(input.mediaBase64!, 'base64'),
+            bytes,
           })
           const ref = archiveMediaRef(asset)
           input.archiveMediaRef = {
@@ -242,6 +307,15 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
         input.archiveMediaAvailability = 'failed'
         console.error('[whatsapp] archive media completion failed:', err)
       }
+    }
+
+    // Hosted media intake is mounted as the later closed router. Let it own
+    // streamed references; otherwise this BYON router ACKs first and the bytes
+    // are uploaded successfully but never become a recording/document artifact.
+    // Staging above has already run, so the archive keeps its copy either way.
+    if (input.mediaRef && !input.mediaRef.assetId && opts.passUnknownToFallback) {
+      next()
+      return
     }
 
     if (!input.text.trim() && !input.mediaBase64 && !input.mediaRef) {

--- a/packages/api/src/routes/whatsapp-byon.ts
+++ b/packages/api/src/routes/whatsapp-byon.ts
@@ -192,7 +192,7 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
     // operator's disk with nothing to consume it. The archive is on-premise
     // only, so hosted keeps the workspace path below untouched: it has no
     // archive to send bytes to.
-    if (opts.archiveMedia && parsed.data.sha256 && parsed.data.providerMessageId) {
+    if (opts.archiveMedia && parsed.data.providerMessageId) {
       try {
         const integration = await opts.integrationStore.getByChannelForWebhook(parsed.data.channelId, 'whatsapp')
         const ownerUserId = await (opts.getWorkspaceOwnerUserId ?? resolveWorkspaceOwnerUserId)(channel.workspaceId)
@@ -214,6 +214,15 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
               conversationId: parsed.data.channelId,
             })
           if (instanceId) {
+            // Two-step by necessity. The signature commits to the digest, and
+            // the connector cannot know it until it has read the attachment —
+            // so the first call only says where the bytes belong. Answering
+            // with a workspace URL here instead would send it down the old
+            // path and quietly keep the duplicate copy.
+            if (!parsed.data.sha256) {
+              res.json({ target: 'archive' })
+              return
+            }
             const target = opts.archiveMedia.uploadTarget({
               workspaceId: channel.workspaceId,
               instanceId,
@@ -223,7 +232,7 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
               kind,
               filename: parsed.data.fileName ?? '',
               mime,
-              sha256: parsed.data.sha256,
+              sha256: parsed.data.sha256!,
             })
             res.json({ target: 'archive', uploadUrl: target.url, headers: target.headers })
             return


### PR DESCRIPTION
Two fixes found by live end-to-end testing across WeChat and WhatsApp.

## Common workplace documents

A `.pages` sent over WeChat was archived but marked `unsupported`. The cause was
wider than iWork: `extract-service.ts` kept its own MIME allowlist instead of the
shared `DOCUMENT_FORMATS` registry, so it rejected formats `parseFileContent`
already reads through `@firecrawl/anydoc` — ODF, RTF, EPUB — and treated
`application/octet-stream` as proof of unreadability. That is exactly what WeChat
sends for every document, so real `.docx` files were parked without a parser ever
seeing them.

Identify by evidence instead — bytes, then extension, then declared MIME — which
`detectDocumentFormat` already does.

### Verified, not inferred

Every format below was probed against the running service under
`application/octet-stream`, each carrying a unique phrase recovered from the
extracted text:

| Format | Result |
|---|---|
| `.docx` `.xlsx` `.pptx` | text extracted |
| `.odt` `.ods` `.odp` | text extracted |
| `.rtf` `.epub` `.csv` `.txt` | text extracted |
| PDF | text extracted (vision distiller) |
| `.pages` | **415 unsupported** |
| `.doc` (real legacy binary) | **415 unsupported** |

The last row is a correction. I first wrote this table from the parser library's
declared format list, which includes `doc`/`xls`/`ppt`. Probing a real `.doc`
showed the library declines it — the registry admits the format, the parser
cannot read it. The docs now say so rather than promising legacy Office support.

### The bug that probe exposed

`parseFileContent` does not throw for a file it cannot read. It returns a
bracketed notice written for a human — `[Document: x.doc. Could not parse this
document.]` — and that text is non-empty, so the first version of this change
indexed it as the document's contents. Left alone it fills the index with
apologies matching every question about a document, the same failure the media
stub segments had. Now recognised and reported as unsupported. Its test drives
the real parser, so rewording those notices upstream fails loudly here.

## Streamed WhatsApp media

The connector streams video and audio files straight to workspace storage
regardless of size and relays only a reference. Staging ran solely for inlined
base64, and the reference path returned from the handler before reaching it — so
a live video was archived as a message row with `availability: 'missing'`, no
asset and no segments.

The `KNOWN GAP` comment framed this as a decision: the store issues its own
upload URLs, or the platform proxies the bytes. This takes the second, so the
archive's HMAC secret stays in the API process. The connector awaits its PUT
before relaying, so the object is durably written by the time `/inbound` runs.

Verified live, same conversation, before and after:

| Sent | availability | assets | segments |
|---|---|---|---|
| before | `missing` | 0 | 0 |
| after | `stored` | 1 | frame + transcript, embedded |

The video is now retrievable at rank 1 by its own frame content.

Size is checked with `statBlob` before reading, since `storeBuffer` takes a
Buffer and video is allowed up to 512 MB. Baileys reports no filename for video,
so one is synthesized — otherwise the attachment gets no segment 0 and stays
unfindable until extraction produces frame text.

## Notes

- Needs `brian-message-store#5`: this widening only reaches assets already parked
  as `unsupported` once that migration re-queues them.
- The test that asserted the gap deliberately now asserts the fix, plus the
  hosted-intake handoff still happening and the size guard declining rather than
  buffering.
- First tests for extraction dispatch; there were none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)