### PR TITLE
fix(files): a deleted file must release its path and its segments

### DIFF
--- a/packages/api/migrations/445_workspace_files_current_path_unique.sql
+++ b/packages/api/migrations/445_workspace_files_current_path_unique.sql
@@ -1,0 +1,31 @@
+-- 445: workspace_files — scope the (workspace_id, path) uniqueness to the
+-- CURRENT bi-temporal version.
+--
+-- `workspace_files` is bi-temporal (`valid_to IS NULL` = current version), but
+-- the legacy constraint from mig 119 (`workspace_files_workspace_id_path_key`)
+-- was unscoped, so a row that LEFT the current window still owned its path
+-- forever: soft-deleted from the Brain drawer, superseded by a staged write, or
+-- retracted by the BYO-storage staleness sweep.
+--
+-- Every current-version read filters `valid_to IS NULL`, so such a row was
+-- invisible to the Brain list, invisible to the upload pre-checks
+-- (`getWorkspaceFileByPath` in both `filesApi.persist` and the chunked-upload
+-- start/complete gates) — and still fatal at INSERT. Re-uploading a file the
+-- user had just deleted failed with "A file with that name already exists",
+-- permanently, with nothing on any surface to explain it. The same constraint
+-- is what blocked path-stable supersession in `supersedeWorkspaceFile`.
+--
+-- No dedup pre-pass is needed: the unscoped constraint guarantees no two rows
+-- share (workspace_id, path) at all, so the narrower partial index cannot find
+-- a conflict among current rows.
+
+BEGIN;
+
+ALTER TABLE workspace_files
+  DROP CONSTRAINT IF EXISTS workspace_files_workspace_id_path_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_workspace_files_current_path
+  ON workspace_files (workspace_id, path)
+  WHERE valid_to IS NULL;
+
+COMMIT;

--- a/packages/api/migrations/447_close_segments_of_deleted_files.sql
+++ b/packages/api/migrations/447_close_segments_of_deleted_files.sql
@@ -1,0 +1,31 @@
+-- 447: close the `file_segments` left inside the current window by files that
+-- are already outside it.
+--
+-- The Brain drawer's delete soft-closed `workspace_files` only. Retrieval reads
+-- the SEGMENT's own bi-temporal window (`visibilityPredicate` in
+-- retrieval-store.ts never joins the parent row), so every file deleted before
+-- the cascade landed is still fully searchable through `searchFileContent`,
+-- `readFileSegmentRange` and the brain `file_segment` arm - the user deleted it
+-- and Brian keeps quoting it.
+--
+-- The code fix (`closeWorkspaceFileSegmentsSystem`, wired into the delete route)
+-- only covers deletes from here on; nothing else ever revisits an already-closed
+-- file, so this backfill is the only way those users get the delete they asked
+-- for. It is the invariant stated as SQL - a file outside the current window has
+-- no segments inside it - so it is safe to re-run and correct for every closing
+-- reason. Supersession and the BYO staleness sweep already cascade, so their
+-- segments are closed and the predicate skips them.
+--
+-- `valid_to` is set to the PARENT's `valid_to`, not `now()`, so an `as_of` read
+-- of a past moment still sees the segments that were live at that moment.
+
+BEGIN;
+
+UPDATE file_segments fs
+   SET valid_to = wf.valid_to
+  FROM workspace_files wf
+ WHERE fs.file_id = wf.id
+   AND wf.valid_to IS NOT NULL
+   AND fs.valid_to IS NULL;
+
+COMMIT;

--- a/packages/api/src/db/__tests__/row-history-store.integration.test.ts
+++ b/packages/api/src/db/__tests__/row-history-store.integration.test.ts
@@ -294,9 +294,9 @@ describeIf('[COMP:corrections/row-history] unified getRowHistory dispatch', () =
       // WU-4.5 authorship enforcement requires this on every insert.
       createdByUserId: userId,
     })
