### PR TITLE
fix(app-web): reveal local directory connect form

### DIFF
--- a/apps/app-web/src/app/w/[workspaceId]/studio/connectors/page.tsx
+++ b/apps/app-web/src/app/w/[workspaceId]/studio/connectors/page.tsx
@@ -1726,6 +1726,7 @@ function ConnectorsList() {
 
     if (id === "local") {
       setShowLocalForm(rid);
+      revealConnectForm(rid);
       setLocalDirError(null);
       setConnecting(null);
       return;

--- a/apps/app-web/src/lib/__tests__/local-storage-connect-form.test.ts
+++ b/apps/app-web/src/lib/__tests__/local-storage-connect-form.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const page = readFileSync(
+  fileURLToPath(
+    new URL(
+      "../../app/w/[workspaceId]/studio/connectors/page.tsx",
+      import.meta.url,
+    ),
+  ),
+  "utf8",
+);
+
+describe("[COMP:app-web/studio-connectors] Local Directory connect form", () => {
+  it("reveals the selected row when Connect starts from the directory", () => {
+    const start = page.indexOf('if (id === "local")');
+    const end = page.indexOf('if (id === "cli")', start);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+
+    const localConnectBranch = page.slice(start, end);
+    expect(localConnectBranch).toContain("setShowLocalForm(rid)");
+    expect(localConnectBranch).toContain("revealConnectForm(rid)");
+  });
+});


### PR DESCRIPTION
Fixes the Local Directory connector flow so selecting Connect from the connector directory reveals the selected row and its configuration form. Adds a regression test for the transition. Tests: pnpm test; pnpm smoke; pnpm --filter app-web typecheck; focused connector tests.