### PR TITLE
fix(chat): probe custom endpoints for vision, and answer image turns instead of refusing them

### DIFF
--- a/apps/app-web/src/components/chat-app/chat-surface.tsx
+++ b/apps/app-web/src/components/chat-app/chat-surface.tsx
@@ -334,6 +334,11 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
    * session switch — it explains one event, it is not a status line.
    */
   const [turnEndNotice, setTurnEndNotice] = useState<string | null>(null);
+  // A server `notice` about how THIS turn was served (e.g. the workspace's
+  // model endpoint cannot read images, so a built-in model answered). Not an
+  // error - the answer is right there - but it must be visible, because an
+  // unannounced substitution is exactly what byo-llm-key.md forbids.
+  const [turnNotice, setTurnNotice] = useState<string | null>(null);
   /** The user message open in the inline editor, and its working text. */
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editingText, setEditingText] = useState("");
@@ -1035,6 +1040,7 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
   // rooms must not carry it across.
   useEffect(() => {
     setTurnEndNotice(null);
+    setTurnNotice(null);
   }, [activeSessionId]);
 
   useEffect(() => {
@@ -1785,6 +1791,7 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
     setQueuedNotice(false);
     // The previous turn's ending is explained; this send moves past it.
     setTurnEndNotice(null);
+    setTurnNotice(null);
     responseGroupAbortRef.current = false;
     let sourceMessageId: string | null = null;
     const responseAssistantIds = targets.map((assistant) => assistant.id);
@@ -2186,6 +2193,19 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
               sessionId: sessionIdRef.current ?? "",
               status: "pending",
             });
+            break;
+          }
+          case "notice": {
+            const code = typeof payload.code === "string" ? payload.code : "";
+            if (code === "custom_model_image_fallback") {
+              setTurnNotice(tChat.noticeCustomModelImageFallback);
+            } else if (code === "budget_downgraded") {
+              setTurnNotice(tChat.noticeBudgetDowngraded);
+            } else if (typeof payload.message === "string") {
+              // Server-authored English is better than silence for a code
+              // this build has never heard of.
+              setTurnNotice(payload.message);
+            }
             break;
           }
           case "error": {
@@ -3651,6 +3671,16 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
                 onAnswered={() => setPendingQuestion(null)}
                 onCancelled={() => setPendingQuestion(null)}
               />
+            )}
+            {/* How this turn was served, when it was not served the way the
+                workspace normally serves turns. Never an error. */}
+            {turnNotice && (
+              <p
+                role="status"
+                className="rounded-lg border border-border/70 bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
+              >
+                {turnNotice}
+              </p>
             )}
             {/* Quiet queue notice (T5) — a mention landed mid-turn; the
                 follow-up turn is armed. Never an error. */}

--- a/apps/app-web/src/components/chrome/floating-chat.tsx
+++ b/apps/app-web/src/components/chrome/floating-chat.tsx
@@ -2067,6 +2067,13 @@ export function FloatingChat({
                   code,
                   message: t.noticeBudgetDowngraded,
                 });
+              } else if (code === "custom_model_image_fallback") {
+                // Server-authored English rides in `payload.message`; prefer
+                // the translated copy for a code we know.
+                setNotice({
+                  code,
+                  message: t.noticeCustomModelImageFallback,
+                });
               } else if (typeof payload.message === "string") {
                 setNotice({ code, message: payload.message });
               }