-    // Path-stable supersession trips mig 119's UNIQUE constraint until a
-    // follow-up partial-index migration lands; pass an alternate path
-    // per WorkspaceFileSupersedePatch docs.
+    // Rename variant — the history chain is what this test asserts, so the
+    // successor moves paths. (Path-stable supersession is exercised in
+    // workspace-files-supersession.integration.test.ts.)
     const f2 = await files.supersedeWorkspaceFile(userId, workspaceId, f1.id, {
       editorUserId: userId,
       storageUri: 'gs://bucket/draft.md-v2',

--- a/packages/api/src/db/__tests__/workspace-files-supersession.integration.test.ts
+++ b/packages/api/src/db/__tests__/workspace-files-supersession.integration.test.ts
@@ -7,14 +7,14 @@ import { randomUUID } from 'node:crypto'
  * WU-2.4 (workspace_files store update). Schema is mig 119 + mig 128;
  * supersession SQL lives in `workspace-files.ts`.
  *
- * Constraint blocker: `workspace_files` carries `UNIQUE (workspace_id,
- * path)` from mig 119 (not relaxed in mig 128). The SV(2) path-stable
- * supersession the spec calls for therefore cannot run end-to-end yet
- * — those variants are marked `it.todo()` until a follow-up migration
- * makes the constraint partial on `valid_to IS NULL`. The variants
- * here use a `path` override on the supersede patch so the successor
- * lands on a fresh path; that still exercises the full transactional
- * SQL (UPDATE old + INSERT new + chain wiring).
+ * Path uniqueness: mig 445 replaced mig 119's unscoped `UNIQUE
+ * (workspace_id, path)` with the partial `uq_workspace_files_current_path
+ * ... WHERE valid_to IS NULL`, so the key belongs to the CURRENT version
+ * only. That is what makes path-stable supersession and re-upload after a
+ * Brain delete possible; both are covered below alongside the still-live
+ * guarantee that two current rows cannot share a path. The older variants
+ * keep their `path` override on the patch — a rename is a real supersession
+ * shape and still exercises the same transactional SQL.
  *
  * Skips silently when the DB is unavailable or mig 128 hasn't applied.
  */
@@ -116,10 +116,10 @@ describeIf('[COMP:files/supersession] workspace_files supersession (integration)
   it('supersede closes the old window and inserts a successor', async () => {
     const v1 = await seedFile('/drafts/x.md', { tags: ['draft'], sizeBytes: 10 })
 
-    // Use a path override to dodge the mig-119 UNIQUE(workspace_id, path)
-    // constraint until the follow-up migration relaxes it. This still
-    // exercises the full supersession SQL — UPDATE old + INSERT new in
-    // one transaction, chain wiring, and the universal-column carry-over.
+    // Rename variant: the successor lands on a fresh path. Exercises the full
+    // supersession SQL — UPDATE old + INSERT new in one transaction, chain
+    // wiring, and the universal-column carry-over. The path-STABLE variant
+    // (mig 445) is covered separately below.
     const v2 = await store.supersede(userId, workspaceId, v1.id, {
       editorUserId: userId,
       storageUri: `gs://test/${workspaceId}/${randomUUID()}`,
@@ -144,6 +144,47 @@ describeIf('[COMP:files/supersession] workspace_files supersession (integration)
     )
     expect(old.rows[0].valid_to).not.toBeNull()
     expect(old.rows[0].superseded_by).toBe(v2!.id)
+  })
+
+  it('a soft-deleted file releases its path, so the same file can be uploaded again', async () => {
+    const v1 = await seedFile('/uploads/report.pdf')
+
+    // Exactly what DELETE /api/brain-inbox/:ws/workspace_file/:id writes.
+    await pool!.query(`UPDATE workspace_files SET valid_to = now() WHERE id = $1`, [v1.id])
+
+    // Before mig 445 this threw 23505: the row was gone from every
+    // current-version read (so the upload pre-checks waved it through) yet
+    // still owned the path, and the user could never re-upload the file they
+    // had just deleted.
+    const v2 = await seedFile('/uploads/report.pdf')
+    expect(v2.id).not.toBe(v1.id)
+    expect(v2.validTo).toBeNull()
+
+    const current = await store.getByPath(
+      { workspaceId, userId, assistantId: userId, assistantKind: 'standard' },
+      '/uploads/report.pdf',
+    )
+    expect(current?.id).toBe(v2.id)
+  })
+
+  it('two CURRENT rows still cannot share a path', async () => {
+    await seedFile('/uploads/dup.pdf')
+    await expect(seedFile('/uploads/dup.pdf')).rejects.toMatchObject({ code: '23505' })
+  })
+
+  it('supersession can keep the path (the successor claims it in the same transaction)', async () => {
+    const v1 = await seedFile('/drafts/stable.md', { sizeBytes: 10 })
+
+    const v2 = await store.supersede(userId, workspaceId, v1.id, {
+      editorUserId: userId,
+      storageUri: `gs://test/${workspaceId}/${randomUUID()}`,
+      sizeBytes: 20,
+    })
+
+    expect(v2).not.toBeNull()
+    expect(v2!.path).toBe('/drafts/stable.md')
+    expect(v2!.id).not.toBe(v1.id)
+    expect(v2!.validTo).toBeNull()
   })
 
   it('reads of superseded rows return null by default', async () => {
@@ -233,7 +274,29 @@ describeIf('[COMP:files/supersession] workspace_files supersession (integration)
     expect(current?.validTo).toBeNull()
   })
 
-  it.todo('path-stable supersession (SV(2) convention) — blocked by UNIQUE(workspace_id, path) on mig 119; needs follow-up migration to make the constraint partial on valid_to IS NULL')
+  it('a path-stable chain keeps three versions at one path, only the last current', async () => {
+    const v1 = await seedFile('/drafts/stable-chain.md', { sizeBytes: 1 })
+    const v2 = await store.supersede(userId, workspaceId, v1.id, {
+      editorUserId: userId,
+      storageUri: `gs://test/${workspaceId}/${randomUUID()}`,
+      sizeBytes: 2,
+    })
+    const v3 = await store.supersede(userId, workspaceId, v2!.id, {
+      editorUserId: userId,
+      storageUri: `gs://test/${workspaceId}/${randomUUID()}`,
+      sizeBytes: 3,
+    })
 
-  it.todo('path-stable transitive chain — blocked by the same UNIQUE constraint as the path-reuse single-step case')
+    const rows = await pool!.query<{ id: string; path: string; valid_to: Date | null }>(
+      `SELECT id, path, valid_to FROM workspace_files
+        WHERE workspace_id = $1 AND path = '/drafts/stable-chain.md'
+        ORDER BY valid_from`,
+      [workspaceId],
+    )
+    expect(rows.rows.map((r) => r.id)).toEqual([v1.id, v2!.id, v3!.id])
+    // Three rows share the path; exactly one is current, which is the whole
+    // point of scoping the unique index to `valid_to IS NULL`.
+    expect(rows.rows.filter((r) => r.valid_to === null)).toHaveLength(1)
+    expect(rows.rows[2].valid_to).toBeNull()
+  })
 })

