### PR TITLE
fix(email): make configured tool policy authoritative

### DIFF
--- a/packages/api/src/connector-action-port.ts
+++ b/packages/api/src/connector-action-port.ts
@@ -62,8 +62,22 @@ export type ConnectorActionPreflight = {
   classifierMatches: string[]
   /** True iff classifier outranks ceiling AND env flag enforces. */
   shouldDeny: boolean
-  /** True iff classifier outranks ceiling AND env flag is OFF (shadow). */
+  /** True iff classifier outranks ceiling but the result is advisory. */
   shadowOnly: boolean
+}
+
+export type ConnectorActionPreflightParams = Pick<
+  ConnectorActionEmitParams,
+  'audienceClearance' | 'payload'
+> & {
+  /**
+   * `enforce` lets the classifier veto before the network call. `advisory`
+   * records the same detection as a warning but leaves the configured tool
+   * grant/policy authoritative. Email sends and drafts use `advisory` because
+   * reaching execution means their frozen payload was already admitted by
+   * Allow/Ask/Block governance.
+   */
+  enforcement?: 'enforce' | 'advisory'
 }
 
 export type EmitConnectorActionResult = {
@@ -80,9 +94,7 @@ export type EmitConnectorActionResult = {
  */
 export interface ConnectorActionAudit extends ConnectorActionAuditDeps {
   /** Classify a payload BEFORE the network call (no audit row written). */
-  preflight(
-    params: Pick<ConnectorActionEmitParams, 'audienceClearance' | 'payload'>,
-  ): ConnectorActionPreflight
+  preflight(params: ConnectorActionPreflightParams): ConnectorActionPreflight
   /** Emit the `connector_action` Episode + audit row after the action runs. */
   emit(
     idCtx: { userId: string; assistantId: string },

--- a/packages/api/src/mcp/__tests__/inject-agentmail.test.ts
+++ b/packages/api/src/mcp/__tests__/inject-agentmail.test.ts
@@ -5,6 +5,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Tool } from '@use-brian/core'
+import type { ConnectorActionAudit, ConnectorActionPreflight } from '../../connector-action-port.js'
 
 vi.mock('../../connector-config.js', () => ({
   getConnectorConfig: () => undefined,
@@ -53,6 +54,7 @@ function providerStub() {
 async function injectAgentmail(over: {
   handled?: string[]
   getGrant?: ReturnType<typeof vi.fn>
+  audit?: ConnectorActionAudit
 } = {}) {
   const provider = providerStub()
   const tools = new Map<string, Tool>()
@@ -76,10 +78,23 @@ async function injectAgentmail(over: {
     connectorInstanceStore: connectorInstanceStore as never,
     assistantConnectorGrantsStore: { getForAssistantSystem } as never,
     emailInboxProvider: provider as never,
+    ...(over.audit ? { connectorActionAudit: over.audit } : {}),
     keepBuiltinsDirect: true,
   })
 
   return { tools, provider, result, getForAssistantSystem }
+}
+
+function preflightResult(over: Partial<ConnectorActionPreflight> = {}): ConnectorActionPreflight {
+  return {
+    responseCeiling: 'public',
+    retrievalMax: 'public',
+    classifierDetected: 'public',
+    classifierMatches: [],
+    shouldDeny: false,
+    shadowOnly: false,
+    ...over,
+  }
 }
 
 beforeEach(() => {
@@ -135,6 +150,42 @@ describe('[COMP:tools/agentmail] Channel-owned mailbox injection', () => {
       2,
       'assistant-1',
       'agentmail:inbox-primary',
+    )
+  })
+
+  it('treats payload classification as advisory after the exact inbox grant admits the send', async () => {
+    const preflight = vi.fn(() => preflightResult({
+      shouldDeny: true,
+      classifierDetected: 'confidential',
+      classifierMatches: ['credential'],
+    }))
+    const emit = vi.fn(async () => ({ status: 'executed' as const }))
+    const audit = { preflight, emit } as unknown as ConnectorActionAudit
+    const { tools, provider } = await injectAgentmail({ audit })
+
+    const result = await tools.get('agentmailSendMessage')!.execute(
+      {
+        to: ['contact@example.com'],
+        subject: 'Hello',
+        body: 'sk_live_secret',
+      },
+      {} as never,
+    )
+
+    expect(result.isError).toBeFalsy()
+    expect(provider.sendMessage).toHaveBeenCalledTimes(1)
+    expect(preflight).toHaveBeenCalledWith(expect.objectContaining({
+      enforcement: 'advisory',
+      payload: expect.objectContaining({ body: 'sk_live_secret' }),
+    }))
+    expect(emit).toHaveBeenCalledWith(
+      { userId: 'user-1', assistantId: 'assistant-1' },
+      expect.objectContaining({
+        connectorId: 'agentmail',
+        actionKind: 'send_email',
+        status: 'executed',
+        payload: expect.not.objectContaining({ body: expect.anything() }),
+      }),
     )
   })
 

--- a/packages/api/src/mcp/__tests__/inject-mailbox.test.ts
+++ b/packages/api/src/mcp/__tests__/inject-mailbox.test.ts
@@ -2,8 +2,8 @@
  * Injection-level tests for the company-mailbox (imap) connector:
  * Layer-1/Layer-2 gating, the unavailable[] notice, and the send governance
  * chain — `ask` classification in the registry, connector_actions
- * `send_email` audit, and the classifier preflight short-circuiting BEFORE
- * any network call (plan §10 "Governance" row).
+ * `send_email` audit, and advisory classifier preflight after app policy
+ * admits the exact email payload (plan §10 "Governance" row).
  *
  * [COMP:tools/mailbox-imap]
  */
@@ -17,6 +17,34 @@ vi.mock('../../connector-config.js', () => ({
   getConnectorConfig: (provider: string) => provider === 'google'
     ? { clientId: 'gmail-client', clientSecret: 'gmail-secret' }
     : undefined,
+}))
+
+const mailboxSendMessage = vi.fn(async (_params: unknown) => ({ messageId: '<sent@harborlane.example>' }))
+const createMailboxApiMock = vi.fn((opts: {
+  getSettings: () => Promise<typeof IMAP_CREDS>
+}) => ({
+  searchMessages: vi.fn(),
+  getMessage: vi.fn(),
+  getAttachment: vi.fn(async () => {
+    await opts.getSettings()
+    return {
+      filename: 'proposal.pdf',
+      mime: 'application/pdf',
+      bytes: new Uint8Array([1, 2, 3]),
+    }
+  }),
+  resolveSender: vi.fn(async (p: { from?: string }) => {
+    const settings = await opts.getSettings()
+    return { from: p.from ?? settings.email, allowed: [settings.email] }
+  }),
+  sendMessage: vi.fn(async (p: { from?: string }) => {
+    const settings = await opts.getSettings()
+    await mailboxSendMessage(p)
+    return { messageId: '<sent@harborlane.example>', from: p.from ?? settings.email }
+  }),
+}))
+vi.mock('../../mailbox/mailbox-api.js', () => ({
+  createMailboxApi: (opts: never) => createMailboxApiMock(opts),
 }))
 
 import { OFFICIAL_CONNECTOR_TOOLS } from '@use-brian/shared'
@@ -58,6 +86,7 @@ function instanceStoreStub(): ConnectorInstanceStore {
   return {
     getAuthCredentialsSystem: vi.fn(async () => IMAP_CREDS),
     getCredentialsSystem: vi.fn(async () => null),
+    markHealth: vi.fn(async () => false),
   } as unknown as ConnectorInstanceStore
 }
 
@@ -127,6 +156,8 @@ async function injectImap(
 beforeEach(() => {
   vi.spyOn(console, 'error').mockImplementation(() => {})
   vi.spyOn(console, 'debug').mockImplementation(() => {})
+  mailboxSendMessage.mockClear()
+  createMailboxApiMock.mockClear()
 })
 
 describe('[COMP:tools/mailbox-imap] imap injection', () => {
@@ -194,9 +225,7 @@ describe('[COMP:tools/mailbox-imap] imap injection', () => {
       getCredentialsSystem: vi.fn(async () => null),
     } as unknown as ConnectorInstanceStore
 
-    // Deny preflight short-circuits the send before any IMAP/SMTP call — we only
-    // assert the audited `from`, which the injector sets from the RESOLVED account.
-    const emit = vi.fn(async () => ({ status: 'denied' as const }))
+    const emit = vi.fn(async (_idCtx: unknown, _params: { payload: Record<string, unknown> }) => ({ status: 'executed' as const }))
     const audit = {
       preflight: vi.fn(() => preflightResult({ shouldDeny: true, classifierMatches: ['x'] })),
       emit,
@@ -224,14 +253,14 @@ describe('[COMP:tools/mailbox-imap] imap injection', () => {
     await opsSend.execute({ to: ['x@y.z'], subject: 's', body: 'b' }, {} as never)
     expect(emit).toHaveBeenLastCalledWith(
       { userId: 'u-1', assistantId: 'a-1' },
-      expect.objectContaining({ status: 'denied', payload: expect.objectContaining({ from: 'ops@harborlane.example' }) }),
+      expect.objectContaining({ status: 'executed', payload: expect.objectContaining({ from: 'ops@harborlane.example' }) }),
     )
 
     // The primary retains canonical names for compatibility and is bound too.
     await primarySend.execute({ to: ['x@y.z'], subject: 's', body: 'b' }, {} as never)
     expect(emit).toHaveBeenLastCalledWith(
       { userId: 'u-1', assistantId: 'a-1' },
-      expect.objectContaining({ status: 'denied', payload: expect.objectContaining({ from: 'maya@harborlane.example' }) }),
+      expect.objectContaining({ status: 'executed', payload: expect.objectContaining({ from: 'maya@harborlane.example' }) }),
     )
   })
 
@@ -313,7 +342,7 @@ describe('[COMP:tools/mailbox-imap] imap injection', () => {
     }))
     const audit = {
       preflight: vi.fn(() => preflightResult({ shouldDeny: true, classifierMatches: ['test'] })),
-      emit: vi.fn(async () => ({ status: 'denied' as const })),
+      emit: vi.fn(async () => ({ status: 'executed' as const })),
     } as unknown as ConnectorActionAudit
     const tools = new Map<string, Tool>()
     await injectMcpTools({
@@ -371,7 +400,7 @@ describe('[COMP:tools/mailbox-imap] imap injection', () => {
         grant('imap-teammate', 'teammate@harborlane.example', 'u-2', '2026-07-03T00:00:00Z'),
       ]),
     }
-    const emit = vi.fn(async () => ({ status: 'denied' as const }))
+    const emit = vi.fn(async (_idCtx: unknown, _params: { payload: Record<string, unknown> }) => ({ status: 'executed' as const }))
     const audit = {
       preflight: vi.fn(() => preflightResult({ shouldDeny: true, classifierMatches: ['test'] })),
       emit,
@@ -477,31 +506,36 @@ describe('[COMP:tools/mailbox-imap] imap injection', () => {
     expect(instanceStore.getAuthCredentialsSystem).toHaveBeenCalledWith('inst-imap-team-2')
   })
 
-  it('classifier preflight deny short-circuits the send BEFORE any network call and audits status=denied', async () => {
-    const emit = vi.fn(async () => ({ status: 'denied' as const }))
+  it('classifier detection is advisory after policy admission and cannot veto the send', async () => {
+    const emit = vi.fn(async (_idCtx: unknown, _params: { payload: Record<string, unknown> }) => ({ status: 'executed' as const }))
+    const preflight = vi.fn(() => preflightResult({ shouldDeny: true, classifierMatches: ['credential'] }))
     const audit = {
-      preflight: vi.fn(() => preflightResult({ shouldDeny: true, classifierMatches: ['credential'] })),
+      preflight,
       emit,
     } as unknown as ConnectorActionAudit
     const { tools } = await injectImap({ audit })
     const send = tools.get('imapSendMessage')!
     const result = await send.execute(
-      { to: ['x@y.z'], subject: 's', body: 'sk_live_secret' },
+      { to: ['recipient@example.com'], subject: 's', body: 'sk_live_secret' },
       {} as never,
     )
-    expect(result.isError).toBe(true)
-    expect(String(result.data)).toMatch(/classifier blocked/)
+    expect(result.isError, JSON.stringify(result)).toBeFalsy()
+    expect(mailboxSendMessage).toHaveBeenCalledTimes(1)
+    expect(preflight).toHaveBeenCalledWith(expect.objectContaining({
+      enforcement: 'advisory',
+      payload: expect.objectContaining({ body: 'sk_live_secret' }),
+    }))
     expect(emit).toHaveBeenCalledWith(
       { userId: 'u-1', assistantId: 'a-1' },
-      expect.objectContaining({ connectorId: 'imap', actionKind: 'send_email', status: 'denied' }),
+      expect.objectContaining({
+        connectorId: 'imap', actionKind: 'send_email', status: 'executed',
+        payload: expect.not.objectContaining({ body: expect.anything() }),
+      }),
     )
-    // The deny threw before createMailboxApi's sendMessage — no IMAP/SMTP
-    // connection was ever attempted (nothing here stubs the network; a real
-    // attempt would reject with a connection error, not the classifier copy).
   })
 
-  it('includes attachment metadata, never bytes, in classifier preflight and denied audit', async () => {
-    const emit = vi.fn(async () => ({ status: 'denied' as const }))
+  it('includes attachment metadata, never bytes or body text, in the executed audit', async () => {
+    const emit = vi.fn(async (_idCtx: unknown, _params: { payload: Record<string, unknown> }) => ({ status: 'executed' as const }))
     const preflight = vi.fn((_input: unknown) => preflightResult({
       shouldDeny: true,
       classifierMatches: ['proposal.pdf'],
@@ -512,7 +546,7 @@ describe('[COMP:tools/mailbox-imap] imap injection', () => {
 
     const result = await send.execute(
       {
-        to: ['x@y.z'],
+        to: ['recipient@example.com'],
         subject: 'Proposal',
         body: 'Attached.',
         attachments: ['file-1'],
@@ -520,14 +554,16 @@ describe('[COMP:tools/mailbox-imap] imap injection', () => {
       { workspaceId: 'ws-1', userId: 'u-1', assistantId: 'a-1' } as never,
     )
 
-    expect(result.isError).toBe(true)
+    expect(result.isError, JSON.stringify(result)).toBeFalsy()
     const expectedAttachments = [{
       name: 'proposal.pdf',
       mime: 'application/pdf',
       size_bytes: 3,
     }]
     expect(preflight).toHaveBeenCalledWith(expect.objectContaining({
+      enforcement: 'advisory',
       payload: expect.objectContaining({
+        body: 'Attached.',
         attachment_count: 1,
         attachments: expectedAttachments,
       }),
@@ -535,10 +571,12 @@ describe('[COMP:tools/mailbox-imap] imap injection', () => {
     expect(emit).toHaveBeenCalledWith(
       { userId: 'u-1', assistantId: 'a-1' },
       expect.objectContaining({
-        status: 'denied',
+        status: 'executed',
         payload: expect.objectContaining({ attachments: expectedAttachments }),
       }),
     )
+    const emittedPayload = emit.mock.calls[0][1].payload
+    expect(emittedPayload).not.toHaveProperty('body')
     expect(JSON.stringify(preflight.mock.calls[0][0])).not.toContain('data')
   })
 })

--- a/packages/api/src/mcp/__tests__/inject.test.ts
+++ b/packages/api/src/mcp/__tests__/inject.test.ts
@@ -41,6 +41,10 @@ const getDriveFileContentWithMetadata = vi.fn(async (_token: string, _fileId: st
   },
   content: 'Renewals require finance approval.',
 }))
+const sendGmailMessage = vi.fn(async (_token: string, _params: unknown) => ({
+  id: 'gmail-message-1',
+  threadId: 'gmail-thread-1',
+}))
 vi.mock('../../google/client.js', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   refreshGoogleAccessToken: (refreshToken: string, clientId: string, clientSecret: string) =>
@@ -51,6 +55,7 @@ vi.mock('../../google/client.js', async (importOriginal) => ({
     getCalendarEvent(token, eventId, calendarId),
   getDriveFileContentWithMetadata: (token: string, fileId: string, mime?: string) =>
     getDriveFileContentWithMetadata(token, fileId, mime),
+  sendGmailMessage: (token: string, params: unknown) => sendGmailMessage(token, params),
 }))
 
 const enqueueGDriveLazyEnrichment = vi.fn(async (_input: unknown) => ({ enqueued: true, jobId: 'job-1' }))
@@ -1187,6 +1192,7 @@ describe('[COMP:api/mcp-inject] multi-account Google built-ins', () => {
     refreshGoogleAccessToken.mockClear()
     getGoogleTask.mockClear()
     getCalendarEvent.mockClear()
+    sendGmailMessage.mockClear()
   })
   afterEach(() => {
     getConnectorConfig.mockReset()
@@ -1257,6 +1263,50 @@ describe('[COMP:api/mcp-inject] multi-account Google built-ins', () => {
     }
     expect(await variant.describeConfirmation(input, {})).toContain(
       '• From: work@example.com',
+    )
+  })
+
+  it('lets admitted Gmail sends proceed while classification remains advisory audit metadata', async () => {
+    const tools = new Map()
+    const { connectorStore, connectorInstanceStore } = googleStores()
+    connectorStore.list.mockResolvedValue([
+      { id: 'ci-gm1', connectorId: 'gmail', name: 'Gmail', connectedEmail: 'primary@example.com', connected: true, url: null, custom: false, createdAt: new Date('2026-01-01T00:00:00Z') },
+    ])
+    const preflight = vi.fn(() => ({
+      responseCeiling: 'public' as const,
+      retrievalMax: 'public' as const,
+      classifierDetected: 'confidential' as const,
+      classifierMatches: ['credential'],
+      shouldDeny: true,
+      shadowOnly: false,
+    }))
+    const emit = vi.fn(async () => ({ status: 'executed' as const }))
+    await injectMcpTools({
+      userId: 'u-1', assistantId: 'a-1', tools,
+      connectorStore: connectorStore as never,
+      settingsStore: settingsStoreStub() as never,
+      connectorInstanceStore: connectorInstanceStore as never,
+      connectorActionAudit: { preflight, emit } as never,
+      keepBuiltinsDirect: true,
+    })
+
+    const result = await tools.get('gmailSendMessage')!.execute(
+      { to: ['client@example.com'], subject: 'Hello', body: 'sk_live_secret' },
+      {} as never,
+    )
+
+    expect(result.isError).toBeFalsy()
+    expect(sendGmailMessage).toHaveBeenCalledTimes(1)
+    expect(preflight).toHaveBeenCalledWith(expect.objectContaining({
+      enforcement: 'advisory',
+      payload: expect.objectContaining({ body: 'sk_live_secret' }),
+    }))
+    expect(emit).toHaveBeenCalledWith(
+      { userId: 'u-1', assistantId: 'a-1' },
+      expect.objectContaining({
+        connectorId: 'gmail', actionKind: 'send_email', status: 'executed',
+        payload: expect.not.objectContaining({ body: expect.anything() }),
+      }),
     )
   })
 

--- a/packages/api/src/mcp/inject.ts
+++ b/packages/api/src/mcp/inject.ts
@@ -2779,14 +2779,11 @@ async function injectGoogleTools(
         },
         sendMessage: async (params) => {
           const token = await getToken()
-          // Connector-action audit wrap (per `connector-actions.md`).
-          // With the payload classifier (#3) in place, the email body
-          // CAN be recorded in the audit payload — the classifier
-          // guarantees the recorded content is at-or-below the
-          // computed ceiling. In shadow mode the body is still
-          // recorded but a `classifier_would_have_denied` warning
-          // attaches; in enforce mode a deny short-circuits before the
-          // network call.
+          // Connector-action audit wrap (per `connector-actions.md`). The
+          // classifier sees the transient full draft, but email governance is
+          // authoritative: reaching this callback means the exact frozen
+          // input passed its grant + Allow/Ask/Block policy. Classification is
+          // therefore advisory and raw body text is not persisted.
           //
           // v1 `audienceClearance='public'` for all recipients —
           // per-recipient classification (internal vs external) is a
@@ -2799,7 +2796,6 @@ async function injectGoogleTools(
             subject: params.subject,
             has_body: Boolean(params.body),
             body_length: params.body?.length ?? 0,
-            body: params.body ?? '',
             // Attachment METADATA only — never bytes. Filenames ride
             // through the payload classifier with the rest.
             attachment_count: params.attachments?.length ?? 0,
@@ -2810,38 +2806,20 @@ async function injectGoogleTools(
             })),
           }
 
-          // Preflight: classifier decides BEFORE the network call. In
-          // enforce mode + breach → deny without sending. In shadow
-          // mode the audit captures the warning but execution proceeds.
+          const classifierPayload = {
+            ...auditPayload,
+            body: params.body ?? '',
+          }
+
+          // Advisory preflight: audit the detection without adding a hidden
+          // post-policy veto after the user admitted this exact email.
           let preflight: ConnectorActionPreflight | undefined
           if (connectorActionAudit) {
             preflight = connectorActionAudit.preflight({
               audienceClearance: 'public',
-              payload: auditPayload,
+              payload: classifierPayload,
+              enforcement: 'advisory',
             })
-            if (preflight.shouldDeny) {
-              try {
-                await connectorActionAudit.emit(
-                  { userId, assistantId },
-                  {
-                    connectorId: 'gmail',
-                    actionKind: 'send_email',
-                    audienceClearance: 'public',
-                    status: 'denied',
-                    payload: auditPayload,
-                    preflight,
-                  },
-                )
-              } catch (auditErr) {
-                console.warn(
-                  '[mcp-inject] gmail classifier-deny audit emit failed:',
-                  auditErr instanceof Error ? auditErr.message : String(auditErr),
-                )
-              }
-              throw new Error(
-                `This email contains content the classifier blocked (matched patterns: ${preflight.classifierMatches.join(', ')}). Revise the message and try again.`,
-              )
-            }
           }
 
           try {
@@ -4431,10 +4409,9 @@ async function injectMsGraphTools(
 // sets: primary canonical names plus stable suffixed variants. Credentials are
 // the typed `type:'imap'` blob on each connector_instance;
 // `imapSendMessage` reuses the Gmail governance chain verbatim: `ask`
-// classification + write-grant gate
-// (registry-derived), the connector_actions `send_email` audit with the
-// payload-classifier preflight before the network call, and the
-// confidential-turn egress refusal inside the core tool.
+// classification + write-grant gate (registry-derived), then advisory
+// connector_actions classification + audit. Reaching execution means the
+// exact frozen payload already passed configured governance.
 
 async function injectMailboxTools(params: {
   connectors: Array<{ connectorId: string; connected: boolean; id?: string; createdAt?: Date; name?: string }>
@@ -4528,7 +4505,7 @@ async function injectMailboxTools(params: {
     }
   }
 
-  // Audit-wrapped send (the Gmail pattern): classifier preflight decides
+  // Audit-wrapped send (the Gmail pattern): classifier preflight observes
   // BEFORE the network call; executed/failed both audit. v1
   // `audienceClearance='public'` for all recipients, like gmail. `from` is the
   // sending identity — the RESOLVED sender when the seam reports one (a
@@ -4549,7 +4526,6 @@ async function injectMailboxTools(params: {
         subject: p.subject,
         has_body: Boolean(p.body),
         body_length: p.body?.length ?? 0,
-        body: p.body ?? '',
         in_reply_to: p.inReplyTo ?? null,
         attachment_count: p.attachments?.length ?? 0,
         attachments: (p.attachments ?? []).map((attachment) => ({
@@ -4558,22 +4534,14 @@ async function injectMailboxTools(params: {
           size_bytes: attachment.data.byteLength,
         })),
       }
+      const classifierPayload = { ...auditPayload, body: p.body ?? '' }
       let preflight: ConnectorActionPreflight | undefined
       if (connectorActionAudit) {
-        preflight = connectorActionAudit.preflight({ audienceClearance: 'public', payload: auditPayload })
-        if (preflight.shouldDeny) {
-          try {
-            await connectorActionAudit.emit(
-              { userId, assistantId },
-              { connectorId: 'imap', actionKind: 'send_email', audienceClearance: 'public', status: 'denied', payload: auditPayload, preflight },
-            )
-          } catch (auditErr) {
-            console.warn('[mcp-inject] imap classifier-deny audit emit failed:', auditErr instanceof Error ? auditErr.message : String(auditErr))
-          }
-          throw new Error(
-            `This email contains content the classifier blocked (matched patterns: ${preflight.classifierMatches.join(', ')}). Revise the message and try again.`,
-          )
-        }
+        preflight = connectorActionAudit.preflight({
+          audienceClearance: 'public',
+          payload: classifierPayload,
+          enforcement: 'advisory',
+        })
       }
       try {
         const result = await raw.sendMessage(p)
@@ -4798,9 +4766,8 @@ async function injectMailboxTools(params: {
 // One tool set covers every inbox handled by this assistant (decision D1): the
 // tools take an optional `fromInbox` and default to its first (oldest) inbox.
 // Sends and drafts reuse the Gmail governance chain — `ask` classification
-// (OFFICIAL_CONNECTOR_TOOLS), the connector_actions audit + payload
-// classifier preflight here, and the confidential-turn egress refusal inside
-// the core tool.
+// (OFFICIAL_CONNECTOR_TOOLS), exact inbox grants, then advisory
+// connector_actions classification + audit.
 
 async function injectAgentmailTools(params: {
   provider: EmailInboxProvider
@@ -4819,26 +4786,18 @@ async function injectAgentmailTools(params: {
 
   const auditedEgress = async <T>(
     actionKind: 'send_email' | 'draft_email',
-    payload: Record<string, unknown>,
+    auditPayload: Record<string, unknown>,
+    classifierPayload: Record<string, unknown>,
     run: () => Promise<T>,
     externalIdOf: (result: T) => string | null,
   ): Promise<T> => {
     let preflight: ConnectorActionPreflight | undefined
     if (connectorActionAudit) {
-      preflight = connectorActionAudit.preflight({ audienceClearance: 'public', payload })
-      if (preflight.shouldDeny) {
-        try {
-          await connectorActionAudit.emit(
-            { userId, assistantId },
-            { connectorId: 'agentmail', actionKind, audienceClearance: 'public', status: 'denied', payload, preflight },
-          )
-        } catch (auditErr) {
-          console.warn('[mcp-inject] agentmail classifier-deny audit emit failed:', auditErr instanceof Error ? auditErr.message : String(auditErr))
-        }
-        throw new Error(
-          `This email contains content the classifier blocked (matched patterns: ${preflight.classifierMatches.join(', ')}). Revise the message and try again.`,
-        )
-      }
+      preflight = connectorActionAudit.preflight({
+        audienceClearance: 'public',
+        payload: classifierPayload,
+        enforcement: 'advisory',
+      })
     }
     try {
       const result = await run()
@@ -4846,7 +4805,7 @@ async function injectAgentmailTools(params: {
         try {
           await connectorActionAudit.emit(
             { userId, assistantId },
-            { connectorId: 'agentmail', actionKind, audienceClearance: 'public', status: 'executed', externalId: externalIdOf(result), payload, preflight },
+            { connectorId: 'agentmail', actionKind, audienceClearance: 'public', status: 'executed', externalId: externalIdOf(result), payload: auditPayload, preflight },
           )
         } catch (auditErr) {
           console.warn('[mcp-inject] agentmail connector_action audit emit failed (best-effort, suppressed):', auditErr instanceof Error ? auditErr.message : String(auditErr))
@@ -4860,7 +4819,7 @@ async function injectAgentmailTools(params: {
             { userId, assistantId },
             {
               connectorId: 'agentmail', actionKind, audienceClearance: 'public', status: 'failed',
-              payload: { ...payload, error: err instanceof Error ? err.message : String(err) },
+              payload: { ...auditPayload, error: err instanceof Error ? err.message : String(err) },
               preflight,
             },
           )
@@ -4901,7 +4860,7 @@ async function injectAgentmailTools(params: {
     },
     async send(p) {
       await assertInboxAction(p.inboxAddress, 'agentmailSendMessage')
-      const payload = {
+      const auditPayload = {
         from: p.inboxAddress,
         to: p.to,
         cc: p.cc ?? [],
@@ -4909,15 +4868,15 @@ async function injectAgentmailTools(params: {
         subject: p.subject,
         has_body: Boolean(p.body),
         body_length: p.body.length,
-        body: p.body,
       }
       // The model composes `body` in markdown; render the
-      // multipart/alternative pair at this egress boundary (the audit
-      // payload above keeps the raw markdown for the classifier).
+      // multipart/alternative pair at this egress boundary. Classification
+      // sees the raw markdown transiently; the persisted audit omits it.
       const rendered = renderEmailBody(p.body)
       return auditedEgress(
         'send_email',
-        payload,
+        auditPayload,
+        { ...auditPayload, body: p.body },
         () =>
           provider.sendMessage(p.inboxAddress, {
             to: p.to,
@@ -4950,7 +4909,7 @@ async function injectAgentmailTools(params: {
     },
     async createDraft(p) {
       await assertInboxAction(p.inboxAddress, 'agentmailCreateDraft')
-      const payload = {
+      const auditPayload = {
         from: p.inboxAddress,
         to: p.to,
         cc: p.cc ?? [],
@@ -4958,7 +4917,6 @@ async function injectAgentmailTools(params: {
         subject: p.subject,
         has_body: Boolean(p.body),
         body_length: p.body.length,
-        body: p.body,
         send_at: p.sendAt ?? null,
       }
       // Same markdown → text+html rendering as send — a draft (scheduled or
@@ -4966,7 +4924,8 @@ async function injectAgentmailTools(params: {
       const rendered = renderEmailBody(p.body)
       const draft = await auditedEgress(
         'draft_email',
-        payload,
+        auditPayload,
+        { ...auditPayload, body: p.body },
         () =>
           provider.createDraft(p.inboxAddress, {
             to: p.to,

--- a/packages/core/src/tools/__tests__/agentmail.test.ts
+++ b/packages/core/src/tools/__tests__/agentmail.test.ts
@@ -110,22 +110,21 @@ describe('[COMP:tools/agentmail] Assistant Email tools', () => {
     expect(api.send).toHaveBeenCalledTimes(1)
   })
 
-  it('refuses send AND scheduled draft on a confidential turn (egress gate)', async () => {
+  it('does not let unrelated confidential turn context veto send or scheduled draft', async () => {
     const api = makeApi()
     const tools = createAgentmailTools(api)
     const send = await toolByName(tools, 'agentmailSendMessage').execute(
       { to: ['x@y.z'], subject: 's', body: 'b' },
       CONFIDENTIAL_CTX,
     )
-    expect(send.isError).toBe(true)
-    expect(send.data).toContain('confidential')
+    expect(send.isError).toBeFalsy()
     const draft = await toolByName(tools, 'agentmailCreateDraft').execute(
       { to: ['x@y.z'], subject: 's', body: 'b', sendAt: '2026-07-16T09:00:00Z' },
       CONFIDENTIAL_CTX,
     )
-    expect(draft.isError).toBe(true)
-    expect(api.send).not.toHaveBeenCalled()
-    expect(api.createDraft).not.toHaveBeenCalled()
+    expect(draft.isError).toBeFalsy()
+    expect(api.send).toHaveBeenCalledTimes(1)
+    expect(api.createDraft).toHaveBeenCalledTimes(1)
   })
 
   it('errors honestly when the workspace has no inbox yet', async () => {

--- a/packages/core/src/tools/__tests__/google-gmail-attachments.test.ts
+++ b/packages/core/src/tools/__tests__/google-gmail-attachments.test.ts
@@ -191,7 +191,7 @@ describe('[COMP:tools/gmail-attachments] gmailSendMessage attachments', () => {
     expect(sent).toHaveLength(0)
   })
 
-  it('refuses confidential files by name', async () => {
+  it('sends a readable confidential file once tool governance admits the frozen payload', async () => {
     const secret = fakeFile({ sensitivity: 'confidential', path: '/hr/salaries.xlsx', name: 'salaries.xlsx' })
     const { api, sent } = gmailApi()
     const tool = sendTool(api, filesApiFor([secret]))
@@ -201,25 +201,21 @@ describe('[COMP:tools/gmail-attachments] gmailSendMessage attachments', () => {
       makeContext(),
     )
 
-    expect(result.isError).toBe(true)
-    expect(result.data).toContain('/hr/salaries.xlsx is confidential')
-    expect(sent).toHaveLength(0)
+    expect(result.isError).toBeUndefined()
+    expect(sent).toHaveLength(1)
+    expect(sent[0]?.attachments).toEqual([
+      expect.objectContaining({ filename: 'salaries.xlsx' }),
+    ])
   })
 
-  // WS3 finding #6: the confidential refusal now covers the email BODY too,
-  // not only attachments. The body is free text the model composes, so a
-  // secret read this turn could be pasted in; the turn sensitivity floor
-  // (context.sensitivity.max) gates the send the same way a confidential
-  // attachment does.
-  it('refuses the send when the turn sensitivity floor is confidential (body egress)', async () => {
+  it('does not let unrelated confidential turn context veto a policy-authorized send', async () => {
     const { api, sent } = gmailApi()
     const result = await sendTool(api).execute(
       SEND,
       makeContext({ sensitivity: { max: 'confidential' } as never }),
     )
-    expect(result.isError).toBe(true)
-    expect(String(result.data)).toMatch(/confidential/i)
-    expect(sent).toHaveLength(0)
+    expect(result.isError).toBeUndefined()
+    expect(sent).toHaveLength(1)
   })
 
   it('sends normally when the turn floor is internal', async () => {
@@ -365,7 +361,7 @@ describe('[COMP:tools/gmail-attachments] gmailSendMessage attachments', () => {
       expect(lines).toContain('• Attachment: /uploads/missing.pdf (not found)')
     })
 
-    it('flags confidential files as refusable and dedupes refs to the same file', async () => {
+    it('labels confidential files for informed approval and dedupes refs to the same file', async () => {
       const secret = fakeFile({ sensitivity: 'confidential', name: 'salaries.xlsx', path: '/hr/salaries.xlsx' })
       const tool = sendTool(gmailApi().api, filesApiFor([secret]))
 
@@ -376,7 +372,7 @@ describe('[COMP:tools/gmail-attachments] gmailSendMessage attachments', () => {
 
       const attachmentLines = lines!.filter((l) => l.startsWith('• Attachment:'))
       expect(attachmentLines).toEqual([
-        '• Attachment: salaries.xlsx (confidential: send will be refused)',
+        '• Attachment: salaries.xlsx (1 KB; sensitivity: confidential)',
       ])
     })
   })

--- a/packages/core/src/tools/__tests__/mailbox.test.ts
+++ b/packages/core/src/tools/__tests__/mailbox.test.ts
@@ -264,13 +264,12 @@ describe('[COMP:tools/mailbox-imap] Company mailbox tools', () => {
     expect(data.note).toBe('degraded')
   })
 
-  it('refuses send on a confidential turn (egress gate) without touching the network', async () => {
+  it('does not let unrelated confidential turn context veto a policy-authorized send', async () => {
     const api = makeApi()
     const send = toolByName(toolsFor(api), 'imapSendMessage')
     const result = await send.execute({ to: ['x@y.z'], subject: 's', body: 'b' }, CONFIDENTIAL_CTX)
-    expect(result.isError).toBe(true)
-    expect(result.data).toContain('confidential')
-    expect(api.sendMessage).not.toHaveBeenCalled()
+    expect(result.isError).toBeFalsy()
+    expect(api.sendMessage).toHaveBeenCalledTimes(1)
   })
 
   it('passes inReplyTo through to the seam and returns the message id', async () => {
@@ -494,7 +493,7 @@ describe('[COMP:tools/imap-attachments] imapSendMessage (workspace file → SMTP
     expect(api.sendMessage).not.toHaveBeenCalled()
   })
 
-  it('refuses confidential files before reading bytes or sending', async () => {
+  it('sends a readable confidential file once tool governance admits the frozen payload', async () => {
     const api = makeApi()
     const filesApi = makeFilesApi({
       stat: vi.fn(async () => ({
@@ -508,10 +507,15 @@ describe('[COMP:tools/imap-attachments] imapSendMessage (workspace file → SMTP
       CTX,
     )
 
-    expect(result.isError).toBe(true)
-    expect(result.data).toContain('/hr/payroll.pdf is confidential')
-    expect(filesApi.readBytes).not.toHaveBeenCalled()
-    expect(api.sendMessage).not.toHaveBeenCalled()
+    expect(result.isError).toBeFalsy()
+    expect(filesApi.readBytes).toHaveBeenCalledTimes(1)
+    expect(api.sendMessage).toHaveBeenCalledWith(expect.objectContaining({
+      attachments: [expect.objectContaining({ filename: 'payroll.pdf' })],
+    }))
+    expect(await send.describeConfirmation!(
+      { to: ['client@example.com'], subject: 'Proposal', body: 'Attached.', attachments: ['file-1'] },
+      CTX,
+    )).toContain('• Attachment: payroll.pdf (1 KB; sensitivity: confidential)')
   })
 
   it('enforces the total-size cap before reading any attachment bytes', async () => {

--- a/packages/core/src/tools/base/agentmail.ts
+++ b/packages/core/src/tools/base/agentmail.ts
@@ -12,9 +12,8 @@
  * inboxes (decision D1), so send/draft/search take an optional `fromInbox`
  * and default to the answering assistant's bound inbox.
  *
- * Egress: sends reuse the Gmail chain — confidential-turn refusal here
- * (WS3 finding #6 pattern), classification `ask` + connector_actions audit
- * at the injection layer.
+ * Egress: sends reuse the Gmail chain — exact inbox grant plus configured
+ * Allow/Ask/Block policy, with connector_actions audit at the injection layer.
  *
  * Spec: docs/architecture/integrations/agentmail.md → "Connector tools".
  * Component tag: [COMP:tools/agentmail]
@@ -71,12 +70,6 @@ export type AgentmailToolApi = {
     inReplyTo?: string
   }): Promise<{ draftId: string; sendAt: string | null }>
 }
-
-const CONFIDENTIAL_REFUSAL =
-  'This turn is handling confidential workspace content, so the email cannot go out — ' +
-  'recipients are outside the workspace and the message could carry it. Share confidential ' +
-  'material from the web app instead, or compose the email in a separate turn that does not ' +
-  'read confidential data.'
 
 async function resolveInbox(
   api: AgentmailToolApi,
@@ -158,11 +151,8 @@ export function createAgentmailTools(api: AgentmailToolApi): Tool[] {
     requiresConfirmation: true,
     timeoutMs: 30_000,
 
-    async execute(input, context) {
+    async execute(input) {
       try {
-        if (context.sensitivity?.max === 'confidential') {
-          return { data: CONFIDENTIAL_REFUSAL, isError: true }
-        }
         const inbox = await resolveInbox(api, input.fromInbox)
         if (!inbox.ok) return { data: inbox.error, isError: true }
         const result = await api.send({
@@ -263,13 +253,8 @@ export function createAgentmailTools(api: AgentmailToolApi): Tool[] {
     requiresConfirmation: true,
     timeoutMs: 30_000,
 
-    async execute(input, context) {
+    async execute(input) {
       try {
-        // A scheduled draft egresses without another human step, so the
-        // confidential-turn refusal applies here exactly as it does to send.
-        if (context.sensitivity?.max === 'confidential') {
-          return { data: CONFIDENTIAL_REFUSAL, isError: true }
-        }
         const inbox = await resolveInbox(api, input.fromInbox)
         if (!inbox.ok) return { data: inbox.error, isError: true }
         const result = await api.createDraft({

--- a/packages/core/src/tools/base/google-gmail.ts
+++ b/packages/core/src/tools/base/google-gmail.ts
@@ -153,7 +153,7 @@ export function createGmailTools(
       'pass their ids or paths in `attachments`. Only files already SAVED in the workspace brain can be attached — ' +
       'a photo or document the user just sent in this conversation is an upload, not a saved file yet, so save it first ' +
       'and pass the path that save returns. An `<attached_file id="…">` id will NOT resolve here. ' +
-      'Confidential files cannot be emailed. Limits: 10 attachments, 18 MB total. ' +
+      'Attachment access follows workspace permissions; configured Allow/Ask/Block policy decides whether the exact email may be sent. Limits: 10 attachments, 18 MB total. ' +
       'If attaching fails, relay the reason honestly and do not send the email claiming an attachment that is not on it — ' +
       'either send it without and say so, or stop and tell the user what is blocking you.',
     inputSchema: z.object({
@@ -241,9 +241,8 @@ export function createGmailTools(
         if (seen.has(f.id)) continue
         seen.add(f.id)
         lines.push(
-          f.sensitivity === 'confidential'
-            ? `• Attachment: ${f.name} (confidential: send will be refused)`
-            : `• Attachment: ${f.name} (${formatSize(f.sizeBytes)})`,
+          `• Attachment: ${f.name} (${formatSize(f.sizeBytes)}` +
+          `${f.sensitivity === 'confidential' ? '; sensitivity: confidential' : ''})`,
         )
       }
       return lines.length > 0 ? lines : null
@@ -251,24 +250,6 @@ export function createGmailTools(
 
     async execute(input, context) {
       try {
-        // Egress-safety gate: if confidential content entered the model's
-        // context this turn, refuse the send. The body is free text the model
-        // composes and could carry the secret, and email recipients are
-        // outside the workspace. This mirrors the confidential *attachment*
-        // refusal below (which blocks even with human approval) — memory/CRM
-        // writes only *label* at this floor, but an email egresses, so it is
-        // refused. Before this, the attachment path was guarded but the body
-        // was not. WS3 injection→action finding #6, 2026-07-07.
-        if (context.sensitivity?.max === 'confidential') {
-          return {
-            data:
-              'This turn is handling confidential workspace content, so the email cannot be sent — ' +
-              'recipients are outside the workspace and the message body could carry it. Share confidential ' +
-              'material from the web app instead, or compose the email in a separate turn that does not read ' +
-              'confidential data.',
-            isError: true,
-          }
-        }
         let attachments: GmailOutgoingAttachment[] | undefined
         if (input.attachments && input.attachments.length > 0) {
           const filesApi = opts?.filesApi
@@ -296,12 +277,6 @@ export function createGmailTools(
             const file = result.value
             if (seen.has(file.id)) continue
             seen.add(file.id)
-            if (file.sensitivity === 'confidential') {
-              return {
-                data: `${file.path} is confidential and cannot be emailed — email recipients are outside the workspace. Tell the user to share it from the web app instead.`,
-                isError: true,
-              }
-            }
             files.push({ id: file.id, path: file.path, name: file.name, mime: file.mime, sizeBytes: file.sizeBytes })
           }
 

--- a/packages/core/src/tools/base/mailbox.ts
+++ b/packages/core/src/tools/base/mailbox.ts
@@ -564,7 +564,7 @@ export function createMailboxTools(
       'A reply goes out from the address the original was sent to when that is one of the account\'s configured send-as aliases (otherwise from the account itself); pass `from` only to pick a specific configured alias - any other address is refused. ' +
       'Copy additional people with `cc` (visible to every recipient) or `bcc` (hidden from the others); put an internal colleague you are looping in on `cc` unless the user asks to keep them hidden. ' +
       'Workspace files can be attached as real email attachments: pass their ids or absolute paths in `attachments`. ' +
-      'Only brain-saved files can be attached; confidential files are refused. Limits: 10 attachments, 18 MB total. ' +
+      'Only brain-saved files can be attached; attachment access follows workspace permissions and configured Allow/Ask/Block policy decides the exact send. Limits: 10 attachments, 18 MB total. ' +
       'If attachment resolution fails, relay the reason honestly and never claim the document was attached. ' +
       accountRoutingDescription,
     inputSchema: z.object({
@@ -675,9 +675,8 @@ export function createMailboxTools(
           if (seen.has(file.id)) continue
           seen.add(file.id)
           lines.push(
-            file.sensitivity === 'confidential'
-              ? `• Attachment: ${file.name} (confidential: send will be refused)`
-              : `• Attachment: ${file.name} (${formatSize(file.sizeBytes)})`,
+            `• Attachment: ${file.name} (${formatSize(file.sizeBytes)}` +
+            `${file.sensitivity === 'confidential' ? '; sensitivity: confidential' : ''})`,
           )
         }
       }
@@ -688,19 +687,6 @@ export function createMailboxTools(
       const resolved = resolveForInput(input)
       if (!resolved.ok) return { data: resolved.error, isError: true }
       try {
-        // Egress-safety gate (the gmailSendMessage / agentmail precedent):
-        // if confidential content entered the model's context this turn, the
-        // free-text body could carry it out of the workspace — refuse.
-        if (context.sensitivity?.max === 'confidential') {
-          return {
-            data:
-              'This turn is handling confidential workspace content, so the email cannot be sent — ' +
-              'recipients are outside the workspace and the message body could carry it. Share confidential ' +
-              'material from the web app instead, or compose the email in a separate turn that does not read ' +
-              'confidential data.',
-            isError: true,
-          }
-        }
         let attachments: MailboxOutgoingAttachment[] | undefined
         if (input.attachments && input.attachments.length > 0) {
           if (!attachmentDeps) {
@@ -724,14 +710,6 @@ export function createMailboxTools(
             const file = stat.value
             if (seen.has(file.id)) continue
             seen.add(file.id)
-            if (file.sensitivity === 'confidential') {
-              return {
-                data:
-                  `${file.path} is confidential and cannot be emailed — email recipients are outside the workspace. ` +
-                  'Tell the user to share it from the web app instead.',
-                isError: true,
-              }
-            }
             files.push({
               id: file.id,
               path: file.path,


### PR DESCRIPTION
## Summary
- make exact connector action grants and configured Allow/Ask/Block policy authoritative for email draft and send actions
- keep content classification advisory without persisting raw email body text\n- preserve objective delivery and attachment failures

## Verification
- pnpm verify:api-deploy
- pnpm test
- pnpm smoke
- pnpm check