--- a/apps/app-web/src/components/settings-modal/sections/__tests__/models-section-edit.test.tsx
+++ b/apps/app-web/src/components/settings-modal/sections/__tests__/models-section-edit.test.tsx
@@ -69,6 +69,7 @@ const profile = {
   contextWindow: 32768,
   maxOutputTokens: 4096,
   supportsTools: true,
+  supportsVision: false,
   verifiedAt: "2026-08-12T00:00:00.000Z",
   createdAt: "2026-08-12T00:00:00.000Z",
   updatedAt: "2026-08-12T00:00:00.000Z",
@@ -110,6 +111,39 @@ beforeEach(() => {
 });
 
 describe("[COMP:app-web/models-settings] custom profile editing", () => {
+  // A profile verified before the vision probe existed reads `false`, and the
+  // only way a workspace admin can learn that (or fix it) is if the row says
+  // so: image turns on this endpoint are answered by a built-in model, and
+  // re-saving the profile is what re-runs the probe.
+  it("says whether the endpoint reads images, and how to re-check", async () => {
+    const render = async () => {
+      const container = document.createElement("div");
+      const root = createRoot(container);
+      await act(async () => {
+        root.render(
+          <I18nProvider locale="en" dict={en as unknown as Dictionary}>
+            <ModelsSection />
+          </I18nProvider>,
+        );
+      });
+      await act(async () => {
+        click(container, (button) => button.textContent === en.chrome.settingsModal.models.viewProviders);
+      });
+      return container;
+    };
+
+    const sightless = await render();
+    expect(sightless.textContent).toContain(en.chrome.settingsModal.models.textOnly);
+    expect(sightless.textContent).not.toContain(en.chrome.settingsModal.models.readsImages);
+
+    getCustomLlmConfiguration.mockResolvedValue({
+      endpoints: [{ ...endpoint, profiles: [{ ...profile, supportsVision: true }] }],
+      tierDefaults: [],
+    });
+    const seeing = await render();
+    expect(seeing.textContent).toContain(en.chrome.settingsModal.models.readsImages);
+  });
+
   it("opens the profile editor and saves a reverified context-window update in place", async () => {
     const container = document.createElement("div");
     const root = createRoot(container);

--- a/apps/app-web/src/components/settings-modal/sections/models-section.tsx
+++ b/apps/app-web/src/components/settings-modal/sections/models-section.tsx
@@ -491,6 +491,7 @@ export function ModelsSection() {
                           <div className="truncate text-[13px] font-medium">{customProfileLabel(endpoint, profile)}</div>
                           <div className="truncate text-[11.5px] text-muted-foreground">
                             {profile.modelId}
+                            {` · ${profile.supportsVision ? t.readsImages : t.textOnly}`}
                             {assigned.length > 0 ? ` · ${t.assignedTo.replace("{tiers}", assigned.join(", "))}` : ""}
                           </div>
                         </div>

--- a/apps/app-web/src/lib/api/custom-llm-endpoints.ts
+++ b/apps/app-web/src/lib/api/custom-llm-endpoints.ts
@@ -14,6 +14,12 @@ export type CustomLlmProfile = {
   contextWindow: number;
   maxOutputTokens: number;
   supportsTools: boolean;
+  /**
+   * Probe-verified image support. False means an image turn on this profile is
+   * answered by a built-in model instead (announced), so the settings row says
+   * "Text only" and re-saving the profile re-runs the probe.
+   */
+  supportsVision: boolean;
   verifiedAt: string;
   createdAt: string;
   updatedAt: string;

--- a/apps/app-web/src/lib/i18n/dictionaries/en.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/en.ts
@@ -2369,6 +2369,8 @@ export const en = {
         customProfilesBlurb: "Create several verified models from one endpoint connection without entering its URL or bearer key again.",
         noCustomProfiles: "No custom profiles yet. Connect an endpoint to create the first profile.",
         assignedTo: "Assigned to {tiers}",
+        readsImages: "Reads images",
+        textOnly: "Text only. Save this profile again to re-check image support.",
         customCreateTitle: "New custom profile",
         customEditTitle: "Edit custom profile",
         customEditBlurb: "Saving tests the model again. Existing tier assignments stay connected.",

--- a/apps/app-web/src/lib/i18n/dictionaries/en.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/en.ts
@@ -261,6 +261,8 @@ export const en = {
     // Inline system notices (e.g. budget downgrade).
     noticeBudgetDowngraded:
       "You've used this month's credit allowance. Running on the standard model until it resets.",
+    noticeCustomModelImageFallback:
+      "This workspace's model endpoint can't read images, so a built-in Brian model answered this message.",
     noticeDismiss: "Dismiss",
     // askQuestion suspend-resume — inline answer surface shown when the
     // assistant pauses to ask a clarifying question. See

--- a/apps/app-web/src/lib/i18n/dictionaries/ja.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/ja.ts
@@ -219,6 +219,8 @@ export const ja: Dictionary = {
     },
     noticeBudgetDowngraded:
       "今月のクレジット枠を使い切ったため、リセットまでスタンダードモデルで動作しています。",
+    noticeCustomModelImageFallback:
+      "このワークスペースのモデルエンドポイントは画像を読み取れないため、このメッセージには Brian の標準モデルが回答しました。",
     noticeDismiss: "閉じる",
     pendingQuestion: {
       heading: "確認させてください",

--- a/apps/app-web/src/lib/i18n/dictionaries/ja.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/ja.ts
@@ -2181,6 +2181,8 @@ export const ja: Dictionary = {
         customProfilesBlurb: "URL や Bearer キーを再入力せず、1 つのエンドポイント接続から複数の検証済みモデルを作成できます。",
         noCustomProfiles: "カスタムプロファイルはまだありません。エンドポイントを接続すると最初のプロファイルが作成されます。",
         assignedTo: "{tiers} に割り当て済み",
+        readsImages: "画像を読み取れます",
+        textOnly: "テキストのみ。画像対応を再確認するには、このプロファイルを保存し直してください。",
         customCreateTitle: "新しいカスタムプロファイル",
         customEditTitle: "カスタムプロファイルを編集",
         customEditBlurb: "保存時にモデルを再テストします。既存のティア割り当ては維持されます。",

--- a/apps/app-web/src/lib/i18n/dictionaries/zh.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh.ts
@@ -2165,6 +2165,8 @@ export const zh: Dictionary = {
         customProfilesBlurb: "無需再次輸入 URL 或 Bearer 金鑰,即可從同一個端點連線建立多個已驗證模型。",
         noCustomProfiles: "尚無自訂設定檔。請連接端點以建立第一個設定檔。",
         assignedTo: "已指派給 {tiers}",
+        readsImages: "可讀取圖片",
+        textOnly: "僅限文字。再次儲存此設定檔可重新檢測圖片支援。",
         customCreateTitle: "新增自訂設定檔",
         customEditTitle: "編輯自訂設定檔",
         customEditBlurb: "儲存時會重新測試模型。現有級別指派會保持不變。",

--- a/apps/app-web/src/lib/i18n/dictionaries/zh.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh.ts
@@ -215,6 +215,7 @@ export const zh: Dictionary = {
       downloadFailed: "下載失敗，點一下重試。",
     },
     noticeBudgetDowngraded: "本月額度已用罄，重置前將以標準模型運作。",
+    noticeCustomModelImageFallback: "此工作區的模型端點無法讀取圖片，因此本則訊息由 Brian 內建模型回答。",
     noticeDismiss: "關閉",
     pendingQuestion: {
       heading: "需要您的補充",

--- a/packages/api/migrations/446_custom_llm_profile_vision.sql
+++ b/packages/api/migrations/446_custom_llm_profile_vision.sql
@@ -1,0 +1,17 @@
+-- Custom OpenAI-compatible profiles record whether their endpoint can READ an
+-- inline image, so a turn carrying a screenshot no longer has to be refused on
+-- the assumption that no custom endpoint ever can.
+--
+-- Default false: an unverified endpoint is treated as text-only, which is the
+-- v1 behavior. The connection probe flips it on for endpoints that accept an
+-- `image_url` part and describe the image correctly; every profile verified
+-- before this migration keeps the safe answer until it is re-verified.
+BEGIN;
+
+ALTER TABLE workspace_custom_llm_profiles
+  ADD COLUMN IF NOT EXISTS supports_vision boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN workspace_custom_llm_profiles.supports_vision IS
+  'Probe-verified: the endpoint accepted an inline image_url part and read it. False means image turns fall back to a built-in model.';
+
+COMMIT;

--- a/packages/api/src/__tests__/custom-llm-runtime.test.ts
+++ b/packages/api/src/__tests__/custom-llm-runtime.test.ts
@@ -4,7 +4,9 @@ import {
   customLlmAlias,
   customLlmEndpointIdFromAlias,
   normalizeCustomLlmBaseUrl,
+  decideImageTurnRoute,
   probeCustomLlmEndpoint,
+  probeCustomLlmVision,
 } from '../custom-llm-runtime.js'
 import type { WorkspaceCustomLlmEndpointStore } from '../db/workspace-custom-llm-endpoints.js'
 import type { LLMProvider, ProviderRequest } from '@use-brian/core'
@@ -15,6 +17,16 @@ function toolSse(): Response {
   const events = [
     { choices: [{ delta: { tool_calls: [{ index: 0, id: 'call_1', function: { name: 'connectionCheck', arguments: '{"ok":' } }] } }] },
     { choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: 'true}' } }] } }] },
+    { choices: [{ delta: {}, finish_reason: 'tool_calls' }] },
+    '[DONE]',
+  ]
+  return new Response(events.map((event) => `data: ${typeof event === 'string' ? event : JSON.stringify(event)}\n\n`).join(''))
+}
+
+function visionSse(color: string): Response {
+  const events = [
+    { choices: [{ delta: { tool_calls: [{ index: 0, id: 'call_v', function: { name: 'describeImage', arguments: `{"color":"` } }] } }] },
+    { choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: `${color}"}` } }] } }] },
     { choices: [{ delta: {}, finish_reason: 'tool_calls' }] },
     '[DONE]',
   ]
@@ -342,5 +354,132 @@ describe('[COMP:api/custom-llm-endpoints] custom endpoint runtime', () => {
       requestedTier: 'standard',
       allowManagedRoutes: false,
     })).resolves.toBeNull()
+  })
+})
+
+describe('[COMP:api/custom-llm-endpoints] endpoint vision probe', () => {
+  const connection = { baseUrl: 'http://model.example/v1', modelId: 'local-model', apiKey: null }
+
+  // The probe asks a question the prompt cannot answer: the image is a solid
+  // red square and nothing in the text says so. Naming the color is therefore
+  // evidence the bytes arrived AND were read.
+  it('reports vision when the endpoint names the color of the probe image', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(visionSse('red'))
+    expect(await probeCustomLlmVision(connection, { fetchFn, timeoutMs: 1000 })).toBe(true)
+    const [, init] = fetchFn.mock.calls[0] as [string, RequestInit]
+    expect(JSON.stringify(JSON.parse(init.body as string).messages)).toContain('image_url')
+  })
+
+  // A gateway in front of a text-only model can accept the image_url part and
+  // drop it. That answers without an error, which is worse than a rejection,
+  // so a wrong answer has to count as "no vision" exactly like a refusal.
+  it('treats an accepted-but-unread image as no vision', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(visionSse('blue'))
+    expect(await probeCustomLlmVision(connection, { fetchFn, timeoutMs: 1000 })).toBe(false)
+  })
+
+  it('never throws when the endpoint refuses the image', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response('nope', { status: 400 }))
+    expect(await probeCustomLlmVision(connection, { fetchFn, timeoutMs: 1000 })).toBe(false)
+  })
+
+  // Vision is an extra, never a gate: an endpoint that streams and calls tools
+  // is a usable Brian model whether or not it can see.
+  it('still verifies a text-only endpoint, recording it as sightless', async () => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(toolSse())
+      .mockResolvedValueOnce(new Response('no image support', { status: 400 }))
+    const result = await probeCustomLlmEndpoint(connection, { fetchFn, timeoutMs: 1000 })
+    expect(result).toMatchObject({ supportsTools: true, supportsVision: false })
+  })
+
+  it('carries a probed vision profile through to image_url parts on the wire', async () => {
+    const profileId = '00000000-0000-4000-8000-000000000003'
+    const runtime = {
+      id: profileId,
+      endpointId: profileId,
+      workspaceId: '00000000-0000-4000-8000-000000000010',
+      name: 'Seeing',
+      endpointName: 'Gateway',
+      baseUrl: 'http://model.example/v1',
+      apiKey: null,
+      modelId: 'vision-local',
+      contextWindow: 32768,
+      maxOutputTokens: 4096,
+      supportsTools: true,
+      supportsVision: true,
+      verifiedAt: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }
+    const store = {
+      getRuntimeSystem: vi.fn().mockResolvedValue(runtime),
+      getTierRuntimeSystem: vi.fn(),
+      getTierRouteSystem: vi.fn(),
+    } as unknown as WorkspaceCustomLlmEndpointStore
+    const fetchFn = vi.fn().mockResolvedValue(textSse())
+    const resolved = await createWorkspaceCustomLlmResolver(store, { fetchFn })({
+      workspaceId: runtime.workspaceId,
+      requestedModel: customLlmAlias(profileId),
+    })
+    expect(resolved).toMatchObject({ routeKind: 'custom', supportsVision: true })
+    if (!resolved) throw new Error('expected a resolved custom provider')
+    for await (const _chunk of resolved.provider.stream({
+      model: resolved.selector,
+      systemPrompt: '',
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'image', mimeType: 'image/png', data: 'iVBORw0KGgo=' },
+          { type: 'text', text: 'What is in this screenshot?' },
+        ],
+      }],
+    })) {
+      // Drain so the request body can be inspected.
+    }
+    const [, init] = fetchFn.mock.calls[0] as [string, RequestInit]
+    const messages = JSON.stringify(JSON.parse(init.body as string).messages)
+    expect(messages).toContain('image_url')
+    expect(messages).not.toContain('text-only model cannot inspect it')
+  })
+})
+
+describe('[COMP:api/custom-llm-endpoints] image turn routing policy', () => {
+  const sightless = { supportsVision: false }
+  const seeing = { supportsVision: true }
+  const base = { turnHasImage: true, explicitCustomSelection: false, builtInServable: true }
+
+  it('serves on the route whenever the route can see, or the turn has no image', () => {
+    expect(decideImageTurnRoute({ ...base, route: seeing })).toBe('serve_on_route')
+    expect(decideImageTurnRoute({ ...base, route: sightless, turnHasImage: false })).toBe('serve_on_route')
+    expect(decideImageTurnRoute({ ...base, route: null })).toBe('serve_on_route')
+  })
+
+  // The 2026-08-19 incident: every tier in the workspace routed to a
+  // text-only endpoint, so refusing sent the user to a model picker where
+  // every entry lands back on the same endpoint. There was a built-in model
+  // available the whole time.
+  it('falls back to a built-in model for a tier-routed workspace', () => {
+    expect(decideImageTurnRoute({ ...base, route: sightless })).toBe('fall_back_to_builtin')
+  })
+
+  // Answering on a model the user just declined for this message is a worse
+  // answer than saying why the one they picked cannot be used.
+  it('refuses when the user picked this endpoint for this very message', () => {
+    expect(decideImageTurnRoute({ ...base, route: sightless, explicitCustomSelection: true }))
+      .toBe('refuse')
+  })
+
+  // A self-host whose only configured model IS the endpoint. Falling back
+  // would hand the turn to a provider that is not there.
+  it('refuses when there is no built-in model to fall back to', () => {
+    expect(decideImageTurnRoute({ ...base, route: sightless, builtInServable: false }))
+      .toBe('refuse')
+  })
+
+  it('never refuses a sighted route, whatever else is true', () => {
+    expect(decideImageTurnRoute({
+      route: seeing, turnHasImage: true, explicitCustomSelection: true, builtInServable: false,
+    })).toBe('serve_on_route')
   })
 })

