### PR TITLE
fix(sandbox): report a blocked browser profile as blocked, not absent, without leaking its name

### DIFF
--- a/apps/app-web/src/components/studio/__tests__/browser-identities-panel.test.tsx
+++ b/apps/app-web/src/components/studio/__tests__/browser-identities-panel.test.tsx
@@ -5,6 +5,7 @@ import { en } from "@/lib/i18n/dictionaries/en";
 import type { Dictionary } from "@/lib/i18n/dictionaries";
 import {
   BrowserIdentityList,
+  clearanceCovers,
   manageableBrowserProfiles,
 } from "../browser-identities-panel";
 import type { BrowserProfile } from "@/lib/api/computer";
@@ -34,12 +35,17 @@ function profile(
   };
 }
 
-function render(profiles: BrowserProfile[], drafts: Record<string, string> = {}) {
+function render(
+  profiles: BrowserProfile[],
+  drafts: Record<string, string> = {},
+  assistantClearance?: "public" | "internal" | "confidential",
+) {
   return renderToString(
     <I18nProvider locale="en" dict={en as unknown as Dictionary}>
       <BrowserIdentityList
         profiles={profiles}
         assistantId="assistant-1"
+        assistantClearance={assistantClearance}
         drafts={drafts}
         savingId={null}
         savedId={null}
@@ -80,6 +86,45 @@ describe("[COMP:app-web/browser-identities] assistant browser identity selection
     expect(html).not.toContain("Use for personal accounts.");
     expect(html).toContain("Remote");
     expect(html).toContain("Local");
+  });
+
+  /**
+   * 2026-08-19: toggling this switch ON wrote `enabledAssistantIds` and
+   * reported success, but the runtime gate (`canUseProfile`) also requires the
+   * assistant's clearance to cover the profile's rung. An `internal` assistant
+   * enabled for a `confidential` profile was refused every turn while this
+   * panel showed it as granted, so the user re-toggled it four times.
+   */
+  it("warns that enabling is not enough when the assistant's clearance is below the profile's rung", () => {
+    const enabled = profile("work", {
+      name: "hinson-work",
+      clearance: "confidential",
+      enabledAssistantIds: ["assistant-1"],
+    });
+    const html = render([enabled], {}, "internal");
+    expect(html).toContain("Enabling is not enough");
+    // Both sides of the mismatch, and both real remedies.
+    expect(html).toContain("confidential");
+    expect(html).toContain("internal");
+    expect(html).toContain("Raise this assistant&#x27;s clearance");
+  });
+
+  it("stays silent when the clearance covers the rung, and while the clearance is unknown", () => {
+    const covered = profile("ok", { clearance: "internal", enabledAssistantIds: ["assistant-1"] });
+    expect(render([covered], {}, "internal")).not.toContain("Enabling is not enough");
+    expect(render([covered], {}, "confidential")).not.toContain("Enabling is not enough");
+    // Undefined is the parent still loading, never a fabricated denial.
+    const top = profile("top", { clearance: "confidential", enabledAssistantIds: ["assistant-1"] });
+    expect(render([top])).not.toContain("Enabling is not enough");
+  });
+
+  it("clearanceCovers mirrors the runtime ladder", () => {
+    expect(clearanceCovers("internal", "confidential")).toBe(false);
+    expect(clearanceCovers("internal", "internal")).toBe(true);
+    expect(clearanceCovers("internal", "public")).toBe(true);
+    expect(clearanceCovers("public", "internal")).toBe(false);
+    expect(clearanceCovers("confidential", "confidential")).toBe(true);
+    expect(clearanceCovers(undefined, "confidential")).toBe(true);
   });
 
   it("reveals the compact save action only after the note changes", () => {

--- a/apps/app-web/src/components/studio/__tests__/browser-identities-panel.test.tsx
+++ b/apps/app-web/src/components/studio/__tests__/browser-identities-panel.test.tsx
@@ -107,6 +107,12 @@ describe("[COMP:app-web/browser-identities] assistant browser identity selection
     expect(html).toContain("confidential");
     expect(html).toContain("internal");
     expect(html).toContain("Raise this assistant&#x27;s clearance");
+    // The remedy must name the control the user will actually see. The profile
+    // pane labels the rung in plain language ("Who can use it": Only me /
+    // Cleared teammates), never "confidential" / "internal", so a remedy
+    // phrased in tier words sends them hunting on the destination screen.
+    expect(html).toContain("Who can use it");
+    expect(html).toContain("Cleared teammates");
   });
 
   it("stays silent when the clearance covers the rung, and while the clearance is unknown", () => {

--- a/apps/app-web/src/components/studio/assistant-detail.tsx
+++ b/apps/app-web/src/components/studio/assistant-detail.tsx
@@ -309,7 +309,13 @@ export function AssistantDetail({
         {tab === "brain" && (
           <BrainTab assistantId={id} workspaceId={assistant.workspaceId ?? null} />
         )}
-        {tab === "tools" && <ConnectorsTab assistantId={id} workspaceId={assistant.workspaceId ?? null} />}
+        {tab === "tools" && (
+          <ConnectorsTab
+            assistantId={id}
+            assistantClearance={assistant.clearance}
+            workspaceId={assistant.workspaceId ?? null}
+          />
+        )}
         {tab === "api" && (
           <ApiKeysTab
             assistantId={id}
@@ -1292,7 +1298,16 @@ function sortSkillsForDisplay<T extends SkillItem>(items: T[]): T[] {
   });
 }
 
-function ConnectorsTab({ assistantId, workspaceId }: { assistantId: string; workspaceId: string | null }) {
+function ConnectorsTab({
+  assistantId,
+  assistantClearance,
+  workspaceId,
+}: {
+  assistantId: string;
+  /** Threaded to the browser-identities panel: enablement alone is not a grant. */
+  assistantClearance?: Sensitivity;
+  workspaceId: string | null;
+}) {
   const t = useT();
   const params = useParams<{ workspaceId: string }>();
   const routeWs = params?.workspaceId ?? "";
@@ -1542,7 +1557,11 @@ function ConnectorsTab({ assistantId, workspaceId }: { assistantId: string; work
       </div>
 
       {subTab === "browser-identities" ? (
-        <BrowserIdentitiesPanel assistantId={assistantId} workspaceId={workspaceId} />
+        <BrowserIdentitiesPanel
+          assistantId={assistantId}
+          assistantClearance={assistantClearance}
+          workspaceId={workspaceId}
+        />
       ) : subTab === "skills" ? (
         <div className="space-y-3">
           <div className="flex items-start justify-between gap-4">

--- a/apps/app-web/src/components/studio/browser-identities-panel.tsx
+++ b/apps/app-web/src/components/studio/browser-identities-panel.tsx
@@ -10,6 +10,8 @@
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useT } from "@/lib/i18n/client";
+import { format } from "@/lib/i18n/format";
+import { type Sensitivity } from "@/components/sensitivity-badge";
 import {
   listBrowserProfiles,
   updateBrowserProfile,
@@ -18,6 +20,31 @@ import {
 
 export function manageableBrowserProfiles(profiles: BrowserProfile[]): BrowserProfile[] {
   return profiles.filter((profile) => profile.canManage === true);
+}
+
+/** Mirrors the `public < internal < confidential` ladder the runtime gates on. */
+const CLEARANCE_RANK: Record<Sensitivity, number> = {
+  public: 1,
+  internal: 2,
+  confidential: 3,
+};
+
+/**
+ * The runtime gate this toggle is a UI for (`canUseProfile`, core
+ * `sandbox/profiles.ts`): enablement alone does not grant use, the assistant's
+ * clearance must also cover the profile's rung. A toggle that reports "granted"
+ * for a grant the gate refuses is the bug this exists to prevent - on
+ * 2026-08-19 an `internal` assistant was enabled for a `confidential` profile
+ * four times, and every surface said it had worked.
+ */
+export function clearanceCovers(
+  assistantClearance: Sensitivity | null | undefined,
+  profileClearance: Sensitivity,
+): boolean {
+  // Unknown clearance never fabricates a warning: the runtime gate is the
+  // authority and a missing value here is a loading state, not a denial.
+  if (!assistantClearance) return true;
+  return CLEARANCE_RANK[profileClearance] <= CLEARANCE_RANK[assistantClearance];
 }
 
 function ProfileIcon({ backend }: { backend: BrowserProfile["defaultBackend"] }) {
@@ -36,6 +63,8 @@ function ProfileIcon({ backend }: { backend: BrowserProfile["defaultBackend"] })
 type BrowserIdentityListProps = {
   profiles: BrowserProfile[];
   assistantId: string;
+  /** The acting assistant's rung; undefined while the parent is still loading. */
+  assistantClearance?: Sensitivity;
   drafts: Record<string, string>;
   savingId: string | null;
   savedId: string | null;
@@ -49,6 +78,7 @@ type BrowserIdentityListProps = {
 export function BrowserIdentityList({
   profiles,
   assistantId,
+  assistantClearance,
   drafts,
   savingId,
   savedId,
@@ -66,6 +96,9 @@ export function BrowserIdentityList({
         const draft = drafts[profile.id] ?? savedNote;
         const noteChanged = draft.trim() !== savedNote.trim();
         const saving = savingId === profile.id;
+        // Enabled but out of clearance is the silent failure: the toggle reads
+        // ON, the runtime refuses, and every remedy on offer is "enable it".
+        const outOfClearance = !clearanceCovers(assistantClearance, profile.clearance);
         return (
           <section key={profile.id} className="rounded-xl border border-border bg-card px-4 py-3">
             <div className="flex items-center gap-3">
@@ -103,6 +136,18 @@ export function BrowserIdentityList({
                 />
               </button>
             </div>
+
+            {outOfClearance ? (
+              <p className="mt-2 rounded-lg bg-destructive/10 px-3 py-2 text-xs leading-relaxed text-destructive">
+                {format(t.assistant.toolsTab.browserIdentitiesClearanceBlocked, {
+                  profile: t.manage.sensitivity[profile.clearance],
+                  assistant: assistantClearance
+                    ? t.manage.sensitivity[assistantClearance]
+                    : "",
+                })}{" "}
+                {t.assistant.toolsTab.browserIdentitiesClearanceRemedy}
+              </p>
+            ) : null}
 
             {available ? (
               <div className="mt-3 border-t border-border pt-3">
@@ -156,9 +201,11 @@ export function BrowserIdentityList({
 
 export function BrowserIdentitiesPanel({
   assistantId,
+  assistantClearance,
   workspaceId,
 }: {
   assistantId: string;
+  assistantClearance?: Sensitivity;
   workspaceId: string | null;
 }) {
   const t = useT();
@@ -304,6 +351,7 @@ export function BrowserIdentitiesPanel({
         <BrowserIdentityList
           profiles={state.profiles}
           assistantId={assistantId}
+          assistantClearance={assistantClearance}
           drafts={drafts}
           savingId={savingId}
           savedId={savedId}

--- a/apps/app-web/src/lib/i18n/dictionaries/en.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/en.ts
@@ -7878,6 +7878,8 @@ export const en = {
       browserIdentitiesSaving: "Saving...",
       browserIdentitiesSaved: "Saved",
       browserIdentitiesUpdateFailed: "Couldn't update this browser identity.",
+      browserIdentitiesClearanceBlocked: "Enabling is not enough. This profile's clearance ({profile}) is above this assistant's clearance ({assistant}), so the assistant still cannot use it.",
+      browserIdentitiesClearanceRemedy: "Raise this assistant's clearance, or lower the profile's rung under Browser profiles > Advanced.",
       connectorsDesc: "Enable or disable services for this assistant. Per-tool permissions can be stricter than the app default but not looser.",
       setUpInSettings: "Set up in Settings",
       setUpInWorkspace: "Set up in Team",

--- a/apps/app-web/src/lib/i18n/dictionaries/en.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/en.ts
@@ -7879,7 +7879,7 @@ export const en = {
       browserIdentitiesSaved: "Saved",
       browserIdentitiesUpdateFailed: "Couldn't update this browser identity.",
       browserIdentitiesClearanceBlocked: "Enabling is not enough. This profile's clearance ({profile}) is above this assistant's clearance ({assistant}), so the assistant still cannot use it.",
-      browserIdentitiesClearanceRemedy: "Raise this assistant's clearance, or lower the profile's rung under Browser profiles > Advanced.",
+      browserIdentitiesClearanceRemedy: "Raise this assistant's clearance, or set \"Who can use it\" to \"Cleared teammates\" under Browsers > Browser profiles > Advanced settings.",
       connectorsDesc: "Enable or disable services for this assistant. Per-tool permissions can be stricter than the app default but not looser.",
       setUpInSettings: "Set up in Settings",
       setUpInWorkspace: "Set up in Team",

--- a/apps/app-web/src/lib/i18n/dictionaries/ja.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/ja.ts
@@ -7656,6 +7656,8 @@ export const ja: Dictionary = {
       browserIdentitiesSaving: "保存中...",
       browserIdentitiesSaved: "保存しました",
       browserIdentitiesUpdateFailed: "このブラウザー ID を更新できませんでした。",
+      browserIdentitiesClearanceBlocked: "有効化だけでは足りません。このプロファイルの機密レベル ({profile}) がこのアシスタントの権限レベル ({assistant}) を上回っているため、まだ使用できません。",
+      browserIdentitiesClearanceRemedy: "このアシスタントの権限レベルを上げるか、ブラウザープロファイル > 詳細設定でプロファイルの機密レベルを下げてください。",
       connectorsDesc: "このアシスタント向けにサービスを有効・無効にします。ツールごとの権限は、アプリ既定より厳しくはできますが、緩くはできません。",
       setUpInSettings: "設定で構成",
       setUpInWorkspace: "チーム設定で構成",

--- a/apps/app-web/src/lib/i18n/dictionaries/ja.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/ja.ts
@@ -7657,7 +7657,7 @@ export const ja: Dictionary = {
       browserIdentitiesSaved: "保存しました",
       browserIdentitiesUpdateFailed: "このブラウザー ID を更新できませんでした。",
       browserIdentitiesClearanceBlocked: "有効化だけでは足りません。このプロファイルの機密レベル ({profile}) がこのアシスタントの権限レベル ({assistant}) を上回っているため、まだ使用できません。",
-      browserIdentitiesClearanceRemedy: "このアシスタントの権限レベルを上げるか、ブラウザープロファイル > 詳細設定でプロファイルの機密レベルを下げてください。",
+      browserIdentitiesClearanceRemedy: "このアシスタントの権限レベルを上げるか、ブラウザー > ブラウザープロファイル > 詳細設定で「使用できる人」を「許可されたチームメイト」に設定してください。",
       connectorsDesc: "このアシスタント向けにサービスを有効・無効にします。ツールごとの権限は、アプリ既定より厳しくはできますが、緩くはできません。",
       setUpInSettings: "設定で構成",
       setUpInWorkspace: "チーム設定で構成",

--- a/apps/app-web/src/lib/i18n/dictionaries/zh.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh.ts
@@ -7596,7 +7596,7 @@ export const zh: Dictionary = {
       browserIdentitiesSaved: "已儲存",
       browserIdentitiesUpdateFailed: "無法更新這個瀏覽器身分。",
       browserIdentitiesClearanceBlocked: "只啟用還不夠。這個設定檔的機密等級 ({profile}) 高於這位助理的權限等級 ({assistant})，所以助理仍然無法使用。",
-      browserIdentitiesClearanceRemedy: "請提高這位助理的權限等級，或在瀏覽器設定檔 > 進階中調降設定檔的機密等級。",
+      browserIdentitiesClearanceRemedy: "請提高這位助理的權限等級，或在瀏覽器 > 瀏覽器設定檔 > 進階設定中將「誰可以使用」設為「已授權的隊友」。",
       connectorsDesc: "為此助理啟用或停用服務。個別工具的權限可比 app 預設更嚴格，但不能更寬鬆。",
       setUpInSettings: "在設定中設定",
       setUpInWorkspace: "在工作空間中設定",

--- a/apps/app-web/src/lib/i18n/dictionaries/zh.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh.ts
@@ -7595,6 +7595,8 @@ export const zh: Dictionary = {
       browserIdentitiesSaving: "儲存中...",
       browserIdentitiesSaved: "已儲存",
       browserIdentitiesUpdateFailed: "無法更新這個瀏覽器身分。",
+      browserIdentitiesClearanceBlocked: "只啟用還不夠。這個設定檔的機密等級 ({profile}) 高於這位助理的權限等級 ({assistant})，所以助理仍然無法使用。",
+      browserIdentitiesClearanceRemedy: "請提高這位助理的權限等級，或在瀏覽器設定檔 > 進階中調降設定檔的機密等級。",
       connectorsDesc: "為此助理啟用或停用服務。個別工具的權限可比 app 預設更嚴格，但不能更寬鬆。",
       setUpInSettings: "在設定中設定",
       setUpInWorkspace: "在工作空間中設定",

--- a/packages/core/src/sandbox/__tests__/profiles.test.ts
+++ b/packages/core/src/sandbox/__tests__/profiles.test.ts
@@ -7,7 +7,9 @@
  */
 import { describe, it, expect } from 'vitest'
 import {
+  blockedProfilesFor,
   canUseProfile,
+  describeProfileDenial,
   createInMemoryBrowserProfileStore,
   createInMemorySessionVault,
   describeProfileResolution,
@@ -178,5 +180,80 @@ describe('[COMP:sandbox/profiles] Profile at call time (R2-10)', () => {
     const s = store()
     const res = await resolveProfileForCall({ store: s, actor: OWNER })
     expect(res).toEqual({ kind: 'none' })
+  })
+
+  /**
+   * 2026-08-19: an `internal` assistant was ENABLED for a `confidential`
+   * profile. `canUseProfile` refused on clearance, but every surface filtered
+   * on `.ok` and dropped the reason, so the only remedy on offer was the
+   * enablement the user had already done. They did it four more times.
+   */
+  it('a denial is not an absence: an enabled-but-under-clearance profile is named with its reason', async () => {
+    const s = store()
+    await s.create({
+      workspaceId: 'ws-1',
+      ownerUserId: 'owner-1',
+      name: 'hinson-work',
+      clearance: 'confidential',
+      enabledAssistantIds: ['asst-1'],
+    })
+    const actor: ProfileActor = { ...OWNER, assistantClearance: 'internal' }
+    const res = await resolveProfileForCall({ store: s, actor })
+    expect(res.kind).toBe('none')
+    if (res.kind !== 'none') return
+    expect(res.blocked).toEqual([
+      { name: 'hinson-work', reason: 'clearance', clearance: 'confidential' },
+    ])
+
+    const text = describeProfileResolution(res, actor.assistantClearance)
+    // Names the profile, both sides of the mismatch, and BOTH real remedies.
+    expect(text).toContain('hinson-work')
+    expect(text).toMatch(/confidential/)
+    expect(text).toMatch(/internal/)
+    expect(text).toMatch(/raise this assistant's clearance/i)
+    expect(text).toMatch(/lower the profile's rung/i)
+    // And never the remedy that cannot work.
+    expect(text).not.toMatch(/create one in Browsers/i)
+  })
+
+  it('blockedProfilesFor reports every gated profile with the gate’s own reason', async () => {
+    const s = store()
+    await s.create({
+      workspaceId: 'ws-1', ownerUserId: 'owner-1', name: 'not-enabled',
+      clearance: 'public', enabledAssistantIds: [],
+    })
+    await s.create({
+      workspaceId: 'ws-1', ownerUserId: 'owner-1', name: 'too-high',
+      clearance: 'confidential', enabledAssistantIds: ['asst-1'],
+    })
+    const actor: ProfileActor = { ...OWNER, assistantClearance: 'internal' }
+    const all = await s.list({ workspaceId: 'ws-1' })
+    expect(blockedProfilesFor(all, actor)).toEqual([
+      { name: 'not-enabled', reason: 'not_enabled', clearance: 'public' },
+      { name: 'too-high', reason: 'clearance', clearance: 'confidential' },
+    ])
+  })
+
+  it('the clearance denial says enabling again will not help; the not-enabled one still points at the toggle', () => {
+    const clearance = describeProfileDenial(
+      { name: 'p', reason: 'clearance', clearance: 'confidential' },
+      'internal',
+    )
+    expect(clearance).toMatch(/enabling it again will not help/i)
+
+    const notEnabled = describeProfileDenial(
+      { name: 'p', reason: 'not_enabled', clearance: 'public' },
+      'internal',
+    )
+    expect(notEnabled).toMatch(/Assistant > Tools > Browser identities/)
+    expect(notEnabled).not.toMatch(/will not help/i)
+  })
+
+  it('a workspace with genuinely zero profiles still returns a bare none', async () => {
+    const s = store()
+    const res = await resolveProfileForCall({ store: s, actor: OWNER })
+    expect(res).toEqual({ kind: 'none' })
+    if (res.kind === 'ok') throw new Error('unreachable: an empty store cannot resolve')
+    expect(describeProfileResolution(res, 'internal')).toMatch(/create one in Browsers/i)
   })
 })

--- a/packages/core/src/sandbox/__tests__/profiles.test.ts
+++ b/packages/core/src/sandbox/__tests__/profiles.test.ts
@@ -10,6 +10,7 @@ import {
   blockedProfilesFor,
   canUseProfile,
   describeProfileDenial,
+  describeProfileDenials,
   createInMemoryBrowserProfileStore,
   createInMemorySessionVault,
   describeProfileResolution,
@@ -206,14 +207,56 @@ describe('[COMP:sandbox/profiles] Profile at call time (R2-10)', () => {
     ])
 
     const text = describeProfileResolution(res, actor.assistantClearance)
-    // Names the profile, both sides of the mismatch, and BOTH real remedies.
-    expect(text).toContain('hinson-work')
-    expect(text).toMatch(/confidential/)
+    // The obstacle is named; the PROFILE is not. An assistant's clearance
+    // exists so it sees less than its user, so a rung it cannot cover is a
+    // rung whose profile names it must not learn.
+    expect(text).not.toContain('hinson-work')
     expect(text).toMatch(/internal/)
     expect(text).toMatch(/raise this assistant's clearance/i)
-    expect(text).toMatch(/lower the profile's rung/i)
+    expect(text).toMatch(/who can use it/i)
     // And never the remedy that cannot work.
+    expect(text).toMatch(/will NOT help/i)
     expect(text).not.toMatch(/create one in Browsers/i)
+  })
+
+  /**
+   * The disclosure test is `canRead`, never the denial reason.
+   * `canUseProfile` returns `not_enabled` BEFORE it evaluates clearance, so a
+   * `confidential` profile that is merely un-toggled reports `not_enabled` -
+   * naming it on that basis would leak exactly what the rung withholds.
+   */
+  it('withholds the name of an un-toggled profile that is ALSO above clearance', () => {
+    const text = describeProfileDenial(
+      { name: 'acme-diligence-login', reason: 'not_enabled', clearance: 'confidential' },
+      'internal',
+    )
+    expect(text).not.toContain('acme-diligence-login')
+    expect(text).toMatch(/name is deliberately withheld/i)
+  })
+
+  it('names a profile the assistant IS cleared for, so the ordinary toggle case stays actionable', () => {
+    const text = describeProfileDenial(
+      { name: 'team-shared', reason: 'not_enabled', clearance: 'internal' },
+      'internal',
+    )
+    expect(text).toContain('team-shared')
+    expect(text).toMatch(/Assistant > Tools > Browser identities/)
+  })
+
+  it('collapses several unnameable profiles into one obstacle, disclosing no count', () => {
+    const text = describeProfileDenials(
+      [
+        { name: 'zenith-vault', reason: 'clearance', clearance: 'confidential' },
+        { name: 'quorum-books', reason: 'not_enabled', clearance: 'confidential' },
+        { name: 'lodestar-admin', reason: 'owner_only', clearance: 'confidential' },
+      ],
+      'internal',
+    )
+    for (const name of ['zenith-vault', 'quorum-books', 'lodestar-admin']) {
+      expect(text).not.toContain(name)
+    }
+    // One sentence run, not three identical paragraphs that also count them.
+    expect(text.match(/deliberately withheld/gi)).toHaveLength(1)
   })
 
   it('blockedProfilesFor reports every gated profile with the gate’s own reason', async () => {
@@ -239,14 +282,16 @@ describe('[COMP:sandbox/profiles] Profile at call time (R2-10)', () => {
       { name: 'p', reason: 'clearance', clearance: 'confidential' },
       'internal',
     )
-    expect(clearance).toMatch(/enabling it again will not help/i)
+    expect(clearance).toMatch(/will NOT help/i)
+    expect(clearance).not.toContain('"p"')
 
     const notEnabled = describeProfileDenial(
       { name: 'p', reason: 'not_enabled', clearance: 'public' },
       'internal',
     )
+    expect(notEnabled).toContain('"p"')
     expect(notEnabled).toMatch(/Assistant > Tools > Browser identities/)
-    expect(notEnabled).not.toMatch(/will not help/i)
+    expect(notEnabled).not.toMatch(/will NOT help/i)
   })
 
   it('a workspace with genuinely zero profiles still returns a bare none', async () => {

--- a/packages/core/src/sandbox/bu-fallback.ts
+++ b/packages/core/src/sandbox/bu-fallback.ts
@@ -171,6 +171,7 @@ export function createBuFallbackTool(opts: CreateBuFallbackToolOptions): { brows
       // public price-check was refused for want of a profile).
       let profile: BrowserProfile | null = null
       if (opts.profiles) {
+        const actorClearance = await opts.profiles.assistantClearance(context)
         const resolution = await resolveProfileForCall({
           store: opts.profiles.store,
           vault: opts.profiles.vault,
@@ -178,7 +179,7 @@ export function createBuFallbackTool(opts: CreateBuFallbackToolOptions): { brows
             userId: context.userId,
             workspaceId: context.workspaceId,
             assistantId: context.assistantId,
-            assistantClearance: await opts.profiles.assistantClearance(context),
+            assistantClearance: actorClearance,
           },
           site,
           profileName: input.profile,
@@ -186,7 +187,7 @@ export function createBuFallbackTool(opts: CreateBuFallbackToolOptions): { brows
         if (resolution.kind === 'ok') {
           profile = resolution.profile
         } else if (resolution.kind !== 'none') {
-          return { data: `ERROR: ${describeProfileResolution(resolution)}`, isError: true }
+          return { data: `ERROR: ${describeProfileResolution(resolution, actorClearance)}`, isError: true }
         }
       }
       if (profile && profile.defaultBackend === 'local') {

--- a/packages/core/src/sandbox/profiles.ts
+++ b/packages/core/src/sandbox/profiles.ts
@@ -110,12 +110,28 @@ export function routingNoteFor(profile: BrowserProfile, assistantId: string): st
   return note || null
 }
 
+/**
+ * A workspace profile the actor cannot use, with the reason WHY. A denial is
+ * not an absence: reporting "no profile" for a profile that exists and is
+ * enabled sends the user to re-do the one thing they already did (2026-08-19
+ * — an `internal` assistant enabled for a `confidential` profile was told
+ * four times to enable it). Existence + metadata are workspace-visible
+ * governance data at every rung (spec §2), so naming a blocked profile to a
+ * member's own turn leaks nothing; only session USE stays gated.
+ */
+export type BlockedProfile = {
+  name: string
+  reason: ProfileDenialReason
+  /** The profile's rung, so the remedy can name both sides of the mismatch. */
+  clearance: Sensitivity
+}
+
 export type ProfileResolution =
   | { kind: 'ok'; profile: BrowserProfile }
   | { kind: 'must_name'; candidates: string[]; guidance?: Record<string, string> }
   | { kind: 'not_found'; name: string }
   | { kind: 'denied'; profile: BrowserProfile; reason: ProfileDenialReason }
-  | { kind: 'none' }
+  | { kind: 'none'; blocked?: BlockedProfile[] }
 
 /**
  * Call-time profile choice (R2-10): a block/browse is site-scoped and
@@ -170,11 +186,44 @@ export async function resolveProfileForCall(params: {
       ...(Object.keys(guidance).length > 0 ? { guidance } : {}),
     }
   }
-  return { kind: 'none' }
+  // Zero usable profiles is NOT the same as zero profiles. Carry the denials
+  // so the caller can tell "you have none" from "you have one you cannot use".
+  const blocked = blockedProfilesFor(all, actor)
+  return blocked.length > 0 ? { kind: 'none', blocked } : { kind: 'none' }
+}
+
+/** Every workspace profile the actor is gated out of, with the gate's reason. */
+export function blockedProfilesFor(
+  profiles: BrowserProfile[],
+  actor: ProfileActor,
+): BlockedProfile[] {
+  return profiles.flatMap((profile) => {
+    const gate = canUseProfile(profile, actor)
+    return gate.ok ? [] : [{ name: profile.name, reason: gate.reason, clearance: profile.clearance }]
+  })
+}
+
+/**
+ * One phrasing of a denial, shared by every surface that reports one, so the
+ * tool result, the discovery listing, and the navigate error cannot drift into
+ * three different remedies for one cause.
+ */
+export function describeProfileDenial(blocked: BlockedProfile, actorClearance: Sensitivity): string {
+  switch (blocked.reason) {
+    case 'not_enabled':
+      return `"${blocked.name}" is not enabled for this assistant. Its owner can enable it under Assistant > Tools > Browser identities.`
+    case 'clearance':
+      return `"${blocked.name}" IS enabled for this assistant, but the profile's clearance rung (${blocked.clearance}) is above this assistant's clearance (${actorClearance}), so enabling it again will not help. Either raise this assistant's clearance to ${blocked.clearance} in Studio > Assistants, or lower the profile's rung to ${actorClearance} or below under Browsers > Browser profiles > Advanced > Clearance.`
+    case 'owner_only':
+      return `"${blocked.name}" sits at the top (confidential) rung, which only its owner's own turns may use. Its owner can lower the rung under Browsers > Browser profiles > Advanced > Clearance to share it.`
+  }
 }
 
 /** Human-readable tool error for a non-`ok` resolution (shared by the browse tools). */
-export function describeProfileResolution(res: Exclude<ProfileResolution, { kind: 'ok' }>): string {
+export function describeProfileResolution(
+  res: Exclude<ProfileResolution, { kind: 'ok' }>,
+  actorClearance: Sensitivity = 'public',
+): string {
   switch (res.kind) {
     case 'must_name':
       return `Several browser profiles match. Name one with the "profile" parameter: ${res.candidates
@@ -200,6 +249,13 @@ export function describeProfileResolution(res: Exclude<ProfileResolution, { kind
       // and explore proceed identity-less on 'none' (R2-10). Keep the
       // requirement honest but never let it read as "browsing is blocked"
       // (the 2026-07-15 refusal was the model echoing exactly that belief).
+      // A profile that EXISTS but is gated is reported as such: the generic
+      // "create one, then enable it" line is a wrong remedy for a denial.
+      if (res.blocked?.length) {
+        return `No browser profile is USABLE by this assistant, but ${res.blocked.length === 1 ? 'one exists' : `${res.blocked.length} exist`} in this workspace: ${res.blocked
+          .map((blocked) => describeProfileDenial(blocked, actorClearance))
+          .join(' ')} Report this to the user verbatim rather than asking them to enable it again. Public pages still need no profile.`
+      }
       return 'No browser profile is available to this assistant. Running a saved browser skill requires one (skills replay signed-in flows). The user can create one in Browsers > Browser profiles, then make it available under Assistant > Tools > Browser identities. Public pages need no profile: browse them directly with browserNavigate or browserExplore instead.'
   }
 }

--- a/packages/core/src/sandbox/profiles.ts
+++ b/packages/core/src/sandbox/profiles.ts
@@ -207,16 +207,49 @@ export function blockedProfilesFor(
  * One phrasing of a denial, shared by every surface that reports one, so the
  * tool result, the discovery listing, and the navigate error cannot drift into
  * three different remedies for one cause.
+ *
+ * **What may be said is decided by clearance, never by the reason.** An
+ * assistant's clearance exists so it sees LESS than the user it acts for, so a
+ * profile whose rung it does not cover is not nameable to it: the name is
+ * metadata above its clearance ("Acme-diligence-login" is itself a disclosure).
+ * "Existence stays workspace-visible" is a rule about MEMBERS reading the
+ * Browsers surface, and does not extend to a lower-cleared principal.
+ *
+ * Keying this off `reason` would leak, because `canUseProfile` returns
+ * `not_enabled` BEFORE it evaluates clearance — a `confidential` profile that
+ * is merely un-toggled reports `not_enabled`, and naming it on that basis
+ * would disclose exactly what the rung exists to withhold. So the test is
+ * `canRead` directly: name it only when the assistant is cleared for the rung;
+ * otherwise report the SHAPE of the obstacle and nothing that identifies it.
  */
 export function describeProfileDenial(blocked: BlockedProfile, actorClearance: Sensitivity): string {
+  if (!canRead(actorClearance, blocked.clearance)) {
+    return `A browser profile exists in this workspace whose clearance is above this assistant's (${actorClearance}), so this assistant can neither see nor use it — its name is deliberately withheld. Enabling it under Assistant > Tools > Browser identities will NOT help: the clearance rung is the obstacle, not the toggle. The user can raise this assistant's clearance, or lower that profile's "Who can use it" setting (Browsers > Browser profiles > Advanced settings) to a level ${actorClearance} covers.`
+  }
   switch (blocked.reason) {
     case 'not_enabled':
       return `"${blocked.name}" is not enabled for this assistant. Its owner can enable it under Assistant > Tools > Browser identities.`
-    case 'clearance':
-      return `"${blocked.name}" IS enabled for this assistant, but the profile's clearance rung (${blocked.clearance}) is above this assistant's clearance (${actorClearance}), so enabling it again will not help. Either raise this assistant's clearance to ${blocked.clearance} in Studio > Assistants, or lower the profile's rung to ${actorClearance} or below under Browsers > Browser profiles > Advanced > Clearance.`
     case 'owner_only':
-      return `"${blocked.name}" sits at the top (confidential) rung, which only its owner's own turns may use. Its owner can lower the rung under Browsers > Browser profiles > Advanced > Clearance to share it.`
+      return `"${blocked.name}" sits at the top (confidential) rung, which only its owner's own turns may use. Its owner can lower its "Who can use it" setting under Browsers > Browser profiles > Advanced settings to share it.`
+    case 'clearance':
+      // Unreachable: `canUseProfile` returns `clearance` only when `canRead`
+      // failed, which the guard above already answered. Kept total rather than
+      // thrown, so a future reason-ordering change degrades to the safe text.
+      return `A browser profile in this workspace is not usable by this assistant at its current clearance (${actorClearance}).`
   }
+}
+
+/**
+ * The denials for one zero-candidate resolution, as one sentence run.
+ * Deduplicated because every withheld profile yields the same shape-only
+ * sentence: three unnameable profiles must read as one obstacle, not as three
+ * identical paragraphs that also happen to disclose the count.
+ */
+export function describeProfileDenials(
+  blocked: BlockedProfile[],
+  actorClearance: Sensitivity,
+): string {
+  return [...new Set(blocked.map((entry) => describeProfileDenial(entry, actorClearance)))].join(' ')
 }
 
 /** Human-readable tool error for a non-`ok` resolution (shared by the browse tools). */
@@ -252,9 +285,7 @@ export function describeProfileResolution(
       // A profile that EXISTS but is gated is reported as such: the generic
       // "create one, then enable it" line is a wrong remedy for a denial.
       if (res.blocked?.length) {
-        return `No browser profile is USABLE by this assistant, but ${res.blocked.length === 1 ? 'one exists' : `${res.blocked.length} exist`} in this workspace: ${res.blocked
-          .map((blocked) => describeProfileDenial(blocked, actorClearance))
-          .join(' ')} Report this to the user verbatim rather than asking them to enable it again. Public pages still need no profile.`
+        return `No browser profile is USABLE by this assistant. ${describeProfileDenials(res.blocked, actorClearance)} Report this to the user rather than asking them to enable a profile again. Public pages still need no profile.`
       }
       return 'No browser profile is available to this assistant. Running a saved browser skill requires one (skills replay signed-in flows). The user can create one in Browsers > Browser profiles, then make it available under Assistant > Tools > Browser identities. Public pages need no profile: browse them directly with browserNavigate or browserExplore instead.'
   }

--- a/packages/core/src/sandbox/skill-runner.ts
+++ b/packages/core/src/sandbox/skill-runner.ts
@@ -28,7 +28,9 @@ import {
   extractEffectContract,
 } from './effect-contract.js'
 import {
+  blockedProfilesFor,
   canUseProfile,
+  describeProfileDenial,
   describeProfileResolution,
   resolveProfileForCall,
   routingNoteFor,
@@ -350,6 +352,7 @@ export function createSkillRunnerTools(opts: CreateSkillRunnerToolsOptions): {
           isError: true,
         }
       }
+      const actorClearance = await opts.profiles.assistantClearance(context)
       const resolution = await resolveProfileForCall({
         store: opts.profiles.store,
         vault: opts.profiles.vault,
@@ -357,13 +360,13 @@ export function createSkillRunnerTools(opts: CreateSkillRunnerToolsOptions): {
           userId: context.userId,
           workspaceId: context.workspaceId,
           assistantId: context.assistantId,
-          assistantClearance: await opts.profiles.assistantClearance(context),
+          assistantClearance: actorClearance,
         },
         site: skill.site,
         profileName: input.profile,
       })
       if (resolution.kind !== 'ok') {
-        return { data: `ERROR: ${describeProfileResolution(resolution)}`, isError: true }
+        return { data: `ERROR: ${describeProfileResolution(resolution, actorClearance)}`, isError: true }
       }
       const profile = resolution.profile
       const rehearsal = input.rehearsal === true
@@ -682,6 +685,21 @@ export function createSkillRunnerTools(opts: CreateSkillRunnerToolsOptions): {
       }
       const profiles = allProfiles.filter((profile) => canUseProfile(profile, actor).ok)
       if (profiles.length === 0) {
+        // A denial is not an absence. Filtering on `.ok` and discarding the
+        // reason made an enabled-but-under-clearance profile indistinguishable
+        // from having none, so the only remedy this tool could offer was the
+        // enablement the user had already done — five identical rounds of it
+        // on 2026-08-19. Report WHICH profile is blocked and WHY.
+        const blocked = blockedProfilesFor(allProfiles, actor)
+        if (blocked.length > 0) {
+          return {
+            data:
+              `No browser profile is usable by this assistant, but ${blocked.length === 1 ? 'one exists' : `${blocked.length} exist`} in this workspace. ` +
+              `${blocked.map((entry) => describeProfileDenial(entry, clearance)).join(' ')} ` +
+              'Tell the user exactly this. Do NOT ask them to enable the profile again: the gate above is what is blocking it, and re-enabling changes nothing. ' +
+              'Public sites still need no profile (browserNavigate / browserExplore run identity-less) unless this deployment browses only through My Browser.',
+          }
+        }
         // The 2026-07-15 refusal echoed this line verbatim — it must never
         // read as "browsing is unavailable". Profiles only add saved logins.
         return {

--- a/packages/core/src/sandbox/skill-runner.ts
+++ b/packages/core/src/sandbox/skill-runner.ts
@@ -30,7 +30,7 @@ import {
 import {
   blockedProfilesFor,
   canUseProfile,
-  describeProfileDenial,
+  describeProfileDenials,
   describeProfileResolution,
   resolveProfileForCall,
   routingNoteFor,
@@ -694,9 +694,9 @@ export function createSkillRunnerTools(opts: CreateSkillRunnerToolsOptions): {
         if (blocked.length > 0) {
           return {
             data:
-              `No browser profile is usable by this assistant, but ${blocked.length === 1 ? 'one exists' : `${blocked.length} exist`} in this workspace. ` +
-              `${blocked.map((entry) => describeProfileDenial(entry, clearance)).join(' ')} ` +
-              'Tell the user exactly this. Do NOT ask them to enable the profile again: the gate above is what is blocking it, and re-enabling changes nothing. ' +
+              'No browser profile is usable by this assistant. ' +
+              `${describeProfileDenials(blocked, clearance)} ` +
+              'Relay this to the user. Do NOT ask them to enable a profile again: the gate above is what is blocking it, and re-enabling changes nothing. ' +
               'Public sites still need no profile (browserNavigate / browserExplore run identity-less) unless this deployment browses only through My Browser.',
           }
         }

--- a/packages/core/src/sandbox/tools.ts
+++ b/packages/core/src/sandbox/tools.ts
@@ -31,8 +31,10 @@ import {
   registrableSiteOf,
 } from './orchestrator.js'
 import {
+  describeProfileDenial,
   describeProfileResolution,
   resolveProfileForCall,
+  type BlockedProfile,
   type BrowserBackendKind,
   type BrowserProfile,
   type BrowserProfileStore,
@@ -655,7 +657,10 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
       // name, a named miss / gate denial is an honest error. No profile
       // config (OSS) or no profiles → identity-less browse.
       let profile: BrowserProfile | null = null
+      let blockedProfiles: BlockedProfile[] = []
+      let actorClearance: Sensitivity = 'public'
       if (opts.profiles) {
+        actorClearance = await opts.profiles.assistantClearance(context)
         const resolution = await resolveProfileForCall({
           store: opts.profiles.store,
           vault: opts.profiles.vault,
@@ -663,7 +668,7 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
             userId: context.userId,
             workspaceId: context.workspaceId ?? '',
             assistantId: context.assistantId,
-            assistantClearance: await opts.profiles.assistantClearance(context),
+            assistantClearance: actorClearance,
           },
           site: registrableSiteOf(input.url),
           profileName: input.profile ?? gate.state.profileName,
@@ -671,12 +676,28 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
         if (resolution.kind === 'ok') {
           profile = resolution.profile
         } else if (resolution.kind !== 'none') {
-          return { data: `ERROR: ${describeProfileResolution(resolution)}`, isError: true }
+          return { data: `ERROR: ${describeProfileResolution(resolution, actorClearance)}`, isError: true }
+        } else {
+          blockedProfiles = resolution.blocked ?? []
         }
       }
       gate.state.profileId = profile?.id ?? null
       gate.state.profileName = profile?.name ?? null
       const backend = resolveBackend(gate.state, profile)
+      // On a local-only deployment (no cloud sandbox) "no profile" is not a
+      // soft degrade to identity-less browsing — the local provider hard-fails
+      // `profile_required`, whose remedy ("choose or create a profile") is
+      // wrong when a profile exists and the GATE is what refused it. Answer
+      // with the gate's own reason before the provider can flatten it.
+      if (backend === 'local' && !profile && blockedProfiles.length > 0) {
+        return {
+          data:
+            `ERROR: This deployment browses through My Browser, which needs a browser profile, and every profile in this workspace is gated for this assistant. ` +
+            `${blockedProfiles.map((blocked) => describeProfileDenial(blocked, actorClearance)).join(' ')} ` +
+            'Report this to the user verbatim; re-enabling the profile will not change it.',
+          isError: true,
+        }
+      }
       gate.state.backend = backend
       const fused = backendFuseGate(gate.state, backend)
       if (fused) return fused

--- a/packages/core/src/sandbox/tools.ts
+++ b/packages/core/src/sandbox/tools.ts
@@ -31,7 +31,7 @@ import {
   registrableSiteOf,
 } from './orchestrator.js'
 import {
-  describeProfileDenial,
+  describeProfileDenials,
   describeProfileResolution,
   resolveProfileForCall,
   type BlockedProfile,
@@ -692,9 +692,9 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
       if (backend === 'local' && !profile && blockedProfiles.length > 0) {
         return {
           data:
-            `ERROR: This deployment browses through My Browser, which needs a browser profile, and every profile in this workspace is gated for this assistant. ` +
-            `${blockedProfiles.map((blocked) => describeProfileDenial(blocked, actorClearance)).join(' ')} ` +
-            'Report this to the user verbatim; re-enabling the profile will not change it.',
+            'ERROR: This deployment browses through My Browser, which needs a browser profile, and no profile in this workspace is usable by this assistant. ' +
+            `${describeProfileDenials(blockedProfiles, actorClearance)} ` +
+            'Relay this to the user; re-enabling a profile will not change it.',
           isError: true,
         }
       }


### PR DESCRIPTION
502d0665 fix(sandbox): withhold the NAME of a profile above the assistant's clearance
3ba70972 fix(app-web): the clearance remedy must name the control, not the tier
f04dc997 fix(sandbox): report a blocked browser profile as blocked, not absent