--- a/packages/api/src/db/workspace-files.ts
+++ b/packages/api/src/db/workspace-files.ts
@@ -376,6 +376,33 @@ export async function deleteWorkspaceFile(
   return result.rows.length > 0
 }
 
+/**
+ * Close the derived `file_segments` of a file that just left the current
+ * bi-temporal window (soft delete).
+ *
+ * Every retrieval predicate reads the SEGMENT's own window — `visibilityPredicate`
+ * in `retrieval-store.ts` filters `fs.valid_to` / `fs.retracted_at` and never
+ * joins the parent `workspace_files` row. Closing only the file therefore drops
+ * it off the Brain list while leaving its extracted text fully searchable and
+ * readable: `searchFileContent`, `readFileSegmentRange` and the brain
+ * `file_segment` arm all keep answering from a file the user deleted. The
+ * hard-delete path never had this problem (mig 297's FK is
+ * `ON DELETE CASCADE`); only the soft path needs the explicit close.
+ *
+ * System-level (no RLS) — the caller has already proven workspace ownership.
+ * Mirrors the same cascade `supersedeWorkspaceFile` runs in-transaction and
+ * `retractWorkspaceFilesByStorageBucket` runs for the staleness sweep.
+ */
+export async function closeWorkspaceFileSegmentsSystem(fileId: string): Promise<number> {
+  const result = await query(
+    `UPDATE file_segments
+        SET valid_to = now()
+      WHERE file_id = $1 AND valid_to IS NULL`,
+    [fileId],
+  )
+  return result.rowCount ?? 0
+}
+
 export async function retractWorkspaceFilesByStorageBucket(
   workspaceId: string,
   bucket: string,
@@ -589,13 +616,12 @@ export async function sumWorkspaceFilesSizeBytes(
  * write lands without the other. RLS is engaged for the duration of
  * the transaction.
  *
- * NOTE: The legacy `UNIQUE (workspace_id, path)` constraint from mig
- * 119 blocks path-stable supersession — the old row still owns the
- * path until physically removed, so an INSERT with the same path
- * violates the constraint. A follow-up migration must relax this to
- * `UNIQUE (workspace_id, path) WHERE valid_to IS NULL`. Until then,
- * supersession only works when the patch changes the path or the
- * legacy row is independently moved aside.
+ * Path-stable supersession works because the `(workspace_id, path)`
+ * uniqueness is scoped to the current version — mig 445 replaced mig
+ * 119's unscoped `workspace_files_workspace_id_path_key` with the
+ * partial `uq_workspace_files_current_path ... WHERE valid_to IS NULL`.
+ * The close and the insert run in one transaction, so the old row has
+ * already left the current window when the successor claims the path.
  */
 export async function supersedeWorkspaceFile(
   userId: string,

--- a/packages/api/src/files/__tests__/files-api.test.ts
+++ b/packages/api/src/files/__tests__/files-api.test.ts
@@ -72,7 +72,12 @@ function makeFakeStore(): WorkspaceFilesStore & { rows: Map<string, WorkspaceFil
     async create(_userId, input: WorkspaceFileCreateInput) {
       for (const r of rows.values()) {
         if (r.workspaceId === input.workspaceId && r.path === input.path) {
-          const dupe = new Error('duplicate key value violates unique constraint "workspace_files_workspace_id_path_key"')
+          // Shaped like the real pg error — `code` is what the API classifies
+          // on, so a fake that omits it would test a violation that can't happen.
+          const dupe = Object.assign(
+            new Error('duplicate key value violates unique constraint "uq_workspace_files_current_path"'),
+            { code: '23505' },
+          )
           throw dupe
         }
       }
@@ -258,6 +263,31 @@ describe('[COMP:files/api] createFilesApi.write', () => {
     await expect(api.write(ctx, { path: '/r.md', content: 'data' })).rejects.toThrow('simulated DB failure')
     expect(gcs.blobs.size).toBe(0)
     expect(originalCreate).toBeDefined()
+  })
+
+  it('maps an insert-time unique violation to conflict, not a bare throw', async () => {
+    // The `getByPath` gate is a CURRENT-version, access-scoped read; the DB
+    // constraint is neither. A row the caller cannot see — one that left the
+    // current window between the check and the insert, or one above their
+    // clearance — passes the gate and still collides at INSERT. That has to
+    // answer `conflict` (which the surface can explain) rather than a 500.
+    const gcs = makeFakeGcs()
+    const store = makeFakeStore()
+    store.create = vi.fn(async () => {
+      throw Object.assign(
+        new Error('duplicate key value violates unique constraint "uq_workspace_files_current_path"'),
+        { code: '23505' },
+      )
+    }) as typeof store.create
+
+    const api = createFilesApi({ gcs, store, auditStore: makeFakeAudit(), bucket: 'b' })
+    const result = await api.write(ctx, { path: '/hidden.md', content: 'data' })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.kind).toBe('conflict')
+    }
+    // Blob rollback still runs — the bytes must not outlive the failed insert.
+    expect(gcs.blobs.size).toBe(0)
   })
 })
 

--- a/packages/api/src/files/files-api.ts
+++ b/packages/api/src/files/files-api.ts
@@ -166,6 +166,11 @@ function ok<T>(value: T): FilesResult<T> {
   return { ok: true, value }
 }
 
+/** Postgres `unique_violation`. Same test the chunked-upload completer uses. */
+function isUniqueViolation(e: unknown): boolean {
+  return Boolean(e && typeof e === 'object' && 'code' in e && (e as { code?: string }).code === '23505')
+}
+
 export type CreateFilesApiDeps = {
   store: WorkspaceFilesStore
   auditStore: WorkspaceAuditStore
@@ -310,6 +315,16 @@ export function createFilesApi(deps: CreateFilesApiDeps): FilesApi {
           `[files-api] write rollback failed for key=${storageKey} after DB insert failure:`,
           rollbackErr,
         )
+      }
+      // The `getByPath` gate above is a CURRENT-version, access-scoped read;
+      // the DB constraint is neither. A row the caller cannot see — one that
+      // left the current window between the check and the insert, or one
+      // above their clearance / outside their visibility axes — passes the
+      // gate and still collides. Answer the same `conflict` the gate answers
+      // rather than throwing to a bare 500, so the surface can say which
+      // path is taken instead of "Failed to store file".
+      if (isUniqueViolation(dbErr)) {
+        return err({ kind: 'conflict', path })
       }
       throw dbErr
     }