--- a/packages/api/src/custom-llm-runtime.ts
+++ b/packages/api/src/custom-llm-runtime.ts
@@ -95,6 +95,7 @@ export type CustomLlmConnectionInput = {
 function providerFor(
   profile: CustomLlmConnectionInput & { profileId: string },
   fetchFn: typeof fetch = fetch,
+  supportsVision = false,
 ): LLMProvider {
   const recordedModel = customLlmAlias(profile.profileId)
   const usageCompatibleFetch: typeof fetch = async (input, init) => {
@@ -120,7 +121,11 @@ function providerFor(
     includeStreamUsage: true,
     enableThinkingField: false,
     supportsJsonMode: false,
-    supportsVision: false,
+    // Vision is a PROBED fact per profile, not a property of "custom
+    // endpoints" as a class. An unprobed profile stays text-only: the
+    // compat layer then degrades an image block to an honest note instead
+    // of posting bytes an endpoint may reject or silently drop.
+    supportsVision,
     includeErrorDetail: false,
   })
 }
@@ -137,7 +142,7 @@ export async function probeCustomLlmEndpoint(
     timeoutMs?: number
     networkPolicy?: CustomLlmNetworkPolicy
   },
-): Promise<{ supportsTools: true; verifiedAt: Date }> {
+): Promise<{ supportsTools: true; supportsVision: boolean; verifiedAt: Date }> {
   const networkPolicy = options?.networkPolicy ?? 'private-network'
   const baseUrl = normalizeCustomLlmBaseUrl(input.baseUrl, networkPolicy)
   const controller = new AbortController()
@@ -204,7 +209,102 @@ export async function probeCustomLlmEndpoint(
   } catch (err) {
     throw new CustomLlmProbeError('endpoint_invalid_response', 'The endpoint returned invalid tool-call arguments', 422, { cause: err })
   }
-  return { supportsTools: true, verifiedAt: new Date() }
+  return {
+    supportsTools: true,
+    supportsVision: await probeCustomLlmVision(input, options),
+    verifiedAt: new Date(),
+  }
+}
+
+/**
+ * A solid #FF0000 8x8 PNG (100 base64 chars). Every pixel is the same color,
+ * so a model that receives the bytes at all can name it, and a model that
+ * cannot has nothing in the prompt to guess from - the question is
+ * unanswerable from the text alone, which is exactly what makes the answer
+ * evidence.
+ */
+const VISION_PROBE_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAEUlEQVR42mP4z8CAFTEMLQkAKP8/wc53yE8AAAAASUVORK5CYII='
+
+const VISION_PROBE_ACCEPTED = /red|crimson|scarlet|maroon/i
+
+/**
+ * Does this endpoint actually READ an inline image?
+ *
+ * Accepting an `image_url` part without a 400 is not enough. An
+ * OpenAI-compatible gateway in front of a text-only model can take the part
+ * and drop it, and that failure is worse than a rejection: the turn succeeds,
+ * the model answers confidently about an image it never saw, and nothing in
+ * the response says so. So the probe asks a question only sight can answer
+ * and checks the answer.
+ *
+ * It never throws. A refusal, a timeout, an unreachable host, a wrong color
+ * all mean the same thing to the caller - treat this profile as text-only -
+ * and none of them is a reason to fail a connection that already proved it
+ * can stream and call tools.
+ */
+export async function probeCustomLlmVision(
+  input: CustomLlmConnectionInput,
+  options?: {
+    fetchFn?: typeof fetch
+    timeoutMs?: number
+    networkPolicy?: CustomLlmNetworkPolicy
+  },
+): Promise<boolean> {
+  const networkPolicy = options?.networkPolicy ?? 'private-network'
+  let baseUrl: string
+  try {
+    baseUrl = normalizeCustomLlmBaseUrl(input.baseUrl, networkPolicy)
+  } catch {
+    return false
+  }
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), options?.timeoutMs ?? 30_000)
+  const provider = providerFor(
+    { ...input, baseUrl, profileId: '00000000-0000-4000-8000-000000000000' },
+    options?.fetchFn ?? (networkPolicy === 'public-only' ? createPublicCustomLlmFetch() : fetch),
+    true,
+  )
+  let toolName = ''
+  let toolInput = ''
+  try {
+    for await (const chunk of provider.stream({
+      model: 'custom-probe',
+      systemPrompt: 'You are verifying image support. Call describeImage exactly once with the dominant color of the attached image. Do not answer with text.',
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'image', mimeType: 'image/png', data: VISION_PROBE_PNG_BASE64 },
+          { type: 'text', text: 'Call describeImage with the dominant color of this image, as one lowercase English word.' },
+        ],
+      }],
+      tools: [{
+        name: 'describeImage',
+        description: 'Report what the attached image looks like.',
+        parameters: {
+          type: 'object',
+          properties: { color: { type: 'string', description: 'Dominant color, one lowercase English word.' } },
+          required: ['color'],
+        },
+      }],
+      maxTokens: 128,
+      signal: controller.signal,
+    })) {
+      if (chunk.type === 'tool_use_start') toolName = chunk.name
+      if (chunk.type === 'tool_use_delta') toolInput += chunk.input
+    }
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timeout)
+  }
+  if (toolName !== 'describeImage') return false
+  try {
+    const parsed = JSON.parse(toolInput) as { color?: unknown }
+    return typeof parsed.color === 'string' && VISION_PROBE_ACCEPTED.test(parsed.color)
+  } catch {
+    return false
+  }
 }
 
 export type ResolvedWorkspaceCustomLlm = {
@@ -216,6 +316,16 @@ export type ResolvedWorkspaceCustomLlm = {
   maxTokens: number
   providerKeySource: 'user' | 'platform'
   routeKind: 'custom' | 'managed'
+  /**
+   * Can the model behind this route read an inline image?
+   *
+   * For a managed route it is the registry's answer about a Brian model. For
+   * a custom endpoint it is what the connection probe measured, and it
+   * defaults to false: an image turn on a text-only endpoint is served by a
+   * built-in model rather than forwarding bytes the endpoint would reject or
+   * quietly discard.
+   */
+  supportsVision: boolean
   /** Per-run connection for the isolated browser-use process. Never serialize. */
   browserUse?: {
     apiKeyEnvName: 'OPENAI_API_KEY'
@@ -223,6 +333,38 @@ export type ResolvedWorkspaceCustomLlm = {
     model: string
     baseUrl: string
   }
+}
+
+/**
+ * What to do with a turn that carries an inline image.
+ *
+ * One policy, two call sites (the chat route and the channel pipeline), for
+ * the reason forked surfaces keep teaching this codebase: the two used to
+ * hold the same rule as two copies of one `if`, and the copies drifted the
+ * moment the rule gained a third outcome. A channel turn cannot carry an
+ * explicit `custom:<id>`, so it simply never produces that branch.
+ *
+ *   serve_on_route       - the route can see; nothing to decide.
+ *   fall_back_to_builtin - the route is sightless but a built-in model can
+ *                          answer. The caller MUST announce it (byo-llm-key.md
+ *                          forbids a silent fallback, not a fallback).
+ *   refuse               - either the user picked this endpoint for this very
+ *                          message, or there is no built-in to fall back to.
+ */
+export type ImageTurnRouteDecision = 'serve_on_route' | 'fall_back_to_builtin' | 'refuse'
+
+export function decideImageTurnRoute(params: {
+  /** The resolved workspace route, or null when none applies. */
+  route: { supportsVision: boolean } | null
+  turnHasImage: boolean
+  /** The request named `custom:<id>` itself, rather than resolving a tier. */
+  explicitCustomSelection: boolean
+  /** A built-in model is configured AND servable on this deployment. */
+  builtInServable: boolean
+}): ImageTurnRouteDecision {
+  if (!params.route || !params.turnHasImage || params.route.supportsVision) return 'serve_on_route'
+  if (params.explicitCustomSelection || !params.builtInServable) return 'refuse'
+  return 'fall_back_to_builtin'
 }
 
 export type WorkspaceCustomLlmResolver = (params: {
@@ -322,6 +464,7 @@ export function createWorkspaceCustomLlmResolver(
         maxTokens: row.maxOutput,
         providerKeySource: 'platform',
         routeKind: 'managed',
+        supportsVision: row.capabilities.vision,
       }
     }
 
@@ -334,7 +477,7 @@ export function createWorkspaceCustomLlmResolver(
       baseUrl: selectedProfile.baseUrl,
       apiKey: selectedProfile.apiKey,
       modelId: selectedProfile.modelId,
-    }, fetchFn))
+    }, fetchFn, selectedProfile.supportsVision))
     const limitedProvider: LLMProvider = {
       ...provider,
       stream: (request) => provider.stream({
@@ -357,6 +500,7 @@ export function createWorkspaceCustomLlmResolver(
       maxTokens: selectedProfile.maxOutputTokens,
       providerKeySource: 'user',
       routeKind: 'custom',
+      supportsVision: selectedProfile.supportsVision,
       browserUse: {
         apiKeyEnvName: 'OPENAI_API_KEY',
         apiKey: selectedProfile.apiKey?.trim() || 'not-required',

--- a/packages/api/src/db/__tests__/workspace-custom-llm-endpoints.test.ts
+++ b/packages/api/src/db/__tests__/workspace-custom-llm-endpoints.test.ts
@@ -38,7 +38,7 @@ const profileRow = {
   modelId: 'local-balanced',
   contextWindow: 32768,
   maxOutputTokens: 4096,
-  supportsTools: true,
+  supportsTools: true, supportsVision: false,
   verifiedAt: new Date(),
   createdAt: new Date(),
   updatedAt: new Date(),
@@ -73,7 +73,7 @@ describe('[COMP:api/custom-llm-endpoints] custom connection/profile store', () =
         modelId: profileRow.modelId,
         contextWindow: 32768,
         maxOutputTokens: 4096,
-        supportsTools: true,
+        supportsTools: true, supportsVision: false,
         verifiedAt: new Date(),
       },
     })
@@ -91,7 +91,7 @@ describe('[COMP:api/custom-llm-endpoints] custom connection/profile store', () =
       input: {
         name: endpointRow.name, baseUrl: endpointRow.baseUrl, apiKey: null,
         modelId: profileRow.modelId, contextWindow: 32768, maxOutputTokens: 4096,
-        supportsTools: true, verifiedAt: new Date(),
+        supportsTools: true, supportsVision: false, verifiedAt: new Date(),
       },
     })
     expect((clientQuery.mock.calls[1]![1] as unknown[])[4]).toBeNull()
@@ -104,7 +104,7 @@ describe('[COMP:api/custom-llm-endpoints] custom connection/profile store', () =
       input: {
         name: endpointRow.name, baseUrl: endpointRow.baseUrl, apiKey: 'secret',
         modelId: profileRow.modelId, contextWindow: 32768, maxOutputTokens: 4096,
-        supportsTools: true, verifiedAt: new Date(),
+        supportsTools: true, supportsVision: false, verifiedAt: new Date(),
       },
     })).rejects.toBeInstanceOf(CustomLlmEncryptionKeyRequiredError)
     expect(mockGetAppPool).not.toHaveBeenCalled()
@@ -142,7 +142,7 @@ describe('[COMP:api/custom-llm-endpoints] custom connection/profile store', () =
         modelId: updated.modelId,
         contextWindow: updated.contextWindow,
         maxOutputTokens: updated.maxOutputTokens,
-        supportsTools: true,
+        supportsTools: true, supportsVision: false,
         verifiedAt,
       },
     })).resolves.toEqual(updated)
