### PR TITLE
feat(chat-archive): media on archive-only exits, saveChatMedia, bridg…

### DIFF
--- a/apps/wa-connector/src/__tests__/socket-manager.test.ts
+++ b/apps/wa-connector/src/__tests__/socket-manager.test.ts
@@ -826,3 +826,67 @@ describe('[COMP:wa-connector/socket-manager] LID sender resolution (Baileys v7)'
     vi.unstubAllGlobals()
   })
 })
+
+describe('[COMP:wa-connector/socket-manager] contact directory relay', () => {
+  async function settle() {
+    await new Promise((r) => setImmediate(r))
+    await new Promise((r) => setImmediate(r))
+  }
+
+  it('relays saved names + pushNames from contact sync, filtering groups and nameless entries', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({}) })
+    vi.stubGlobal('fetch', fetchMock)
+    const mgr = manager()
+    await mgr.connect('a-1')
+
+    fakeSockets[0].ev.emit('contacts.upsert', [
+      { id: '85266986281@s.whatsapp.net', name: 'Jack Chan', notify: 'jackie' },
+      { id: '15551234567@s.whatsapp.net', notify: 'Sam' },
+      { id: 'nameless@s.whatsapp.net' },
+      { id: 'somegroup@g.us', name: 'Family' },
+    ])
+    await settle()
+
+    const call = fetchMock.mock.calls.find((c: unknown[]) => String(c[0]).endsWith('/internal/whatsapp/contacts'))
+    expect(call).toBeTruthy()
+    const body = JSON.parse((call![1] as { body: string }).body)
+    expect(body.channelId).toBe('a-1')
+    expect(body.contacts).toEqual([
+      { contactId: '85266986281@s.whatsapp.net', savedName: 'Jack Chan', pushName: 'jackie' },
+      { contactId: '15551234567@s.whatsapp.net', pushName: 'Sam' },
+    ])
+    const headers = (call![1] as { headers: Record<string, string> }).headers
+    expect(headers['X-Connector-Secret']).toBe('secret')
+  })
+
+  it('relays the pairing-time history contact set the same way', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({}) })
+    vi.stubGlobal('fetch', fetchMock)
+    const mgr = manager()
+    await mgr.connect('a-1')
+
+    fakeSockets[0].ev.emit('messaging-history.set', {
+      chats: [], messages: [],
+      contacts: [{ id: '85266986281@s.whatsapp.net', name: 'Jack Chan' }],
+    })
+    await settle()
+
+    const call = fetchMock.mock.calls.find((c: unknown[]) => String(c[0]).endsWith('/internal/whatsapp/contacts'))
+    expect(call).toBeTruthy()
+    expect(JSON.parse((call![1] as { body: string }).body).contacts).toEqual([
+      { contactId: '85266986281@s.whatsapp.net', savedName: 'Jack Chan' },
+    ])
+  })
+
+  it('a nothing-but-nameless sync sends no request at all', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({}) })
+    vi.stubGlobal('fetch', fetchMock)
+    const mgr = manager()
+    await mgr.connect('a-1')
+
+    fakeSockets[0].ev.emit('contacts.update', [{ id: 'x@s.whatsapp.net' }])
+    await settle()
+
+    expect(fetchMock.mock.calls.some((c: unknown[]) => String(c[0]).endsWith('/internal/whatsapp/contacts'))).toBe(false)
+  })
+})

--- a/apps/wa-connector/src/socket-manager.ts
+++ b/apps/wa-connector/src/socket-manager.ts
@@ -25,6 +25,18 @@ import {
 } from '@whiskeysockets/baileys'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+
+/**
+ * The slice of a Baileys `Contact` (and `contacts.update` partial) the relay
+ * reads. `name` = the owner's saved address-book name; `notify` = the
+ * contact's self-set pushName; `verifiedName` = business verification.
+ */
+type ContactSyncEntry = {
+  id?: string | null
+  name?: string | null
+  notify?: string | null
+  verifiedName?: string | null
+}
 import { createHash, randomUUID } from 'node:crypto'
 import { createReadStream, createWriteStream } from 'node:fs'
 import { rm } from 'node:fs/promises'
@@ -348,6 +360,51 @@ export function createSocketManager(options: SocketManagerOptions): SocketManage
       }
     } catch (err) {
       console.error('[socket-manager] API inbound forward error:', err)
+    }
+  }
+
+  // ── Forward the owner's contact directory to brian-api ──
+
+  /**
+   * Relay contact sync entries for the archive's name directory.
+   *
+   * Only user JIDs with at least one name survive the filter — groups,
+   * broadcasts, and nameless entries carry nothing worth storing. Batched at
+   * 200 per request because pairing-time sync can deliver the whole address
+   * book at once. Best-effort: a failed relay costs display names, never
+   * messages, and the next sync event retries naturally.
+   */
+  async function forwardContacts(channelId: string, entries: ContactSyncEntry[]): Promise<void> {
+    const contacts = entries
+      .filter((c): c is ContactSyncEntry & { id: string } => {
+        if (!c.id) return false
+        if (c.id.endsWith('@g.us') || c.id.endsWith('@broadcast') || c.id.endsWith('@status')) return false
+        return Boolean(c.name || c.notify || c.verifiedName)
+      })
+      .map((c) => ({
+        contactId: c.id,
+        ...(c.name ? { savedName: c.name } : {}),
+        ...(c.notify ? { pushName: c.notify } : {}),
+        ...(c.verifiedName ? { verifiedName: c.verifiedName } : {}),
+      }))
+    if (contacts.length === 0) return
+    for (let i = 0; i < contacts.length; i += 200) {
+      const batch = contacts.slice(i, i + 200)
+      try {
+        const res = await fetch(`${apiUrl}/internal/whatsapp/contacts`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Connector-Secret': connectorSecret,
+          },
+          body: JSON.stringify({ channelId, contacts: batch }),
+        })
+        if (!res.ok) {
+          console.error(`[socket-manager] contact relay failed: ${res.status} ${res.statusText}`)
+        }
+      } catch (err) {
+        console.error('[socket-manager] contact relay error:', err)
+      }
     }
   }
 
@@ -743,6 +800,29 @@ export function createSocketManager(options: SocketManagerOptions): SocketManage
     sock.ev.on('group-participants.update', (update) => {
       handleGroupParticipantsUpdate(channelId, sock, update).catch((err) => {
         console.error(`[socket-manager] group-participants error for ${channelId}:`, err)
+      })
+    })
+
+    // ── Contact directory sync ──
+    // The primary phone syncs its address book to companions: `name` is the
+    // name the OWNER saved for the contact, `notify` the contact's own
+    // pushName. Relayed so archived history is searchable by the names the
+    // owner actually uses, not just by number. `contacts.upsert` fires in bulk
+    // at pairing (app-state sync) and incrementally afterwards.
+    sock.ev.on('contacts.upsert', (contacts) => {
+      forwardContacts(channelId, contacts).catch((err) => {
+        console.error(`[socket-manager] contacts.upsert relay error for ${channelId}:`, err)
+      })
+    })
+    sock.ev.on('contacts.update', (updates) => {
+      forwardContacts(channelId, updates).catch((err) => {
+        console.error(`[socket-manager] contacts.update relay error for ${channelId}:`, err)
+      })
+    })
+    sock.ev.on('messaging-history.set', (history: { contacts?: ContactSyncEntry[] }) => {
+      if (!history.contacts || history.contacts.length === 0) return
+      forwardContacts(channelId, history.contacts).catch((err) => {
+        console.error(`[socket-manager] history contacts relay error for ${channelId}:`, err)
       })
     })
 

--- a/apps/wechat-desktop-bridge/src/index.ts
+++ b/apps/wechat-desktop-bridge/src/index.ts
@@ -71,7 +71,7 @@ async function main(): Promise<void> {
     console.error(`fatal: ${errorMessage(err)}`)
     shutdown(3)
   }
-  await bridge.putState({ status: 'connecting', message: 'Waiting for the agent-wechat container.', bridgeVersion }).catch(
+  await bridge.putState({ status: 'connecting', message: 'Waiting for the agent-wechat container.', bridgeVersion, capabilities: { documents: true } }).catch(
     (err) => (err instanceof FatalConfigError ? fatal(err) : log.warn(`state publish failed: ${errorMessage(err)}`)),
   )
   let backoff = 1000

--- a/apps/wechat-desktop-bridge/src/login-supervisor.ts
+++ b/apps/wechat-desktop-bridge/src/login-supervisor.ts
@@ -69,7 +69,14 @@ export function createLoginSupervisor(deps: LoginSupervisorDeps): LoginSuperviso
   let ticking = false
 
   async function publish(state: BridgeState): Promise<void> {
-    const next: BridgeState = { ...state, bridgeVersion: deps.bridgeVersion }
+    // `documents: true` is a promise the outbox worker keeps: it performs a
+    // real file send for `payload.documents` (outbox-worker.ts), so the
+    // platform's `sendFile` may admit this channel.
+    const next: BridgeState = {
+      ...state,
+      bridgeVersion: deps.bridgeVersion,
+      capabilities: { documents: true, ...state.capabilities },
+    }
     if (last && JSON.stringify(last) === JSON.stringify(next)) return
     try {
       await deps.bridge.putState(next)

--- a/apps/wechat-desktop-bridge/src/protocol-types.ts
+++ b/apps/wechat-desktop-bridge/src/protocol-types.ts
@@ -25,6 +25,8 @@ export type BridgeState = {
   action?: BridgeAction
   /** Bridge build / version string for the Studio card. */
   bridgeVersion?: string
+  /** What this bridge can put on the wire; unlocks `sendFile` on the platform side. */
+  capabilities?: { documents?: boolean }
 }
 
 export type BridgeMediaKind = 'image' | 'document' | 'voice' | 'audio' | 'video'

--- a/packages/api/migrations/452_custom_channel_bridge_capabilities.sql
+++ b/packages/api/migrations/452_custom_channel_bridge_capabilities.sql
@@ -1,0 +1,14 @@
+-- 452: custom bridge declared capabilities.
+--
+-- A custom bridge reports what it can put on the wire (today: `documents`)
+-- in its PUT /state payload. The route threads the stored answer into the
+-- sendFile gate per turn, so file delivery unlocks only on bridges that
+-- actually perform a file send for outbox `payload.documents` — an
+-- undeclared bridge keeps refusing honestly instead of silently dropping.
+
+BEGIN;
+
+ALTER TABLE custom_channel_bridge_state
+  ADD COLUMN IF NOT EXISTS capabilities JSONB;
+
+COMMIT;

--- a/packages/api/src/agent-surface/toolset.ts
+++ b/packages/api/src/agent-surface/toolset.ts
@@ -52,6 +52,7 @@ const BRIDGE_READ_NAMES = [
   'getRowHistory',
   // Person-compartmented local chat archive
   'searchChatHistory',
+  'listChatChannels',
   // Scheduling + ingest reads
   'searchScheduledJobs',
   'listIngestRules',

--- a/packages/api/src/boot.ts
+++ b/packages/api/src/boot.ts
@@ -194,6 +194,7 @@ import { setGlobalMailboxArchiveDeps } from './mailbox/archive-search-tool.js'
 import { setGlobalMailboxSyncDeps } from './mailbox/sync-tool.js'
 import { createMailboxIdleWatcher } from './mailbox/idle-watcher.js'
 import { createChatArchiveTools } from './chat-archive/chat-tools.js'
+import { createSaveChatMediaTool } from './chat-archive/save-media-tool.js'
 import { resolveIngestPlaceholders } from './ingest/placeholder-resolver.js'
 import { createMeteredProfileStore } from './db/metered-profile-store.js'
 import { createWorkspaceModelDefaultsStore } from './db/workspace-model-defaults-store.js'
@@ -3579,6 +3580,13 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
     allTools.set('saveFileToBrain', fileTools.saveFileToBrain)
     allTools.set('sendFile', fileTools.sendFile)
     allTools.set('renderPdf', fileTools.renderPdf)
+    // Archive media retrieval needs BOTH seams: the store (bytes) and the
+    // file layer (where sendFile and the web Files view can reach them) —
+    // which is why it registers here and not with the read-only archive
+    // tools at their earlier block.
+    if (messageStoreClient) {
+      allTools.set('saveChatMedia', createSaveChatMediaTool({ client: messageStoreClient, filesApi }))
+    }
     brainFileTools = {
       fileWrite: fileTools.fileWrite,
       fileAppend: fileTools.fileAppend,
@@ -7365,6 +7373,7 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
             incomingChannelMessageId: input.messageId,
             archiveIncoming: {
               userId: input.senderPnJid ?? input.senderJid,
+              senderDisplay: input.senderName,
               channelId: input.chatJid,
               messageId: input.messageId,
               text: /^<media:[^>]+>$/.test(input.text.trim()) ? '' : input.text,
@@ -7436,6 +7445,9 @@ export async function bootOpenApi(opts: BootOpenApiOptions): Promise<BootResult>
         }),
         passUnknownToFallback: ports.whatsappOfficialFallback,
         archiveMedia: chatArchiveLiveMedia,
+        archiveContacts: messageStoreClient
+          ? (input) => messageStoreClient.upsertContacts(input)
+          : undefined,
       }))
     }
 