--- a/packages/api/src/routes/__tests__/brain-inbox.test.ts
+++ b/packages/api/src/routes/__tests__/brain-inbox.test.ts
@@ -773,7 +773,26 @@ describe('[COMP:api/brain-inbox-explain] Source descriptor', () => {
     expect(mockRejectTask).not.toHaveBeenCalled()
   })
 
-  it('DELETE of a non-task primitive runs no goal cascade', async () => {
+  it('DELETE of a workspace_file closes its derived file_segments (deleted content must stop being retrievable)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ workspace_id: WS }] } as never) // ownership
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never) // soft delete
+    mockQuery.mockResolvedValueOnce({ rowCount: 3 } as never) // segment cascade
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never) // brain_verifications audit
+
+    const res = await request(makeApp()).delete(`/api/brain-inbox/${WS}/workspace_file/${ROW}`)
+
+    expect(res.status).toBe(200)
+    // Retrieval reads the SEGMENT's own bi-temporal window, never the parent
+    // file's — closing workspace_files alone leaves the deleted file's text
+    // searchable through searchFileContent and the brain file_segment arm.
+    const cascade = mockQuery.mock.calls.find((c) => /UPDATE file_segments/.test(String(c[0])))
+    expect(cascade).toBeDefined()
+    expect(String(cascade?.[0])).toMatch(/valid_to = now\(\)/)
+    expect(String(cascade?.[0])).toMatch(/valid_to IS NULL/)
+    expect(cascade?.[1]).toEqual([ROW])
+  })
+
+  it('DELETE of a non-task primitive runs no goal cascade, and a non-file primitive no segment cascade', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ workspace_id: WS }] } as never) // ownership
     mockQuery.mockResolvedValueOnce({ rows: [] } as never) // soft delete
     mockQuery.mockResolvedValueOnce({ rows: [] } as never) // memory_verifications audit
