### PR TITLE
fix(browser,files,chat): native select options chosen through the DOM; deleted files release path + segments; SSE post-flush refusal

### DIFF
--- a/apps/browser-extension/src/__tests__/executor.test.ts
+++ b/apps/browser-extension/src/__tests__/executor.test.ts
@@ -182,53 +182,187 @@ describe('[COMP:ext/agent] CDP attachment lifecycle', () => {
   })
 })
 
+/**
+ * Native `<select>` handling. The 2026-08-12 version of this suite asserted
+ * that clicking an option ref SENT `Home, ArrowDown x N, Enter` — and the
+ * mocked CDP boundary is exactly where that approach fails: the native popup
+ * those keys were meant to drive is not part of the page (an OS menu on
+ * macOS), so the value never moved and the executor still returned success.
+ * On 2026-08-19 an assistant filling a marathon entry form clicked option
+ * "18" three times, got "Clicked" each time, watched the dropdown stay on
+ * "Select", and told the user "clicking them does not change the selected
+ * value". These tests pin the DOM-selection contract instead: the option is
+ * marked selected on its owning select, `input` + `change` are dispatched,
+ * the value is VERIFIED, and no popup is ever opened.
+ */
 describe('[COMP:ext/agent] Native dropdown option clicks', () => {
-  it('selects an option through its owning select when the option has no box model', async () => {
-    const executor = new TabExecutor()
-    await executor.attach(42)
+  /** A CDP stub whose `Runtime.callFunctionOn` evaluates the executor's page
+   * function against a tiny fake `<option>` / `<select>` model, so the test
+   * proves what the injected code DOES rather than which strings it sends. */
+  function installSelectPage(opts: {
+    optionBackendNodeId?: number
+    disabled?: boolean
+    multiple?: boolean
+    /** Force `selectedIndex` to stay put after the assignment (a page that reverts). */
+    stuck?: boolean
+  } = {}) {
+    const optionId = opts.optionBackendNodeId ?? 7
+    const events: string[] = []
+    let selected = false
+    let selectedIndex = 0
+    class HTMLSelectElement {
+      multiple = opts.multiple ?? false
+      disabled = false
+      focused = false
+      get selectedIndex() { return selectedIndex }
+      focus() { this.focused = true }
+      dispatchEvent(event: { type: string }) { events.push(event.type); return true }
+    }
+    class HTMLOptionElement {
+      index = 3
+      label = '18'
+      text = '18'
+      value = '18'
+      disabled = opts.disabled ?? false
+      parentElement = { tagName: 'SELECT', disabled: false }
+      select = new HTMLSelectElement()
+      get selected() { return selected }
+      set selected(value: boolean) { selected = value; if (!opts.stuck && value && !this.select.multiple) selectedIndex = this.index }
+      closest(sel: string) { return sel === 'select' ? this.select : null }
+    }
+    const option = new HTMLOptionElement()
+    const select = option.select
+    ;(globalThis as unknown as { Event: unknown }).Event = class { constructor(public type: string, public init?: unknown) {} }
+    ;(globalThis as unknown as { HTMLSelectElement: unknown }).HTMLSelectElement = HTMLSelectElement
+    ;(globalThis as unknown as { HTMLOptionElement: unknown }).HTMLOptionElement = HTMLOptionElement
     dbg.sendCommand.mockImplementation(async (_target, method, params) => {
       if (method === 'Accessibility.getFullAXTree') {
         return {
           nodes: [
-            {
-              nodeId: 'station-option',
-              backendDOMNodeId: 7,
-              role: { value: 'option' },
-              name: { value: 'Olympic' },
-              ignored: false,
-            },
+            { nodeId: 'day', backendDOMNodeId: 6, role: { value: 'combobox' }, name: { value: 'Day' }, ignored: false },
+            { nodeId: 'day-18', backendDOMNodeId: optionId, role: { value: 'option' }, name: { value: '18' }, ignored: false },
           ],
         }
       }
-      if (method === 'DOM.scrollIntoViewIfNeeded' && params?.backendNodeId === 7) {
-        throw new Error('Could not compute box model.')
+      if (method === 'DOM.resolveNode') {
+        if (params?.backendNodeId === optionId) return { object: { objectId: 'option-object' } }
+        if (params?.backendNodeId === 6) return { object: { objectId: 'select-object' } }
+        return {}
       }
-      if (method === 'DOM.getBoxModel' && params?.backendNodeId === 7) {
-        throw new Error('Could not compute box model.')
+      if (method === 'Runtime.callFunctionOn') {
+        const self = params?.objectId === 'option-object' ? option : params?.objectId === 'select-object' ? select : null
+        // eslint-disable-next-line @typescript-eslint/no-implied-eval
+        const fn = new Function(`return (${String(params?.functionDeclaration)})`)() as (this: unknown) => unknown
+        return { result: { value: fn.call(self) } }
       }
-      if (method === 'DOM.resolveNode') return { object: { objectId: 'option-object' } }
-      if (method === 'Runtime.callFunctionOn' && params?.returnByValue === true) {
-        // Disabled line-heading options are excluded, so Olympic is the third selectable item.
-        return { result: { value: { disabled: false, enabledIndex: 2, multiple: false } } }
+      if (method === 'DOM.getBoxModel') throw new Error('Could not compute box model.')
+      return {}
+    })
+    return { events, select, option, get selectedIndex() { return selectedIndex } }
+  }
+
+  it('selects an option through the DOM, dispatches input+change, and verifies the value', async () => {
+    const page = installSelectPage()
+    const executor = new TabExecutor()
+    await executor.attach(42)
+    const snapshot = await executor.snapshot()
+    const optionRef = snapshot.nodes.find((n) => n.role === 'option')!.ref
+
+    await expect(executor.click(optionRef)).resolves.toBeUndefined()
+
+    expect(page.selectedIndex).toBe(3)
+    expect(page.events).toEqual(['input', 'change'])
+    expect(page.select.focused).toBe(true)
+    // No popup walk: no mouse events, no key events.
+    const inputCalls = dbg.sendCommand.mock.calls.filter((c) => String(c[1]).startsWith('Input.'))
+    expect(inputCalls).toHaveLength(0)
+  })
+
+  it('fails loudly when the page did not take the selection', async () => {
+    installSelectPage({ stuck: true })
+    const executor = new TabExecutor()
+    await executor.attach(42)
+    const snapshot = await executor.snapshot()
+    const optionRef = snapshot.nodes.find((n) => n.role === 'option')!.ref
+
+    const err = (await executor.click(optionRef).catch((e: unknown) => e)) as ExecutorError
+    expect(err).toBeInstanceOf(ExecutorError)
+    expect(err.message).toMatch(/did not change its dropdown/)
+    expect(err.message).toContain('"18"')
+    expect(err.message).toMatch(/fresh browserSnapshot/)
+  })
+
+  it('refuses a disabled option instead of pretending', async () => {
+    installSelectPage({ disabled: true })
+    const executor = new TabExecutor()
+    await executor.attach(42)
+    const snapshot = await executor.snapshot()
+    const optionRef = snapshot.nodes.find((n) => n.role === 'option')!.ref
+    const err = (await executor.click(optionRef).catch((e: unknown) => e)) as ExecutorError
+    expect(err.message).toBe(`Ref ${optionRef} is a disabled native dropdown option.`)
+  })
+
+  it('toggles an option of a multi-select', async () => {
+    const page = installSelectPage({ multiple: true })
+    const executor = new TabExecutor()
+    await executor.attach(42)
+    const snapshot = await executor.snapshot()
+    const optionRef = snapshot.nodes.find((n) => n.role === 'option')!.ref
+    await expect(executor.click(optionRef)).resolves.toBeUndefined()
+    expect(page.option.selected).toBe(true)
+    expect(page.events).toEqual(['input', 'change'])
+  })
+
+  it('focuses a native select on click instead of opening the popup', async () => {
+    installSelectPage()
+    const executor = new TabExecutor()
+    await executor.attach(42)
+    const snapshot = await executor.snapshot()
+    const selectRef = snapshot.nodes.find((n) => n.role === 'combobox')!.ref
+
+    await expect(executor.click(selectRef)).resolves.toBeUndefined()
+
+    const focus = dbg.sendCommand.mock.calls.filter((c) => c[1] === 'DOM.focus')
+    expect(focus).toHaveLength(1)
+    expect(focus[0]?.[2]).toMatchObject({ backendNodeId: 6 })
+    expect(dbg.sendCommand.mock.calls.filter((c) => c[1] === 'Input.dispatchMouseEvent')).toHaveLength(0)
+  })
+
+  it('refuses to type into a native select and names the remedy', async () => {
+    installSelectPage()
+    const executor = new TabExecutor()
+    await executor.attach(42)
+    const snapshot = await executor.snapshot()
+    const selectRef = snapshot.nodes.find((n) => n.role === 'combobox')!.ref
+
+    const err = (await executor.type(selectRef, '18').catch((e: unknown) => e)) as ExecutorError
+    expect(err).toBeInstanceOf(ExecutorError)
+    expect(err.message).toMatch(/is a dropdown/)
+    expect(err.message).toMatch(/browserClick on one of its option refs/)
+    expect(dbg.sendCommand.mock.calls.filter((c) => c[1] === 'Input.insertText')).toHaveLength(0)
+  })
+
+  it('still clicks a rendered ARIA combobox for real', async () => {
+    // A `[role=combobox]` <div> is not a <select>: the DOM-class probe says
+    // null and the ordinary click path (box model + mouse events) runs.
+    const executor = new TabExecutor()
+    await executor.attach(42)
+    dbg.sendCommand.mockImplementation(async (_target, method, params) => {
+      if (method === 'Accessibility.getFullAXTree') {
+        return { nodes: [{ nodeId: 'cb', backendDOMNodeId: 11, role: { value: 'combobox' }, name: { value: 'City' }, ignored: false }] }
       }
-      if (method === 'Runtime.callFunctionOn') return { result: { objectId: 'select-object' } }
-      if (method === 'DOM.describeNode') return { node: { backendNodeId: 8 } }
-      if (method === 'DOM.getBoxModel' && params?.backendNodeId === 8) {
+      if (method === 'DOM.resolveNode') return { object: { objectId: 'div-object' } }
+      if (method === 'Runtime.callFunctionOn') return { result: { value: null } }
+      if (method === 'DOM.getBoxModel' && params?.backendNodeId === 11) {
         return { model: { content: [0, 0, 100, 0, 100, 20, 0, 20] } }
       }
       return {}
     })
-
     const snapshot = await executor.snapshot()
     await expect(executor.click(snapshot.nodes[0]!.ref)).resolves.toBeUndefined()
-
-    const mouse = dbg.sendCommand.mock.calls.filter((call) => call[1] === 'Input.dispatchMouseEvent')
+    const mouse = dbg.sendCommand.mock.calls.filter((c) => c[1] === 'Input.dispatchMouseEvent')
     expect(mouse).toHaveLength(3)
     expect(mouse[1]?.[2]).toMatchObject({ type: 'mousePressed', x: 50, y: 10 })
-    const keys = dbg.sendCommand.mock.calls
-      .filter((call) => call[1] === 'Input.dispatchKeyEvent' && call[2]?.type === 'keyDown')
-      .map((call) => call[2]?.key)
-    expect(keys).toEqual(['Home', 'ArrowDown', 'ArrowDown', 'Enter'])
   })
 
   it('keeps an unresolved box-model failure actionable without claiming the page control is hidden', async () => {
@@ -254,35 +388,6 @@ describe('[COMP:ext/agent] Native dropdown option clicks', () => {
     )
     expect(err.message).not.toMatch(/box model/i)
     expect(err.message).not.toMatch(/not visible/i)
-  })
-
-  it('does not leak a box-model failure from the owning native select', async () => {
-    const executor = new TabExecutor()
-    await executor.attach(42)
-    dbg.sendCommand.mockImplementation(async (_target, method, params) => {
-      if (method === 'Accessibility.getFullAXTree') {
-        return {
-          nodes: [{
-            nodeId: 'station-option', backendDOMNodeId: 7, role: { value: 'option' },
-            name: { value: 'Olympic' }, ignored: false,
-          }],
-        }
-      }
-      if (method === 'DOM.getBoxModel') throw new Error('Could not compute box model.')
-      if (method === 'DOM.resolveNode') return { object: { objectId: 'option-object' } }
-      if (method === 'Runtime.callFunctionOn' && params?.returnByValue === true) {
-        return { result: { value: { disabled: false, enabledIndex: 0, multiple: false } } }
-      }
-      if (method === 'Runtime.callFunctionOn') return { result: { objectId: 'select-object' } }
-      if (method === 'DOM.describeNode') return { node: { backendNodeId: 8 } }
-      return {}
-    })
-
-    const snapshot = await executor.snapshot()
-    const err = (await executor.click(snapshot.nodes[0]!.ref).catch((error: unknown) => error)) as ExecutorError
-
-    expect(err.message).toMatch(/dropdown.*no usable rendered target/i)
-    expect(err.message).not.toMatch(/box model|not visible/i)
   })
 })
 

--- a/apps/browser-extension/src/executor.ts
+++ b/apps/browser-extension/src/executor.ts
@@ -104,6 +104,13 @@ const TAKEOVER_KEYS: Record<
   PageDown: { key: 'PageDown', code: 'PageDown', windowsVirtualKeyCode: 34 },
 }
 
+/**
+ * AX roles under which a ref may be a native `<select>` or one of its
+ * `<option>`s. Membership only gates the DOM-class check in
+ * `nativeSelectKind`; it never decides on its own.
+ */
+const NATIVE_SELECT_ROLES = new Set(['combobox', 'popupbutton', 'menulistpopup', 'option', 'listboxoption', 'menuitem'])
+
 async function sendCdp<T = unknown>(tabId: number, method: string, params?: Record<string, unknown>): Promise<T> {
   return (await chrome.debugger.sendCommand({ tabId }, method, params)) as T
 }
@@ -378,83 +385,112 @@ export class TabExecutor {
     }
   }
 
-  /** Native option popups have no page-layout box of their own in Chromium. */
-  private async clickNativeOption(tabId: number, backendNodeId: number, ref: string): Promise<void> {
+  /**
+   * Native `<select>` / `<option>` detection by DOM class, not by AX role: the
+   * `combobox` role is shared with ARIA widgets that need a real click, and an
+   * `option` role can belong to a custom listbox whose rows have real boxes.
+   */
+  private async nativeSelectKind(tabId: number, backendNodeId: number): Promise<'select' | 'option' | null> {
+    const objectGroup = 'use-brian-native-select-kind'
+    try {
+      const resolved = await this.cdp<{ object?: { objectId?: string } }>(tabId, 'DOM.resolveNode', {
+        backendNodeId,
+        objectGroup,
+      })
+      const objectId = resolved.object?.objectId
+      if (!objectId) return null
+      const result = await this.cdp<{ result?: { value?: unknown } }>(tabId, 'Runtime.callFunctionOn', {
+        objectId,
+        objectGroup,
+        returnByValue: true,
+        functionDeclaration: `function () {
+          if (this instanceof HTMLSelectElement) return 'select';
+          if (this instanceof HTMLOptionElement && this.closest('select')) return 'option';
+          return null;
+        }`,
+      })
+      const kind = result.result?.value
+      return kind === 'select' || kind === 'option' ? kind : null
+    } catch (err) {
+      if (isDetachedError(err)) throw err
+      return null
+    } finally {
+      await this.cdp(tabId, 'Runtime.releaseObjectGroup', { objectGroup }).catch(() => undefined)
+    }
+  }
+
+  /**
+   * Choose a native `<option>` through the DOM, the way Playwright's
+   * `selectOption` and Puppeteer's `page.select` do: mark it selected on the
+   * owning `<select>`, dispatch `input` + `change` so the page's listeners run,
+   * then VERIFY the control's value moved and fail loudly if it did not.
+   *
+   * Never through the popup. The native menu a `<select>` opens is not part of
+   * the page: on macOS it is an OS menu that `Input.dispatchKeyEvent` cannot
+   * reach at all, and on every platform it is not in the accessibility tree
+   * this executor snapshots. The previous keyboard walk (click the select,
+   * Home, ArrowDown x N, Enter) therefore left the value untouched, left the
+   * popup open on the user's screen, and still returned success - which is
+   * how an assistant came to tell a user "clicking them does not change the
+   * selected value" (2026-08-19). A verified DOM selection cannot fail
+   * silently.
+   */
+  private async selectNativeOption(tabId: number, backendNodeId: number, ref: string): Promise<void> {
+    const objectGroup = 'use-brian-native-option'
     const resolved = await this.cdp<{ object?: { objectId?: string } }>(tabId, 'DOM.resolveNode', {
       backendNodeId,
-      objectGroup: 'use-brian-native-option',
+      objectGroup,
     })
     const optionObjectId = resolved.object?.objectId
     if (!optionObjectId) {
       throw new ExecutorError(`Ref ${ref} is no longer attached to the page. Take a fresh browserSnapshot.`, 'stale_ref')
     }
     try {
-      const infoResult = await this.cdp<{ result?: { value?: unknown } }>(tabId, 'Runtime.callFunctionOn', {
+      const outcome = await this.cdp<{ result?: { value?: unknown } }>(tabId, 'Runtime.callFunctionOn', {
         objectId: optionObjectId,
+        objectGroup,
         returnByValue: true,
         functionDeclaration: `function () {
           const select = this.closest('select');
-          if (!select) return null;
-          const enabled = Array.from(select.options).filter((option) =>
-            !option.disabled && !(option.parentElement?.tagName === 'OPTGROUP' && option.parentElement.disabled)
-          );
-          return {
-            disabled: this.disabled || (this.parentElement?.tagName === 'OPTGROUP' && this.parentElement.disabled),
-            enabledIndex: enabled.indexOf(this),
-            multiple: select.multiple
-          };
+          if (!select) return { outcome: 'no_select' };
+          const group = this.parentElement;
+          const disabled = this.disabled || select.disabled ||
+            (group && group.tagName === 'OPTGROUP' && group.disabled);
+          if (disabled) return { outcome: 'disabled' };
+          const label = this.label || this.text || this.value;
+          if (select.multiple) {
+            const before = this.selected;
+            this.selected = !before;
+            select.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+            select.dispatchEvent(new Event('change', { bubbles: true }));
+            return { outcome: this.selected === !before ? 'selected' : 'unchanged', label, multiple: true, selected: this.selected };
+          }
+          if (typeof select.focus === 'function') select.focus();
+          this.selected = true;
+          select.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+          select.dispatchEvent(new Event('change', { bubbles: true }));
+          return { outcome: select.selectedIndex === this.index ? 'selected' : 'unchanged', label, multiple: false };
         }`,
       })
-      const info = infoResult.result?.value as {
-        disabled?: boolean
-        enabledIndex?: number
-        multiple?: boolean
-      } | null | undefined
-      if (!info || info.disabled || !Number.isInteger(info.enabledIndex) || info.enabledIndex! < 0) {
-        throw new ExecutorError(`Ref ${ref} is a disabled native dropdown option.`, 'backend_error')
+      const info = outcome.result?.value as
+        | { outcome?: string; label?: string; multiple?: boolean; selected?: boolean }
+        | null
+        | undefined
+      switch (info?.outcome) {
+        case 'selected':
+          return
+        case 'disabled':
+          throw new ExecutorError(`Ref ${ref} is a disabled native dropdown option.`, 'backend_error')
+        case 'no_select':
+          throw new ExecutorError(`Ref ${ref} has no selectable dropdown. Take a fresh browserSnapshot.`, 'stale_ref')
+        default:
+          throw new ExecutorError(
+            `Choosing option ${ref}${info?.label ? ` ("${info.label}")` : ''} did not change its dropdown. Take a fresh browserSnapshot and check the dropdown's current value before retrying.`,
+            'backend_error',
+          )
       }
-      if (info.multiple) {
-        throw new ExecutorError(`Ref ${ref} belongs to a multi-select control, which cannot be chosen with browserClick.`, 'backend_error')
-      }
-
-      const selectResult = await this.cdp<{ result?: { objectId?: string } }>(tabId, 'Runtime.callFunctionOn', {
-        objectId: optionObjectId,
-        functionDeclaration: `function () { return this.closest('select'); }`,
-      })
-      const selectObjectId = selectResult.result?.objectId
-      if (!selectObjectId) {
-        throw new ExecutorError(`Ref ${ref} has no selectable dropdown. Take a fresh browserSnapshot.`, 'stale_ref')
-      }
-      const described = await this.cdp<{ node?: { backendNodeId?: number } }>(tabId, 'DOM.describeNode', {
-        objectId: selectObjectId,
-      })
-      const selectBackendNodeId = described.node?.backendNodeId
-      if (typeof selectBackendNodeId !== 'number') {
-        throw new ExecutorError(`Ref ${ref} has no selectable dropdown. Take a fresh browserSnapshot.`, 'stale_ref')
-      }
-
-      const quad = await this.targetBox(tabId, selectBackendNodeId)
-      if (!quad) {
-        throw new ExecutorError(
-          `The dropdown for ref ${ref} has no usable rendered target. Take a fresh browserSnapshot and use the ref for the visible control.`,
-          'backend_error',
-        )
-      }
-      const x = (quad[0] + quad[4]) / 2
-      const y = (quad[1] + quad[5]) / 2
-      const base = { x, y, button: 'left', clickCount: 1 } as const
-      await this.cdp(tabId, 'Input.dispatchMouseEvent', { type: 'mouseMoved', x, y })
-      await this.cdp(tabId, 'Input.dispatchMouseEvent', { type: 'mousePressed', ...base })
-      await this.cdp(tabId, 'Input.dispatchMouseEvent', { type: 'mouseReleased', ...base })
-      await this.pressKey(tabId, 'Home')
-      for (let index = 0; index < info.enabledIndex!; index += 1) {
-        await this.pressKey(tabId, 'ArrowDown')
-      }
-      await this.pressKey(tabId, 'Enter')
     } finally {
-      await this.cdp(tabId, 'Runtime.releaseObjectGroup', {
-        objectGroup: 'use-brian-native-option',
-      }).catch(() => undefined)
+      await this.cdp(tabId, 'Runtime.releaseObjectGroup', { objectGroup }).catch(() => undefined)
     }
   }
 
@@ -480,11 +516,22 @@ export class TabExecutor {
     const tabId = this.mustTab()
     const backendNodeId = this.resolveRef(ref)
     const role = this.lastSnapshot?.nodes.find((node) => node.ref === ref)?.role
-    let quad = await this.targetBox(tabId, backendNodeId)
-    if (!quad && (role === 'option' || role === 'listboxoption')) {
-      await this.clickNativeOption(tabId, backendNodeId, ref)
-      return
+    if (role && NATIVE_SELECT_ROLES.has(role)) {
+      const kind = await this.nativeSelectKind(tabId, backendNodeId)
+      if (kind === 'option') {
+        await this.selectNativeOption(tabId, backendNodeId, ref)
+        return
+      }
+      if (kind === 'select') {
+        // A real click would open the native popup, which nothing here can
+        // drive or even see, and which stays open on the user's screen. The
+        // options are already in the snapshot: focus the control and let the
+        // caller click an option ref.
+        await this.cdp(tabId, 'DOM.focus', { backendNodeId })
+        return
+      }
     }
+    let quad = await this.targetBox(tabId, backendNodeId)
     if (!quad) {
       const associated = await this.resolveAssociatedTarget(tabId, backendNodeId, 'click')
       if (associated != null) quad = await this.targetBox(tabId, associated)
@@ -506,6 +553,15 @@ export class TabExecutor {
   async type(ref: string, text: string): Promise<void> {
     const tabId = this.mustTab()
     const backendNodeId = this.resolveRef(ref)
+    const role = this.lastSnapshot?.nodes.find((node) => node.ref === ref)?.role
+    if (role && NATIVE_SELECT_ROLES.has(role) && (await this.nativeSelectKind(tabId, backendNodeId)) === 'select') {
+      // `Input.insertText` into a `<select>` changes nothing and reports
+      // nothing; the earlier "Typed N characters" success was a lie.
+      throw new ExecutorError(
+        `Ref ${ref} is a dropdown, and typing has no effect on it. Choose a value with browserClick on one of its option refs (listed after the dropdown in the snapshot).`,
+        'backend_error',
+      )
+    }
     try {
       await this.cdp(tabId, 'DOM.focus', { backendNodeId })
     } catch (err) {

--- a/packages/api/migrations/445_workspace_files_current_path_unique.sql
+++ b/packages/api/migrations/445_workspace_files_current_path_unique.sql
@@ -1,0 +1,31 @@
+-- 445: workspace_files — scope the (workspace_id, path) uniqueness to the
+-- CURRENT bi-temporal version.
+--
+-- `workspace_files` is bi-temporal (`valid_to IS NULL` = current version), but
+-- the legacy constraint from mig 119 (`workspace_files_workspace_id_path_key`)
+-- was unscoped, so a row that LEFT the current window still owned its path
+-- forever: soft-deleted from the Brain drawer, superseded by a staged write, or
+-- retracted by the BYO-storage staleness sweep.
+--
+-- Every current-version read filters `valid_to IS NULL`, so such a row was
+-- invisible to the Brain list, invisible to the upload pre-checks
+-- (`getWorkspaceFileByPath` in both `filesApi.persist` and the chunked-upload
+-- start/complete gates) — and still fatal at INSERT. Re-uploading a file the
+-- user had just deleted failed with "A file with that name already exists",
+-- permanently, with nothing on any surface to explain it. The same constraint
+-- is what blocked path-stable supersession in `supersedeWorkspaceFile`.
+--
+-- No dedup pre-pass is needed: the unscoped constraint guarantees no two rows
+-- share (workspace_id, path) at all, so the narrower partial index cannot find
+-- a conflict among current rows.
+
+BEGIN;
+
+ALTER TABLE workspace_files
+  DROP CONSTRAINT IF EXISTS workspace_files_workspace_id_path_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_workspace_files_current_path
+  ON workspace_files (workspace_id, path)
+  WHERE valid_to IS NULL;
+
+COMMIT;

--- a/packages/api/migrations/447_close_segments_of_deleted_files.sql
+++ b/packages/api/migrations/447_close_segments_of_deleted_files.sql
@@ -1,0 +1,31 @@
+-- 447: close the `file_segments` left inside the current window by files that
+-- are already outside it.
+--
+-- The Brain drawer's delete soft-closed `workspace_files` only. Retrieval reads
+-- the SEGMENT's own bi-temporal window (`visibilityPredicate` in
+-- retrieval-store.ts never joins the parent row), so every file deleted before
+-- the cascade landed is still fully searchable through `searchFileContent`,
+-- `readFileSegmentRange` and the brain `file_segment` arm - the user deleted it
+-- and Brian keeps quoting it.
+--
+-- The code fix (`closeWorkspaceFileSegmentsSystem`, wired into the delete route)
+-- only covers deletes from here on; nothing else ever revisits an already-closed
+-- file, so this backfill is the only way those users get the delete they asked
+-- for. It is the invariant stated as SQL - a file outside the current window has
+-- no segments inside it - so it is safe to re-run and correct for every closing
+-- reason. Supersession and the BYO staleness sweep already cascade, so their
+-- segments are closed and the predicate skips them.
+--
+-- `valid_to` is set to the PARENT's `valid_to`, not `now()`, so an `as_of` read
+-- of a past moment still sees the segments that were live at that moment.
+
+BEGIN;
+
+UPDATE file_segments fs
+   SET valid_to = wf.valid_to
+  FROM workspace_files wf
+ WHERE fs.file_id = wf.id
+   AND wf.valid_to IS NOT NULL
+   AND fs.valid_to IS NULL;
+
+COMMIT;

--- a/packages/api/src/db/__tests__/row-history-store.integration.test.ts
+++ b/packages/api/src/db/__tests__/row-history-store.integration.test.ts
@@ -294,9 +294,9 @@ describeIf('[COMP:corrections/row-history] unified getRowHistory dispatch', () =
       // WU-4.5 authorship enforcement requires this on every insert.
       createdByUserId: userId,
     })
-    // Path-stable supersession trips mig 119's UNIQUE constraint until a
-    // follow-up partial-index migration lands; pass an alternate path
-    // per WorkspaceFileSupersedePatch docs.
+    // Rename variant — the history chain is what this test asserts, so the
+    // successor moves paths. (Path-stable supersession is exercised in
+    // workspace-files-supersession.integration.test.ts.)
     const f2 = await files.supersedeWorkspaceFile(userId, workspaceId, f1.id, {
       editorUserId: userId,
       storageUri: 'gs://bucket/draft.md-v2',

--- a/packages/api/src/db/__tests__/workspace-files-supersession.integration.test.ts
+++ b/packages/api/src/db/__tests__/workspace-files-supersession.integration.test.ts
@@ -7,14 +7,14 @@ import { randomUUID } from 'node:crypto'
  * WU-2.4 (workspace_files store update). Schema is mig 119 + mig 128;
  * supersession SQL lives in `workspace-files.ts`.
  *
- * Constraint blocker: `workspace_files` carries `UNIQUE (workspace_id,
- * path)` from mig 119 (not relaxed in mig 128). The SV(2) path-stable
- * supersession the spec calls for therefore cannot run end-to-end yet
- * — those variants are marked `it.todo()` until a follow-up migration
- * makes the constraint partial on `valid_to IS NULL`. The variants
- * here use a `path` override on the supersede patch so the successor
- * lands on a fresh path; that still exercises the full transactional
- * SQL (UPDATE old + INSERT new + chain wiring).
+ * Path uniqueness: mig 445 replaced mig 119's unscoped `UNIQUE
+ * (workspace_id, path)` with the partial `uq_workspace_files_current_path
+ * ... WHERE valid_to IS NULL`, so the key belongs to the CURRENT version
+ * only. That is what makes path-stable supersession and re-upload after a
+ * Brain delete possible; both are covered below alongside the still-live
+ * guarantee that two current rows cannot share a path. The older variants
+ * keep their `path` override on the patch — a rename is a real supersession
+ * shape and still exercises the same transactional SQL.
  *
  * Skips silently when the DB is unavailable or mig 128 hasn't applied.
  */
@@ -116,10 +116,10 @@ describeIf('[COMP:files/supersession] workspace_files supersession (integration)
   it('supersede closes the old window and inserts a successor', async () => {
     const v1 = await seedFile('/drafts/x.md', { tags: ['draft'], sizeBytes: 10 })
 
-    // Use a path override to dodge the mig-119 UNIQUE(workspace_id, path)
-    // constraint until the follow-up migration relaxes it. This still
-    // exercises the full supersession SQL — UPDATE old + INSERT new in
-    // one transaction, chain wiring, and the universal-column carry-over.
+    // Rename variant: the successor lands on a fresh path. Exercises the full
+    // supersession SQL — UPDATE old + INSERT new in one transaction, chain
+    // wiring, and the universal-column carry-over. The path-STABLE variant
+    // (mig 445) is covered separately below.
     const v2 = await store.supersede(userId, workspaceId, v1.id, {
       editorUserId: userId,
       storageUri: `gs://test/${workspaceId}/${randomUUID()}`,
@@ -144,6 +144,47 @@ describeIf('[COMP:files/supersession] workspace_files supersession (integration)
     )
     expect(old.rows[0].valid_to).not.toBeNull()
     expect(old.rows[0].superseded_by).toBe(v2!.id)
+  })
+
+  it('a soft-deleted file releases its path, so the same file can be uploaded again', async () => {
+    const v1 = await seedFile('/uploads/report.pdf')
+
+    // Exactly what DELETE /api/brain-inbox/:ws/workspace_file/:id writes.
+    await pool!.query(`UPDATE workspace_files SET valid_to = now() WHERE id = $1`, [v1.id])
+
+    // Before mig 445 this threw 23505: the row was gone from every
+    // current-version read (so the upload pre-checks waved it through) yet
+    // still owned the path, and the user could never re-upload the file they
+    // had just deleted.
+    const v2 = await seedFile('/uploads/report.pdf')
+    expect(v2.id).not.toBe(v1.id)
+    expect(v2.validTo).toBeNull()
+
+    const current = await store.getByPath(
+      { workspaceId, userId, assistantId: userId, assistantKind: 'standard' },
+      '/uploads/report.pdf',
+    )
+    expect(current?.id).toBe(v2.id)
+  })
+
+  it('two CURRENT rows still cannot share a path', async () => {
+    await seedFile('/uploads/dup.pdf')
+    await expect(seedFile('/uploads/dup.pdf')).rejects.toMatchObject({ code: '23505' })
+  })
+
+  it('supersession can keep the path (the successor claims it in the same transaction)', async () => {
+    const v1 = await seedFile('/drafts/stable.md', { sizeBytes: 10 })
+
+    const v2 = await store.supersede(userId, workspaceId, v1.id, {
+      editorUserId: userId,
+      storageUri: `gs://test/${workspaceId}/${randomUUID()}`,
+      sizeBytes: 20,
+    })
+
+    expect(v2).not.toBeNull()
+    expect(v2!.path).toBe('/drafts/stable.md')
+    expect(v2!.id).not.toBe(v1.id)
+    expect(v2!.validTo).toBeNull()
   })
 
   it('reads of superseded rows return null by default', async () => {
@@ -233,7 +274,29 @@ describeIf('[COMP:files/supersession] workspace_files supersession (integration)
     expect(current?.validTo).toBeNull()
   })
 
-  it.todo('path-stable supersession (SV(2) convention) — blocked by UNIQUE(workspace_id, path) on mig 119; needs follow-up migration to make the constraint partial on valid_to IS NULL')
+  it('a path-stable chain keeps three versions at one path, only the last current', async () => {
+    const v1 = await seedFile('/drafts/stable-chain.md', { sizeBytes: 1 })
+    const v2 = await store.supersede(userId, workspaceId, v1.id, {
+      editorUserId: userId,
+      storageUri: `gs://test/${workspaceId}/${randomUUID()}`,
+      sizeBytes: 2,
+    })
+    const v3 = await store.supersede(userId, workspaceId, v2!.id, {
+      editorUserId: userId,
+      storageUri: `gs://test/${workspaceId}/${randomUUID()}`,
+      sizeBytes: 3,
+    })
 
-  it.todo('path-stable transitive chain — blocked by the same UNIQUE constraint as the path-reuse single-step case')
+    const rows = await pool!.query<{ id: string; path: string; valid_to: Date | null }>(
+      `SELECT id, path, valid_to FROM workspace_files
+        WHERE workspace_id = $1 AND path = '/drafts/stable-chain.md'
+        ORDER BY valid_from`,
+      [workspaceId],
+    )
+    expect(rows.rows.map((r) => r.id)).toEqual([v1.id, v2!.id, v3!.id])
+    // Three rows share the path; exactly one is current, which is the whole
+    // point of scoping the unique index to `valid_to IS NULL`.
+    expect(rows.rows.filter((r) => r.valid_to === null)).toHaveLength(1)
+    expect(rows.rows[2].valid_to).toBeNull()
+  })
 })

--- a/packages/api/src/db/workspace-files.ts
+++ b/packages/api/src/db/workspace-files.ts
@@ -376,6 +376,33 @@ export async function deleteWorkspaceFile(
   return result.rows.length > 0
 }
 
+/**
+ * Close the derived `file_segments` of a file that just left the current
+ * bi-temporal window (soft delete).
+ *
+ * Every retrieval predicate reads the SEGMENT's own window — `visibilityPredicate`
+ * in `retrieval-store.ts` filters `fs.valid_to` / `fs.retracted_at` and never
+ * joins the parent `workspace_files` row. Closing only the file therefore drops
+ * it off the Brain list while leaving its extracted text fully searchable and
+ * readable: `searchFileContent`, `readFileSegmentRange` and the brain
+ * `file_segment` arm all keep answering from a file the user deleted. The
+ * hard-delete path never had this problem (mig 297's FK is
+ * `ON DELETE CASCADE`); only the soft path needs the explicit close.
+ *
+ * System-level (no RLS) — the caller has already proven workspace ownership.
+ * Mirrors the same cascade `supersedeWorkspaceFile` runs in-transaction and
+ * `retractWorkspaceFilesByStorageBucket` runs for the staleness sweep.
+ */
+export async function closeWorkspaceFileSegmentsSystem(fileId: string): Promise<number> {
+  const result = await query(
+    `UPDATE file_segments
+        SET valid_to = now()
+      WHERE file_id = $1 AND valid_to IS NULL`,
+    [fileId],
+  )
+  return result.rowCount ?? 0
+}
+
 export async function retractWorkspaceFilesByStorageBucket(
   workspaceId: string,
   bucket: string,
@@ -589,13 +616,12 @@ export async function sumWorkspaceFilesSizeBytes(
  * write lands without the other. RLS is engaged for the duration of
  * the transaction.
  *
- * NOTE: The legacy `UNIQUE (workspace_id, path)` constraint from mig
- * 119 blocks path-stable supersession — the old row still owns the
- * path until physically removed, so an INSERT with the same path
- * violates the constraint. A follow-up migration must relax this to
- * `UNIQUE (workspace_id, path) WHERE valid_to IS NULL`. Until then,
- * supersession only works when the patch changes the path or the
- * legacy row is independently moved aside.
+ * Path-stable supersession works because the `(workspace_id, path)`
+ * uniqueness is scoped to the current version — mig 445 replaced mig
+ * 119's unscoped `workspace_files_workspace_id_path_key` with the
+ * partial `uq_workspace_files_current_path ... WHERE valid_to IS NULL`.
+ * The close and the insert run in one transaction, so the old row has
+ * already left the current window when the successor claims the path.
  */
 export async function supersedeWorkspaceFile(
   userId: string,

--- a/packages/api/src/files/__tests__/files-api.test.ts
+++ b/packages/api/src/files/__tests__/files-api.test.ts
@@ -72,7 +72,12 @@ function makeFakeStore(): WorkspaceFilesStore & { rows: Map<string, WorkspaceFil
     async create(_userId, input: WorkspaceFileCreateInput) {
       for (const r of rows.values()) {
         if (r.workspaceId === input.workspaceId && r.path === input.path) {
-          const dupe = new Error('duplicate key value violates unique constraint "workspace_files_workspace_id_path_key"')
+          // Shaped like the real pg error — `code` is what the API classifies
+          // on, so a fake that omits it would test a violation that can't happen.
+          const dupe = Object.assign(
+            new Error('duplicate key value violates unique constraint "uq_workspace_files_current_path"'),
+            { code: '23505' },
+          )
           throw dupe
         }
       }
@@ -258,6 +263,31 @@ describe('[COMP:files/api] createFilesApi.write', () => {
     await expect(api.write(ctx, { path: '/r.md', content: 'data' })).rejects.toThrow('simulated DB failure')
     expect(gcs.blobs.size).toBe(0)
     expect(originalCreate).toBeDefined()
+  })
+
+  it('maps an insert-time unique violation to conflict, not a bare throw', async () => {
+    // The `getByPath` gate is a CURRENT-version, access-scoped read; the DB
+    // constraint is neither. A row the caller cannot see — one that left the
+    // current window between the check and the insert, or one above their
+    // clearance — passes the gate and still collides at INSERT. That has to
+    // answer `conflict` (which the surface can explain) rather than a 500.
+    const gcs = makeFakeGcs()
+    const store = makeFakeStore()
+    store.create = vi.fn(async () => {
+      throw Object.assign(
+        new Error('duplicate key value violates unique constraint "uq_workspace_files_current_path"'),
+        { code: '23505' },
+      )
+    }) as typeof store.create
+
+    const api = createFilesApi({ gcs, store, auditStore: makeFakeAudit(), bucket: 'b' })
+    const result = await api.write(ctx, { path: '/hidden.md', content: 'data' })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.kind).toBe('conflict')
+    }
+    // Blob rollback still runs — the bytes must not outlive the failed insert.
+    expect(gcs.blobs.size).toBe(0)
   })
 })
 

--- a/packages/api/src/files/files-api.ts
+++ b/packages/api/src/files/files-api.ts
@@ -166,6 +166,11 @@ function ok<T>(value: T): FilesResult<T> {
   return { ok: true, value }
 }
 
+/** Postgres `unique_violation`. Same test the chunked-upload completer uses. */
+function isUniqueViolation(e: unknown): boolean {
+  return Boolean(e && typeof e === 'object' && 'code' in e && (e as { code?: string }).code === '23505')
+}
+
 export type CreateFilesApiDeps = {
   store: WorkspaceFilesStore
   auditStore: WorkspaceAuditStore
@@ -310,6 +315,16 @@ export function createFilesApi(deps: CreateFilesApiDeps): FilesApi {
           `[files-api] write rollback failed for key=${storageKey} after DB insert failure:`,
           rollbackErr,
         )
+      }
+      // The `getByPath` gate above is a CURRENT-version, access-scoped read;
+      // the DB constraint is neither. A row the caller cannot see — one that
+      // left the current window between the check and the insert, or one
+      // above their clearance / outside their visibility axes — passes the
+      // gate and still collides. Answer the same `conflict` the gate answers
+      // rather than throwing to a bare 500, so the surface can say which
+      // path is taken instead of "Failed to store file".
+      if (isUniqueViolation(dbErr)) {
+        return err({ kind: 'conflict', path })
       }
       throw dbErr
     }

--- a/packages/api/src/routes/__tests__/brain-inbox.test.ts
+++ b/packages/api/src/routes/__tests__/brain-inbox.test.ts
@@ -773,7 +773,26 @@ describe('[COMP:api/brain-inbox-explain] Source descriptor', () => {
     expect(mockRejectTask).not.toHaveBeenCalled()
   })
 
-  it('DELETE of a non-task primitive runs no goal cascade', async () => {
+  it('DELETE of a workspace_file closes its derived file_segments (deleted content must stop being retrievable)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ workspace_id: WS }] } as never) // ownership
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never) // soft delete
+    mockQuery.mockResolvedValueOnce({ rowCount: 3 } as never) // segment cascade
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never) // brain_verifications audit
+
+    const res = await request(makeApp()).delete(`/api/brain-inbox/${WS}/workspace_file/${ROW}`)
+
+    expect(res.status).toBe(200)
+    // Retrieval reads the SEGMENT's own bi-temporal window, never the parent
+    // file's — closing workspace_files alone leaves the deleted file's text
+    // searchable through searchFileContent and the brain file_segment arm.
+    const cascade = mockQuery.mock.calls.find((c) => /UPDATE file_segments/.test(String(c[0])))
+    expect(cascade).toBeDefined()
+    expect(String(cascade?.[0])).toMatch(/valid_to = now\(\)/)
+    expect(String(cascade?.[0])).toMatch(/valid_to IS NULL/)
+    expect(cascade?.[1]).toEqual([ROW])
+  })
+
+  it('DELETE of a non-task primitive runs no goal cascade, and a non-file primitive no segment cascade', async () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ workspace_id: WS }] } as never) // ownership
     mockQuery.mockResolvedValueOnce({ rows: [] } as never) // soft delete
     mockQuery.mockResolvedValueOnce({ rows: [] } as never) // memory_verifications audit
@@ -783,6 +802,7 @@ describe('[COMP:api/brain-inbox-explain] Source descriptor', () => {
     expect(res.status).toBe(200)
     for (const call of mockQuery.mock.calls) {
       expect(String(call[0])).not.toMatch(/UPDATE goals/)
+      expect(String(call[0])).not.toMatch(/UPDATE file_segments/)
     }
   })
 

--- a/packages/api/src/routes/__tests__/chat-provider-resolution.test.ts
+++ b/packages/api/src/routes/__tests__/chat-provider-resolution.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { resolveWorkspaceTurnLlm } from '../chat.js'
+import { ChatTurnRefusal, chatTurnErrorEvent, customModelMediaRefusal, resolveWorkspaceTurnLlm } from '../chat.js'
+import { CUSTOM_MODEL_IMAGE_REJECTION } from '../_channel-error-text.js'
 
 describe('[COMP:api/chat-route] workspace provider precedence', () => {
   it('uses a valid custom endpoint without touching stale legacy BYO settings', async () => {
@@ -43,5 +44,57 @@ describe('[COMP:api/chat-route] workspace provider precedence', () => {
       resolveLegacyByoKey: vi.fn().mockRejectedValue(error),
       buildLegacyByoProvider: vi.fn() as never,
     })).rejects.toThrow(error)
+  })
+})
+
+describe('[COMP:api/chat-route] post-SSE turn refusals', () => {
+  // The chat route flushes `text/event-stream` headers a few lines into the
+  // handler, so `res.status(...).json(...)` past that point is not a reply,
+  // it is an ERR_HTTP_HEADERS_SENT throw that the outer catch flattens into
+  // "Something went wrong". That is how a workspace whose tiers all route to
+  // a text-only custom endpoint got a generic red banner instead of the one
+  // sentence explaining why its screenshots were refused (2026-08-19).
+  it('renders a refusal with its own code and sentence, not the generic banner', () => {
+    const refusal = new ChatTurnRefusal('metered_at_cap', 'Add credits to use this model.', {
+      usedCredits: 42,
+    })
+    expect(chatTurnErrorEvent(refusal)).toEqual({
+      code: 'metered_at_cap',
+      error: 'Add credits to use this model.',
+      usedCredits: 42,
+    })
+  })
+
+  it('still says nothing specific about an unknown crash', () => {
+    expect(chatTurnErrorEvent(new Error('Cannot set headers after they are sent to the client')))
+      .toEqual({ error: 'Something went wrong' })
+    expect(chatTurnErrorEvent('not even an error')).toEqual({ error: 'Something went wrong' })
+  })
+
+  // A tier route captures every built-in in the model picker, so the old copy
+  // ("choose a built-in model") named a recovery step that workspace does not
+  // have. Only an explicit `custom:<id>` pick can be undone that way.
+  it('points a tier-routed workspace at Settings rather than the model picker', () => {
+    const viaTierRoute = customModelMediaRefusal(false)
+    expect(viaTierRoute.code).toBe('custom_model_media_unsupported')
+    expect(viaTierRoute.message).toMatch(/Settings > Models/)
+    expect(viaTierRoute.message).not.toMatch(/choose a built-in model/)
+    // One sentence across every surface: a channel turn reaches the endpoint
+    // the same way (tier route) and must not learn a second wording.
+    expect(viaTierRoute.message).toBe(CUSTOM_MODEL_IMAGE_REJECTION)
+  })
+
+  it('offers the model picker when the custom endpoint was picked for this turn', () => {
+    expect(customModelMediaRefusal(true).message).toMatch(/choose a built-in model/)
+  })
+
+  // Every user-facing string in this file goes out verbatim over SSE.
+  it('keeps em dashes out of the refusal copy', () => {
+    for (const message of [
+      customModelMediaRefusal(true).message,
+      customModelMediaRefusal(false).message,
+    ]) {
+      expect(message).not.toContain('—')
+    }
   })
 })

--- a/packages/api/src/routes/__tests__/telegram-byo.test.ts
+++ b/packages/api/src/routes/__tests__/telegram-byo.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import request from 'supertest'
 import { createTestApp } from './helpers.js'
 import { TelegramApiError } from '@use-brian/channels'
+import { CUSTOM_MODEL_IMAGE_REJECTION } from '../_channel-error-text.js'
 
 /**
  * [COMP:api/telegram-byo-route]
@@ -354,9 +355,10 @@ describe('[COMP:api/telegram-byo-route] safe error delivery', () => {
   }
 
   it('explains that a custom text-only model cannot inspect an inbound image', async () => {
-    pipelineError = new Error(
-      'Custom model endpoints currently support text and tools only. Remove the inline image or use the web app to choose a built-in model.',
-    )
+    // The one shared copy of this sentence — matched by identity in
+    // `channelUserErrorText`, so a literal here would drift out of the
+    // whitelist the moment the copy is corrected (it was, on 2026-08-19).
+    pipelineError = new Error(CUSTOM_MODEL_IMAGE_REJECTION)
 
     await postUpdate(makeApp(), {
       update_id: 700,

--- a/packages/api/src/routes/_channel-error-text.ts
+++ b/packages/api/src/routes/_channel-error-text.ts
@@ -23,8 +23,16 @@
  * Spec: docs/architecture/platform/byo-llm-key.md → "Strict fallback and
  * attachments".
  */
+/**
+ * A channel turn never carries an explicit `custom:<id>` selection, so it
+ * reaches a custom endpoint through the workspace's TIER ROUTE - and a tier
+ * route captures every built-in model in the picker too. "Use the web app to
+ * choose a built-in model", the wording this constant carried until
+ * 2026-08-19, therefore sent the user somewhere that refuses the same image
+ * for the same reason. Name the setting that actually lifts the restriction.
+ */
 export const CUSTOM_MODEL_IMAGE_REJECTION =
-  'Custom model endpoints currently support text and tools only. Remove the inline image or use the web app to choose a built-in model.'
+  'This workspace routes its models to a custom endpoint, which supports text and tools only. Send the message without the image, or point this tier at a built-in model in Settings > Models.'
 
 export function channelUserErrorText(
   err: Error,

--- a/packages/api/src/routes/brain-inbox.ts
+++ b/packages/api/src/routes/brain-inbox.ts
@@ -48,6 +48,7 @@ import {
   abandonGoalsForHostTaskSystem,
   GOAL_TERMINAL_STATUSES,
 } from '../db/goals.js'
+import { closeWorkspaceFileSegmentsSystem } from '../db/workspace-files.js'
 import { rejectTask as rejectTaskWithReason } from '../db/task-admission-store.js'
 import {
   reclassifyEntityKind,
@@ -1295,6 +1296,17 @@ export function brainInboxRoutes({
           WHERE id = $1 AND valid_to IS NULL`,
         [rowId],
       )
+
+      // Derived-content cascade (files only): `file_segments` carry their OWN
+      // bi-temporal window and every retrieval predicate reads the segment's
+      // `valid_to`, never the parent file's. Closing `workspace_files` alone
+      // drops the file off the Brain list while leaving its extracted text
+      // fully searchable — so "I deleted that file" and "Brian still quotes it"
+      // were both true at once. See docs/architecture/features/files.md →
+      // "Deleting a file".
+      if (primitiveParam === 'workspace_file') {
+        await closeWorkspaceFileSegmentsSystem(rowId)
+      }
 
       // Host-lifecycle cascade (tasks only): `goals.host_id` is not a FK, so
       // nothing in the DB retires the goals bound to a task the user just

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -56,6 +56,7 @@ import { registryRow } from '@use-brian/shared/model-registry'
 import type { ConnectorStore } from '../db/connector-store.js'
 import { getToolDisplayName, stripFollowUps, stripCommentThreadReplyTag, resolveCharter, charterMission } from '@use-brian/shared'
 import { listActivePlaybookRules } from '../db/playbook-store.js'
+import { CUSTOM_MODEL_IMAGE_REJECTION } from './_channel-error-text.js'
 import { resolveUser, buildBrowserEscalationPrompt, buildUnavailableCapabilitiesPrompt, injectSkills, isSkillOfferable, checkUsageBudget, applyMcpInjection, type CreditBudgetGate } from './route-helpers.js'
 import { createDocRunClient } from '../doc/run-presence-client.js'
 import type { AssistantRunChannel } from '@use-brian/doc-model'
@@ -1607,6 +1608,86 @@ const roomTurnAddressers = new Map<string, string>()
  * `sessions.ts` cannot import this module without closing an ESM cycle.
  */
 export { mayAssistantAnswerInRoom }
+
+/**
+ * A refusal raised AFTER the SSE headers are on the wire.
+ *
+ * The chat route flushes `text/event-stream` headers within a few lines of
+ * entry, so from that point on `res.status(...).json(...)` is not a response,
+ * it is a throw: Express calls `setHeader` on an already-committed response
+ * and Node raises `ERR_HTTP_HEADERS_SENT`. The outer catch then does what it
+ * does with any unknown crash and sends `Something went wrong`, which is the
+ * exact opposite of what a capability refusal owes the user. That is how a
+ * workspace on a text-only custom endpoint saw a generic red banner instead
+ * of "this endpoint takes text and tools only" when it attached a screenshot
+ * (2026-08-19, twice in fifteen minutes, once in a workspace room).
+ *
+ * So a post-flush refusal THROWS this instead of answering with a status.
+ * It deliberately reuses the outer catch rather than adding a second exit:
+ * that path already pairs `turn_started` with `turn_completed`, releases the
+ * turn lease, flips the session back to idle, and ends the response. A
+ * hand-rolled `sendEvent` + `return` beside it would be another one of the
+ * "two paths you happened to think of" that left a room locked for half an
+ * hour on 2026-08-08. The catch only has to render this one differently.
+ *
+ * `code` is the machine-readable reason the client may branch on; `message`
+ * is the sentence the user reads; `detail` carries any extra fields the
+ * pre-SSE JSON body used to include (an estimate, the credits at the cap).
+ */
+export class ChatTurnRefusal extends Error {
+  readonly code: string
+  readonly detail: Record<string, unknown>
+  constructor(code: string, message: string, detail: Record<string, unknown> = {}) {
+    super(message)
+    this.name = 'ChatTurnRefusal'
+    this.code = code
+    this.detail = detail
+  }
+}
+
+/**
+ * The `error` SSE payload for whatever reached the outer catch.
+ *
+ * A refusal keeps its own sentence and code; anything else stays the generic
+ * banner, because an unknown crash has nothing safe to say. Pure, so the
+ * distinction is testable without standing up the streaming handler.
+ */
+export function chatTurnErrorEvent(err: unknown): Record<string, unknown> {
+  if (err instanceof ChatTurnRefusal) {
+    return { code: err.code, error: err.message, ...err.detail }
+  }
+  return { error: 'Something went wrong' }
+}
+
+/**
+ * Refusal for an inline image on a workspace custom endpoint.
+ *
+ * The recovery step differs by how the endpoint was reached, and only one of
+ * the two is ever real:
+ *
+ *   - an explicit `custom:<id>` pick is this turn's own choice, so choosing a
+ *     built-in model for the next message undoes it;
+ *   - a TIER ROUTE captures the tier the model picker resolves to, so every
+ *     built-in in the menu lands back on the same endpoint. Telling that user
+ *     to "choose a built-in model" sends them around a loop with no exit. The
+ *     route is workspace configuration, so the exits are Settings, or sending
+ *     without the image.
+ *
+ * The refusal itself is the spec (byo-llm-key.md, "Strict fallback and
+ * attachments"): a text-only endpoint must never silently forward image bytes,
+ * and must never quietly fall back to a platform provider the workspace admin
+ * did not choose.
+ */
+export function customModelMediaRefusal(explicitCustomSelection: boolean): ChatTurnRefusal {
+  return new ChatTurnRefusal(
+    'custom_model_media_unsupported',
+    explicitCustomSelection
+      ? 'Custom model endpoints currently support text and tools only. Remove the image, or choose a built-in model for this message.'
+      // The tier-route case is the one every channel also hits, so it reuses
+      // the single shared sentence rather than growing a second wording.
+      : CUSTOM_MODEL_IMAGE_REJECTION,
+  )
+}
 
 /** Atomically claim a room session's turn slot. True = we own the turn. */
 async function claimRoomTurn(sessionId: string): Promise<boolean> {
@@ -5290,18 +5371,22 @@ export function chatRoutes(options: WebChatOptions): Router {
         const meteredRow = registryRow(requestedModel!)
         if (meteredRow?.class === 'metered') {
           if (options.meteredModelsAvailable && !options.meteredModelsAvailable.has(meteredRow.alias)) {
-            res.status(400).json({ error: 'model_unavailable', message: 'This model is not available on this deployment.' })
-            return
+            throw new ChatTurnRefusal('model_unavailable', 'This model is not available on this deployment.')
           }
           if (budgetStatus !== 'ok') {
-            res.status(402).json({ error: 'metered_at_cap', message: 'Metered models need available credits. Add an extra usage pack or upgrade the plan.' })
-            return
+            throw new ChatTurnRefusal(
+              'metered_at_cap',
+              'Metered models need available credits. Add an extra usage pack or upgrade the plan.',
+            )
           }
           if (assistant.workspaceId && options.checkMeteredSpendCap) {
             const cap = await options.checkMeteredSpendCap(assistant.workspaceId)
             if (!cap.allowed) {
-              res.status(402).json({ error: 'metered_spend_cap_reached', usedCredits: cap.usedCredits, capCredits: cap.capCredits })
-              return
+              throw new ChatTurnRefusal(
+                'metered_spend_cap_reached',
+                'This workspace has reached its metered spend cap. Raise the cap or wait for it to reset.',
+                { usedCredits: cap.usedCredits, capCredits: cap.capCredits },
+              )
             }
           }
           // Resolve the budget: saved profile wins (validated against this
@@ -5312,8 +5397,10 @@ export function chatRoutes(options: WebChatOptions): Router {
           if (meteredProfileId && options.meteredProfileStore && assistant.workspaceId) {
             const profile = await options.meteredProfileStore.get(assistant.workspaceId, meteredProfileId)
             if (!profile || profile.modelAlias !== meteredRow.alias) {
-              res.status(400).json({ error: 'metered_profile_invalid' })
-              return
+              throw new ChatTurnRefusal(
+                'metered_profile_invalid',
+                'That saved budget profile does not apply to this model. Pick another profile or set the tool rounds directly.',
+              )
             }
             profileId = profile.id
             toolRounds = profile.toolRounds
@@ -5325,11 +5412,11 @@ export function chatRoutes(options: WebChatOptions): Router {
             // Pre-flight invariant: estimate at the CHOSEN budget → confirm →
             // run. The client shows the estimate in a confirm dialog and
             // resends with meteredAccepted.
-            res.status(400).json({
-              error: 'metered_confirm_required',
-              estimate: options.estimateMeteredTurn?.(meteredRow.alias, toolRounds) ?? null,
-            })
-            return
+            throw new ChatTurnRefusal(
+              'metered_confirm_required',
+              'This model bills per turn and needs a confirmation before it runs.',
+              { estimate: options.estimateMeteredTurn?.(meteredRow.alias, toolRounds) ?? null },
+            )
           }
           const hasImageInput = userContentBlocks.some((b) => b.type === 'image')
           if (hasImageInput && !meteredRow.capabilities.vision) {
@@ -5385,19 +5472,14 @@ export function chatRoutes(options: WebChatOptions): Router {
         usedByoKey = resolvedTurnLlm.providerKeySource === 'user'
         usedLegacyByoKey = resolvedTurnLlm.usedLegacyByoKey
         if (explicitCustomSelector && !customLlmRuntime) {
-          res.status(400).json({
-            error: 'custom_model_unavailable',
-            message: 'This custom model endpoint is unavailable in this workspace.',
-          })
-          return
+          throw new ChatTurnRefusal(
+            'custom_model_unavailable',
+            'This custom model endpoint is unavailable in this workspace.',
+          )
         }
         if (customLlmRuntime) {
           if (customLlmRuntime.routeKind === 'custom' && userContentBlocks.some((block) => block.type === 'image')) {
-            res.status(400).json({
-              error: 'custom_model_media_unsupported',
-              message: 'Custom model endpoints currently support text and tools only. Remove the inline image or choose a built-in model.',
-            })
-            return
+            throw customModelMediaRefusal(Boolean(explicitCustomSelector))
           }
           // A selected custom endpoint is authoritative. It supersedes both
           // the platform provider and a workspace Gemini key, and never falls
@@ -7716,7 +7798,13 @@ export function chatRoutes(options: WebChatOptions): Router {
       sendEvent('done', {})
       res.end()
     } catch (err) {
-      console.error('Chat error:', err)
+      // A `ChatTurnRefusal` is not a crash — it is this route declining the
+      // turn after the SSE headers went out, and it arrives here only
+      // because the catch owns the cleanup (see the class doc). It carries
+      // its own sentence; the whole point is that the user reads THAT and
+      // not the generic banner, so it must not be flattened into one.
+      const refusal = err instanceof ChatTurnRefusal ? err : null
+      if (!refusal) console.error('Chat error:', err)
       // When the inner catch already delivered a context-aware recovery
       // message, surface a clean `done` so the client treats the turn
       // as complete (it is — the user already saw the recovery text).
@@ -7725,7 +7813,7 @@ export function chatRoutes(options: WebChatOptions): Router {
       if (recoveryDelivered) {
         sendEvent('done', {})
       } else {
-        sendEvent('error', { error: 'Something went wrong' })
+        sendEvent('error', chatTurnErrorEvent(err))
       }
       // If a turn_started was broadcast for a draft session before the
       // crash, pair it with turn_completed so collaborators don't see the
@@ -7755,7 +7843,21 @@ export function chatRoutes(options: WebChatOptions): Router {
       // Only log if we have at least user context — earlier failures (e.g.
       // user lookup crash) go to console only since analytics_events requires
       // a non-null user_id.
-      if (userIdForError) {
+      //
+      // A refusal gets its OWN event name. Filing "this endpoint cannot read
+      // images" under `chat_route_error` would bury the real crashes in error
+      // triage while making a working deployment look broken, and the count
+      // that actually matters for a refusal is how often users hit the dead
+      // end — which is a `reason`, not a stack.
+      if (userIdForError && refusal) {
+        options.analytics?.logEvent({
+          userId: userIdForError,
+          assistantId: assistantIdForError ?? undefined,
+          sessionId: sessionIdForError ?? undefined,
+          eventName: 'chat_turn_refused', channelType: 'web',
+          metadata: { reason: sanitize(refusal.code) },
+        })
+      } else if (userIdForError) {
         options.analytics?.logEvent({
           userId: userIdForError,
           assistantId: assistantIdForError ?? undefined,

--- a/packages/core/src/sandbox/tools.ts
+++ b/packages/core/src/sandbox/tools.ts
@@ -1036,7 +1036,7 @@ export function createComputerTools(opts: CreateComputerToolsOptions): ComputerT
     name: 'browserClick',
     requiresCapability: 'computer',
     description:
-      'Click an element by its ref from the latest snapshot, and get back a fresh snapshot of the page after the click. Set intent:"submit" when the click sends, posts, buys, deletes, or otherwise commits an outward action — such clicks require user approval before they run. Ordinary clicks (opening a thread, focusing a field) need no approval.',
+      'Click an element by its ref from the latest snapshot, and get back a fresh snapshot of the page after the click. To choose a value in a dropdown (a combobox followed by option refs), click the option ref, then read the new dropdown value in the returned snapshot. Set intent:"submit" when the click sends, posts, buys, deletes, or otherwise commits an outward action — such clicks require user approval before they run. Ordinary clicks (opening a thread, focusing a field) need no approval.',
     inputSchema: z.object({
       ref: z.string().min(1).describe('Element ref from the latest browserSnapshot, e.g. "@e12"'),
       intent: z

--- a/packages/core/src/workspace-files/types.ts
+++ b/packages/core/src/workspace-files/types.ts
@@ -168,12 +168,11 @@ export type WorkspaceFileSupersedePatch = {
   sizeBytes: number
   mime?: string
   /**
-   * Optional successor path. The SV(2) convention is path-stable
-   * (omit and the successor inherits the prior row's path); however
-   * mig 119's `UNIQUE (workspace_id, path)` is not yet partial on
-   * `valid_to IS NULL`, so path-stable supersession trips the
-   * constraint. Pass an alternate path to work around this until a
-   * follow-up migration relaxes the constraint.
+   * Optional successor path. The SV(2) convention is path-stable — omit
+   * and the successor inherits the prior row's path, which mig 445 made
+   * possible by scoping the `(workspace_id, path)` uniqueness to the
+   * current version (`WHERE valid_to IS NULL`). Pass a path only for a
+   * genuine rename.
    */
   path?: string
   parentPath?: string
@@ -189,9 +188,10 @@ export type WorkspaceFileSupersedePatch = {
 
 export type WorkspaceFilesStore = {
   /**
-   * Insert a row. Throws on UNIQUE(workspace_id, path) collision — the
-   * caller decides whether to surface as overwrite (delete + create) or
-   * a clear error.
+   * Insert a row. Throws pg `23505` on a collision with the CURRENT row
+   * at that path (`uq_workspace_files_current_path`, mig 445) — the caller
+   * decides whether to surface as overwrite (delete + create) or a clear
+   * error. Historical versions at the same path never collide.
    */
   create(userId: string, input: WorkspaceFileCreateInput): Promise<WorkspaceFile>
 
@@ -264,10 +264,10 @@ export type WorkspaceFilesStore = {
    * null if the source id has no current row.
    *
    * Called by the WU-6 staged_write approval flow when an iteration
-   * lands. The legacy UNIQUE(workspace_id, path) constraint on mig 119
-   * blocks path-stable supersession; a follow-up migration must make
-   * the constraint partial (`WHERE valid_to IS NULL`) before the SV(2)
-   * convention works end-to-end.
+   * lands. Path-stable per the SV(2) convention: the close and the insert
+   * share one transaction, and mig 445 scoped the `(workspace_id, path)`
+   * uniqueness to the current version, so the successor can claim the
+   * path the predecessor just released.
    */
   supersede(
     userId: string,

--- a/packages/shared/src/browser-extension-build.ts
+++ b/packages/shared/src/browser-extension-build.ts
@@ -19,7 +19,7 @@
  * Do not hand-edit. `pnpm check` (`invariants/browser-extension-build-stamp`)
  * prints the value to paste when extension source moves.
  */
-export const CURRENT_EXTENSION_BUILD = '5efef48ae075'
+export const CURRENT_EXTENSION_BUILD = '7d0e8be1f84d'
 
 /**
  * A reported build is stale unless it matches exactly.


### PR DESCRIPTION
9ec3a7fe Merge remote-tracking branch 'origin/develop' into HEAD
465c1615 fix(browser): choose native <select> options through the DOM, never the popup
b3712698 Merge pull request #223 from use-brian/fix/sse-post-flush-refusal
e6975707 Merge pull request #222 from use-brian/fix/file-delete-path-reuse
1472bdb7 fix(files): repair the segments already orphaned by past deletes
50522cfc fix(files): a deleted file must release its path and its segments