--- a/packages/api/src/chat-archive/__tests__/chat-tools.test.ts
+++ b/packages/api/src/chat-archive/__tests__/chat-tools.test.ts
@@ -12,7 +12,7 @@ function fakeClient(overrides: Partial<MessageStoreClient> = {}): MessageStoreCl
 
 const context = { userId: 'alice', workspaceId: 'w1', assistantId: 'a1' } as never
 
-describe('chat archive tools', () => {
+describe('[COMP:tools/chat-archive] chat archive tools', () => {
   it('exposes search and its channel resolver', () => {
     const names = createChatArchiveTools({ client: fakeClient() }).map((tool) => tool.name)
     // Without a resolver a model can only narrow a search using a handle lifted

--- a/packages/api/src/chat-archive/__tests__/normalize.test.ts
+++ b/packages/api/src/chat-archive/__tests__/normalize.test.ts
@@ -122,4 +122,56 @@ describe('[COMP:api/chat-archive-live-capture] normalizer', () => {
       media_ref: { filename: 'report.pdf', mime: 'application/pdf', size_bytes: 7 },
     })
   })
+
+  it('normalizes an outbound self message with a STAGED archive asset as a stored v2 ref', () => {
+    // The owner's own photo relayed by a bridge: bytes were staged before the
+    // append, so the ref must carry asset identity + availability=stored —
+    // that is what lets the store link the bytes and run extraction.
+    const result = normalizeOutboundChatMessage({
+      providerMessageId: 'wx-self-9',
+      conversationId: 'c-1',
+      assistantId: 'me',
+      assistantName: 'Ken',
+      text: '',
+      archiveMedia: {
+        kind: 'image',
+        ref: { assetId: 'asset-1', sha256: 'f'.repeat(64), filename: 'sent.jpg', mime: 'image/jpeg', sizeBytes: 123 },
+      },
+    })
+    expect(result).toMatchObject({
+      direction: 'outbound',
+      kind: 'image',
+      body_text: null,
+      media_ref: {
+        asset_id: 'asset-1',
+        sha256: 'f'.repeat(64),
+        availability: 'stored',
+        filename: 'sent.jpg',
+        mime: 'image/jpeg',
+        size_bytes: 123,
+      },
+    })
+  })
+
+  it('normalizes an outbound self message whose staging failed as availability=failed, never silently text-only', () => {
+    const result = normalizeOutboundChatMessage({
+      providerMessageId: 'wx-self-10',
+      conversationId: 'c-1',
+      assistantId: 'me',
+      assistantName: 'Ken',
+      text: '',
+      archiveMedia: {
+        kind: 'image',
+        ref: null,
+        availability: 'failed',
+        filename: 'sent.jpg',
+        mime: 'image/jpeg',
+        sizeBytes: 0,
+      },
+    })
+    expect(result).toMatchObject({
+      kind: 'image',
+      media_ref: { availability: 'failed', filename: 'sent.jpg', mime: 'image/jpeg' },
+    })
+  })
 })

--- a/packages/api/src/chat-archive/__tests__/save-media-tool.test.ts
+++ b/packages/api/src/chat-archive/__tests__/save-media-tool.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createSaveChatMediaTool, MAX_SAVE_CHAT_MEDIA_BYTES } from '../save-media-tool.js'
+import type { MessageStoreClient } from '../message-store-client.js'
+import type { FilesApi } from '@use-brian/core'
+
+const SHA = 'a'.repeat(64)
+
+function fakeClient(overrides: Partial<MessageStoreClient> = {}): MessageStoreClient {
+  return {
+    downloadMedia: vi.fn(async () => ({ bytes: Buffer.from('jpeg-bytes'), mime: 'image/jpeg' })),
+    ...overrides,
+  } as unknown as MessageStoreClient
+}
+
+function fakeFilesApi(over: Partial<FilesApi> = {}): FilesApi {
+  return {
+    writeBytes: vi.fn(async (_ctx: unknown, input: { path: string; bytes: Buffer }) => ({
+      ok: true,
+      value: { id: 'file-1', path: input.path, sizeBytes: input.bytes.length },
+    })),
+    ...over,
+  } as unknown as FilesApi
+}
+
+const context = {
+  userId: 'alice',
+  workspaceId: 'w1',
+  assistantId: 'a1',
+  channelType: 'telegram',
+  clearance: 'confidential',
+} as never
+
+describe('[COMP:tools/chat-archive-save-media] saveChatMedia', () => {
+  it('binds the owner from tool context, never from model input', async () => {
+    const client = fakeClient()
+    const tool = createSaveChatMediaTool({ client, filesApi: fakeFilesApi() })
+
+    await tool.execute({ sha256: SHA } as never, context)
+
+    expect(client.downloadMedia).toHaveBeenCalledWith(
+      expect.objectContaining({ ownerUserId: 'alice', sha256: SHA, maxBytes: MAX_SAVE_CHAT_MEDIA_BYTES }),
+    )
+    const shape = (tool.inputSchema as never as { shape: Record<string, unknown> }).shape
+    expect(Object.keys(shape)).not.toContain('ownerUserId')
+    expect(Object.keys(shape)).not.toContain('userId')
+  })
+
+  it('saves under /uploads/chat-archive with internal sensitivity and hands the fileId to sendFile', async () => {
+    const filesApi = fakeFilesApi()
+    const tool = createSaveChatMediaTool({ client: fakeClient(), filesApi })
+
+    const result = await tool.execute({ sha256: SHA, filename: 'sushi platter.jpg' } as never, context) as {
+      data: { fileId: string; path: string; next: string }
+      isError?: boolean
+    }
+
+    expect(result.isError).toBeFalsy()
+    const writeInput = vi.mocked(filesApi.writeBytes).mock.calls[0][1] as { path: string; sensitivity: string; mime: string }
+    expect(writeInput.path).toMatch(/^\/uploads\/chat-archive\/.+sushi platter\.jpg$/)
+    expect(writeInput.sensitivity).toBe('internal')
+    expect(writeInput.mime).toBe('image/jpeg')
+    expect(result.data.fileId).toBe('file-1')
+    // The hand-off sentence is the contract: delivery stays sendFile's job.
+    expect(result.data.next).toContain('sendFile')
+    expect(result.data.next).toContain('file-1')
+  })
+
+  it('derives a safe name from the digest when none is given', async () => {
+    const filesApi = fakeFilesApi()
+    const tool = createSaveChatMediaTool({ client: fakeClient(), filesApi })
+
+    await tool.execute({ sha256: SHA } as never, context)
+
+    const writeInput = vi.mocked(filesApi.writeBytes).mock.calls[0][1] as { path: string }
+    expect(writeInput.path).toContain(`chat-media-${SHA.slice(0, 12)}.jpg`)
+  })
+
+  it('strips path traversal from a model-supplied filename', async () => {
+    const filesApi = fakeFilesApi()
+    const tool = createSaveChatMediaTool({ client: fakeClient(), filesApi })
+
+    await tool.execute({ sha256: SHA, filename: '../../etc/passwd' } as never, context)
+
+    const writeInput = vi.mocked(filesApi.writeBytes).mock.calls[0][1] as { path: string }
+    expect(writeInput.path).toMatch(/^\/uploads\/chat-archive\/[^/]+$/)
+  })
+
+  it('reports a missing digest as a failure, never a silent success', async () => {
+    const client = fakeClient({
+      downloadMedia: vi.fn(async () => {
+        throw new Error('message store GET /media failed: 404 not found')
+      }) as never,
+    })
+    const tool = createSaveChatMediaTool({ client, filesApi: fakeFilesApi() })
+
+    const result = await tool.execute({ sha256: SHA } as never, context) as { isError?: boolean; data: unknown }
+
+    expect(result.isError).toBe(true)
+    expect(String(result.data)).toContain('404')
+  })
+
+  it('refuses without a workspace instead of writing nowhere', async () => {
+    const tool = createSaveChatMediaTool({ client: fakeClient(), filesApi: fakeFilesApi() })
+    const result = await tool.execute({ sha256: SHA } as never, { ...(context as object), workspaceId: null } as never) as { isError?: boolean }
+    expect(result.isError).toBe(true)
+  })
+})

--- a/packages/api/src/chat-archive/live-writer.ts
+++ b/packages/api/src/chat-archive/live-writer.ts
@@ -65,6 +65,13 @@ export type LiveChatArchiveWriter = {
     workspaceId: string
     conversationId: string
     message: IncomingMessage
+    /**
+     * The channel's connector instance, when the route has one. Threading it
+     * keeps unrouted rows — and any media asset staged before this append —
+     * under the SAME binding the routed path uses: the store links assets by
+     * exact (workspace, instance, owner) and fails the append on a mismatch.
+     */
+    connectorInstanceId?: string | null
   }): Promise<void>
   persistInbound<T>(
     input: LiveArchiveContext & { message: IncomingMessage },
@@ -75,6 +82,7 @@ export type LiveChatArchiveWriter = {
     providerMessageId?: string | null
     text: string
     documents?: OutgoingDocument[]
+    archiveMedia?: Parameters<typeof normalizeOutboundChatMessage>[0]['archiveMedia']
     replyToProviderId?: string | null
   }): Promise<void>
 }