@@ -156,6 +156,10 @@ describe('[COMP:api/custom-llm-endpoints] custom connection/profile store', () =
       'terra-high',
       1_048_576,
       65_536,
+      // Vision rides the same verified-profile write as the tool flag, so an
+      // edit that re-probes a sightless endpoint records it as sightless
+      // rather than leaving a stale `true` behind.
+      false,
       verifiedAt,
     ])
   })
@@ -171,7 +175,7 @@ describe('[COMP:api/custom-llm-endpoints] custom connection/profile store', () =
       input: {
         name: endpointRow.name, baseUrl: endpointRow.baseUrl, apiKey: 'system-only',
         modelId: profileRow.modelId, contextWindow: 32768, maxOutputTokens: 4096,
-        supportsTools: true, verifiedAt: new Date(),
+        supportsTools: true, supportsVision: false, verifiedAt: new Date(),
       },
     })
     const realEncrypted = (clientQuery.mock.calls[1]![1] as unknown[])[4] as Buffer

--- a/packages/api/src/db/workspace-custom-llm-endpoints.ts
+++ b/packages/api/src/db/workspace-custom-llm-endpoints.ts
@@ -20,6 +20,13 @@ export type WorkspaceCustomLlmProfile = {
   contextWindow: number
   maxOutputTokens: number
   supportsTools: boolean
+  /**
+   * Probe-verified: this endpoint accepted an inline `image_url` part and read
+   * it back correctly. False is the safe answer, not an unknown one - a turn
+   * carrying an image is served by a built-in model instead of forwarding the
+   * bytes to an endpoint that may reject or silently ignore them.
+   */
+  supportsVision: boolean
   verifiedAt: Date
   createdAt: Date
   updatedAt: Date
@@ -67,6 +74,7 @@ export type VerifiedCustomLlmProfileInput = {
   contextWindow: number
   maxOutputTokens: number
   supportsTools: true
+  supportsVision: boolean
   verifiedAt: Date
 }
 
@@ -113,6 +121,7 @@ const PROFILE_COLS = `
   context_window AS "contextWindow",
   max_output_tokens AS "maxOutputTokens",
   supports_tools AS "supportsTools",
+  supports_vision AS "supportsVision",
   verified_at AS "verifiedAt",
   created_at AS "createdAt",
   updated_at AS "updatedAt"
@@ -127,6 +136,7 @@ const RUNTIME_PROFILE_COLS = `
   p.context_window AS "contextWindow",
   p.max_output_tokens AS "maxOutputTokens",
   p.supports_tools AS "supportsTools",
+  p.supports_vision AS "supportsVision",
   p.verified_at AS "verifiedAt",
   p.created_at AS "createdAt",
   p.updated_at AS "updatedAt",
@@ -257,10 +267,10 @@ export function createDbWorkspaceCustomLlmEndpointStore(
         const profileResult = await client.query<WorkspaceCustomLlmProfile>(
           `INSERT INTO workspace_custom_llm_profiles
              (id, endpoint_id, workspace_id, name, model_id, context_window,
-              max_output_tokens, supports_tools, verified_at)
-           VALUES ($1, $1, $2, $3, $4, $5, $6, true, $7)
+              max_output_tokens, supports_tools, supports_vision, verified_at)
+           VALUES ($1, $1, $2, $3, $4, $5, $6, true, $7, $8)
            RETURNING ${PROFILE_COLS}`,
-          [id, workspaceId, input.name, input.modelId, input.contextWindow, input.maxOutputTokens, input.verifiedAt],
+          [id, workspaceId, input.name, input.modelId, input.contextWindow, input.maxOutputTokens, input.supportsVision, input.verifiedAt],
         )
         await client.query('COMMIT')
         return { ...endpointResult.rows[0]!, profiles: [profileResult.rows[0]!] }
@@ -274,12 +284,12 @@ export function createDbWorkspaceCustomLlmEndpointStore(
         actingUserId,
         `INSERT INTO workspace_custom_llm_profiles
            (endpoint_id, workspace_id, name, model_id, context_window,
-            max_output_tokens, supports_tools, verified_at)
-         SELECT e.id, e.workspace_id, $3, $4, $5, $6, true, $7
+            max_output_tokens, supports_tools, supports_vision, verified_at)
+         SELECT e.id, e.workspace_id, $3, $4, $5, $6, true, $7, $8
            FROM workspace_custom_llm_endpoints e
           WHERE e.workspace_id = $1 AND e.id = $2
          RETURNING ${PROFILE_COLS}`,
-        [workspaceId, endpointId, input.name, input.modelId, input.contextWindow, input.maxOutputTokens, input.verifiedAt],
+        [workspaceId, endpointId, input.name, input.modelId, input.contextWindow, input.maxOutputTokens, input.supportsVision, input.verifiedAt],
       )
       return result.rows[0] ?? null
     },
@@ -293,11 +303,12 @@ export function createDbWorkspaceCustomLlmEndpointStore(
                 context_window = $6,
                 max_output_tokens = $7,
                 supports_tools = true,
-                verified_at = $8,
+                supports_vision = $8,
+                verified_at = $9,
                 updated_at = now()
           WHERE workspace_id = $1 AND endpoint_id = $2 AND id = $3
           RETURNING ${PROFILE_COLS}`,
-        [workspaceId, endpointId, profileId, input.name, input.modelId, input.contextWindow, input.maxOutputTokens, input.verifiedAt],
+        [workspaceId, endpointId, profileId, input.name, input.modelId, input.contextWindow, input.maxOutputTokens, input.supportsVision, input.verifiedAt],
       )
       return result.rows[0] ?? null
     },

--- a/packages/api/src/routes/_channel-error-text.ts
+++ b/packages/api/src/routes/_channel-error-text.ts
@@ -30,9 +30,27 @@
  * choose a built-in model", the wording this constant carried until
  * 2026-08-19, therefore sent the user somewhere that refuses the same image
  * for the same reason. Name the setting that actually lifts the restriction.
+ *
+ * Since the same day this sentence is also RARE: a tier-routed turn whose
+ * endpoint cannot read images is served by a built-in model instead (see
+ * `CUSTOM_MODEL_IMAGE_FALLBACK_NOTICE`). It survives for the one case with
+ * nowhere to fall back to - a deployment whose only configured model is the
+ * endpoint itself - so it must not promise a built-in that does not exist.
  */
 export const CUSTOM_MODEL_IMAGE_REJECTION =
-  'This workspace routes its models to a custom endpoint, which supports text and tools only. Send the message without the image, or point this tier at a built-in model in Settings > Models.'
+  'This workspace routes its models to an endpoint that cannot read images, and no built-in model is configured to answer instead. Send the message without the image, or point this tier at a model that reads images in Settings > Models.'
+
+/**
+ * Said when the fallback DID happen: the endpoint could not read the image,
+ * so a built-in model answered this one turn.
+ *
+ * It exists because byo-llm-key.md forbids a SILENT fallback, not a fallback:
+ * moving a turn to a provider the workspace admin did not choose is only
+ * acceptable while the person reading the answer can see that it happened.
+ * Delete this sentence and the fallback becomes the thing the spec forbids.
+ */
+export const CUSTOM_MODEL_IMAGE_FALLBACK_NOTICE =
+  'This workspace routes its models to an endpoint that cannot read images, so a built-in Brian model answered this message.'
 
 export function channelUserErrorText(
   err: Error,

--- a/packages/api/src/routes/channel-pipeline.ts
+++ b/packages/api/src/routes/channel-pipeline.ts
@@ -36,7 +36,8 @@ import { runProactiveCompaction } from './proactive-compaction.js'
 import { notifyBrainWriteIfMatch } from '../brain-stream/notify.js'
 import { recordOverheadUsage } from './_overhead-usage.js'
 import { composeRecoveryMessage } from './_recovery-message.js'
-import { CUSTOM_MODEL_IMAGE_REJECTION } from './_channel-error-text.js'
+import { CUSTOM_MODEL_IMAGE_FALLBACK_NOTICE, CUSTOM_MODEL_IMAGE_REJECTION } from './_channel-error-text.js'
+import { decideImageTurnRoute } from '../custom-llm-runtime.js'
 import { resolveReplyText } from './_reply-context.js'
 import {
   attachUserVisibleContext,
@@ -83,6 +84,7 @@ import { billingPartyForAssistant } from '../billing-party.js'
 import { promotePastedText, shouldPromotePaste } from '../files/paste-promotion.js'
 import type { ArtifactPromoter } from '../files/artifact-promote.js'
 import { appendInboundChatArchive, appendOutboundChatArchive, persistInboundChatArchive } from '../chat-archive/live-writer.js'
+import { isRegistryModelAvailable, registryRow } from '@use-brian/shared/model-registry'
 import type { ProviderAvailability } from '@use-brian/shared/model-registry'
 
 /**
@@ -828,14 +830,36 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
     budgetStatus,
     params.configuredProviders,
   )
-  const customLlmRuntime = assistant.workspaceId && params.resolveWorkspaceCustomLlm
+  const resolvedCustomLlm = assistant.workspaceId && params.resolveWorkspaceCustomLlm
     ? await params.resolveWorkspaceCustomLlm({
         workspaceId: assistant.workspaceId,
         requestedTier: logicalTier,
         allowDefault: true,
       })
     : null
-  if (customLlmRuntime?.routeKind === 'custom' && userContentBlocks.some((block) => block.type === 'image')) {
+  // The same policy object the chat route uses, deliberately: one rule about
+  // images and a route that cannot read them, decided in one place. A channel
+  // user has even less recourse than a web one (no model picker at all), and
+  // a channel turn never carries an explicit `custom:<id>`, so the refusal
+  // here is only ever the nothing-to-fall-back-to case.
+  const imageRoute = decideImageTurnRoute({
+    route: resolvedCustomLlm,
+    turnHasImage: userContentBlocks.some((block) => block.type === 'image'),
+    explicitCustomSelection: false,
+    builtInServable: !params.configuredProviders
+      || (() => {
+        const row = registryRow(model)
+        return row ? isRegistryModelAvailable(row, params.configuredProviders) : false
+      })(),
+  })
+  // Announced, never silent - see CUSTOM_MODEL_IMAGE_FALLBACK_NOTICE. The
+  // ordinary path archives the inbound message a few lines below, so the
+  // fallback needs no archive of its own.
+  let imageFallbackNotice: string | null = imageRoute === 'fall_back_to_builtin'
+    ? CUSTOM_MODEL_IMAGE_FALLBACK_NOTICE
+    : null
+  const customLlmRuntime = imageRoute === 'serve_on_route' ? resolvedCustomLlm : null
+  if (imageRoute === 'refuse') {
     // Archive BEFORE refusing. This return used to happen first, so an image
     // sent to a workspace on a custom endpoint left no message row and no
     // bytes — the user saw only "Something went wrong" and the content was
@@ -1587,7 +1611,12 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
   // path that never flushed) also skips. Errors during the stamp are
   // logged but don't propagate — the user already saw the message.
   const sendResponseAndStampChannelId = async (text: string, documents?: OutgoingDocument[]): Promise<void> => {
-    const result = await hooks.sendResponse(text, documents)
+    // A channel has no `notice` lane, so an announced fallback has to travel
+    // in the message itself - once, on the first thing the user sees, then
+    // cleared so a multi-part reply does not repeat it.
+    const noticed = imageFallbackNotice ? `${imageFallbackNotice}\n\n${text}` : text
+    imageFallbackNotice = null
+    const result = await hooks.sendResponse(noticed, documents)
     const channelMessageId = result && typeof result === 'object'
       ? result.channelMessageId
       : undefined

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -52,11 +52,12 @@ import { recordExternalCostFromMeta } from '../billing-external.js'
 import type { Message, LLMProvider, Tool, MemoryStore, UsageStore, AnalyticsLogger, FileStore, ContentBlock, CacheStore, McpSettingsStore, ConfirmationDecision, ConfirmationResolver, TopicClassification, ClassifierRecentTurn, EpisodicStore, CapabilityStore, RetrievalStore, TranscribeResult, TokenUsage, WorkerResult, EngineHooks } from '@use-brian/core'
 
 import { resolveModel, ensureServableModel, backgroundLatencyBudgetMs, backgroundModelFor, isStandardTier, chatTierBudget, planNudgeCap, tierForModel, isExplicitMeteredModelSelection } from '../model-resolution.js'
-import { registryRow } from '@use-brian/shared/model-registry'
+import { isRegistryModelAvailable, registryRow } from '@use-brian/shared/model-registry'
 import type { ConnectorStore } from '../db/connector-store.js'
 import { getToolDisplayName, stripFollowUps, stripCommentThreadReplyTag, resolveCharter, charterMission } from '@use-brian/shared'
 import { listActivePlaybookRules } from '../db/playbook-store.js'
-import { CUSTOM_MODEL_IMAGE_REJECTION } from './_channel-error-text.js'
+import { CUSTOM_MODEL_IMAGE_FALLBACK_NOTICE, CUSTOM_MODEL_IMAGE_REJECTION } from './_channel-error-text.js'
+import { decideImageTurnRoute } from '../custom-llm-runtime.js'
 import { resolveUser, buildBrowserEscalationPrompt, buildUnavailableCapabilitiesPrompt, injectSkills, isSkillOfferable, checkUsageBudget, applyMcpInjection, type CreditBudgetGate } from './route-helpers.js'
 import { createDocRunClient } from '../doc/run-presence-client.js'
 import type { AssistantRunChannel } from '@use-brian/doc-model'
@@ -1660,29 +1661,27 @@ export function chatTurnErrorEvent(err: unknown): Record<string, unknown> {
 }
 
 /**
- * Refusal for an inline image on a workspace custom endpoint.
+ * Refusal for an inline image the resolved route cannot read.
  *
- * The recovery step differs by how the endpoint was reached, and only one of
- * the two is ever real:
+ * Only two turns still reach it, because a tier-routed workspace with a
+ * servable built-in model falls back instead (byo-llm-key.md, "Fallback and
+ * attachments"), and vision is a per-profile probed fact rather than a claim
+ * about custom endpoints as a class:
  *
  *   - an explicit `custom:<id>` pick is this turn's own choice, so choosing a
- *     built-in model for the next message undoes it;
- *   - a TIER ROUTE captures the tier the model picker resolves to, so every
- *     built-in in the menu lands back on the same endpoint. Telling that user
- *     to "choose a built-in model" sends them around a loop with no exit. The
- *     route is workspace configuration, so the exits are Settings, or sending
+ *     built-in model for the next message undoes it. Answering on a model the
+ *     user just declined would be the wrong repair;
+ *   - a TIER ROUTE on a deployment with no servable built-in model. There is
+ *     nothing to fall back to, and "choose a built-in model" would name a
+ *     recovery step that workspace does not have: the tier captures every
+ *     entry in the picker. Its exits are the tier's configuration, or sending
  *     without the image.
- *
- * The refusal itself is the spec (byo-llm-key.md, "Strict fallback and
- * attachments"): a text-only endpoint must never silently forward image bytes,
- * and must never quietly fall back to a platform provider the workspace admin
- * did not choose.
  */
 export function customModelMediaRefusal(explicitCustomSelection: boolean): ChatTurnRefusal {
   return new ChatTurnRefusal(
     'custom_model_media_unsupported',
     explicitCustomSelection
-      ? 'Custom model endpoints currently support text and tools only. Remove the image, or choose a built-in model for this message.'
+      ? 'This custom model endpoint cannot read images. Remove the image, or choose a built-in model for this message.'
       // The tier-route case is the one every channel also hits, so it reuses
       // the single shared sentence rather than growing a second wording.
       : CUSTOM_MODEL_IMAGE_REJECTION,
@@ -5451,41 +5450,103 @@ export function chatRoutes(options: WebChatOptions): Router {
         : logicalModel
 
       if (assistant.workspaceId && !meteredTurn) {
+        const legacyByoKeyResolver = options.buildWorkspaceProvider && (options.resolveWorkspaceByoGeminiKey || options.llmProviderSettingsStore)
+          ? () => options.resolveWorkspaceByoGeminiKey
+              ? options.resolveWorkspaceByoGeminiKey(assistant.workspaceId!)
+              : options.llmProviderSettingsStore!.getPlaintextKeySystem({
+                  workspaceId: assistant.workspaceId!,
+                  provider: 'gemini',
+                })
+          : null
         const resolvedTurnLlm = await resolveWorkspaceTurnLlm({
           workspaceId: assistant.workspaceId,
           requestedModel: explicitCustomSelector,
           requestedTier: logicalTier,
           platformProvider: options.provider,
           resolveWorkspaceCustomLlm: options.resolveWorkspaceCustomLlm ?? null,
-          resolveLegacyByoKey: options.buildWorkspaceProvider && (options.resolveWorkspaceByoGeminiKey || options.llmProviderSettingsStore)
-            ? () => options.resolveWorkspaceByoGeminiKey
-                ? options.resolveWorkspaceByoGeminiKey(assistant.workspaceId!)
-                : options.llmProviderSettingsStore!.getPlaintextKeySystem({
-                    workspaceId: assistant.workspaceId!,
-                    provider: 'gemini',
-                  })
-            : null,
+          resolveLegacyByoKey: legacyByoKeyResolver,
           buildLegacyByoProvider: options.buildWorkspaceProvider ?? null,
         })
-        customLlmRuntime = resolvedTurnLlm.customRuntime
-        turnProvider = resolvedTurnLlm.provider
-        usedByoKey = resolvedTurnLlm.providerKeySource === 'user'
-        usedLegacyByoKey = resolvedTurnLlm.usedLegacyByoKey
-        if (explicitCustomSelector && !customLlmRuntime) {
+        if (explicitCustomSelector && !resolvedTurnLlm.customRuntime) {
           throw new ChatTurnRefusal(
             'custom_model_unavailable',
             'This custom model endpoint is unavailable in this workspace.',
           )
         }
-        if (customLlmRuntime) {
-          if (customLlmRuntime.routeKind === 'custom' && userContentBlocks.some((block) => block.type === 'image')) {
-            throw customModelMediaRefusal(Boolean(explicitCustomSelector))
+        // Whether the route can READ an image is decided BEFORE any of its
+        // fields are adopted. Resolving first and un-resolving afterwards
+        // would leave `turnProvider`, `usedByoKey` and the recorded
+        // `custom:<id>` selector pointing at an endpoint this turn never
+        // reached, so the usage row would name the wrong model.
+        //
+        // A deployment whose only working model IS the custom endpoint (an
+        // OSS self-host with no platform key) has nothing to fall back to.
+        // Refusing there is honest; handing the turn to an unconfigured
+        // provider would trade a clear sentence for a mid-stream crash.
+        const imageRoute = decideImageTurnRoute({
+          route: resolvedTurnLlm.customRuntime,
+          turnHasImage: userContentBlocks.some((block) => block.type === 'image'),
+          explicitCustomSelection: Boolean(explicitCustomSelector),
+          builtInServable: !options.configuredProviders
+            || (() => {
+              const row = registryRow(model)
+              return row ? isRegistryModelAvailable(row, options.configuredProviders) : false
+            })(),
+        })
+        if (imageRoute === 'refuse') {
+          // An explicit `custom:<id>` pick is a choice this turn made, so the
+          // turn is the right thing to refuse: the next message can choose a
+          // built-in model and leave the rest of the workspace alone.
+          // Substituting a model the user just declined would be worse.
+          throw customModelMediaRefusal(Boolean(explicitCustomSelector))
+        }
+        if (imageRoute === 'fall_back_to_builtin') {
+          // A TIER ROUTE is workspace configuration, not this message's
+          // choice, and it captures every built-in in the picker - so
+          // refusing here dead-ends a user whose only exit is a setting they
+          // may not own. The turn falls back to the flow this workspace
+          // would have had with no custom route at all, which is also how it
+          // picks up a legacy workspace Gemini key when one is configured.
+          //
+          // The fallback is ANNOUNCED, never silent. byo-llm-key.md forbids a
+          // silent one because it would move workspace content to a provider
+          // the admin did not choose; the notice is what keeps that promise
+          // while still answering the question that was asked.
+          const fallbackTurnLlm = await resolveWorkspaceTurnLlm({
+            workspaceId: assistant.workspaceId,
+            requestedTier: logicalTier,
+            platformProvider: options.provider,
+            resolveWorkspaceCustomLlm: null,
+            resolveLegacyByoKey: legacyByoKeyResolver,
+            buildLegacyByoProvider: options.buildWorkspaceProvider ?? null,
+          })
+          customLlmRuntime = null
+          turnProvider = fallbackTurnLlm.provider
+          usedByoKey = fallbackTurnLlm.providerKeySource === 'user'
+          usedLegacyByoKey = fallbackTurnLlm.usedLegacyByoKey
+          sendEvent('notice', {
+            code: 'custom_model_image_fallback',
+            message: CUSTOM_MODEL_IMAGE_FALLBACK_NOTICE,
+          })
+          options.analytics?.logEvent({
+            userId: user.id, assistantId: assistant.id, sessionId: session.id,
+            eventName: 'custom_model_image_fallback', channelType: 'web',
+            metadata: { model_tier: sanitize(logicalTier) },
+          })
+        } else {
+          customLlmRuntime = resolvedTurnLlm.customRuntime
+          turnProvider = resolvedTurnLlm.provider
+          usedByoKey = resolvedTurnLlm.providerKeySource === 'user'
+          usedLegacyByoKey = resolvedTurnLlm.usedLegacyByoKey
+          if (customLlmRuntime) {
+            // A selected custom endpoint is authoritative for everything it
+            // can serve. It supersedes both the platform provider and a
+            // workspace Gemini key, and never falls back to either if its
+            // request FAILS - the image case above is a capability the route
+            // does not have, decided before any request, not a failed one.
+            turnProvider = customLlmRuntime.provider
+            usedByoKey = customLlmRuntime.providerKeySource === 'user'
           }
-          // A selected custom endpoint is authoritative. It supersedes both
-          // the platform provider and a workspace Gemini key, and never falls
-          // back to either if its request fails.
-          turnProvider = customLlmRuntime.provider
-          usedByoKey = customLlmRuntime.providerKeySource === 'user'
         }
       }
 

--- a/packages/api/src/routes/workspace-custom-llm-endpoints.ts
+++ b/packages/api/src/routes/workspace-custom-llm-endpoints.ts
@@ -41,7 +41,7 @@ type Options = {
   endpointStore: WorkspaceCustomLlmEndpointStore
   workspaceStore: WorkspaceStore
   networkPolicy?: CustomLlmNetworkPolicy
-  probe?: (input: CustomLlmConnectionInput) => Promise<{ supportsTools: true; verifiedAt: Date }>
+  probe?: (input: CustomLlmConnectionInput) => Promise<{ supportsTools: true; supportsVision: boolean; verifiedAt: Date }>
 }
 
 function isUniqueViolation(err: unknown): boolean {


### PR DESCRIPTION
8a8a1efd feat(app-web): say whether a custom model endpoint reads images
ae2a2976 fix(chat): probe custom endpoints for vision, and answer image turns instead of refusing them