@@ -783,6 +802,7 @@ describe('[COMP:api/brain-inbox-explain] Source descriptor', () => {
     expect(res.status).toBe(200)
     for (const call of mockQuery.mock.calls) {
       expect(String(call[0])).not.toMatch(/UPDATE goals/)
+      expect(String(call[0])).not.toMatch(/UPDATE file_segments/)
     }
   })
 

--- a/packages/api/src/routes/brain-inbox.ts
+++ b/packages/api/src/routes/brain-inbox.ts
@@ -48,6 +48,7 @@ import {
   abandonGoalsForHostTaskSystem,
   GOAL_TERMINAL_STATUSES,
 } from '../db/goals.js'
+import { closeWorkspaceFileSegmentsSystem } from '../db/workspace-files.js'
 import { rejectTask as rejectTaskWithReason } from '../db/task-admission-store.js'
 import {
   reclassifyEntityKind,
@@ -1295,6 +1296,17 @@ export function brainInboxRoutes({
           WHERE id = $1 AND valid_to IS NULL`,
         [rowId],
       )
+
+      // Derived-content cascade (files only): `file_segments` carry their OWN
+      // bi-temporal window and every retrieval predicate reads the segment's
+      // `valid_to`, never the parent file's. Closing `workspace_files` alone
+      // drops the file off the Brain list while leaving its extracted text
+      // fully searchable — so "I deleted that file" and "Brian still quotes it"
+      // were both true at once. See docs/architecture/features/files.md →
+      // "Deleting a file".
+      if (primitiveParam === 'workspace_file') {
+        await closeWorkspaceFileSegmentsSystem(rowId)
+      }
 
       // Host-lifecycle cascade (tasks only): `goals.host_id` is not a FK, so
       // nothing in the DB retires the goals bound to a task the user just

--- a/packages/core/src/workspace-files/types.ts
+++ b/packages/core/src/workspace-files/types.ts
@@ -168,12 +168,11 @@ export type WorkspaceFileSupersedePatch = {
   sizeBytes: number
   mime?: string
   /**
-   * Optional successor path. The SV(2) convention is path-stable
-   * (omit and the successor inherits the prior row's path); however
-   * mig 119's `UNIQUE (workspace_id, path)` is not yet partial on
-   * `valid_to IS NULL`, so path-stable supersession trips the
-   * constraint. Pass an alternate path to work around this until a
-   * follow-up migration relaxes the constraint.
+   * Optional successor path. The SV(2) convention is path-stable — omit
+   * and the successor inherits the prior row's path, which mig 445 made
+   * possible by scoping the `(workspace_id, path)` uniqueness to the
+   * current version (`WHERE valid_to IS NULL`). Pass a path only for a
+   * genuine rename.
    */
   path?: string
   parentPath?: string
@@ -189,9 +188,10 @@ export type WorkspaceFileSupersedePatch = {
 
 export type WorkspaceFilesStore = {
   /**
-   * Insert a row. Throws on UNIQUE(workspace_id, path) collision — the
-   * caller decides whether to surface as overwrite (delete + create) or
-   * a clear error.
+   * Insert a row. Throws pg `23505` on a collision with the CURRENT row
+   * at that path (`uq_workspace_files_current_path`, mig 445) — the caller
+   * decides whether to surface as overwrite (delete + create) or a clear
+   * error. Historical versions at the same path never collide.
    */
   create(userId: string, input: WorkspaceFileCreateInput): Promise<WorkspaceFile>
 
@@ -264,10 +264,10 @@ export type WorkspaceFilesStore = {
    * null if the source id has no current row.
    *
    * Called by the WU-6 staged_write approval flow when an iteration
-   * lands. The legacy UNIQUE(workspace_id, path) constraint on mig 119
-   * blocks path-stable supersession; a follow-up migration must make
-   * the constraint partial (`WHERE valid_to IS NULL`) before the SV(2)
-   * convention works end-to-end.
+   * lands. Path-stable per the SV(2) convention: the close and the insert
+   * share one transaction, and mig 445 scoped the `(workspace_id, path)`
+   * uniqueness to the current version, so the successor can claim the
+   * path the predecessor just released.
    */
   supersede(
     userId: string,


### PR DESCRIPTION
Deleting a file in Brain runs a generic soft delete on `workspace_files` (`valid_to = now()`) and stops there. Two things did not travel with that close, and each was independently invisible.

### 1. The path stayed claimed forever

`workspace_files` carried mig 119's unscoped `UNIQUE (workspace_id, path)`, written before the table had bi-temporal columns. A row that left the current window therefore owned its path permanently, while being invisible to everything that looks — both upload pre-checks call `getWorkspaceFileByPath`, which filters `valid_to IS NULL` **and** applies the caller's access predicate. The pre-check waved the upload through, the INSERT died on the constraint, and the user saw *"A file with that name already exists"* for a file no surface could show. Permanently, with no self-recovery path except renaming the file.

The same constraint is what blocked path-stable supersession (`WorkspaceFileSupersedePatch.path` existed only to dodge it).

**Migration 445** replaces it with the partial `uq_workspace_files_current_path ... WHERE valid_to IS NULL`. No dedup pre-pass is needed — the old constraint guarantees current rows are already unique (verified against production: 0 duplicate current paths).

### 2. The extracted text stayed searchable

`file_segments` carry their **own** bi-temporal window, and every retrieval predicate reads the segment's `valid_to` / `retracted_at` — `visibilityPredicate` in `retrieval-store.ts` never joins the parent row. Closing only `workspace_files` dropped the file off the Brain list while `searchFileContent`, `readFileSegmentRange` and the brain `file_segment` arm kept answering from it. "I deleted that file" and "Brian still quotes it" were both true.

The delete route now calls `closeWorkspaceFileSegmentsSystem(fileId)`, mirroring the cascade `supersedeWorkspaceFile` already runs in-transaction and `retractWorkspaceFilesByStorageBucket` runs for the BYO staleness sweep. (Hard delete never needed it — mig 297's FK is `ON DELETE CASCADE`.)

**Migration 447** repairs the files deleted before the cascade existed — nothing else ever revisits an already-closed file, so it is the only path that makes those deletes take effect. Segments take the **parent's** `valid_to`, not `now()`, so an `as_of` read of a past moment still sees what was live then. Idempotent by predicate.

### 3. A collision the caller cannot see must still answer honestly

`FilesApi.persist` now maps pg `23505` to the same `conflict` result its pre-check returns, instead of throwing to a bare 500. The pre-check can never be authoritative: it is narrower than the constraint on **both** the version axis and the caller's visibility/clearance axes. (The chunked-upload completer already did this.)

## Confirmed in production

Nine stuck paths platform-wide; four still hold live segments under a closed file, one with **183**. Zero duplicate current paths, so 445 applies cleanly.

## Tests

- brain-inbox delete cascades for `workspace_file`, and a negative case asserting no cascade for other primitives
- files-api: insert-time `23505` → `conflict`, blob rollback still runs (and the fake store now carries a real pg `code`, since that is what the API classifies on)
- integration (real Postgres, mig 445 applied): re-upload at a soft-deleted path succeeds; two **current** rows still collide; path-stable supersession; a three-version path-stable chain with exactly one current row — retiring the two `it.todo`s the old constraint had blocked since WU-2.4

`pnpm typecheck` clean · `pnpm smoke` OK · api suite green (one unrelated `computer.test.ts` flake, passes in isolation) · `pnpm check` shows no new violations from this diff.

Migration numbering: 446 is claimed by another in-flight branch (`446_custom_llm_profile_vision.sql`), hence 447.

Spec (platform repo, separate docs-only PR): `docs/architecture/features/files.md` → "Deleting a file".

🤖 Generated with [Claude Code](https://claude.com/claude-code)