### PR TITLE
fix(channels): personal-account archive fidelity — own-message direction + contact names

### DIFF
--- a/apps/wa-connector/src/message-parser.ts
+++ b/apps/wa-connector/src/message-parser.ts
@@ -402,6 +402,10 @@ export function extractEditedMessage(
 
 export type WhatsAppIncomingMessage = {
   messageId: string
+  /** True when the owner sent this from their own phone (Baileys key.fromMe).
+   * The connector already suppresses AI self-echoes, so a forwarded fromMe is
+   * always a human owner message; the API archives it as outbound, no turn. */
+  fromMe?: boolean
   channelId: string
   chatJid: string
   senderJid: string

--- a/apps/wa-connector/src/socket-manager.ts
+++ b/apps/wa-connector/src/socket-manager.ts
@@ -883,6 +883,10 @@ export function createSocketManager(options: SocketManagerOptions): SocketManage
       channelId,
       chatJid: remoteJid,
       senderJid,
+      // A human message typed from the connected companion number. AI
+      // self-echoes are already suppressed above, so this only ever tags the
+      // owner's own outgoing messages.
+      ...(msg.key?.fromMe ? { fromMe: true } : {}),
       ...(senderPnJid && { senderPnJid }),
       senderName: msg.pushName ?? undefined,
       text,

--- a/apps/wechat-desktop-bridge/src/__tests__/monitor.test.ts
+++ b/apps/wechat-desktop-bridge/src/__tests__/monitor.test.ts
@@ -111,15 +111,17 @@ describe('[COMP:app/wechat-desktop-bridge] monitor', () => {
     expect(bridge.inbound.map((i) => i.message.text)).toEqual(['hello 1', 'hello 2', 'hello 3'])
   })
 
-  it('skips official accounts and the file helper', async () => {
+  it('skips official accounts but forwards File Transfer (filehelper)', async () => {
     state.cursors['gh_official1'] = 0
     state.cursors['filehelper'] = 0
     agent.chats = [chat({ id: 'gh_official1', lastMsgLocalId: 5 }), chat({ id: 'filehelper', lastMsgLocalId: 5 })]
     agent.messages.set('gh_official1', [msg({ localId: 5, chatId: 'gh_official1' })])
-    agent.messages.set('filehelper', [msg({ localId: 5, chatId: 'filehelper' })])
+    agent.messages.set('filehelper', [msg({ localId: 5, chatId: 'filehelper', content: 'note to self' })])
     await makeMonitor().tick()
-    expect(bridge.inbound).toHaveLength(0)
+    // gh_ skipped, filehelper forwarded
+    expect(bridge.inbound.map((i) => i.message.text)).toEqual(['note to self'])
     expect(isSkippedChat({ id: 'gh_abc', username: 'gh_abc' })).toBe(true)
+    expect(isSkippedChat({ id: 'filehelper', username: 'filehelper' })).toBe(false)
     expect(isSkippedChat({ id: 'wxid_example1', username: 'wxid_example1' })).toBe(false)
   })
 

--- a/apps/wechat-desktop-bridge/src/monitor.ts
+++ b/apps/wechat-desktop-bridge/src/monitor.ts
@@ -14,7 +14,6 @@ const CHAT_LIST_LIMIT = 200
 const MESSAGE_FETCH_LIMIT = 50
 const MEDIA_RETRY_ATTEMPTS = 15
 const MEDIA_RETRY_INTERVAL_MS = 1000
-const FILE_HELPER = 'filehelper'
 
 export type MonitorDeps = {
   agent: AgentWechatClient
@@ -41,10 +40,15 @@ function chatIdOf(chat: Pick<AgentWechatChat, 'id' | 'username'>): string {
   return chat.id || chat.username
 }
 
-/** Official accounts (`gh_…`) and the file-transfer helper are never forwarded. */
+/**
+ * Official accounts (`gh_…`) are never forwarded (subscription/marketing spam).
+ * File Transfer (`filehelper`) IS forwarded: it is the owner's own notes/files
+ * scratchpad and belongs in a personal-account mirror (archived as outbound via
+ * the isSelf path).
+ */
 export function isSkippedChat(chat: Pick<AgentWechatChat, 'id' | 'username'>): boolean {
   const ids = [chat.id, chat.username].filter(Boolean) as string[]
-  return ids.some((id) => id.startsWith('gh_') || id === FILE_HELPER)
+  return ids.some((id) => id.startsWith('gh_'))
 }
 
 export function createMonitor(deps: MonitorDeps): Monitor {

--- a/packages/api/src/chat-archive/__tests__/normalize.test.ts
+++ b/packages/api/src/chat-archive/__tests__/normalize.test.ts
@@ -35,6 +35,17 @@ describe('[COMP:api/chat-archive-live-capture] normalizer', () => {
     })
   })
 
+  it('stores the sender display name so the agent can search by name', () => {
+    const withName = normalizeInboundChatMessage({
+      source: 'whatsapp',
+      message: incoming({ userId: '15551230000@s.whatsapp.net', senderDisplay: 'Alice Chen' }),
+    })
+    expect(withName.sender_display).toBe('Alice Chen')
+    // absent name -> null (unchanged for channels that supply none)
+    const noName = normalizeInboundChatMessage({ source: 'whatsapp', message: incoming() })
+    expect(noName.sender_display).toBeNull()
+  })
+
   it('derives a stable id when a channel supplies none', () => {
     const message = incoming()
     const first = normalizeInboundChatMessage({ source: 'email', message })

--- a/packages/api/src/chat-archive/normalize.ts
+++ b/packages/api/src/chat-archive/normalize.ts
@@ -68,7 +68,7 @@ export function normalizeInboundChatMessage(input: {
     provider_message_id: message.messageId || derivedMessageId(source, message),
     conversation_id: message.channelId,
     sender_id: message.userId,
-    sender_display: null,
+    sender_display: message.senderDisplay ?? null,
     sent_at: sentAt(message.timestamp),
     direction: 'inbound',
     kind: mediaKind(message),

--- a/packages/api/src/routes/__tests__/whatsapp-byon.test.ts
+++ b/packages/api/src/routes/__tests__/whatsapp-byon.test.ts
@@ -64,6 +64,29 @@ describe('[COMP:api/whatsapp-byon-route] internal routing', () => {
     expect(handle).toHaveBeenCalledOnce()
   })
 
+  it('archives the owner\'s own (fromMe) message as outbound and never runs a turn', async () => {
+    const handle = vi.fn(async () => {})
+    const app = express()
+    app.use(express.json())
+    app.use('/internal/whatsapp', whatsappByonRoutes({
+      connectorSecret: 'secret',
+      integrationStore: { getByChannelForWebhook: vi.fn(async () => null), setStatusByChannelSystem: vi.fn() } as never,
+      ingestor: { isIngestChannel: vi.fn(async () => true), ingest: vi.fn() } as never,
+      bot: { resolveHandler: vi.fn(async () => ({ kind: 'bot' as const, handle })) },
+      archiveIncoming: vi.fn(async () => {}),
+      getChannel: vi.fn(async () => ({ workspaceId: 'ws-1' })) as never,
+      getWorkspaceOwnerUserId: vi.fn(async () => 'owner-1'),
+    }))
+    app.post('/internal/whatsapp/inbound', (_req, res) => res.status(418).json({ official: true }))
+    const response = await request(app)
+      .post('/internal/whatsapp/inbound')
+      .set('X-Connector-Secret', 'secret')
+      .send({ ...payload, messageId: 'self-1', fromMe: true, text: 'note to self' })
+    expect(response.status).toBe(200)
+    // The assistant must never answer the user's own outgoing message.
+    expect(handle).not.toHaveBeenCalled()
+  })
+
   it('passes an unknown channel to the closed official fallback', async () => {
     const response = await request(appFor(false, null, true))
       .post('/internal/whatsapp/inbound')

--- a/packages/api/src/routes/whatsapp-byon.ts
+++ b/packages/api/src/routes/whatsapp-byon.ts
@@ -3,7 +3,7 @@ import { Router } from 'express'
 import type { ChatArchiveLiveMedia } from '../chat-archive/live-media.js'
 import { archiveMediaRef, mediaByteLimit } from '../chat-archive/live-media.js'
 import type { StagedArchiveMedia } from '../chat-archive/live-media.js'
-import { resolveChatArchiveInstanceId } from '../chat-archive/live-writer.js'
+import { resolveChatArchiveInstanceId, appendOutboundChatArchive } from '../chat-archive/live-writer.js'
 import { z } from 'zod'
 import type { ChannelIntegrationStore } from '../db/channel-integrations.js'
 import type { WhatsappIngestor } from '../ingest/whatsapp-ingest.js'
@@ -26,6 +26,8 @@ const inboundSchema = z.object({
   text: z.string().default(''),
   timestamp: z.number(),
   isGroup: z.boolean(),
+  // The owner sent this from their own phone (Baileys key.fromMe).
+  fromMe: z.boolean().optional(),
   mediaBase64: z.string().optional(),
   mediaMimeType: z.string().optional(),
   mediaFileName: z.string().optional(),
@@ -423,6 +425,40 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
     }
 
     if (!input.text.trim() && !input.mediaBase64 && !input.mediaRef) {
+      res.json({ ok: true })
+      return
+    }
+
+    // The owner's OWN message, typed from the connected phone (Baileys
+    // key.fromMe). Archive it as OUTBOUND and never run a turn — the assistant
+    // must not answer the user's own outgoing messages, and the archive is a
+    // record of the account's history, not only what it received. Mirrors the
+    // custom channel's isSelf path (docs/architecture/channels/custom-channel.md).
+    if (input.fromMe) {
+      try {
+        const channel = await (opts.getChannel ?? getChannelForWebhook)(input.channelId)
+        const ownerUserId = channel
+          ? await (opts.getWorkspaceOwnerUserId ?? resolveWorkspaceOwnerUserId)(channel.workspaceId)
+          : null
+        if (channel && ownerUserId) {
+          const integration = await opts.integrationStore.getByChannelForWebhook(input.channelId, 'whatsapp')
+          await appendOutboundChatArchive({
+            source: 'whatsapp',
+            ownerUserId,
+            workspaceId: channel.workspaceId,
+            connectorInstanceId: integration?.connectorInstanceId,
+            assistantId: input.senderPnJid ?? input.senderJid,
+            assistantName: input.senderName ?? input.senderPnJid ?? input.senderJid,
+            conversationId: input.chatJid,
+            sessionMessageId: `wa-self:${input.messageId}`,
+            providerMessageId: input.messageId,
+            text: /^<media:[^>]+>$/.test(input.text.trim()) ? '' : input.text,
+            replyToProviderId: null,
+          })
+        }
+      } catch (err) {
+        console.error('[whatsapp] self-message outbound archive failed:', err)
+      }
       res.json({ ok: true })
       return
     }

--- a/packages/api/src/routes/whatsapp-byon.ts
+++ b/packages/api/src/routes/whatsapp-byon.ts
@@ -489,6 +489,7 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
             connectorInstanceId: integration?.connectorInstanceId,
             message: {
               userId: input.senderPnJid ?? input.senderJid,
+              senderDisplay: input.senderName,
               channelId: input.chatJid,
               messageId: input.messageId,
               text: /^<media:[^>]+>$/.test(input.text.trim()) ? '' : input.text,

--- a/packages/channels/src/custom/adapter.ts
+++ b/packages/channels/src/custom/adapter.ts
@@ -78,6 +78,7 @@ export function createCustomAdapter(options: CustomAdapterOptions): ChannelAdapt
       if (!msg.text && !(msg.media && msg.media.length > 0)) return null
       return {
         userId: msg.senderId,
+        ...(msg.senderName ? { senderDisplay: msg.senderName } : {}),
         channelId: msg.peerId,
         messageId: msg.messageId,
         text: msg.text ?? '',

--- a/packages/channels/src/discord/adapter.ts
+++ b/packages/channels/src/discord/adapter.ts
@@ -233,6 +233,7 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): ChannelAda
 
     return {
       userId: msg.author.id,
+      senderDisplay: msg.author.global_name ?? msg.author.username,
       channelId: msg.channel_id,
       messageId: msg.id,
       text,
@@ -266,6 +267,7 @@ export function createDiscordAdapter(options: DiscordAdapterOptions): ChannelAda
 
     return {
       userId: user.id,
+      senderDisplay: user.global_name ?? user.username,
       channelId: interaction.channel_id,
       messageId: interaction.id,
       text,

--- a/packages/channels/src/email/adapter.ts
+++ b/packages/channels/src/email/adapter.ts
@@ -24,7 +24,7 @@
  */
 
 import type { ChannelAdapter, IncomingFile, IncomingMessage, OutgoingMessage } from '../types.js'
-import { parseEmailAddress } from './address.js'
+import { parseEmailAddress, parseEmailDisplayName } from './address.js'
 import { renderEmailBody } from './markdown.js'
 
 /**
@@ -127,6 +127,7 @@ export function createEmailAdapter(options: EmailAdapterOptions): ChannelAdapter
       const ts = msg.timestamp ? Date.parse(msg.timestamp) : NaN
       return {
         userId: sender,
+        senderDisplay: parseEmailDisplayName(msg.from) ?? undefined,
         channelId: msg.thread_id,
         messageId: msg.message_id,
         text,

--- a/packages/channels/src/msteams/adapter.ts
+++ b/packages/channels/src/msteams/adapter.ts
@@ -155,6 +155,7 @@ export function createMsTeamsAdapter(options: MsTeamsAdapterOptions): ChannelAda
 
       return {
         userId: fromId,
+        senderDisplay: activity.from?.name,
         channelId: conversationId,
         messageId: activity.id,
         text,

--- a/packages/channels/src/telegram/adapter.ts
+++ b/packages/channels/src/telegram/adapter.ts
@@ -534,6 +534,7 @@ export function createTelegramAdapter(options: TelegramAdapterOptions): ChannelA
 
     return {
       userId: String(msg.from?.id ?? msg.chat.id),
+      senderDisplay: msg.from?.first_name ?? msg.from?.username,
       channelId,
       messageId: String(msg.message_id),
       text: cleanText,

--- a/packages/channels/src/types.ts
+++ b/packages/channels/src/types.ts
@@ -23,6 +23,11 @@ export type IncomingFile = {
 
 export type IncomingMessage = {
   userId: string
+  /** Human-readable sender name when the platform provides one (WhatsApp
+   * pushName, WeChat sender name, Telegram/Slack display name). Stored as
+   * the archive's `sender_display` so the agent can search by name, not
+   * only by the opaque userId. */
+  senderDisplay?: string
   channelId: string
   messageId?: string
   text: string


### PR DESCRIPTION
Three archive-fidelity fixes for personal-account mirrors, reported from local testing.

## 1. WeChat — File Transfer never archived
`monitor.ts` skipped `filehelper` (File Transfer) alongside `gh_` official accounts. It is the owner's own notes/files scratchpad and belongs in the mirror. Now only `gh_` accounts are skipped; filehelper forwards and archives (outbound, isSelf).

## 2. WhatsApp — owner's own messages archived as inbound
The owner's own messages (Baileys `key.fromMe`, typed from the connected phone) had no `fromMe` field on the payload, so they archived as **inbound** and could trigger a turn. Now the connector tags `fromMe`, and `/inbound` archives them as **outbound** via `appendOutboundChatArchive` and never runs a turn (mirrors the custom channel's `isSelf` path).

## 3. Contact names now stored (searchable by name)
The inbound normalizer hardcoded `sender_display=null` and `IncomingMessage` had no name field — so a phone number / opaque id was all the agent could search on. Added `IncomingMessage.senderDisplay`, stored by the normalizer, populated from WhatsApp `pushName` and the WeChat bridge `senderName`. The message store already searches `sender_display` (search.go / channels.go ILIKE), so names are findable end to end.

## Tests
- WeChat monitor forwards filehelper, skips `gh_` (10/10).
- whatsapp-byon: `fromMe` skips the turn (13/13).
- normalizer stores `sender_display` from `senderDisplay`, null when absent (7/7).
- channels + api typecheck clean.

**Caveats:** the WhatsApp connector half needs a `wa-connector` rebuild + a real account to verify end to end. Contact-name storage is wired for WhatsApp + WeChat (the personal-account mirrors); telegram/slack/discord can set `senderDisplay` too — one line each on the field now added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)