@@ -201,6 +209,7 @@ export function createLiveChatArchiveWriter(deps: {
         source: input.source,
         ownerUserId,
         workspaceId: input.workspaceId,
+        connectorInstanceId: input.connectorInstanceId,
       })
       if (!binding) return
       await deps.fanout.fanout({
@@ -273,6 +282,7 @@ export function createLiveChatArchiveWriter(deps: {
           assistantName: input.assistantName,
           text: input.text,
           documents: input.documents,
+          archiveMedia: input.archiveMedia,
           replyToProviderId: input.replyToProviderId,
         })],
         sourceCursor: { session_message_id: input.sessionMessageId },
@@ -301,12 +311,9 @@ export async function persistInboundChatArchive<T>(
  * sits on the inbound path of every channel, so it must never be the reason a
  * message is dropped.
  */
-export async function archiveUnroutedInbound(input: {
-  source: ChannelSource
-  workspaceId: string
-  conversationId: string
-  message: IncomingMessage
-}): Promise<void> {
+export async function archiveUnroutedInbound(
+  input: Parameters<LiveChatArchiveWriter['appendUnroutedInbound']>[0],
+): Promise<void> {
   if (!globalWriter) return
   await globalWriter.appendUnroutedInbound(input)
 }

--- a/packages/api/src/chat-archive/message-store-client.ts
+++ b/packages/api/src/chat-archive/message-store-client.ts
@@ -21,6 +21,7 @@ import { createHash, createHmac } from 'node:crypto'
 
 /** Contract identifiers. Bump deliberately; the store may be an old build. */
 export const SEARCH_CONTRACT_V1 = 'ub.chat.search.v1'
+export const CONTACTS_CONTRACT_V1 = 'ub.chat.contacts.v1'
 
 export type ChatArchiveHit = {
   segment_id: string
@@ -31,6 +32,8 @@ export type ChatArchiveHit = {
   conversation_id: string
   sender_id: string
   sender_display?: string
+  /** The owner's saved name for this sender, from the synced contact directory. */
+  sender_contact_name?: string
   sent_at: string
   direction: string
   kind: string
@@ -77,6 +80,8 @@ export type ChatChannel = {
   last_message_preview: string
   last_sender_id?: string
   last_sender_display?: string
+  /** The owner's saved name for the last sender, from the synced contact directory. */
+  last_sender_contact_name?: string
   last_direction: string
 }
 
@@ -252,6 +257,46 @@ export class MessageStoreClient {
   }
 
   /**
+   * Reads attachment bytes back out of the archive.
+   *
+   * Owner-bound: the store resolves the digest under the owner's row-level
+   * security, and a digest belonging to someone else is a 404 deliberately
+   * indistinguishable from a missing one. The digest comes from a search hit's
+   * `media_sha256`; there is no lookup by asset id.
+   *
+   * `maxBytes` is enforced against Content-Length before buffering — archive
+   * per-kind ceilings (512 MB video) are far above what any delivery path
+   * accepts, so the caller must state its own bound.
+   */
+  async downloadMedia(input: {
+    ownerUserId: string
+    sha256: string
+    maxBytes: number
+  }): Promise<{ bytes: Buffer; mime: string }> {
+    const digest = input.sha256.trim().toLowerCase()
+    if (!/^[0-9a-f]{64}$/.test(digest)) {
+      throw new Error('downloadMedia requires a 64-hex sha256 digest')
+    }
+    const params = new URLSearchParams({ owner_user_id: input.ownerUserId })
+    const requestUri = `/media/${digest}?${params.toString()}`
+    const response = await this.send('GET', requestUri, {
+      'X-UB-Signature': signRequest('GET', requestUri, this.secret),
+    })
+    const declared = Number(response.headers.get('content-length') ?? '0')
+    if (declared > input.maxBytes) {
+      throw new Error(`archive media is ${declared} bytes — over the ${input.maxBytes}-byte limit for this operation`)
+    }
+    const bytes = Buffer.from(await response.arrayBuffer())
+    if (bytes.length > input.maxBytes) {
+      throw new Error(`archive media is ${bytes.length} bytes — over the ${input.maxBytes}-byte limit for this operation`)
+    }
+    return {
+      bytes,
+      mime: response.headers.get('content-type') ?? 'application/octet-stream',
+    }
+  }
+
+  /**
    * Lists archived conversations, most recently active first.
    *
    * Nothing in the archive stores a human-readable channel name — provider
@@ -272,6 +317,48 @@ export class MessageStoreClient {
     })
     const body = (await response.json()) as { channels?: ChatChannel[] }
     return body.channels ?? []
+  }
+
+  /**
+   * Upserts the owner's contact directory for one channel connector.
+   *
+   * Names resolve at QUERY time (search/channels join the directory on
+   * `sender_id`), so a directory entry that arrives after the messages did
+   * still names every old row — the archive's raw `sender_display` stays
+   * whatever the provider sent with each message.
+   *
+   * Empty strings never clobber a stored name; the store keeps the previous
+   * non-empty value per column.
+   */
+  async upsertContacts(input: {
+    workspaceId: string
+    instanceId: string
+    ownerUserId: string
+    source: string
+    contacts: Array<{
+      contactId: string
+      /** The owner's own address-book name for this contact (the strongest label). */
+      savedName?: string | null
+      /** The name the contact set for themselves (WhatsApp pushName). */
+      pushName?: string | null
+      /** Business-verified display name, when the platform provides one. */
+      verifiedName?: string | null
+    }>
+  }): Promise<{ upserted: number }> {
+    if (input.contacts.length === 0) return { upserted: 0 }
+    return this.postJson<{ upserted: number }>('/contacts', {
+      contract: CONTACTS_CONTRACT_V1,
+      workspace_id: input.workspaceId,
+      instance_id: input.instanceId,
+      owner_user_id: input.ownerUserId,
+      source: input.source,
+      contacts: input.contacts.map((c) => ({
+        contact_id: c.contactId,
+        ...(c.savedName ? { saved_name: c.savedName } : {}),
+        ...(c.pushName ? { push_name: c.pushName } : {}),
+        ...(c.verifiedName ? { verified_name: c.verifiedName } : {}),
+      })),
+    })
   }
 
   /** Leases enrichment windows for Pipeline B. */

--- a/packages/api/src/chat-archive/normalize.ts
+++ b/packages/api/src/chat-archive/normalize.ts
@@ -90,8 +90,33 @@ export function normalizeOutboundChatMessage(input: {
   sentAt?: Date
   documents?: OutgoingDocument[]
   replyToProviderId?: string | null
-}): CanonicalIngestMessage {
+  /**
+   * A durable archive asset staged BEFORE this append (the owner's own media
+   * relayed by a bridge, staged the same way inbound attachments are). Takes
+   * precedence over `documents`, which describe an outgoing file by metadata
+   * only — a stored ref is what lets the store link bytes and run extraction.
+   */
+  archiveMedia?: {
+    kind: 'image' | 'video' | 'voice' | 'file'
+    ref: {
+      assetId: string
+      sha256: string
+      filename: string
+      mime: string
+      sizeBytes: number
+    } | null
+    /** Set when the bytes could not be staged; travels as availability. */
+    availability?: 'missing' | 'failed'
+    filename?: string
+    mime?: string
+    sizeBytes?: number
+  }
+}): AnyCanonicalIngestMessage {
   const document = input.documents?.[0]
+  const media = input.archiveMedia
+  const mediaKind = media
+    ? media.kind
+    : document ? 'file' : null
   return {
     provider_message_id: input.providerMessageId,
     conversation_id: input.conversationId,
@@ -99,14 +124,30 @@ export function normalizeOutboundChatMessage(input: {
     sender_display: input.assistantName,
     sent_at: (input.sentAt ?? new Date()).toISOString(),
     direction: 'outbound',
-    kind: document ? 'file' : (/^https?:\/\/\S+$/i.test(input.text.trim()) ? 'link' : 'text'),
+    kind: mediaKind ?? (/^https?:\/\/\S+$/i.test(input.text.trim()) ? 'link' : 'text'),
     body_text: input.text.length > 0 ? input.text : null,
-    media_ref: document ? {
-      filename: document.filename,
-      mime: document.mime,
-      size_bytes: document.data.byteLength,
-    } : null,
+    media_ref: media
+      ? (media.ref
+          ? {
+              asset_id: media.ref.assetId,
+              sha256: media.ref.sha256,
+              availability: 'stored',
+              filename: media.ref.filename,
+              mime: media.ref.mime,
+              size_bytes: media.ref.sizeBytes,
+            }
+          : {
+              availability: media.availability ?? 'missing',
+              filename: media.filename ?? '',
+              mime: media.mime ?? '',
+              size_bytes: Math.max(0, media.sizeBytes ?? 0),
+            })
+      : document ? {
+          filename: document.filename,
+          mime: document.mime,
+          size_bytes: document.data.byteLength,
+        } : null,
     reply_to_provider_id: input.replyToProviderId ?? null,
     raw_provider_blob: null,
-  }
+  } as AnyCanonicalIngestMessage
 }

--- a/packages/api/src/chat-archive/save-media-tool.ts
+++ b/packages/api/src/chat-archive/save-media-tool.ts
@@ -1,0 +1,140 @@
+/**
+ * saveChatMedia — land an archived chat attachment in the workspace file
+ * layer, where every delivery surface can reach it.
+ *
+ * The archive owns the bytes (content-addressed, keyed by sha256) and search
+ * hits carry `media_sha256`/`media_mime`, but until now nothing could get the
+ * bytes back OUT: "can you send me that file" dead-ended with "the record has
+ * no downloadable path". This tool closes the loop the same way
+ * `imapSaveAttachment` does for email: fetch from the seam → workspace file →
+ * hand the returned `fileId` to `sendFile` (or let the user grab it in the
+ * web app's Files view).
+ *
+ * Owner identity comes from ToolContext, never from the input schema — the
+ * store additionally resolves the digest under the owner's row-level
+ * security, so a foreign digest is a 404 indistinguishable from a missing one.
+ *
+ * [COMP:tools/chat-archive-save-media]
+ */
+
+import { z } from 'zod'
+import {
+  buildTool,
+  toolFailure,
+  workspaceFilesCtxFor,
+  workspaceFilesErrorMessage,
+  workspaceFilesGate,
+  type FilesApi,
+  type Tool,
+} from '@use-brian/core'
+import { CHAT_ARCHIVE_SAVE_MEDIA_TOOL } from './tool-catalog.js'
+import type { MessageStoreClient } from './message-store-client.js'
+
+/**
+ * Buffered in memory on the way through, so this is deliberately far below
+ * the archive's 512 MB video ceiling. Everything a chat delivers day to day
+ * (images, voice notes, documents) fits with room to spare.
+ */
+export const MAX_SAVE_CHAT_MEDIA_BYTES = 128 * 1024 * 1024
+
+const EXTENSION_BY_MIME: Record<string, string> = {
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/gif': '.gif',
+  'image/webp': '.webp',
+  'video/mp4': '.mp4',
+  'audio/ogg': '.ogg',
+  'audio/mpeg': '.mp3',
+  'application/pdf': '.pdf',
+}
+
+function safeFileName(raw: string | undefined, mime: string, sha256: string): string {
+  const fallback = `chat-media-${sha256.slice(0, 12)}${EXTENSION_BY_MIME[mime] ?? ''}`
+  if (!raw) return fallback
+  const cleaned = raw
+    .replace(/[/\\]/g, '-')
+    .replace(/[\x00-\x1f\x7f]/g, '')
+    .replace(/^\.+/, '')
+    .trim()
+    .slice(0, 160)
+  return cleaned || fallback
+}
+
+export type SaveChatMediaDeps = {
+  client: MessageStoreClient
+  filesApi: FilesApi
+}
+
+export function createSaveChatMediaTool(deps: SaveChatMediaDeps): Tool {
+  return buildTool({
+    name: CHAT_ARCHIVE_SAVE_MEDIA_TOOL.name,
+    description: CHAT_ARCHIVE_SAVE_MEDIA_TOOL.description,
+    requiresCapability: 'files',
+    inputSchema: z.object({
+      sha256: z
+        .string()
+        .regex(/^[0-9a-fA-F]{64}$/)
+        .describe('The `media_sha256` of a searchChatHistory hit. Identifies the exact stored bytes.'),
+      filename: z
+        .string()
+        .min(1)
+        .max(256)
+        .optional()
+        .describe('Filename to save under. Defaults to a name derived from the digest and MIME type.'),
+      title: z
+        .string()
+        .min(1)
+        .max(256)
+        .optional()
+        .describe('Display label for the saved file. Defaults to the filename.'),
+    }),
+    isConcurrencySafe: false,
+    isReadOnly: false,
+    requiresConfirmation: false,
+    // A large voice note or document over loopback still lands well inside
+    // this; the store serves from local disk.
+    timeoutMs: 60_000,
+    async execute(input, context) {
+      const gate = workspaceFilesGate(context.workspaceId)
+      if (gate) return gate
+      try {
+        const media = await deps.client.downloadMedia({
+          ownerUserId: context.userId,
+          sha256: input.sha256,
+          maxBytes: MAX_SAVE_CHAT_MEDIA_BYTES,
+        })
+        const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+        const name = safeFileName(input.filename, media.mime, input.sha256.toLowerCase())
+        const stored = await deps.filesApi.writeBytes(workspaceFilesCtxFor(context), {
+          path: `/uploads/chat-archive/${stamp}-${name}`,
+          bytes: media.bytes,
+          mime: media.mime,
+          title: input.title ?? name,
+          // Personal chat media: internal by default, same stance as email
+          // attachments — `sendFile`'s sensitivity gate stays the authority
+          // for what may leave the workspace.
+          sensitivity: 'internal',
+        })
+        if (!stored.ok) return { data: workspaceFilesErrorMessage(stored.error), isError: true }
+        const file = stored.value
+        return {
+          data: {
+            fileId: file.id,
+            path: file.path,
+            filename: name,
+            mime: media.mime,
+            sizeBytes: file.sizeBytes,
+            next: 'To deliver it in this chat, call sendFile with file="' + file.id + '".',
+          },
+        }
+      } catch (err) {
+        return toolFailure(err, {
+          tool: CHAT_ARCHIVE_SAVE_MEDIA_TOOL.name,
+          target: `archived media ${input.sha256.slice(0, 12)}…`,
+          next:
+            'A 404 means the archive holds no stored bytes under this digest for THIS user — re-run searchChatHistory and use the hit\'s exact `media_sha256`; a hit whose media coverage is `missing` or `pending` has no bytes to fetch yet. Never invent a digest.',
+        })
+      }
+    },
+  })
+}

--- a/packages/api/src/chat-archive/tool-catalog.ts
+++ b/packages/api/src/chat-archive/tool-catalog.ts
@@ -10,8 +10,30 @@ export const CHAT_ARCHIVE_SEARCH_TOOL = {
     'Narrow with `channel` (get one from listChatChannels or a prior hit) and a `since`/`until` range. ' +
     'Image OCR and descriptions, document passages, audio transcripts, and sampled video content are ' +
     'searched alongside captions and message text. Results report how much of the range is not yet ' +
-    'semantically indexed, so a thin result set can be told apart from an unindexed one.',
+    'semantically indexed, so a thin result set can be told apart from an unindexed one. ' +
+    'Hits carry the sender\'s id (a phone number or platform id), their display/push name, and the ' +
+    'saved contact name when the user\'s synced address book has one — when only a bare number comes ' +
+    'back, cross-check it against the CRM with listContacts before telling the user no name is known. ' +
+    'Hits with media also carry `media_sha256`: pass it to saveChatMedia to save or send the actual file.',
   classification: 'read',
+  defaultPolicy: 'allow',
+} as const
+
+/**
+ * The retrieval half of "send me that file".
+ *
+ * Search hits describe media (`media_sha256`, `media_mime`, extraction state)
+ * but the bytes live in the archive's content-addressed store. This tool pulls
+ * them into the workspace file layer, where `sendFile` and the web app's Files
+ * view can reach them.
+ */
+export const CHAT_ARCHIVE_SAVE_MEDIA_TOOL = {
+  name: 'saveChatMedia',
+  description:
+    'Save a photo, voice note, video, or document from the user\'s archived WeChat/WhatsApp history into the workspace as a real file. ' +
+    'Use when the user asks you to send, save, or forward something that arrived in a chat: find the message with searchChatHistory, take the hit\'s `media_sha256`, save it here, then pass the returned `fileId` to sendFile to deliver it. ' +
+    'Only works for hits whose media is stored (`extraction_status` present and media coverage not `missing`); if the digest is absent the original bytes were never captured and cannot be recovered — say so instead of retrying.',
+  classification: 'write',
   defaultPolicy: 'allow',
 } as const
 

--- a/packages/api/src/db/crm.ts
+++ b/packages/api/src/db/crm.ts
@@ -551,7 +551,15 @@ export async function listContacts(ctx: AccessContext, filters: ContactListFilte
   let idx = ap.nextIdx
 
   if (filters.query) {
-    wheres.push(`(e.display_name ILIKE $${idx} OR e.attributes->>'email' ILIKE $${idx})`)
+    // A phone-shaped query ("+852 6698 6281", "85266986281") must find the
+    // contact regardless of how the stored number is spaced or prefixed, so
+    // both sides compare digits-only. Gated on >= 5 query digits: shorter
+    // digit runs ("Suite 21") are not phone searches and would fan out.
+    const queryDigits = filters.query.replace(/\D/g, '')
+    const phoneArm = queryDigits.length >= 5
+      ? ` OR regexp_replace(COALESCE(e.attributes->>'phone', ''), '[^0-9]', '', 'g') LIKE '%' || regexp_replace($${idx}, '[^0-9]', '', 'g') || '%'`
+      : ''
+    wheres.push(`(e.display_name ILIKE $${idx} OR e.attributes->>'email' ILIKE $${idx}${phoneArm})`)
     values.push(`%${filters.query}%`); idx++
   }
   if (filters.tag) {

--- a/packages/api/src/db/custom-channel-store.ts
+++ b/packages/api/src/db/custom-channel-store.ts
@@ -38,6 +38,8 @@ export type CustomChannelBridgeState = {
   accountLabel?: string
   action?: BridgeAction
   bridgeVersion?: string
+  /** Bridge-declared delivery capabilities (see BridgeState.capabilities). */
+  capabilities?: { documents?: boolean }
 }
 
 export type CustomChannelStateView = CustomChannelBridgeState & {
@@ -98,6 +100,7 @@ type StateRow = {
   account_label: string | null
   action: BridgeAction | null
   bridge_version: string | null
+  capabilities: { documents?: boolean } | null
   last_seen_at: Date | string | null
   updated_at: Date | string | null
   outbox_depth: string | number | null
@@ -121,14 +124,15 @@ export function createCustomChannelStore(): CustomChannelStore {
     async putState(channelId, state) {
       await query(
         `INSERT INTO custom_channel_bridge_state
-           (channel_id, status, message, account_label, action, bridge_version, last_seen_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5::jsonb, $6, now(), now())
+           (channel_id, status, message, account_label, action, bridge_version, capabilities, last_seen_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7::jsonb, now(), now())
          ON CONFLICT (channel_id) DO UPDATE SET
            status = EXCLUDED.status,
            message = EXCLUDED.message,
            account_label = EXCLUDED.account_label,
            action = EXCLUDED.action,
            bridge_version = EXCLUDED.bridge_version,
+           capabilities = EXCLUDED.capabilities,
            last_seen_at = now(),
            updated_at = now()`,
         [
@@ -138,6 +142,7 @@ export function createCustomChannelStore(): CustomChannelStore {
           state.accountLabel ?? null,
           state.action ? JSON.stringify(state.action) : null,
           state.bridgeVersion ?? null,
+          state.capabilities ? JSON.stringify(state.capabilities) : null,
         ],
       )
     },
@@ -145,7 +150,7 @@ export function createCustomChannelStore(): CustomChannelStore {
     async getState(channelId, now = new Date()) {
       const result = await query<StateRow>(
         `SELECT s.channel_id, s.status, s.message, s.account_label, s.action, s.bridge_version,
-                s.last_seen_at, s.updated_at,
+                s.capabilities, s.last_seen_at, s.updated_at,
                 (SELECT count(*) FROM custom_channel_outbox o
                   WHERE o.channel_id = s.channel_id AND o.acked_at IS NULL AND o.expires_at > now()) AS outbox_depth
            FROM custom_channel_bridge_state s
@@ -163,6 +168,7 @@ export function createCustomChannelStore(): CustomChannelStore {
         accountLabel: row.account_label ?? undefined,
         action: row.action ?? undefined,
         bridgeVersion: row.bridge_version ?? undefined,
+        capabilities: row.capabilities ?? undefined,
         lastSeenAt,
         updatedAt: iso(row.updated_at),
         online,

--- a/packages/api/src/routes/__tests__/custom-channel-bridge.test.ts
+++ b/packages/api/src/routes/__tests__/custom-channel-bridge.test.ts
@@ -49,7 +49,7 @@ import { processChannelMessage } from '../channel-pipeline.js'
 import { getChannelForWebhook, resolveRoutingForSurface } from '../../db/channels-store.js'
 import { findAssistantById } from '../../db/users.js'
 import { resolveChannelUser } from '../../db/channel-user-store.js'
-import { archiveUnroutedInbound, appendOutboundChatArchive } from '../../chat-archive/live-writer.js'
+import { archiveUnroutedInbound, appendOutboundChatArchive, resolveChatArchiveInstanceId } from '../../chat-archive/live-writer.js'
 import { hashBridgeToken } from '../../db/custom-channel-token.js'
 import type { CustomChannelStore, ClaimedOutboxItem, CustomChannelBridgeState } from '../../db/custom-channel-store.js'
 
@@ -116,7 +116,11 @@ function makeIntegrationStore(over: { config?: Record<string, unknown>; credenti
   }
 }
 
-function buildApp(opts: { integrationStore?: ReturnType<typeof makeIntegrationStore>; store?: CustomChannelStore } = {}) {
+function buildApp(opts: {
+  integrationStore?: ReturnType<typeof makeIntegrationStore>
+  store?: CustomChannelStore
+  archiveMedia?: { storeBuffer: ReturnType<typeof vi.fn>; uploadTarget: ReturnType<typeof vi.fn> }
+} = {}) {
   const { store } = opts.store ? { store: opts.store } : makeStore()
   const integrationStore = opts.integrationStore ?? makeIntegrationStore()
   const app = createTestApp('/bridge/v1/channels', customChannelBridgeRoutes({
@@ -129,6 +133,7 @@ function buildApp(opts: { integrationStore?: ReturnType<typeof makeIntegrationSt
     memoryStore: {} as never,
     capabilityStore: {} as never,
     sleep: async () => {},
+    archiveMedia: opts.archiveMedia as never,
   }))
   return { app, store, integrationStore }
 }
@@ -405,5 +410,166 @@ describe('[COMP:api/custom-channel-bridge] outbox', () => {
     const { app } = buildApp()
     const res = await request(app).post(`${BASE}/outbox/ack`).set('Authorization', `Bearer ${TOKEN}`).send({ results: [{ id: 'nope' }] })
     expect(res.status).toBe(400)
+  })
+})
+
+// A 1x1 PNG's worth of stand-in bytes, inline like the wechat bridge sends them.
+const PNG_B64 = Buffer.from('fake-image-bytes').toString('base64')
+
+function makeArchiveMedia() {
+  return {
+    storeBuffer: vi.fn(async (input: { filename: string; mime: string; bytes: Buffer }) => ({
+      assetId: '11111111-1111-1111-1111-111111111111',
+      sha256: 'a'.repeat(64),
+      filename: input.filename,
+      mime: input.mime,
+      sizeBytes: input.bytes.length,
+    })),
+    uploadTarget: vi.fn(),
+  }
+}
+
+describe('[COMP:api/custom-channel-bridge] archive-only exits stage media first', () => {
+  it('an unaddressed group image is staged and archived with a stored ref, not filename hints', async () => {
+    const archiveMedia = makeArchiveMedia()
+    vi.mocked(resolveChatArchiveInstanceId).mockResolvedValue('inst-1')
+    const { app } = buildApp({ archiveMedia })
+    const res = await request(app)
+      .post(`${BASE}/inbound`)
+      .set('Authorization', `Bearer ${TOKEN}`)
+      .send(inbound({
+        peerId: 'group-1', senderId: 'u-9', isGroupChat: true, isMentioned: false, text: '',
+        media: [{ kind: 'image', mime: 'image/jpeg', name: 'msg_6.jpg', dataBase64: PNG_B64 }],
+      }))
+    expect(res.status).toBe(202)
+    await flush()
+    expect(archiveMedia.storeBuffer).toHaveBeenCalledTimes(1)
+    expect(archiveMedia.storeBuffer.mock.calls[0][0]).toMatchObject({
+      workspaceId: 'ws-1',
+      instanceId: 'inst-1',
+      ownerUserId: 'owner',
+      source: 'custom',
+      providerMessageId: 'm-1',
+      kind: 'image',
+      filename: 'msg_6.jpg',
+    })
+    expect(archiveUnroutedInbound).toHaveBeenCalledTimes(1)
+    const appended = vi.mocked(archiveUnroutedInbound).mock.calls[0][0]
+    expect(appended.message.archiveMediaRef).toMatchObject({
+      assetId: '11111111-1111-1111-1111-111111111111',
+      sha256: 'a'.repeat(64),
+      filename: 'msg_6.jpg',
+    })
+    expect(appended.message.archiveMediaAvailability).toBeUndefined()
+    expect(processChannelMessage).not.toHaveBeenCalled()
+  })
+
+  it('threads the integration connector instance into staging AND the unrouted append', async () => {
+    const archiveMedia = makeArchiveMedia()
+    const integrationStore = makeIntegrationStore()
+    integrationStore.getByChannelForWebhook.mockResolvedValue({
+      id: 'int-1', channelId: CHANNEL_ID, config: {},
+      credentials: { bridge_token_hash: hashBridgeToken(TOKEN), kind: 'wechat-desktop' },
+      connectorInstanceId: 'inst-from-integration',
+    })
+    const { app } = buildApp({ archiveMedia, integrationStore })
+    await request(app)
+      .post(`${BASE}/inbound`)
+      .set('Authorization', `Bearer ${TOKEN}`)
+      .send(inbound({
+        peerId: 'group-1', senderId: 'u-9', isGroupChat: true, isMentioned: false, text: '',
+        media: [{ kind: 'image', mime: 'image/jpeg', name: 'p.jpg', dataBase64: PNG_B64 }],
+      }))
+    await flush()
+    // The store links assets by exact (instance, provider message id); a
+    // split here orphans the bytes and fails the append.
+    expect(archiveMedia.storeBuffer.mock.calls[0][0]).toMatchObject({ instanceId: 'inst-from-integration' })
+    expect(vi.mocked(archiveUnroutedInbound).mock.calls[0][0]).toMatchObject({ connectorInstanceId: 'inst-from-integration' })
+    expect(resolveChatArchiveInstanceId).not.toHaveBeenCalled()
+  })
+
+  it('a staging failure archives availability=failed, never drops the message', async () => {
+    const archiveMedia = makeArchiveMedia()
+    archiveMedia.storeBuffer.mockRejectedValue(new Error('store is down'))
+    vi.mocked(resolveChatArchiveInstanceId).mockResolvedValue('inst-1')
+    const { app } = buildApp({ archiveMedia })
+    await request(app)
+      .post(`${BASE}/inbound`)
+      .set('Authorization', `Bearer ${TOKEN}`)
+      .send(inbound({
+        peerId: 'group-1', senderId: 'u-9', isGroupChat: true, isMentioned: false, text: '',
+        media: [{ kind: 'image', mime: 'image/jpeg', name: 'p.jpg', dataBase64: PNG_B64 }],
+      }))
+    await flush()
+    expect(archiveUnroutedInbound).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(archiveUnroutedInbound).mock.calls[0][0].message.archiveMediaAvailability).toBe('failed')
+  })
+
+  it("the owner's own media message (isSelf) is staged and archived as outbound with a stored ref", async () => {
+    const archiveMedia = makeArchiveMedia()
+    vi.mocked(resolveChatArchiveInstanceId).mockResolvedValue('inst-1')
+    const { app } = buildApp({ archiveMedia })
+    const res = await request(app)
+      .post(`${BASE}/inbound`)
+      .set('Authorization', `Bearer ${TOKEN}`)
+      .send(inbound({
+        senderId: 'me', senderName: 'Ken', isSelf: true, text: '',
+        media: [{ kind: 'image', mime: 'image/jpeg', name: 'sent.jpg', dataBase64: PNG_B64 }],
+      }))
+    expect(res.status).toBe(202)
+    await flush()
+    expect(archiveMedia.storeBuffer).toHaveBeenCalledTimes(1)
+    expect(appendOutboundChatArchive).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(appendOutboundChatArchive).mock.calls[0][0]).toMatchObject({
+      source: 'custom',
+      archiveMedia: {
+        kind: 'image',
+        ref: { assetId: '11111111-1111-1111-1111-111111111111', filename: 'sent.jpg' },
+      },
+    })
+  })
+})
+
+describe('[COMP:api/custom-channel-bridge] outbound documents', () => {
+  async function runTurnAndGetParams(app: ReturnType<typeof buildApp>['app']) {
+    const res = await request(app).post(`${BASE}/inbound`).set('Authorization', `Bearer ${TOKEN}`).send(inbound())
+    expect(res.status).toBe(200)
+    await flush()
+    expect(processChannelMessage).toHaveBeenCalledTimes(1)
+    return vi.mocked(processChannelMessage).mock.calls[0][0] as unknown as {
+      channelDocumentsSupported?: boolean
+      hooks: { sendResponse: (text: string, documents?: Array<{ filename: string; mime: string; data: Uint8Array; caption?: string }>) => Promise<unknown> }
+    }
+  }
+
+  it('threads channelDocumentsSupported=true only when the bridge declared documents in its state', async () => {
+    const made = makeStore()
+    await made.store.putState(CHANNEL_ID, { status: 'connected', capabilities: { documents: true } })
+    const { app } = buildApp({ store: made.store })
+    const params = await runTurnAndGetParams(app)
+    expect(params.channelDocumentsSupported).toBe(true)
+  })
+
+  it('threads channelDocumentsSupported=false for a bridge that never declared it', async () => {
+    const { app } = buildApp()
+    const params = await runTurnAndGetParams(app)
+    expect(params.channelDocumentsSupported).toBe(false)
+  })
+
+  it('sendResponse forwards documents into the outbox item as base64', async () => {
+    const made = makeStore()
+    await made.store.putState(CHANNEL_ID, { status: 'connected', capabilities: { documents: true } })
+    const { app } = buildApp({ store: made.store })
+    const params = await runTurnAndGetParams(app)
+    await params.hooks.sendResponse('here is the file', [
+      { filename: 'sushi.jpg', mime: 'image/jpeg', data: new Uint8Array([1, 2, 3]), caption: 'from Jack' },
+    ])
+    const messages = made.items.filter((i) => i.type === 'message')
+    expect(messages).toHaveLength(1)
+    const payload = messages[0].payload as { text: string; documents?: Array<{ filename: string; mime: string; dataBase64: string; caption?: string }> }
+    expect(payload.text).toBe('here is the file')
+    expect(payload.documents).toHaveLength(1)
+    expect(payload.documents![0]).toMatchObject({ filename: 'sushi.jpg', mime: 'image/jpeg', caption: 'from Jack' })
+    expect(Buffer.from(payload.documents![0].dataBase64, 'base64')).toEqual(Buffer.from([1, 2, 3]))
   })
 })

--- a/packages/api/src/routes/__tests__/whatsapp-byon.test.ts
+++ b/packages/api/src/routes/__tests__/whatsapp-byon.test.ts
@@ -400,3 +400,76 @@ describe('[COMP:api/whatsapp-byon-route] internal routing', () => {
     expect(captured[0]).toMatchObject({ archiveMediaAvailability: 'failed' })
   })
 })
+
+describe('[COMP:api/whatsapp-contact-directory] contact directory relay', () => {
+  function contactsApp(over: {
+    archiveContacts?: ReturnType<typeof vi.fn>
+    connectorInstanceId?: string | null
+  } = {}) {
+    const archiveContacts = over.archiveContacts
+    const app = express()
+    app.use(express.json())
+    app.use('/internal/whatsapp', whatsappByonRoutes({
+      connectorSecret: 'secret',
+      integrationStore: {
+        getByChannelForWebhook: vi.fn(async () => ({ connectorInstanceId: over.connectorInstanceId ?? 'inst-1' })),
+      } as never,
+      ingestor: {} as never,
+      bot: {} as never,
+      getChannel: vi.fn(async () => ({ workspaceId: 'ws-1' })) as never,
+      getWorkspaceOwnerUserId: vi.fn(async () => 'owner-1'),
+      archiveContacts: archiveContacts as never,
+    }))
+    return app
+  }
+
+  it('rejects a bad secret and a bad payload', async () => {
+    const app = contactsApp({ archiveContacts: vi.fn() })
+    expect((await request(app).post('/internal/whatsapp/contacts').set('X-Connector-Secret', 'wrong')
+      .send({ channelId: 'c', contacts: [{ contactId: 'x' }] })).status).toBe(401)
+    expect((await request(app).post('/internal/whatsapp/contacts').set('X-Connector-Secret', 'secret')
+      .send({ channelId: 'c', contacts: [] })).status).toBe(400)
+  })
+
+  it('202-skips when no archive is deployed, instead of erroring the connector', async () => {
+    const app = contactsApp({ archiveContacts: undefined })
+    const res = await request(app).post('/internal/whatsapp/contacts').set('X-Connector-Secret', 'secret')
+      .send({ channelId: 'byon-channel', contacts: [{ contactId: '852@s.whatsapp.net', savedName: 'Ken' }] })
+    expect(res.status).toBe(202)
+    expect(res.body).toMatchObject({ ok: true, skipped: true })
+  })
+
+  it('upserts named contacts under the channel workspace/owner/instance and drops nameless ones', async () => {
+    const archiveContacts = vi.fn(async () => ({ upserted: 2 }))
+    const app = contactsApp({ archiveContacts })
+    const res = await request(app).post('/internal/whatsapp/contacts').set('X-Connector-Secret', 'secret')
+      .send({
+        channelId: 'byon-channel',
+        contacts: [
+          { contactId: '85266986281@s.whatsapp.net', savedName: 'Jack Chan', pushName: 'jackie' },
+          { contactId: '15551234567@s.whatsapp.net', pushName: 'Sam' },
+          { contactId: 'nameless@s.whatsapp.net' },
+        ],
+      })
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({ ok: true, upserted: 2 })
+    expect(archiveContacts).toHaveBeenCalledWith({
+      workspaceId: 'ws-1',
+      instanceId: 'inst-1',
+      ownerUserId: 'owner-1',
+      source: 'whatsapp',
+      contacts: [
+        { contactId: '85266986281@s.whatsapp.net', savedName: 'Jack Chan', pushName: 'jackie' },
+        { contactId: '15551234567@s.whatsapp.net', pushName: 'Sam' },
+      ],
+    })
+  })
+
+  it('reports an archive failure as 502, never a silent success', async () => {
+    const archiveContacts = vi.fn(async () => { throw new Error('store down') })
+    const app = contactsApp({ archiveContacts })
+    const res = await request(app).post('/internal/whatsapp/contacts').set('X-Connector-Secret', 'secret')
+      .send({ channelId: 'byon-channel', contacts: [{ contactId: 'x@s.whatsapp.net', savedName: 'X' }] })
+    expect(res.status).toBe(502)
+  })
+})

--- a/packages/api/src/routes/channel-pipeline.ts
+++ b/packages/api/src/routes/channel-pipeline.ts
@@ -413,6 +413,13 @@ export type ChannelPipelineParams = {
   archiveInboundAlreadyPersisted?: boolean
   /** Exact connector backing this route, when known. */
   archiveConnectorInstanceId?: string | null
+  /**
+   * Per-channel-instance document capability (custom bridges declare it in
+   * their state report). Threaded onto ToolContext so the `sendFile` gate can
+   * admit a bridge that proved it delivers files — see
+   * `ToolContext.channelDocumentsSupported`.
+   */
+  channelDocumentsSupported?: boolean
 
   // ── Model ──
   /** The model alias string from the assistant record. */
@@ -1936,6 +1943,7 @@ export async function processChannelMessage(params: ChannelPipelineParams): Prom
         workerManager,
         activeCapabilities,
         outboundAttachments: attachmentCollector,
+        channelDocumentsSupported: params.channelDocumentsSupported,
         sensitivity: sensitivityAccumulator,
         compartmentAccumulator,
         evidence: replyEvidence,

--- a/packages/api/src/routes/custom-channel-bridge.ts
+++ b/packages/api/src/routes/custom-channel-bridge.ts
@@ -169,6 +169,7 @@ export const bridgeStateSchema: z.ZodType<BridgeState> = z.object({
   accountLabel: z.string().max(500).optional(),
   action: bridgeActionSchema.optional(),
   bridgeVersion: z.string().max(200).optional(),
+  capabilities: z.object({ documents: z.boolean().optional() }).optional(),
 })
 
 const bridgeInboundMediaSchema = z.object({
@@ -478,7 +479,7 @@ export function customChannelBridgeRoutes(options: CustomChannelBridgeRouteOptio
 
       // 2. The bridge account's own message: archive as outbound, never a turn.
       if (msg.isSelf) {
-        await archiveSelfMessage(channel, msg)
+        await archiveSelfMessage(channel, integration, msg)
         res.status(202).json({ ok: true, archivedOnly: true })
         return
       }
@@ -490,10 +491,25 @@ export function customChannelBridgeRoutes(options: CustomChannelBridgeRouteOptio
       }
 
       const archiveOnly = async (why: string): Promise<void> => {
+        // Stage the bytes FIRST: these exits never reach processMessage's
+        // staging loop, and the bridge cursor advances after this ack — an
+        // attachment archived as filename-only here is unrecoverable.
+        const staged = await stageUnroutedBridgeMedia({
+          channel,
+          connectorInstanceId: integration.connectorInstanceId,
+          msg,
+        })
+        if (staged?.ref) {
+          incoming.archiveMediaRef = staged.ref
+          incoming.archiveMediaAvailability = undefined
+        } else if (staged?.failed) {
+          incoming.archiveMediaAvailability = 'failed'
+        }
         await archiveUnroutedInbound({
           source: 'custom',
           workspaceId: channel.workspaceId,
           conversationId: peerId,
+          connectorInstanceId: integration.connectorInstanceId,
           message: incoming,
         }).catch((err: unknown) => console.error('[custom-channel] unrouted archive append failed:', err))
         console.log(`[custom-channel] ${why} for ${peerId} on channel ${channelId} — archived, not answered`)
@@ -585,6 +601,11 @@ export function customChannelBridgeRoutes(options: CustomChannelBridgeRouteOptio
       }
 
       // 8. Sequentialize per conversation.
+      // A file reply is deliverable only when THIS bridge declared it can put
+      // one on the wire (`capabilities.documents` in its /state report) — the
+      // static sendFile gate cannot answer that for `custom`, where capability
+      // is a per-bridge fact rather than a per-channel-type one.
+      const bridgeState = await store.getState(channelId).catch(() => null)
       await withChatLock(`custom:${channelId}:${peerId}`, () =>
         processMessage({
           adapter,
@@ -598,6 +619,7 @@ export function customChannelBridgeRoutes(options: CustomChannelBridgeRouteOptio
           channelId,
           confirmKey,
           archiveConnectorInstanceId: integration.connectorInstanceId,
+          documentsCapable: bridgeState?.capabilities?.documents === true,
         }),
       )
     } catch (err) {
@@ -607,27 +629,132 @@ export function customChannelBridgeRoutes(options: CustomChannelBridgeRouteOptio
   })
 
   /**
+   * Stage bridge media into the archive for a message that will be archived
+   * WITHOUT running a turn (unaddressed group, allow/blocklist, no routing,
+   * the owner's own message). The routed path stages inside `processMessage`;
+   * these exits used to archive filename hints and silently discard the bytes
+   * the bridge had already delivered — unrecoverable, because the bridge
+   * cursor advances and nothing re-fetches (`msg_6.jpg`, 2026-08-20). Staging
+   * targets the SAME (workspace, instance, owner) triple the append will use:
+   * the store links an asset by exact match and fails the append otherwise.
+   *
+   * Returns the first item's outcome (the append contract carries one media
+   * ref per message); every item is staged so extraction covers all of them.
+   */
+  async function stageUnroutedBridgeMedia(args: {
+    channel: Channel
+    connectorInstanceId: string | null | undefined
+    msg: BridgeInboundMessage
+  }): Promise<
+    | { ref: NonNullable<IncomingMessage['archiveMediaRef']>; failed?: undefined }
+    | { ref?: undefined; failed: true }
+    | null
+  > {
+    const media = args.msg.media ?? []
+    if (media.length === 0 || !options.archiveMedia || !args.msg.messageId) return null
+    let instanceId: string | null = null
+    let ownerUserId: string | null = null
+    try {
+      ownerUserId = await workspaceOwnerId(args.channel.workspaceId)
+      if (!ownerUserId) return null
+      instanceId = args.connectorInstanceId
+        ?? await resolveChatArchiveInstanceId({
+          source: 'custom',
+          ownerUserId,
+          workspaceId: args.channel.workspaceId,
+          assistantId: '',
+          assistantName: '',
+          conversationId: args.msg.peerId,
+        })
+      if (!instanceId) return null
+    } catch (err) {
+      console.error('[custom-channel] unrouted archive media target resolution failed:', err)
+      return { failed: true }
+    }
+    let first: NonNullable<IncomingMessage['archiveMediaRef']> | null = null
+    let firstFailed = false
+    for (const [index, item] of media.entries()) {
+      const kind = item.kind === 'document' ? 'file' : item.kind === 'audio' ? 'voice' : item.kind
+      try {
+        const bytes = await loadMediaBytes(item)
+        const staged = await options.archiveMedia.storeBuffer({
+          workspaceId: args.channel.workspaceId,
+          instanceId,
+          ownerUserId,
+          source: 'custom',
+          providerMessageId: media.length > 1 ? `${args.msg.messageId}#${index}` : args.msg.messageId,
+          kind,
+          filename: item.name,
+          mime: item.mime,
+          bytes,
+        })
+        if (index === 0) {
+          first = {
+            assetId: staged.assetId,
+            sha256: staged.sha256,
+            filename: staged.filename,
+            mime: staged.mime,
+            sizeBytes: staged.sizeBytes,
+          }
+        }
+      } catch (err) {
+        if (index === 0) firstFailed = true
+        console.error('[custom-channel] unrouted archive media staging failed:', err)
+      }
+    }
+    if (first) return { ref: first }
+    if (firstFailed) return { failed: true }
+    return null
+  }
+
+  /**
    * `isSelf`: the owner's own phone reply. It belongs in the archive as an
    * OUTBOUND message on that conversation so the model's history and the
    * owner's real replies line up. The live writer keys outbound appends by a
    * session message id; a bridge-relayed self message has no session row, so
    * a synthetic `bridge-self:<messageId>` cursor stands in.
    */
-  async function archiveSelfMessage(channel: Channel, msg: BridgeInboundMessage): Promise<void> {
+  async function archiveSelfMessage(
+    channel: Channel,
+    integration: ChannelIntegrationWithCredentials,
+    msg: BridgeInboundMessage,
+  ): Promise<void> {
     try {
       const ownerUserId = await workspaceOwnerId(channel.workspaceId)
       if (!ownerUserId) return
       const state = await store.getState(channel.id).catch(() => null)
+      const firstMedia = (msg.media ?? [])[0]
+      let archiveMedia: Parameters<typeof appendOutboundChatArchive>[0]['archiveMedia']
+      if (firstMedia) {
+        const kind = firstMedia.kind === 'document' ? 'file' : firstMedia.kind === 'audio' ? 'voice' : firstMedia.kind
+        const staged = await stageUnroutedBridgeMedia({
+          channel,
+          connectorInstanceId: integration.connectorInstanceId,
+          msg,
+        })
+        archiveMedia = staged?.ref
+          ? { kind, ref: staged.ref }
+          : {
+              kind,
+              ref: null,
+              availability: staged?.failed ? 'failed' : 'missing',
+              filename: firstMedia.name,
+              mime: firstMedia.mime,
+              sizeBytes: firstMedia.sizeBytes ?? 0,
+            }
+      }
       await appendOutboundChatArchive({
         source: 'custom',
         ownerUserId,
         workspaceId: channel.workspaceId,
+        connectorInstanceId: integration.connectorInstanceId,
         assistantId: msg.senderId,
         assistantName: msg.senderName ?? state?.accountLabel ?? msg.senderId,
         conversationId: msg.peerId,
         sessionMessageId: `bridge-self:${msg.messageId}`,
         providerMessageId: msg.messageId,
         text: msg.text,
+        archiveMedia,
         replyToProviderId: msg.replyToMessageId ?? null,
       })
     } catch (err) {
@@ -647,6 +774,7 @@ export function customChannelBridgeRoutes(options: CustomChannelBridgeRouteOptio
     channelId: string
     confirmKey: string
     archiveConnectorInstanceId?: string | null
+    documentsCapable?: boolean
   }): Promise<void> {
     const { adapter, incoming, bridgeMessage, assistant, channelUserId, ownerId, isIdentified, routing, channelId, confirmKey } = params
     const peerId = incoming.channelId
@@ -800,6 +928,7 @@ export function customChannelBridgeRoutes(options: CustomChannelBridgeRouteOptio
       incomingChannelMessageId: incoming.messageId ?? null,
       archiveIncoming: incoming,
       archiveConnectorInstanceId: params.archiveConnectorInstanceId,
+      channelDocumentsSupported: params.documentsCapable === true,
       modelAlias: routing.modelAlias,
       adaptiveResearchEnabled: true,
       abortController,
@@ -853,11 +982,19 @@ export function customChannelBridgeRoutes(options: CustomChannelBridgeRouteOptio
             text: `${displayName}${inputSummary}\n\n${replyHint}`,
           })
         },
-        async sendResponse(text) {
+        async sendResponse(text, documents) {
           const finalText = text.replace(/[\u200B-\u200D\uFEFF]/g, '').trim()
           const reply = finalText || "I couldn't generate a reply - please rephrase or try again."
           await cancelTyping()
-          const channelMessageId = await adapter.sendMessage(peerId, { text: reply, format: 'markdown' })
+          // Documents reach this hook only when the sendFile gate admitted
+          // them, which for `custom` requires the bridge's declared
+          // `capabilities.documents` \u2014 the adapter base64-encodes them into
+          // the outbox item and the bridge performs the real file send.
+          const channelMessageId = await adapter.sendMessage(peerId, {
+            text: reply,
+            format: 'markdown',
+            ...(documents && documents.length > 0 ? { documents } : {}),
+          })
           return channelMessageId ? { channelMessageId } : undefined
         },
         async onDowngraded(resetsAt) {

--- a/packages/api/src/routes/wechat.ts
+++ b/packages/api/src/routes/wechat.ts
@@ -59,6 +59,7 @@ import { billingPartyForAssistant } from '../billing-party.js'
 import type { ChatArchiveLiveMedia } from '../chat-archive/live-media.js'
 import { archiveMediaRef } from '../chat-archive/live-media.js'
 import { resolveChatArchiveInstanceId, archiveUnroutedInbound } from '../chat-archive/live-writer.js'
+import { query } from '../db/client.js'
 
 export type WechatRouteOptions = {
   /** Servable background-lane model, resolved at boot; forwarded to the
@@ -207,6 +208,81 @@ export function wechatRoutes(options: WechatRouteOptions): Router {
     }
   })
 
+  /**
+   * Stage an unrouted message's media into the archive before its append.
+   *
+   * Mirrors processMessage's staging block, but resolves the target from the
+   * WORKSPACE OWNER (what `appendUnroutedInbound` uses) rather than a billing
+   * party — the store links assets by exact (workspace, instance, owner) and
+   * fails the append on a mismatch. Sets `incoming.archiveMediaRef` /
+   * `archiveMediaAvailability` in place, exactly like the routed loop.
+   */
+  async function stageUnroutedWechatMedia(args: {
+    channel: { workspaceId: string }
+    connectorInstanceId: string | null | undefined
+    incoming: IncomingMessage
+    raw: WeixinMessage | undefined
+  }): Promise<void> {
+    const { incoming, raw } = args
+    if (!options.archiveMedia || !raw || !incoming.messageId) return
+    const mediaItem = findWechatMediaItem(raw.item_list)
+    if (!mediaItem) return
+    const fallbackKind = mediaItem.video_item ? 'video'
+      : mediaItem.voice_item ? 'voice'
+        : mediaItem.image_item ? 'image' : 'file'
+    incoming.mediaType = fallbackKind === 'image' ? 'photo'
+      : fallbackKind === 'file' ? 'document' : fallbackKind
+    incoming.archiveMediaAvailability = 'missing'
+    try {
+      const owner = await query<{ ownerUserId: string }>(
+        `SELECT owner_user_id AS "ownerUserId" FROM workspaces WHERE id = $1`,
+        [args.channel.workspaceId],
+      )
+      const ownerUserId = owner.rows[0]?.ownerUserId
+      if (!ownerUserId) return
+      const maxBytes = fallbackKind === 'video' || fallbackKind === 'voice'
+        ? MAX_LARGE_MEDIA_BYTES : MAX_SMALL_MEDIA_BYTES
+      const media = await downloadWechatMediaItem(mediaItem, { maxBytes })
+      if (!media) throw new Error('iLink media item did not contain downloadable bytes')
+      const archiveKind = media.mime === 'image/gif' ? 'video' : media.kind
+      incoming.mediaType = archiveKind === 'image' ? 'photo'
+        : archiveKind === 'file' ? 'document' : archiveKind
+      incoming.mediaMime = media.mime
+      incoming.mediaName = media.name
+      incoming.mediaSizeBytes = media.data.length
+      const instanceId = args.connectorInstanceId
+        ?? await resolveChatArchiveInstanceId({
+          source: 'wechat',
+          ownerUserId,
+          workspaceId: args.channel.workspaceId,
+          assistantId: '',
+          assistantName: '',
+          conversationId: incoming.channelId,
+        })
+      if (!instanceId) throw new Error('wechat archive instance could not be resolved')
+      const asset = await options.archiveMedia.storeBuffer({
+        workspaceId: args.channel.workspaceId,
+        instanceId,
+        ownerUserId,
+        source: 'wechat',
+        providerMessageId: incoming.messageId,
+        kind: archiveKind,
+        filename: media.name,
+        mime: media.mime,
+        bytes: media.data,
+      })
+      const ref = archiveMediaRef(asset)
+      incoming.archiveMediaRef = {
+        assetId: ref.asset_id!, sha256: ref.sha256!, filename: ref.filename,
+        mime: ref.mime, sizeBytes: ref.size_bytes,
+      }
+      incoming.archiveMediaAvailability = undefined
+    } catch (err) {
+      incoming.archiveMediaAvailability = 'failed'
+      throw err
+    }
+  }
+
   // ── Inbound message from the long-poll connector ──────────────
   router.post('/inbound', async (req, res) => {
     const parsed = inboundSchema.safeParse(req.body)
@@ -275,10 +351,23 @@ export function wechatRoutes(options: WechatRouteOptions): Router {
         // A failure here must not change the outcome. The message is already
         // going unanswered; losing it from the archive too is strictly worse
         // than a logged error.
+        //
+        // Media too: this exit never reaches processMessage's staging loop,
+        // and iLink CDN bytes cannot be re-fetched later — an attachment
+        // archived here as filename hints is unrecoverable. Stage first,
+        // under the SAME (workspace owner, instance) the unrouted append
+        // resolves to; the store links assets by exact match.
+        await stageUnroutedWechatMedia({
+          channel,
+          connectorInstanceId: integration.connectorInstanceId,
+          incoming,
+          raw: incoming.raw as WeixinMessage | undefined,
+        }).catch((err) => console.error('[wechat] unrouted archive media staging failed:', err))
         await archiveUnroutedInbound({
           source: 'wechat',
           workspaceId: channel.workspaceId,
           conversationId: peerId,
+          connectorInstanceId: integration.connectorInstanceId,
           message: incoming,
         }).catch((err) => console.error('[wechat] unrouted archive append failed:', err))
         console.log(`[wechat] no assistant routing for ${peerId} on channel ${channelId} — archived, not answered`)

--- a/packages/api/src/routes/whatsapp-byon.ts
+++ b/packages/api/src/routes/whatsapp-byon.ts
@@ -77,6 +77,23 @@ export type WhatsappByonRoutesOptions = {
   }) => Promise<void>
   getChannel?: typeof getChannelForWebhook
   getWorkspaceOwnerUserId?: (workspaceId: string) => Promise<string | null>
+  /**
+   * Upserts the owner's synced contact directory into the archive
+   * (`MessageStoreClient.upsertContacts`). Names resolve at query time, so a
+   * directory that arrives after messages did still names the old rows.
+   */
+  archiveContacts?: (input: {
+    workspaceId: string
+    instanceId: string
+    ownerUserId: string
+    source: string
+    contacts: Array<{
+      contactId: string
+      savedName?: string | null
+      pushName?: string | null
+      verifiedName?: string | null
+    }>
+  }) => Promise<{ upserted: number }>
   /** Let a later closed router handle the shared official number. */
   passUnknownToFallback?: boolean
 }
@@ -154,6 +171,86 @@ export function whatsappByonRoutes(opts: WhatsappByonRoutesOptions): Router {
   ): string {
     return synthesizeFilename(input.mediaFileName ?? input.mediaRef?.fileName, kind, input.messageId, mime)
   }
+
+  /**
+   * The owner's WhatsApp contact directory, relayed by the connector.
+   *
+   * Baileys receives the primary phone's contact sync (`contacts.upsert` /
+   * `contacts.update` and the pairing-time history set): `name` is the name
+   * the OWNER saved in their address book, `notify` is the pushName the
+   * contact set for themselves. Without this sync a sender is a bare number —
+   * "記錄入面冇顯示聯絡人名" (2026-08-20) — even though the owner's phone
+   * knows exactly who it is.
+   */
+  router.post('/contacts', async (req, res, next) => {
+    if (!secretMatches(req.headers['x-connector-secret'], opts.connectorSecret)) {
+      res.status(401).end()
+      return
+    }
+    const parsed = z.object({
+      channelId: z.string().min(1),
+      contacts: z.array(z.object({
+        contactId: z.string().min(1).max(256),
+        savedName: z.string().max(500).nullish(),
+        pushName: z.string().max(500).nullish(),
+        verifiedName: z.string().max(500).nullish(),
+      })).min(1).max(500),
+    }).safeParse(req.body)
+    if (!parsed.success) {
+      res.status(400).json({ error: 'channelId and contacts required' })
+      return
+    }
+    if (!opts.archiveContacts) {
+      // No archive on this deployment: nothing to store, and that is fine.
+      res.status(202).json({ ok: true, skipped: true })
+      return
+    }
+    const channel = await (opts.getChannel ?? getChannelForWebhook)(parsed.data.channelId)
+    if (!channel) {
+      if (opts.passUnknownToFallback) next()
+      else res.status(404).json({ error: 'channel not resolvable' })
+      return
+    }
+    try {
+      const integration = await opts.integrationStore.getByChannelForWebhook(parsed.data.channelId, 'whatsapp')
+      const ownerUserId = await (opts.getWorkspaceOwnerUserId ?? resolveWorkspaceOwnerUserId)(channel.workspaceId)
+      if (!ownerUserId) {
+        res.status(404).json({ error: 'workspace owner not resolvable' })
+        return
+      }
+      // Same lazily-minted instance the append path uses, so the directory
+      // joins the same rows those appends created.
+      const instanceId = integration?.connectorInstanceId
+        ?? await resolveChatArchiveInstanceId({
+          source: 'whatsapp',
+          ownerUserId,
+          workspaceId: channel.workspaceId,
+          assistantId: '',
+          assistantName: '',
+          conversationId: parsed.data.channelId,
+        })
+      if (!instanceId) {
+        res.status(202).json({ ok: true, skipped: true })
+        return
+      }
+      const kept = parsed.data.contacts.filter((c) => c.savedName || c.pushName || c.verifiedName)
+      if (kept.length === 0) {
+        res.json({ ok: true, upserted: 0 })
+        return
+      }
+      const result = await opts.archiveContacts({
+        workspaceId: channel.workspaceId,
+        instanceId,
+        ownerUserId,
+        source: 'whatsapp',
+        contacts: kept,
+      })
+      res.json({ ok: true, upserted: result.upserted })
+    } catch (err) {
+      console.error('[whatsapp-byon] contact directory upsert failed:', err)
+      res.status(502).json({ error: 'archive unavailable' })
+    }
+  })
 
   router.post('/media-upload-url', async (req, res, next) => {
     if (!secretMatches(req.headers['x-connector-secret'], opts.connectorSecret)) {

--- a/packages/api/src/support-diagnostics/bundle.ts
+++ b/packages/api/src/support-diagnostics/bundle.ts
@@ -177,12 +177,8 @@ export class SupportCapsuleBuilder {
       messages: string
       analytics: string
       failedWorkflows: string
-      archiveMessages: string
-      archiveUnembedded: string
       archiveOutboxPending: string
       archiveOutboxDead: string
-      archiveEnrichmentFailed: string
-      archiveBackfillsFailed: string
     }>(
       `SELECT
          (SELECT count(*)::text FROM sessions s
@@ -196,10 +192,6 @@ export class SupportCapsuleBuilder {
           WHERE e.user_id = $2 AND e.created_at BETWEEN $3 AND $4) AS analytics,
          (SELECT count(*)::text FROM workflow_runs
           WHERE workspace_id = $1 AND status IN ('failed', 'timeout')) AS "failedWorkflows",
-         (SELECT count(*)::text FROM chat_archive_messages
-          WHERE workspace_id = $1) AS "archiveMessages",
-         (SELECT count(*)::text FROM chat_archive_segments
-          WHERE workspace_id = $1 AND embedding IS NULL) AS "archiveUnembedded",
          (SELECT count(*)::text FROM ingest_outbox o
           JOIN ingest_external_sink s ON s.id = o.sink_id
           WHERE o.workspace_id = $1
@@ -209,11 +201,7 @@ export class SupportCapsuleBuilder {
           JOIN ingest_external_sink s ON s.id = o.sink_id
           WHERE o.workspace_id = $1
             AND s.managed_by = 'local_chat_archive'
-            AND o.status = 'dead') AS "archiveOutboxDead",
-         (SELECT count(*)::text FROM chat_archive_enrichment_windows
-          WHERE workspace_id = $1 AND status IN ('failed', 'dead')) AS "archiveEnrichmentFailed",
-         (SELECT count(*)::text FROM chat_archive_backfill_runs
-          WHERE workspace_id = $1 AND status = 'failed') AS "archiveBackfillsFailed"`,
+            AND o.status = 'dead') AS "archiveOutboxDead"`,
       [capture.workspaceId, capture.userId, capture.startedAt, capture.expiresAt],
     )
 
@@ -292,12 +280,15 @@ export class SupportCapsuleBuilder {
           messages: Number.parseInt(healthResult.rows[0]?.messages ?? '0', 10),
           analytics: Number.parseInt(healthResult.rows[0]?.analytics ?? '0', 10),
           failedWorkflows: Number.parseInt(healthResult.rows[0]?.failedWorkflows ?? '0', 10),
-          archiveMessages: Number.parseInt(healthResult.rows[0]?.archiveMessages ?? '0', 10),
-          archiveUnembedded: Number.parseInt(healthResult.rows[0]?.archiveUnembedded ?? '0', 10),
+          // Archive row/segment/enrichment/backfill counts moved into
+          // `brian-message-store`'s own database with migration 438 — the
+          // platform can no longer SQL them, and the dropped-table subselects
+          // that used to sit here threw `relation does not exist` at runtime,
+          // killing the WHOLE stats query (sessions/messages counts included).
+          // The capsule keeps what the platform can still see: the relay
+          // outbox to the archive, and whether a sidecar is configured at all.
           archiveOutboxPending: Number.parseInt(healthResult.rows[0]?.archiveOutboxPending ?? '0', 10),
           archiveOutboxDead: Number.parseInt(healthResult.rows[0]?.archiveOutboxDead ?? '0', 10),
-          archiveEnrichmentFailed: Number.parseInt(healthResult.rows[0]?.archiveEnrichmentFailed ?? '0', 10),
-          archiveBackfillsFailed: Number.parseInt(healthResult.rows[0]?.archiveBackfillsFailed ?? '0', 10),
         },
       },
       captureEvents: events.map((event) => ({

--- a/packages/channels/src/custom/protocol.ts
+++ b/packages/channels/src/custom/protocol.ts
@@ -43,6 +43,16 @@ export type BridgeState = {
   action?: BridgeAction
   /** Bridge build / version string for the Studio card. */
   bridgeVersion?: string
+  /**
+   * What this bridge can actually put on the wire. Additive (v1.1): an older
+   * bridge that never reports it is treated as text-only, so `sendFile`
+   * refuses honestly instead of the adapter enqueueing documents the bridge
+   * would silently drop. Declare `documents: true` ONLY when the bridge's
+   * outbox worker performs a real file send for `payload.documents`.
+   */
+  capabilities?: {
+    documents?: boolean
+  }
 }
 
 // ── Inbound (POST /inbound) ────────────────────────────────────

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -234,6 +234,17 @@ export type ToolContext = {
   outboundAttachments?: AttachmentCollector
 
   /**
+   * Per-channel-INSTANCE document capability, for channel types where file
+   * delivery is a per-connection fact rather than a per-type one. A `custom`
+   * bridge declares `capabilities.documents` in its state report and the
+   * route threads the answer here; `sendFile` admits the channel when this is
+   * true even though `custom` stays out of the static
+   * `DOCUMENT_CAPABLE_CHANNELS` set (an undeclared bridge would silently drop
+   * the enqueued documents). Absent everywhere else — the static set decides.
+   */
+  channelDocumentsSupported?: boolean
+
+  /**
    * Per-turn accumulator. Every read of a KB entry / memory / episodic row
    * calls `note(row.sensitivity)` so that subsequent write tools (saveMemory,
    * addKnowledgeEntry) can stamp rows with the max sensitivity of what the

--- a/packages/core/src/workspace-files/__tests__/send-file.test.ts
+++ b/packages/core/src/workspace-files/__tests__/send-file.test.ts
@@ -149,6 +149,38 @@ describe('[COMP:files/send-file] sendFile', () => {
     }
   })
 
+  it('refuses a custom bridge that never declared document capability', async () => {
+    // Capability on `custom` is a per-BRIDGE fact: an undeclared bridge would
+    // silently drop the enqueued documents, so the static set stays closed
+    // and admission requires the route-threaded flag.
+    const tool = createSendFileTool(statOnlyApi(fakeFile()))
+    const result = await tool.execute(
+      { file: '/reports/q1.md' },
+      makeContext({ channelType: 'custom' }),
+    )
+    expect(result.isError).toBe(true)
+    expect(String(result.data)).toContain('custom')
+  })
+
+  it('admits a custom bridge whose state declared documents (channelDocumentsSupported)', async () => {
+    const tool = createSendFileTool(statOnlyApi(fakeFile()))
+    const result = await tool.execute(
+      { file: '/reports/q1.md' },
+      makeContext({ channelType: 'custom', channelDocumentsSupported: true }),
+    )
+    expect(result.isError).toBeFalsy()
+  })
+
+  it('applies the custom bridge 25 MB protocol ceiling to an admitted bridge', async () => {
+    const big = fakeFile({ sizeBytes: 30 * 1024 * 1024 })
+    const result = await createSendFileTool(statOnlyApi(big)).execute(
+      { file: '/reports/q1.md' },
+      makeContext({ channelType: 'custom', channelDocumentsSupported: true }),
+    )
+    expect(result.isError).toBe(true)
+    expect(String(result.data)).toContain('over the')
+  })
+
   it('applies Discord\'s stricter 10 MiB ceiling, not the generic 45 MB one', async () => {
     const big = fakeFile({ sizeBytes: 20 * 1024 * 1024 })
 

--- a/packages/core/src/workspace-files/attachments.ts
+++ b/packages/core/src/workspace-files/attachments.ts
@@ -63,6 +63,10 @@ export const DOCUMENT_CAPABLE_CHANNELS: ReadonlySet<string> = new Set([
  */
 const CHANNEL_DOCUMENT_BYTE_CAPS: Readonly<Record<string, number>> = {
   discord: 10 * 1024 * 1024,
+  // The bridge protocol's per-item media ceiling (base64 in an outbox item).
+  // `custom` is admitted per-instance via `channelDocumentsSupported`, not by
+  // the static set — the cap still applies whenever it is.
+  custom: 25 * 1024 * 1024,
 }
 
 /** The document byte ceiling in force for a channel. Web is uncapped. */

--- a/packages/core/src/workspace-files/send-file.ts
+++ b/packages/core/src/workspace-files/send-file.ts
@@ -84,7 +84,10 @@ export function createSendFileTool(
       // The pipeline hands documents to every adapter and the incapable ones
       // drop them silently, so without this the tool would report success and
       // the model would tell the user a file is attached that never arrives.
-      if (!DOCUMENT_CAPABLE_CHANNELS.has(context.channelType)) {
+      // `channelDocumentsSupported` admits a channel INSTANCE that proved the
+      // capability at runtime (a custom bridge declaring `documents` in its
+      // state report) without widening the static per-type set.
+      if (!DOCUMENT_CAPABLE_CHANNELS.has(context.channelType) && context.channelDocumentsSupported !== true) {
         const where = 'Tell the user to fetch the file from the web app, or to ask again on web chat, Telegram, or Slack.'
         return {
           data:


### PR DESCRIPTION
…e documents, WhatsApp contact directory

Four connected fixes to the message-store path, from one failure model (2026-08-20: a WeChat image archived as msg_6.jpg with no bytes, "can't send you the file" on WhatsApp+WeChat, and a bare +852 number no record could name):

- Archive-only exits stage media BEFORE their append. The custom bridge and iLink WeChat routes staged attachments only on the routed path, so isSelf / unaddressed-group / access-list / no-routing messages archived filename hints while the delivered bytes were discarded - unrecoverable once the bridge cursor advanced. stageUnroutedBridgeMedia / stageUnroutedWechatMedia stage under the same (workspace owner, connector instance) binding the append resolves, threaded through archiveUnroutedInbound + appendOutbound (stored v2 media_ref for self-sent media).

- saveChatMedia closes the "send me that file" loop: search hits carry media_sha256, MessageStoreClient.downloadMedia pulls the owner-scoped bytes back out of the store (GET /media/{sha256}), the tool lands them in /uploads/chat-archive/, and sendFile stays the one delivery gate.

- Custom-bridge outbound documents, per instance: a bridge declares capabilities.documents in PUT /state (migration 452), the route threads ToolContext.channelDocumentsSupported, sendFile admits the channel at the protocol's 25 MB cap, and sendResponse forwards documents into the outbox the wechat-desktop-bridge worker already sends. custom stays out of the static DOCUMENT_CAPABLE_CHANNELS set - an undeclared bridge keeps the honest refusal instead of a silent drop.

- WhatsApp contact directory: wa-connector relays Baileys contact sync (owner-saved names + pushnames) to POST /internal/whatsapp/contacts, which forwards to the store's ub.chat.contacts.v1 upsert; names resolve into hits at query time, so rows archived before a name was known get named retroactively. senderDisplay also now rides the boot.ts full-assistant WhatsApp path, and listContacts matches digits-normalized phone numbers so a bare number cross-checks against the CRM.

Also: support capsule no longer queries the four chat_archive tables migration 438 dropped (the dead subselects killed the whole stats query), and listChatChannels joins searchChatHistory on the agent-surface bridge.