### PR TITLE
fix(chat): every turn survives a disconnect; personal sessions re-attach

### DIFF
--- a/apps/app-web/src/components/chat-app/chat-surface.tsx
+++ b/apps/app-web/src/components/chat-app/chat-surface.tsx
@@ -150,6 +150,8 @@ import {
   dispatchChatSessionActivity,
   dispatchChatSessionsRefresh,
   shouldAcceptRoomMirror,
+  shouldOpenSessionStream,
+  shouldReopenSessionStream,
 } from "@/lib/chat-session-events";
 import {
   createWorkspaceSession,
@@ -364,6 +366,19 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
    * session switch — it explains one event, it is not a status line.
    */
   const [turnEndNotice, setTurnEndNotice] = useState<string | null>(null);
+  /**
+   * The session whose running turn this surface wants to re-attach to over
+   * `GET /api/sessions/:id/stream` (reconnect mode). Set when the direct
+   * `POST /api/chat` body closed with no terminal event (the turn kept
+   * running server-side, 2026-08-24) and once on hydrating a personal
+   * session, so a reload mid-turn finds its turn again. Cleared by the
+   * stream's `done`. Rooms hold a follow stream regardless of this.
+   */
+  const [reconnectSessionId, setReconnectSessionId] = useState<string | null>(null);
+  /** Shown while a turn that lost its direct stream is being carried by the
+   *  mirror. Cleared by `done` and on a session switch; never set by the
+   *  hydrate probe (no connection dropped there). */
+  const [reconnectNotice, setReconnectNotice] = useState(false);
   // A server `notice` about how THIS turn was served (e.g. the workspace's
   // model endpoint cannot read images, so a built-in model answered). Not an
   // error - the answer is right there - but it must be visible, because an
@@ -1048,6 +1063,14 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
     setSelectionQuote(null);
     hydratedRef.current = activeSessionId;
     sessionIdRef.current = activeSessionId;
+    // A personal session opened from the outside (deep link, rail row,
+    // reload) may have a turn running that no stream in this tab is
+    // painting. Want a re-attach once: the route answers `status` then
+    // `done` and closes when idle (one cheap GET), and `status: running`
+    // paints the mirror. Rooms hold their follow stream regardless; a shared
+    // list still loading reads as "not a room" here and the stream effect
+    // simply re-opens in follow mode once the list lands.
+    setReconnectSessionId(activeSessionId && !activeShared ? activeSessionId : null);
     if (!activeSessionId) {
       chat.loadMessages([]);
       // Back on a fresh pane: the assistant pick is per chat, so it resets
@@ -1146,16 +1169,33 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
   useEffect(() => {
     setTurnEndNotice(null);
     setTurnNotice(null);
+    setReconnectNotice(false);
   }, [activeSessionId]);
 
   useEffect(() => {
-    if (!activeSessionId || !isSharedOpen) {
+    const reconnectWanted =
+      !!activeSessionId && reconnectSessionId === activeSessionId;
+    if (
+      !activeSessionId ||
+      !shouldOpenSessionStream({ isRoom: isSharedOpen, reconnectWanted })
+    ) {
       resetRemoteTurn();
       setRemoteConfirmation(null);
       setRoomTypers([]);
       return;
     }
     let cancelled = false;
+    // Reconnect-mode bookkeeping (personal sessions), read at close time:
+    // `sawDone` decides the reopen; `sawRunning` / `sawTurnCompleted` decide
+    // what `done` still owes (see `case "done"`). A room never sees `done`.
+    let sawDone = false;
+    let sawRunning = false;
+    let sawTurnCompleted = false;
+    // Whether the user was told the connection dropped. Read from this
+    // render's closure on purpose: the notice and `reconnectSessionId` are
+    // always set in the same batch, so the value matches the stream this
+    // effect run opens.
+    const noticeShowing = reconnectNotice;
     const controller = new AbortController();
     const sessionId = activeSessionId;
     const mintRemoteId = () => `rev-${remoteSeqRef.current++}`;
@@ -1164,7 +1204,7 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
     setRoomTypers([]);
 
     // Opening a room reads it — stamp the unread watermark (T7).
-    markRoomSeen(workspaceId, sessionId);
+    if (isSharedOpen) markRoomSeen(workspaceId, sessionId);
 
     // A room found suspended on open surfaces its answer panel immediately
     // (any member with read access may answer — D8).
@@ -1184,6 +1224,7 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
       switch (event) {
         case "status": {
           const working = payload.status === "running";
+          if (working) sawRunning = true;
           // A GET opened just before this page's POST may carry a stale `idle`
           // frame after the optimistic start signal. Never let it erase live
           // direct ownership; a returning page has no such owner and trusts
@@ -1204,6 +1245,7 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
           break;
         }
         case "turn_started": {
+          sawRunning = true;
           dispatchChatSessionActivity({ workspaceId, sessionId, working: true });
           if (!acceptsMirror) break;
           resetRemoteTurn();
@@ -1215,6 +1257,7 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
           break;
         }
         case "snapshot": {
+          sawRunning = true;
           if (!acceptsMirror) break;
           setRemoteActive(true);
           setRemoteStartedAt((current) => current ?? Date.now());
@@ -1234,6 +1277,7 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
           break;
         }
         case "activity": {
+          sawRunning = true;
           if (!acceptsMirror) break;
           setRemoteActive(true);
           setRemoteStartedAt((current) => current ?? Date.now());
@@ -1407,6 +1451,11 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
           break;
         }
         case "turn_completed": {
+          sawTurnCompleted = true;
+          // A room never sends `done`, so the "still working" line from a
+          // disconnected direct stream ends here; for a personal session
+          // `done` follows at once and clears it again, harmlessly.
+          setReconnectNotice(false);
           dispatchChatSessionActivity({ workspaceId, sessionId, working: false });
           // A turn that ended because it stalled or was stopped has to say so.
           // Silently clearing the card leaves the room wondering whether the
@@ -1444,8 +1493,41 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
           void loadTranscript(sessionId);
           void reloadShared();
           dispatchChatSessionsRefresh(workspaceId);
-          markRoomSeen(workspaceId, sessionId);
+          if (isSharedOpen) markRoomSeen(workspaceId, sessionId);
           refreshPendingQuestion(sessionId);
+          break;
+        }
+        case "done": {
+          // Reconnect mode only: the server closes a personal session's
+          // stream on purpose once there is nothing left to attach to (the
+          // turn is over, or was never running) and never reopens it. A
+          // room's follow stream has no `done`.
+          if (isSharedOpen) break;
+          sawDone = true;
+          setReconnectSessionId(null);
+          setReconnectNotice(false);
+          resetRemoteTurn();
+          setRemoteConfirmation(null);
+          // The turn is over, so a card the dead POST stream raised is too.
+          chat.dispatch({ type: "confirmation/clear" });
+          // `turn_completed` already refetched the transcript, the rail and
+          // the pending question, and the idle-open probe (`status` then
+          // `done`) has nothing to refetch while the hydrate fetch is still
+          // landing. Only a `done` after `running` with no `turn_completed`
+          // in between still owes the refetch.
+          if (sawRunning && !sawTurnCompleted) {
+            void loadTranscript(sessionId);
+            dispatchChatSessionsRefresh(workspaceId);
+            refreshPendingQuestion(sessionId);
+          }
+          // The dead POST stream could not report `input_applied` for
+          // anything queued mid-turn. Now that the turn is over, whatever
+          // this client still holds goes out as an ordinary turn (the
+          // queue's "client is the durable holder" fallback).
+          if (sawRunning) {
+            setQueuedNotice(false);
+            flushQueuedInputs();
+          }
           break;
         }
         default:
@@ -1459,7 +1541,19 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
           `${API_URL}/api/sessions/${encodeURIComponent(sessionId)}/stream`,
           { signal: controller.signal },
         );
-        if (!res.ok || !res.body) return;
+        if (!res.ok || !res.body) {
+          // A rejected open is not something a retry fixes. A room keeps
+          // its retry cadence as before; a reconnecting personal session
+          // gives up, and reports it only when the user was shown the
+          // reconnect notice (the hydrate probe failing is not news).
+          if (!isSharedOpen) {
+            sawDone = true;
+            setReconnectSessionId(null);
+            setReconnectNotice(false);
+            if (noticeShowing) setError(t.errorGeneric);
+          }
+          return;
+        }
         const reader = res.body.getReader();
         const decoder = new TextDecoder();
         const buf = createSSEBuffer();
@@ -1473,9 +1567,14 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
       } catch {
         // Transport error / abort — reconnect below (or unmount).
       } finally {
-        // Follow mode never closes server-side on idle, so a close means a
-        // deploy / restart / network blip — re-open after a beat.
-        if (!cancelled) {
+        // Follow mode never closes server-side on idle, so a room close means
+        // a deploy / restart / network blip: re-open after a beat. A
+        // personal session's reconnect stream reopens only when the body
+        // closed WITHOUT `done` (the transport gave up on a turn that may
+        // still be running); after `done` the server has nothing more.
+        if (
+          shouldReopenSessionStream({ isRoom: isSharedOpen, sawDone, cancelled })
+        ) {
           setTimeout(() => {
             if (!cancelled) setSubscribeEpoch((n) => n + 1);
           }, 3_000);
@@ -1489,7 +1588,7 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
     // `resetRemoteTurn` / `refreshPendingQuestion` / `loadTranscript` /
     // `reloadShared` are stable callbacks.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeSessionId, isSharedOpen, subscribeEpoch, meId, workspaceId, tChat.toolNarration]);
+  }, [activeSessionId, isSharedOpen, reconnectSessionId, subscribeEpoch, meId, workspaceId, tChat.toolNarration]);
 
   // ── Typing beacon (rooms) ───────────────────────────────────────────
   // Tell the bus while this member composes: a throttled `true` beacon keeps
@@ -1614,20 +1713,32 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
    *  onError, so the state resets here (the dock's `handleAbort`). */
   const handleAbort = useCallback(() => {
     responseGroupAbortRef.current = true;
-    // A room turn is server-owned and continues after the page stream closes.
-    // Releasing direct ownership lets this room's follow stream immediately
-    // render our own mirrored progress instead of making Stop look like a
-    // completed server cancellation.
+    // Every turn is server-owned and continues after the page stream closes
+    // (the server no longer reads a client close as Stop, 2026-08-24), so
+    // Stop is an explicit `POST /api/chat/stop`. Releasing direct ownership
+    // first lets the session stream render our own mirrored progress until
+    // the server's `turn_completed` lands, instead of making Stop look like
+    // a completed cancellation.
+    const sessionId = sessionIdRef.current;
     directTurnSessionRef.current = null;
     stream.abort();
     chat.dispatch({ type: "stream/abort" });
     turnTextRef.current = "";
     resetTurnActivity();
     // An aborted stream never reaches `onDone`, so the flush happens here
-    // too — the queued text is usually WHY the user reached for Stop.
-    flushQueuedInputs();
+    // too: the queued text is usually WHY the user reached for Stop. It
+    // waits for the stop to land, because a flush racing the still-running
+    // turn is answered `turn_in_flight`. No session id means nothing is
+    // running server-side, so the flush goes straight out.
+    if (!sessionId) {
+      flushQueuedInputs();
+      return;
+    }
+    void stopTurn(sessionId)
+      .catch(() => setError(t.stopTurnFailed))
+      .finally(flushQueuedInputs);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [stream, resetTurnActivity, flushQueuedInputs]);
+  }, [stream, resetTurnActivity, flushQueuedInputs, t.stopTurnFailed]);
 
   const copyResetRef = useRef<number | null>(null);
   const handleCopy = useCallback((messageId: string, text: string) => {
@@ -1929,17 +2040,25 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
       turnStartedAtRef.current = Date.now();
       setTurnStartedAt(turnStartedAtRef.current);
 
-      const directRoomSessionId = isRoom ? sessionIdRef.current : null;
-      if (directRoomSessionId) {
-        directTurnSessionRef.current = directRoomSessionId;
+      // EVERY session records direct ownership, not just rooms: the session
+      // stream can be open for a personal session too (reconnect mode), and
+      // `shouldAcceptRoomMirror` is what keeps our own mirror quiet while
+      // this POST is still painting. A fresh pane has no id yet; the
+      // `session` event below adopts it.
+      const directSessionId = sessionIdRef.current;
+      directTurnSessionRef.current = directSessionId;
+      if (directSessionId) {
         dispatchChatSessionActivity({
           workspaceId,
-          sessionId: directRoomSessionId,
+          sessionId: directSessionId,
           working: true,
         });
       }
 
       let turnFailed = false;
+      /** The body closed with no terminal event: the turn is still running
+       *  server-side and the session stream has taken over painting it. */
+      let turnDisconnected = false;
       await stream.start({
       url: `${API_URL}/api/chat`,
       authFetch: (url, init) => authFetch(String(url), init),
@@ -1995,6 +2114,8 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
               // reply that is streaming into it right now.
               sessionIdRef.current = id;
               hydratedRef.current = id;
+              // The POST that minted this id is the one painting it.
+              directTurnSessionRef.current = id;
               // Record the binding so the next turn resolves this thread to
               // the SAME assistant before the rail refetch lands.
               sessionAssistantRef.current.set(id, target.id);
@@ -2381,12 +2502,12 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
         }
       },
       onDone: () => {
-        const settledRoomSessionId = directTurnSessionRef.current;
+        const settledSessionId = directTurnSessionRef.current;
         directTurnSessionRef.current = null;
-        if (settledRoomSessionId) {
+        if (settledSessionId) {
           dispatchChatSessionActivity({
             workspaceId,
-            sessionId: settledRoomSessionId,
+            sessionId: settledSessionId,
             working: false,
           });
         }
@@ -2415,6 +2536,42 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
         // The turn may have auto-titled the thread — refresh the rail.
         dispatchChatSessionsRefresh(workspaceId);
       },
+      onDisconnect: () => {
+        // The transport closed with no `done` / `error`: a request-timeout
+        // cut, a deploy, a network blip. The server no longer reads a client
+        // close as Stop (2026-08-24), so the turn is still running and its
+        // reply lands in the transcript when it finishes. Hand the paint to
+        // the mirror machinery and re-attach over the session stream.
+        turnDisconnected = true;
+        const sessionId = sessionIdRef.current;
+        const streamedText = turnTextRef.current;
+        const startedAt = turnStartedAtRef.current;
+        directTurnSessionRef.current = null;
+        chat.dispatch({ type: "stream/abort" });
+        turnTextRef.current = "";
+        resetTurnActivity();
+        // Not flushed: the turn is still running, so a re-send would only
+        // be answered `turn_in_flight`. The stream's `done` flushes.
+        setQueuedNotice(false);
+        if (!sessionId) {
+          // No `session` frame ever arrived, so there is nothing to
+          // re-attach to. Report it like any other transport failure.
+          setError(t.errorGeneric);
+          dispatchChatSessionsRefresh(workspaceId);
+          return;
+        }
+        // Paint what the dead stream had so far as the remote turn; the
+        // first `snapshot` off the bus replaces it with the server's text.
+        // Not `resetRemoteTurn()`: our own mirror was suppressed while the
+        // POST was live, so there is nothing stale to clear, and a room's
+        // follow stream is already open to carry on from here.
+        setRemoteAssistantId(target.id);
+        setRemoteActive(true);
+        setRemoteText(streamedText);
+        setRemoteStartedAt((current) => current ?? startedAt ?? Date.now());
+        setReconnectSessionId(sessionId);
+        setReconnectNotice(true);
+      },
       onError: () => {
         turnFailed = true;
         directTurnSessionRef.current = null;
@@ -2431,6 +2588,7 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
       });
       if (
         turnFailed ||
+        turnDisconnected ||
         askedQuestionRef.current ||
         responseGroupAbortRef.current
       ) {
@@ -2771,6 +2929,15 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
       setError(t.stopTurnFailed);
     }
   }, [activeSessionId, t.stopTurnFailed]);
+
+  /** A personal session has no Work Bench, so the composer's Stop is its only
+   *  Stop. Keep it while the re-attached mirror carries a turn this tab lost
+   *  its direct stream to; a room keeps the Live card's Stop instead. */
+  const mirrorStopAvailable =
+    !isSharedOpen &&
+    remoteActive &&
+    !!activeSessionId &&
+    reconnectSessionId === activeSessionId;
 
   /** Group-chat timeline metadata: day separators + sender-group headers
    *  (docs/architecture/features/chat-app.md → "Transcript timestamps"). */
@@ -3436,10 +3603,10 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
           chat.state.isStreaming && !canQueueMidTurn && "hidden",
         )}
         slotPostInput={
-          chat.state.isStreaming ? (
+          chat.state.isStreaming || mirrorStopAvailable ? (
             <button
               type="button"
-              onClick={handleAbort}
+              onClick={chat.state.isStreaming ? handleAbort : stopActiveTurn}
               aria-label={tChat.abort}
               title={tChat.abort}
               className={cn(
@@ -3906,6 +4073,17 @@ export function ChatSurface({ workspaceId }: { workspaceId: string }) {
                 className="rounded-lg border border-border/70 bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
               >
                 {turnEndNotice}
+              </p>
+            )}
+            {/* The direct stream died under a turn that is still running;
+                the mirror above is carrying it. Not an error: nothing was
+                lost, the reply lands in the transcript when it finishes. */}
+            {reconnectNotice && (
+              <p
+                role="status"
+                className="rounded-lg border border-border/70 bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
+              >
+                {t.turnReconnecting}
               </p>
             )}
             {/* Typing indicator — teammates mid-composition, off the follow

--- a/apps/app-web/src/components/chrome/floating-chat.tsx
+++ b/apps/app-web/src/components/chrome/floating-chat.tsx
@@ -132,6 +132,8 @@ import {
 import {
   ChatMarkdown,
   ChatComposer,
+  createSSEBuffer,
+  parseSSEStream,
   useChatSession,
   useMessageStream,
   type ChatFileAttachment,
@@ -193,8 +195,10 @@ import {
   fetchLatestSession,
   fetchSessionMessages,
   parseMessageAttachments,
+  stopTurn,
   type MessageAttachmentRef,
 } from "@/lib/api/sessions";
+import { shouldReopenSessionStream } from "@/lib/chat-session-events";
 import { MessageAttachments } from "@/components/doc/message-attachment-card";
 import { fetchPendingQuestion } from "@/lib/api/pending-questions";
 import { PendingQuestionPanel } from "./pending-question-panel";
@@ -257,6 +261,16 @@ type ChatOrigin = "doc" | ChatSurface;
 
 /** Persisted across sessions so the model choice sticks. */
 const MODEL_STORAGE_KEY = "doc-chat-model";
+
+/** `notice.code` while the dock is re-attached to a turn whose POST stream
+ *  died. Keyed so completion clears only this notice, never a later one. */
+const RECONNECT_NOTICE_CODE = "turn_reconnecting";
+/** Bare closes of the reconnect stream reopen after this beat. */
+const RECONNECT_REOPEN_MS = 3_000;
+/** Total time the dock keeps re-attaching before it reports failure. Above
+ *  the Cloud Run request cap (30 min) so a turn that outlives one cut still
+ *  lands; past it the user is told to reload. */
+const RECONNECT_BUDGET_MS = 35 * 60_000;
 type ModelTier = "standard" | "pro" | "max";
 
 /**
@@ -672,6 +686,15 @@ export function FloatingChat({
   // seconds to fire the continuation turn, so we poll session messages
   // for the synthesised reply to land without a manual refresh.
   const [resumePolling, setResumePolling] = useState(false);
+  // Turn reconnect. Set when the direct `POST /api/chat` body closed with no
+  // terminal event (the server no longer reads that close as Stop,
+  // 2026-08-24): the turn is still running, so the dock re-attaches over
+  // `GET /api/sessions/:id/stream` and loads the persisted reply when the
+  // stream reports the turn over. The epoch reopens the stream after a
+  // bare close; `reconnectStartedAtRef` bounds how long it keeps trying.
+  const [reconnectSessionId, setReconnectSessionId] = useState<string | null>(null);
+  const [reconnectEpoch, setReconnectEpoch] = useState(0);
+  const reconnectStartedAtRef = useRef<number | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
@@ -805,6 +828,7 @@ export function FloatingChat({
     session.clearConfirmations();
     setPendingQuestion(null);
     setResumePolling(false);
+    setReconnectSessionId(null);
     setError(null);
     setNotice(null);
   }, [stream, session, midTurn]);
@@ -1174,6 +1198,34 @@ export function FloatingChat({
       void sendMessageRef.current?.(joined);
     }, 0);
   }, [midTurn]);
+  // `midTurn` is a fresh object every render, so `flushQueuedInputs` is too.
+  // Long-lived effects (the reconnect stream) reach it through this ref
+  // rather than listing it as a dep and reopening their stream per render.
+  const flushQueuedInputsRef = useRef(flushQueuedInputs);
+  useEffect(() => {
+    flushQueuedInputsRef.current = flushQueuedInputs;
+  }, [flushQueuedInputs]);
+
+  /**
+   * The user's Stop: tear the local stream down AND tell the server. Since
+   * 2026-08-24 the server no longer reads a client close as Stop (a dropped
+   * connection keeps the turn running so it can be re-attached), so the
+   * explicit `POST /api/chat/stop` is the only thing that ends the turn.
+   * Returns the promise so callers can sequence work after the stop lands;
+   * no session id means nothing is running server-side. Stop is idempotent
+   * server-side and the local teardown already happened, so a failed stop
+   * is swallowed rather than surfaced.
+   */
+  const stopRunningTurn = useCallback((): Promise<void> => {
+    const sessionId = sessionIdRef.current;
+    stream.abort();
+    session.dispatch({ type: "stream/abort" });
+    if (!sessionId) return Promise.resolve();
+    return stopTurn(sessionId).then(
+      () => undefined,
+      () => undefined,
+    );
+  }, [stream, session]);
 
   // ── Live activity mirror to parent + collapsed pill ────────────────────
   const isStreaming = session.state.isStreaming;
@@ -1258,8 +1310,7 @@ export function FloatingChat({
         // closing the panel — matches apps/web's behaviour. Click X to
         // collapse.
         if (stream.inFlight()) {
-          stream.abort();
-          session.dispatch({ type: "stream/abort" });
+          void stopRunningTurn();
           return;
         }
         setExpanded(false);
@@ -1290,7 +1341,7 @@ export function FloatingChat({
       window.removeEventListener("keydown", onKey);
       window.removeEventListener("mousedown", onPointerDown);
     };
-  }, [expanded, stream, session]);
+  }, [expanded, stopRunningTurn, stream]);
 
   // ── Session resume on mount ────────────────────────────────────────────
   //
@@ -1423,6 +1474,130 @@ export function FloatingChat({
       controller.abort();
     };
   }, [resumePolling, session.state.sessionId, session.state.messages.length]);
+
+  // ── Turn reconnect ─────────────────────────────────────────────────────
+  // The direct POST body closed with no `done` / `error`, so the turn is
+  // still running server-side. Follow it over `GET /api/sessions/:id/stream`
+  // (reconnect mode): the first frame is `status`; `snapshot` / `activity`
+  // carry the live turn (ignored here: the dock has no mirror bubble, the
+  // persisted reply lands on completion); `turn_completed` or a `status`
+  // that is not `running` means the turn is over and the server follows with
+  // `done` and closes. The transcript is then re-read from the server, the
+  // same way the askQuestion resume poll above lands its reply. A bare close
+  // (proxy cut, deploy) reopens after a beat; past the budget the dock gives
+  // up and says so. Mirrors `chat-surface.tsx`'s session-stream effect minus
+  // the remote-turn paint.
+  useEffect(() => {
+    const sid = reconnectSessionId;
+    if (!sid) return;
+    let cancelled = false;
+    let sawDone = false;
+    const controller = new AbortController();
+    const epoch = threadEpochRef.current;
+    const narration = t.toolNarration;
+    const clearReconnectNotice = () =>
+      setNotice((current) =>
+        current?.code === RECONNECT_NOTICE_CODE ? null : current,
+      );
+    const onCompleted = () => {
+      if (sawDone) return;
+      sawDone = true;
+      setReconnectSessionId(null);
+      clearReconnectNotice();
+      void fetchSessionMessages(sid)
+        .then((rows) => {
+          // The thread was reset or switched while the fetch was out.
+          if (epoch !== threadEpochRef.current) return;
+          if (sessionIdRef.current !== sid) return;
+          sessionDispatchRef.current({
+            type: "messages/load",
+            messages: mapSessionRows(rows, narration),
+          });
+        })
+        .catch(() => {});
+      // The turn may have suspended on a clarifying question after the
+      // stream died; the dead POST could not report it, so probe.
+      void fetchPendingQuestion(sid)
+        .then((q) => {
+          if (!q || epoch !== threadEpochRef.current) return;
+          setPendingQuestion({
+            approvalId: q.approvalId,
+            question: q.question ?? "",
+            expiresAt: q.expiresAt,
+            sessionId: sid,
+          });
+        })
+        .catch(() => {});
+      if (!isDocOrigin) requestBrainRefresh(workspaceId);
+      // Queued mid-turn input the dead POST never took: the turn is over
+      // now, so it goes out as an ordinary turn (the queue's "client is
+      // the durable holder" fallback).
+      flushQueuedInputsRef.current();
+    };
+    const giveUp = () => {
+      if (sawDone) return;
+      sawDone = true;
+      setReconnectSessionId(null);
+      clearReconnectNotice();
+      setError(t.turnReconnectFailed);
+    };
+
+    void (async () => {
+      try {
+        const res = await authFetch(
+          `${API_URL}/api/sessions/${encodeURIComponent(sid)}/stream`,
+          { signal: controller.signal },
+        );
+        if (cancelled) return;
+        if (!res.ok || !res.body) {
+          // A rejected open is not something a retry fixes.
+          giveUp();
+          return;
+        }
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        const buf = createSSEBuffer();
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done || cancelled) break;
+          for (const ev of parseSSEStream(decoder.decode(value, { stream: true }), buf)) {
+            if (cancelled || sawDone) break;
+            const payload = coercePayload(ev.data);
+            switch (ev.event) {
+              case "status": {
+                if (payload.status !== "running") onCompleted();
+                break;
+              }
+              case "turn_completed":
+              case "done":
+                onCompleted();
+                break;
+              default:
+                // `snapshot` / `activity`: no mirror bubble in the dock.
+                break;
+            }
+          }
+        }
+      } catch {
+        // Transport error / abort: reopen below, or the effect was torn down.
+      } finally {
+        if (shouldReopenSessionStream({ isRoom: false, sawDone, cancelled })) {
+          const startedAt = reconnectStartedAtRef.current ?? Date.now();
+          if (Date.now() - startedAt > RECONNECT_BUDGET_MS) {
+            giveUp();
+          } else {
+            setTimeout(() => {
+              if (!cancelled) setReconnectEpoch((n) => n + 1);
+            }, RECONNECT_REOPEN_MS);
+          }
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [reconnectSessionId, reconnectEpoch, workspaceId, isDocOrigin, t.toolNarration, t.turnReconnectFailed]);
 
   // ── Send + SSE loop ────────────────────────────────────────────────────
 
@@ -2451,6 +2626,29 @@ export function FloatingChat({
             }
           }
         },
+        onDisconnect: () => {
+          // The body closed with no `done` / `error`: a request-timeout cut,
+          // a deploy, a network blip. The server keeps the turn running
+          // (2026-08-24), so drop the live bubble, tell the user, and
+          // re-attach over the session stream; the persisted reply is
+          // loaded when that stream reports the turn over. Queued input is
+          // NOT flushed here: the turn is still running and a re-send
+          // would only be answered `turn_in_flight`.
+          const sid = sessionIdRef.current;
+          session.dispatch({ type: "stream/abort" });
+          resetTurnBuffers();
+          if (!sid) {
+            // No `session` frame ever arrived, so there is nothing to
+            // re-attach to. Report it like any other transport failure.
+            setError(t.streamInterrupted);
+            flushQueuedInputs();
+            return;
+          }
+          reconnectStartedAtRef.current = Date.now();
+          setNotice({ code: RECONNECT_NOTICE_CODE, message: t.turnReconnecting });
+          setReconnectSessionId(sid);
+          setReconnectEpoch((n) => n + 1);
+        },
         onError: (err) => {
           setError(
             isTransportError(err)
@@ -2680,15 +2878,15 @@ export function FloatingChat({
   }, []);
 
   const handleAbort = useCallback(() => {
-    stream.abort();
-    session.dispatch({ type: "stream/abort" });
     // An aborted stream never reaches `onDone`, so the flush has to happen
     // here too. Stopping the current work and still wanting the message you
     // just queued answered is the normal reading of "stop, and here's the
     // thing I actually want" — the queued text is why the user reached for
-    // Stop in the first place.
-    flushQueuedInputs();
-  }, [stream, session, flushQueuedInputs]);
+    // Stop in the first place. It waits for the server-side stop to land,
+    // because a flush racing the still-running turn is answered
+    // `turn_in_flight`.
+    void stopRunningTurn().finally(flushQueuedInputs);
+  }, [stopRunningTurn, flushQueuedInputs]);
 
   const handleConfirmation = useCallback(
     async (
@@ -3138,8 +3336,11 @@ export function FloatingChat({
             />
           ) : null}
 
-          {/* Resume-in-flight indicator while the continuation turn fires. */}
-          {resumePolling ? (
+          {/* Resume-in-flight indicator while the continuation turn fires,
+              and the lightweight "working" state while the dock is
+              re-attached to a turn whose POST stream died (no mirror bubble
+              here; the reply loads on completion). */}
+          {resumePolling || reconnectSessionId ? (
             <ResumingIndicator label={t.pendingQuestion.resuming} />
           ) : null}
 

--- a/apps/app-web/src/components/feed/tuning-chat-panel.tsx
+++ b/apps/app-web/src/components/feed/tuning-chat-panel.tsx
@@ -46,7 +46,11 @@ import {
 } from "@/lib/use-mid-turn-queue";
 import { QueuedInputs } from "@/components/ui/queued-inputs";
 import { fetchFeedSessionIdByChannel } from "@/lib/api/feed";
-import { fetchSessionMessages, extractMessageText } from "@/lib/api/sessions";
+import {
+  fetchSessionMessages,
+  extractMessageText,
+  stopTurn,
+} from "@/lib/api/sessions";
 import { getUsage } from "@/lib/api/usage";
 import { webAppUrl } from "@/lib/primary-auth";
 import { AssistantAvatar } from "@/components/assistant-avatar";
@@ -982,8 +986,23 @@ export const TuningChatPanel = forwardRef<
             {isStreaming && (
               <button
                 onClick={() => {
+                  const sid = fixedSessionId ?? sessionIdRef.current;
                   stream.abort();
-                  flushQueuedInputs();
+                  // The server no longer reads a client close as Stop
+                  // (2026-08-24: a dropped connection keeps the turn running
+                  // so it can be re-attached), so the explicit stop is the
+                  // only thing that ends it. The queued flush waits for it
+                  // to land: a flush racing the still-running turn is
+                  // answered `turn_in_flight`. No session id means nothing
+                  // is running server-side. A failed stop is swallowed (the
+                  // stop is idempotent and the local teardown already ran).
+                  if (!sid) {
+                    flushQueuedInputs();
+                    return;
+                  }
+                  void stopTurn(sid)
+                    .catch(() => {})
+                    .finally(flushQueuedInputs);
                 }}
                 className="p-2 rounded-xl text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors shrink-0"
                 title={t.stop}

--- a/apps/app-web/src/components/knowledge/kb-chat-panel.tsx
+++ b/apps/app-web/src/components/knowledge/kb-chat-panel.tsx
@@ -36,6 +36,7 @@ import { requestApprovalsRefresh } from "@/lib/approvals-events";
 import {
   fetchSessionMessages,
   extractMessageText,
+  stopTurn,
 } from "@/lib/api/sessions";
 import { listWorkspaceAssistants } from "@/lib/api/views";
 import { pickPrimaryAssistant } from "@/lib/primary-assistant";
@@ -424,8 +425,15 @@ export function KbChatPanel({
             <button
               type="button"
               onClick={() => {
+                const sid = sessionIdRef.current;
                 stream.abort();
                 session.dispatch({ type: "stream/abort" });
+                // The server no longer reads a client close as Stop
+                // (2026-08-24: a dropped connection keeps the turn running
+                // so it can be re-attached), so the explicit stop is the
+                // only thing that ends it. Idempotent server-side, and the
+                // local teardown already happened, so a failure is swallowed.
+                if (sid) void stopTurn(sid).catch(() => {});
               }}
               aria-label={copy.stop}
               title={copy.stop}

--- a/apps/app-web/src/lib/__tests__/chat-session-events.test.ts
+++ b/apps/app-web/src/lib/__tests__/chat-session-events.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { shouldAcceptRoomMirror } from "../chat-session-events";
+import {
+  shouldAcceptRoomMirror,
+  shouldOpenSessionStream,
+  shouldReopenSessionStream,
+} from "../chat-session-events";
 
 const base = {
   senderUserId: "user-1",
@@ -50,5 +54,41 @@ describe("[COMP:app-web/chat-surface] room live-progress ownership", () => {
         senderUserId: "user-2",
       }),
     ).toBe(true);
+  });
+});
+
+describe("[COMP:app-web/turn-reconnect] personal-session stream open / reopen", () => {
+  it("always opens the follow stream for a room", () => {
+    expect(shouldOpenSessionStream({ isRoom: true, reconnectWanted: false })).toBe(true);
+    expect(shouldOpenSessionStream({ isRoom: true, reconnectWanted: true })).toBe(true);
+  });
+
+  it("opens a non-room stream only while a re-attach is wanted", () => {
+    expect(shouldOpenSessionStream({ isRoom: false, reconnectWanted: false })).toBe(false);
+    expect(shouldOpenSessionStream({ isRoom: false, reconnectWanted: true })).toBe(true);
+  });
+
+  it("reopens a room stream after any close", () => {
+    expect(shouldReopenSessionStream({ isRoom: true, sawDone: false, cancelled: false })).toBe(true);
+    expect(shouldReopenSessionStream({ isRoom: true, sawDone: true, cancelled: false })).toBe(true);
+  });
+
+  it("never reopens a non-room stream after the immediate not-running done", () => {
+    // status { idle } -> done {} -> end: the route answered "nothing to attach to".
+    expect(shouldReopenSessionStream({ isRoom: false, sawDone: true, cancelled: false })).toBe(false);
+  });
+
+  it("never reopens a non-room stream after the post-turn_completed done", () => {
+    // ... turn_completed {} -> done {} -> end: the turn is over; the transcript was refetched.
+    expect(shouldReopenSessionStream({ isRoom: false, sawDone: true, cancelled: false })).toBe(false);
+  });
+
+  it("reopens a non-room stream on a bare close (no done)", () => {
+    expect(shouldReopenSessionStream({ isRoom: false, sawDone: false, cancelled: false })).toBe(true);
+  });
+
+  it("never reopens once the effect was cancelled", () => {
+    expect(shouldReopenSessionStream({ isRoom: true, sawDone: false, cancelled: true })).toBe(false);
+    expect(shouldReopenSessionStream({ isRoom: false, sawDone: false, cancelled: true })).toBe(false);
   });
 });

--- a/apps/app-web/src/lib/chat-session-events.ts
+++ b/apps/app-web/src/lib/chat-session-events.ts
@@ -92,3 +92,42 @@ export function dispatchChatSessionActivity(
     }),
   );
 }
+
+/**
+ * Whether the chat surface should hold a `GET /api/sessions/:id/stream`
+ * subscription for the open session.
+ *
+ * A room is followed for its whole lifetime (teammate posts, mirrored turns,
+ * presence). A personal session opens the stream only while a re-attach is
+ * WANTED: after the direct `POST /api/chat` body closed without a terminal
+ * event (the turn is still running server-side, see 2026-08-24), and once on
+ * hydrate so a reload mid-turn finds the running turn again. When idle the
+ * route answers `status` then `done` and closes; one cheap GET.
+ */
+export function shouldOpenSessionStream(params: {
+  isRoom: boolean;
+  reconnectWanted: boolean;
+}): boolean {
+  return params.isRoom || params.reconnectWanted;
+}
+
+/**
+ * Whether a closed session stream should be re-opened after a beat.
+ *
+ * Rooms never close server-side on idle, so any close there is a deploy /
+ * restart / network blip and the follow stream comes back. A personal
+ * session's reconnect stream ends on purpose: the server sends `done` when
+ * the turn is over (or was never running) and never reopens. So a non-room
+ * reopens ONLY when the body closed without `done` (the transport gave up on
+ * a turn that may still be running); after `done` there is nothing to attach
+ * to. A cancelled effect (unmount, session switch) never reopens.
+ */
+export function shouldReopenSessionStream(params: {
+  isRoom: boolean;
+  sawDone: boolean;
+  cancelled: boolean;
+}): boolean {
+  if (params.cancelled) return false;
+  if (params.isRoom) return true;
+  return !params.sawDone;
+}

--- a/apps/app-web/src/lib/i18n/dictionaries/en.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/en.ts
@@ -158,6 +158,11 @@ export const en = {
     streamInterrupted:
       "The connection dropped before the reply finished. Any page changes already made were saved. Send another message to continue.",
     // Assistant switcher — pick which workspace assistant this chat talks to.
+    /** The POST body closed with no terminal event: the turn is still running
+     *  server-side and the dock is re-attaching to it. */
+    turnReconnecting:
+      "Connection dropped. Still working in the background; the reply will appear when it finishes.",
+    turnReconnectFailed: "Could not reconnect to the running turn. Reload to check.",
     switchAssistant: "Switch assistant",
     switchAssistantTitle: "Talk to",
     emptyTitle: "Ask Use Brian",
@@ -5653,6 +5658,8 @@ export const en = {
     liveWorkNoProgress: "No progress for {minutes}m",
     turnStoppedBy: "{name} stopped this turn.",
     turnStoppedByYou: "You stopped this turn.",
+    turnReconnecting:
+      "Connection dropped. Your assistant is still working; the reply will appear here when it finishes.",
     turnReclaimed:
       "The previous turn stopped responding and was reset, so the chat is unblocked. Nothing was lost: your messages are still here. Send again to continue.",
     pinnedContext: "Pins",

--- a/apps/app-web/src/lib/i18n/dictionaries/ja.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/ja.ts
@@ -136,6 +136,9 @@ export const ja: Dictionary = {
     error: "送信できませんでした。もう一度お試しください。",
     streamInterrupted:
       "返信の途中で接続が切れました。これまでのページの変更は保存済みです。続けるにはもう一度メッセージを送ってください。",
+    turnReconnecting:
+      "接続が切れました。バックグラウンドで処理を続けています。完了すると返信が表示されます。",
+    turnReconnectFailed: "実行中のターンに再接続できませんでした。再読み込みして確認してください。",
     switchAssistant: "アシスタントを切り替え",
     switchAssistantTitle: "話す相手",
     emptyTitle: "Use Brian に依頼",
@@ -5438,6 +5441,8 @@ export const ja: Dictionary = {
     liveWorkNoProgress: "{minutes} 分間、進捗がありません",
     turnStoppedBy: "{name} がこのターンを停止しました。",
     turnStoppedByYou: "このターンを停止しました。",
+    turnReconnecting:
+      "接続が切れました。アシスタントは処理を続けています。完了すると返信がここに表示されます。",
     turnReclaimed:
       "前のターンが応答しなくなったためリセットし、チャットのブロックを解除しました。メッセージはすべて残っています。もう一度送信すると続けられます。",
     pinnedContext: "ピン",

--- a/apps/app-web/src/lib/i18n/dictionaries/zh.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh.ts
@@ -135,6 +135,9 @@ export const zh: Dictionary = {
     error: "傳送失敗，請再試一次。",
     streamInterrupted:
       "回覆尚未完成，連線就中斷了。先前所做的頁面變更皆已儲存，再傳送一則訊息即可繼續。",
+    turnReconnecting:
+      "連線已中斷。助理仍在背景繼續處理，完成後就會顯示回覆。",
+    turnReconnectFailed: "無法重新連接到執行中的回合，請重新載入頁面確認。",
     switchAssistant: "切換助理",
     switchAssistantTitle: "對話對象",
     emptyTitle: "向 Use Brian 提問",
@@ -5391,6 +5394,8 @@ export const zh: Dictionary = {
     liveWorkNoProgress: "已有 {minutes} 分鐘沒有進展",
     turnStoppedBy: "{name} 停止了這個回合。",
     turnStoppedByYou: "你已停止這個回合。",
+    turnReconnecting:
+      "連線已中斷。助理仍在繼續處理，完成後回覆會顯示在這裡。",
     turnReclaimed:
       "上一個回合停止回應，系統已將它重設並解除聊天封鎖。訊息都還在，重新傳送即可繼續。",
     pinnedContext: "釘選",

--- a/packages/api/src/__tests__/session-turn-reconnect.test.ts
+++ b/packages/api/src/__tests__/session-turn-reconnect.test.ts
@@ -1,0 +1,141 @@
+/**
+ * [COMP:api/session-turn-reconnect] — the reconnect relay behind
+ * `GET /api/sessions/:id/stream` (reconnect mode, every non-room session).
+ *
+ * 2026-08-24: Cloud Run severed a personal `POST /api/chat` stream at its
+ * request cap while the turn kept running. The client took the closed body
+ * for a finished turn, the Live card and Stop vanished, and a write-tool
+ * confirmation raised after the cut parked on the dead socket for its 24h
+ * timeout, locking the session. Every turn now outlives its stream and a
+ * dropped client re-attaches over the reconnect stream, which must relay the
+ * same feed the direct stream carried. The bus-event -> SSE-frame decision is
+ * the pure `reconnectRelayFrames`; these tests pin its contract:
+ *
+ *   - `turn_stream`    -> `snapshot`  (payload as-is)
+ *   - `turn_activity`  -> `activity`  (payload as-is, confirmation cards
+ *                                      included)
+ *   - `turn_completed` -> `turn_completed` + `done`, and finalize
+ *   - every other kind -> nothing
+ *   - the 5s DB backstop sends the same terminal pair with an empty
+ *     completion
+ *
+ * Spec: docs/architecture/features/doc-comments.md → "Live turn reconnect".
+ */
+
+import { describe, it, expect } from 'vitest'
+import { RECONNECT_BACKSTOP_FRAMES, reconnectRelayFrames } from '../routes/sessions.js'
+import type { SessionEvent } from '../session-event-port.js'
+
+describe('[COMP:api/session-turn-reconnect] reconnect relay frames', () => {
+  it('relays a turn_stream snapshot as-is', () => {
+    const payload = { text: 'Drafting the reply so far', activity: null }
+    const relay = reconnectRelayFrames({
+      kind: 'turn_stream',
+      sessionId: 'sess-1',
+      payload,
+    })
+
+    expect(relay).toEqual({
+      frames: [{ event: 'snapshot', data: payload }],
+      finalize: false,
+    })
+    // As-is: the same object, not a reshaped copy.
+    expect(relay.frames[0]!.data).toBe(payload)
+  })
+
+  it('relays a running-tool snapshot before any reply text lands', () => {
+    const payload = { text: '', activity: 'webSearch' }
+    expect(reconnectRelayFrames({ kind: 'turn_stream', sessionId: 'sess-1', payload })).toEqual({
+      frames: [{ event: 'snapshot', data: payload }],
+      finalize: false,
+    })
+  })
+
+  it('relays turn_activity events as-is, confirmation cards included', () => {
+    const toolStart = { event: 'tool_start', senderUserId: 'user-1', id: 'tool-1', name: 'webSearch' }
+    const required = {
+      event: 'tool_confirmation_required',
+      senderUserId: 'user-1',
+      toolCallId: 'tool-2',
+      toolName: 'gmailSendMessage',
+      displayName: 'Send email',
+      input: {},
+      addresserUserId: 'user-1',
+    }
+    const resolved = { event: 'tool_confirmation_resolved', toolCallId: 'tool-2', decision: 'approve' }
+
+    for (const payload of [toolStart, required, resolved]) {
+      const relay = reconnectRelayFrames({ kind: 'turn_activity', sessionId: 'sess-1', payload })
+      expect(relay).toEqual({
+        frames: [{ event: 'activity', data: payload }],
+        finalize: false,
+      })
+      expect(relay.frames[0]!.data).toBe(payload)
+    }
+  })
+
+  it('ends on turn_completed: the payload, then done, and finalizes', () => {
+    const payload = { senderUserId: 'user-1' }
+    expect(reconnectRelayFrames({ kind: 'turn_completed', sessionId: 'sess-1', payload })).toEqual({
+      frames: [
+        { event: 'turn_completed', data: payload },
+        { event: 'done', data: {} },
+      ],
+      finalize: true,
+    })
+  })
+
+  it('carries the end reason through turn_completed (a stop is not an ordinary completion)', () => {
+    const payload = {
+      senderUserId: 'user-2',
+      reason: 'stopped_by_user' as const,
+      stoppedByName: 'Alex Example',
+    }
+    const relay = reconnectRelayFrames({ kind: 'turn_completed', sessionId: 'sess-1', payload })
+    expect(relay.finalize).toBe(true)
+    expect(relay.frames[0]).toEqual({ event: 'turn_completed', data: payload })
+    expect(relay.frames[1]).toEqual({ event: 'done', data: {} })
+  })
+
+  it('ignores bus kinds that are not part of a personal turn', () => {
+    const unrelated: SessionEvent[] = [
+      {
+        kind: 'user_message_saved',
+        sessionId: 'sess-1',
+        payload: { id: 'm1', sequenceNum: 1, senderUserId: 'user-1', content: 'hi' },
+      },
+      {
+        kind: 'assistant_message_saved',
+        sessionId: 'sess-1',
+        payload: { id: 'm2', sequenceNum: 2, content: 'hello' },
+      },
+      { kind: 'tool_input', sessionId: 'sess-1', payload: { name: 'webSearch', input: {} } },
+      { kind: 'turn_started', sessionId: 'sess-1', payload: { senderUserId: 'user-1' } },
+      { kind: 'pins_changed', sessionId: 'sess-1', payload: { byUserId: 'user-1' } },
+      {
+        kind: 'session_assistant_changed',
+        sessionId: 'sess-1',
+        payload: { assistantId: 'asst-2', byUserId: 'user-1' },
+      },
+      { kind: 'presence', sessionId: 'sess-1', payload: { viewers: [] } },
+    ]
+
+    for (const event of unrelated) {
+      expect(reconnectRelayFrames(event)).toEqual({ frames: [], finalize: false })
+    }
+  })
+
+  it('backstop: the DB-status poll sends the same terminal pair with an empty completion', () => {
+    expect(RECONNECT_BACKSTOP_FRAMES).toEqual([
+      { event: 'turn_completed', data: {} },
+      { event: 'done', data: {} },
+    ])
+    // Same terminal shape as the bus path, so a client has one `done` to wait on.
+    const viaBus = reconnectRelayFrames({
+      kind: 'turn_completed',
+      sessionId: 'sess-1',
+      payload: { senderUserId: 'user-1' },
+    })
+    expect(RECONNECT_BACKSTOP_FRAMES.map((f) => f.event)).toEqual(viaBus.frames.map((f) => f.event))
+  })
+})

--- a/packages/api/src/routes/__tests__/room-mechanics.test.ts
+++ b/packages/api/src/routes/__tests__/room-mechanics.test.ts
@@ -41,7 +41,7 @@ describe('[COMP:api/room-mechanics] shared live activity (T13)', () => {
     const publishSessionEvent = vi.fn()
 
     publishRoomTurnActivity({
-      isRoomSession: true,
+      mirror: true,
       sessionId: 'room-1',
       senderUserId: 'user-1',
       event: 'status',
@@ -49,7 +49,7 @@ describe('[COMP:api/room-mechanics] shared live activity (T13)', () => {
       publishSessionEvent,
     })
     publishRoomTurnActivity({
-      isRoomSession: true,
+      mirror: true,
       sessionId: 'room-1',
       senderUserId: 'user-1',
       event: 'worker_start',
@@ -82,7 +82,7 @@ describe('[COMP:api/room-mechanics] shared live activity (T13)', () => {
     const publishSessionEvent = vi.fn()
 
     publishRoomTurnActivity({
-      isRoomSession: true,
+      mirror: true,
       sessionId: 'room-1',
       senderUserId: 'user-1',
       event: 'tool_input',
@@ -103,11 +103,11 @@ describe('[COMP:api/room-mechanics] shared live activity (T13)', () => {
     })
   })
 
-  it('does not put personal-chat activity on the shared bus', () => {
+  it('does not put activity on the shared bus while the mirror is off (a personal chat whose direct stream is alive)', () => {
     const publishSessionEvent = vi.fn()
 
     publishRoomTurnActivity({
-      isRoomSession: false,
+      mirror: false,
       sessionId: 'private-1',
       senderUserId: 'user-1',
       event: 'status',

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -1575,26 +1575,35 @@ export function mayResolveRoomConfirmation(params: {
 }
 
 /**
- * Mirror one display-level activity event from a room turn onto the shared
- * per-session bus. Keeping the room guard, sender attribution, and NOTIFY-size
+ * Mirror one display-level activity event from a live turn onto the shared
+ * per-session bus. Keeping the mirror gate, sender attribution, and NOTIFY-size
  * cap in one seam prevents delegated-worker / preflight streams from silently
  * becoming sender-only while the main query-loop stream remains collaborative.
  *
+ * `mirror` is the gate. Rooms mirror THROUGHOUT (viewers watch live from the
+ * start). Every other session mirrors only once its direct stream is dead
+ * (`isRoomSession || clientGone` at the call site, 2026-08-24): a personal
+ * turn that outlives its `POST /api/chat` body is followed over
+ * `GET /api/sessions/:id/stream`, and that reconnect needs the same activity
+ * feed (tool steps, the pending confirmation card) the direct stream carried.
+ * While the direct stream is alive the bus is pure overhead, so a healthy
+ * personal turn costs no NOTIFY.
+ *
  * Tool inputs are the only unbounded activity field. The initiating client
- * still receives the complete input over its direct response; room viewers get
- * an empty object when the JSON representation exceeds the bus budget, which
- * makes their UI fall back to the tool's static narration.
+ * still receives the complete input over its direct response; bus subscribers
+ * get an empty object when the JSON representation exceeds the bus budget,
+ * which makes their UI fall back to the tool's static narration.
  */
 const ROOM_ACTIVITY_INPUT_CAP = 4_000
 export function publishRoomTurnActivity(params: {
-  isRoomSession: boolean
+  mirror: boolean
   sessionId: string
   senderUserId: string
   event: string
   data: Record<string, unknown>
   publishSessionEvent: PublishSessionEvent
 }): void {
-  if (!params.isRoomSession) return
+  if (!params.mirror) return
 
   let data = params.data
   if ('input' in data) {
@@ -2242,10 +2251,11 @@ export function chatRoutes(options: WebChatOptions): Router {
     res.setHeader('X-Accel-Buffering', 'no') // Disable nginx buffering
     res.flushHeaders()
 
-    // Set true by `req.on('close')` when the client disconnects (e.g. a page
-    // refresh). For a backgrounded `doc_thread` turn the query loop keeps
-    // running after this, so every later SSE write must no-op — writing to the
-    // dead socket would otherwise throw and tear down the still-running turn.
+    // Set true by `req.on('close')` when the client disconnects (a page
+    // refresh, a proxy cutting the response). Every turn keeps running after
+    // this (2026-08-24: a disconnect is not a stop), so every later SSE write
+    // must no-op — writing to the dead socket would otherwise throw and tear
+    // down the still-running turn. The bus mirrors take over from here.
     let clientGone = false
     const sendEvent = (event: string, data: unknown) => {
       if (clientGone || res.writableEnded) return
@@ -2778,11 +2788,17 @@ export function chatRoutes(options: WebChatOptions): Router {
       sessionIdForError = session.id
 
       const isRoomSession = isSharedChatSession(session)
+      // Activity mirror gate, evaluated PER CALL: rooms mirror throughout;
+      // every other session mirrors only once its direct stream is dead, so a
+      // reconnected client (GET /api/sessions/:id/stream) sees the same tool
+      // steps and confirmation card the direct stream carried (2026-08-24).
+      // `clientGone` flips thousands of lines below this closure's creation,
+      // so it must be read inside the arrow body, never captured here.
       const publishRoomActivity = (
         event: string,
         data: Record<string, unknown>,
       ) => publishRoomTurnActivity({
-        isRoomSession,
+        mirror: isRoomSession || clientGone,
         sessionId: session.id,
         senderUserId: user.id,
         event,
@@ -6199,35 +6215,53 @@ export function chatRoutes(options: WebChatOptions): Router {
 
       const abortController = new AbortController()
 
-      // A `doc_thread` (comment-reply) turn runs to completion in the
-      // BACKGROUND so a page refresh — which drops this SSE connection — can't
-      // kill an in-flight reply. The reconnect stream (GET /api/sessions/:id/
-      // stream) re-attaches via the session turn bus; the stuck-session-sweeper
-      // is the 6-min backstop. Every other turn keeps the token-saving
-      // disconnect-abort (closing a normal chat tab stops generation).
+      // EVERY turn runs to completion in the BACKGROUND; a disconnect is not a
+      // stop. Until 2026-08-24 only `doc_thread` and room turns did, and every
+      // other turn aborted itself when its `POST /api/chat` body closed. Then
+      // Cloud Run severed a personal chat stream at its request cap while the
+      // turn kept running (the container gets NO close event at the cut): the
+      // client took the closed body for a finished turn, the Live card and
+      // Stop vanished, and a write-tool confirmation raised three minutes
+      // later was written to the dead socket and parked for its 24h timeout,
+      // locking the session (`turn_in_flight` on every re-send). A client
+      // whose stream dropped now re-attaches over the reconnect stream
+      // (GET /api/sessions/:id/stream, fed by the bus mirrors below), and the
+      // ONLY way to end a turn early is the explicit, token-guarded
+      // `POST /api/chat/stop`. `close` here records that the direct stream is
+      // dead so the SSE writes no-op and the mirrors switch on; it never
+      // aborts. The lease sweeper (90 s stale) stays the backstop for a dead process.
+      // Rooms had the same rule already for a different reason: a room turn
+      // is multiplayer property, and the sender closing their tab must not
+      // kill a reply every other member is watching (multiplayer chat T13).
       // See docs/architecture/features/doc-comments.md → "Live turn reconnect".
-      // Room turns are multiplayer property, not the sender's alone: the
-      // sender closing their tab must not kill a reply every other member is
-      // watching (multiplayer chat T13), so a room turn runs to completion in
-      // the background exactly like a doc_thread comment reply. Viewers (and
-      // the returning sender) follow it over the per-session bus.
-      const isBackgroundTurn = session.channelType === 'doc_thread' || isRoomSession
+      const isBackgroundTurn = true
+      const turnStartedAt = Date.now()
       req.on('close', () => {
         clientGone = true
-        if (!isBackgroundTurn) abortController.abort()
+        // Node also fires `close` after a normal completion; only a body that
+        // closed while the response was still open is a mid-turn disconnect.
+        // Logged so the rate of severed streams is measurable (2026-08-24).
+        if (res.writableEnded) return
+        options.analytics?.logEvent({
+          userId: user.id, assistantId: assistant.id, sessionId: session.id,
+          eventName: 'turn_client_disconnected', channelType: 'web',
+          metadata: { elapsed_ms: Date.now() - turnStartedAt },
+        })
       })
 
       // Live snapshot publishing for the reconnect stream and for room
-      // viewers. `doc_thread` turns publish only after the original client
-      // disconnected (while the SSE is alive the bus is pure overhead — one
-      // watcher, one stream). Room turns publish THROUGHOUT (multiplayer chat
-      // T13): the non-senders are watching live from the start, over the
-      // per-session bus, while the sender streams over their own POST. The
-      // snapshot carries the full reply-so-far (capped to the NOTIFY budget)
-      // so a subscriber joining mid-turn has no missed-prefix gap; published
-      // throttled so a streamed reply can't NOTIFY-storm the bus. Rooms also
-      // carry the live reasoning tail — viewers fold it through the same
-      // reducer the sender's client uses.
+      // viewers. Non-room turns (personal web, doc_thread, notification)
+      // publish only after the original client disconnected (while the SSE is
+      // alive the bus is pure overhead — one watcher, one stream); since
+      // 2026-08-24 that is every non-room turn, not just `doc_thread`, because
+      // every turn now outlives its stream. Room turns publish THROUGHOUT
+      // (multiplayer chat T13): the non-senders are watching live from the
+      // start, over the per-session bus, while the sender streams over their
+      // own POST. The snapshot carries the full reply-so-far (capped to the
+      // NOTIFY budget) so a subscriber joining mid-turn has no missed-prefix
+      // gap; published throttled so a streamed reply can't NOTIFY-storm the
+      // bus. Rooms also carry the live reasoning tail — viewers fold it
+      // through the same reducer the sender's client uses.
       let liveStreamText = ''
       let liveStreamActivity: string | null = null
       let liveStreamReasoning = ''
@@ -6236,6 +6270,7 @@ export function chatRoutes(options: WebChatOptions): Router {
       const STREAM_TEXT_CAP = 4_000 // keeps the NOTIFY payload under budget
       const STREAM_REASONING_CAP = 1_500
       const publishTurnStream = (force: boolean) => {
+        // Rooms: always. Everything else: only once the direct stream is dead.
         if (!isRoomSession && (!isBackgroundTurn || !clientGone)) return
         const now = Date.now()
         if (!force && now - lastStreamPublishAt < STREAM_PUBLISH_THROTTLE_MS) return
@@ -6817,7 +6852,8 @@ export function chatRoutes(options: WebChatOptions): Router {
           if (event.type === 'text_delta') {
             sendEvent('text_delta', { text: event.text })
             // Mirror onto the session bus (throttled) so a reconnected client
-            // sees the reply stream after a refresh. No-op off `doc_thread`.
+            // sees the reply stream after a dropped connection. Off rooms it
+            // is a no-op until the direct stream is dead (2026-08-24).
             liveStreamText += event.text
             liveStreamActivity = null
             publishTurnStream(false)
@@ -7163,6 +7199,9 @@ export function chatRoutes(options: WebChatOptions): Router {
             // Suspended turns are visible in the room (D8/T11): every viewer
             // sees the pending card; the SERVER gates who may act on it (the
             // addresser or a workspace admin — the /confirm check below).
+            // Off rooms the same mirror fires once the direct stream is dead
+            // (2026-08-24): a confirmation raised after the cut used to be
+            // written to the dead socket alone and park for its 24h timeout.
             publishRoomActivity('tool_confirmation_required', {
               toolCallId: event.request.toolCallId,
               toolName: event.request.toolName,
@@ -7725,11 +7764,12 @@ export function chatRoutes(options: WebChatOptions): Router {
           payload: { senderUserId: user.id },
         })
       }
-      // Tell any reconnected comment-thread watcher (the doc reconnect stream,
-      // GET /api/sessions/:id/stream) the turn is done so it refetches the
-      // persisted reply and clears its "working…" bubble. Only meaningful once
-      // the original client disconnected (a reconnect may exist); the endpoint's
-      // 5s status poll is the backstop for any missed signal.
+      // Tell any reconnected watcher (GET /api/sessions/:id/stream; since
+      // 2026-08-24 every session, not just comment threads) the turn is done
+      // so it refetches the persisted reply and clears its "working…" bubble.
+      // Only meaningful once the original client disconnected (a reconnect may
+      // exist); the endpoint's 5s status poll is the backstop for any missed
+      // signal.
       if (isBackgroundTurn && clientGone) {
         publishSessionEvent({
           kind: 'turn_completed',
@@ -8337,15 +8377,15 @@ export function chatRoutes(options: WebChatOptions): Router {
         res.status(500).json({ error: 'Could not record confirmation; please retry' })
         return
       }
-      // Tell room viewers the card is resolved so their pending state clears
-      // without waiting for the next activity event (T13).
-      if (isSharedChatSession(session)) {
-        publishSessionEvent({
-          kind: 'turn_activity',
-          sessionId,
-          payload: { event: 'tool_confirmation_resolved', toolCallId, decision },
-        })
-      }
+      // Tell every watcher the card is resolved so their pending state clears
+      // without waiting for the next activity event: room viewers (T13) and,
+      // since 2026-08-24, a client re-attached to its own turn over
+      // GET /api/sessions/:id/stream after the direct stream dropped.
+      publishSessionEvent({
+        kind: 'turn_activity',
+        sessionId,
+        payload: { event: 'tool_confirmation_resolved', toolCallId, decision },
+      })
       res.json({ ok: true })
       return
     }

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -144,6 +144,61 @@ export type SessionRouteOptions = {
 /** Max characters accepted for one room post (text-only in P1 — T12). */
 const ROOM_POST_MAX_CHARS = 32_000
 
+/** One SSE frame the reconnect relay writes: `event:` name + JSON `data:`. */
+export type ReconnectRelayFrame = { event: string; data: unknown }
+
+/**
+ * Reconnect-mode relay decision for `GET /:id/stream` (the non-room branch),
+ * kept pure so the bus-event -> SSE-frame mapping is unit-testable without a
+ * socket (`[COMP:api/session-turn-reconnect]`).
+ *
+ * A client whose `POST /api/chat` body was severed mid-turn (2026-08-24: Cloud
+ * Run cut a personal stream at its request cap while the turn kept running,
+ * and the client had nothing to re-attach to) re-attaches here and must see
+ * the same feed the direct stream carried:
+ *   - `turn_stream`    -> `snapshot`  (payload as-is: `{ text, activity }`)
+ *   - `turn_activity`  -> `activity`  (payload as-is; `event` is `tool_start`
+ *     | `tool_input` | `tool_result` | `tool_dropped` | `status` |
+ *     `worker_start` | `tool_confirmation_required` |
+ *     `tool_confirmation_resolved`)
+ *   - `turn_completed` -> `turn_completed` (payload as-is: `{ senderUserId,
+ *     reason?, stoppedByName? }`) THEN `done {}`, with `finalize` true: the
+ *     relay writes both frames and ends the response. The server never
+ *     reopens; a client that wants more opens a new stream.
+ * Every other bus kind (room posts, presence, pins, the room-only
+ * `turn_started`) is not part of a personal turn and yields no frame.
+ */
+export function reconnectRelayFrames(
+  event: SessionEvent,
+): { frames: ReconnectRelayFrame[]; finalize: boolean } {
+  switch (event.kind) {
+    case 'turn_stream':
+      return { frames: [{ event: 'snapshot', data: event.payload }], finalize: false }
+    case 'turn_activity':
+      return { frames: [{ event: 'activity', data: event.payload }], finalize: false }
+    case 'turn_completed':
+      return {
+        frames: [
+          { event: 'turn_completed', data: event.payload },
+          { event: 'done', data: {} },
+        ],
+        finalize: true,
+      }
+    default:
+      return { frames: [], finalize: false }
+  }
+}
+
+/**
+ * What the reconnect stream's 5s DB-status backstop sends when it, not the
+ * bus, notices the turn ended: the same terminal pair, with an empty
+ * `turn_completed` because there is no bus payload to relay.
+ */
+export const RECONNECT_BACKSTOP_FRAMES: readonly ReconnectRelayFrame[] = [
+  { event: 'turn_completed', data: {} },
+  { event: 'done', data: {} },
+]
+
 export function sessionRoutes(opts: SessionRouteOptions = {}): Router {
   const subscribeSessionEvents = opts.subscribeSessionEvents ?? noopSubscribeSessionEvents
   const publishSessionEvent = opts.publishSessionEvent ?? noopPublishSessionEvent
@@ -1344,17 +1399,27 @@ export function sessionRoutes(opts: SessionRouteOptions = {}): Router {
 
   // GET /api/sessions/:id/stream — reconnect to an in-flight turn.
   //
-  // A doc comment-reply turn runs to completion in the background after a page
-  // refresh (the `doc_thread` carve-out in chat.ts), so a reloaded thread needs
-  // to re-attach to the live reply. This endpoint emits the session's current
-  // `status`; if it isn't `running` there's nothing in flight, so it sends
-  // `done` and closes. While `running` it subscribes to the session turn bus and
-  // forwards each `turn_stream` snapshot (the full reply-so-far + the running
-  // tool's name) as a `snapshot` SSE frame, ending on `turn_completed`. A 5s
-  // DB-status poll is the backstop finalizer for any missed completion signal
-  // (a cross-instance turn end, a dropped NOTIFY). Same access gate as
-  // `/:id/messages`. See docs/architecture/features/doc-comments.md → "Live
-  // turn reconnect".
+  // Every chat turn runs to completion in the background once its
+  // `POST /api/chat` body is gone (chat.ts; since 2026-08-24 that is every
+  // session, not only `doc_thread` comment replies: Cloud Run severed a
+  // personal stream at its request cap and the client had nothing to
+  // re-attach to). A reloaded or cut-off client re-attaches here.
+  //
+  // RECONNECT mode (every non-room session): emit the session's current
+  // `status`; if it isn't `running` there's nothing in flight, so send `done`
+  // and close. While `running`, subscribe to the session turn bus and relay
+  // through the pure `reconnectRelayFrames`:
+  //   `turn_stream`    -> `snapshot`       (full reply-so-far + running tool)
+  //   `turn_activity`  -> `activity`       (tool steps, confirmation cards)
+  //   `turn_completed` -> `turn_completed`, then `done`, then close.
+  // A 5s DB-status poll is the backstop finalizer for any missed completion
+  // signal (a cross-instance turn end, a dropped NOTIFY); it sends
+  // `turn_completed {}` then `done {}`. A `: keepalive` comment every 25s
+  // defeats proxy idle timeouts (100s). The server never reopens; the client
+  // reopens on a bare close. Same access gate as `/:id/messages`.
+  //
+  // FOLLOW mode (workspace-shared rooms, below) is unchanged.
+  // See docs/architecture/features/doc-comments.md → "Live turn reconnect".
   router.get('/:id/stream', async (req, res) => {
     const jwtUserId = (req as { userId?: string }).userId
     if (!jwtUserId) {
@@ -1471,12 +1536,14 @@ export function sessionRoutes(opts: SessionRouteOptions = {}): Router {
     let closed = false
     let unsubscribe: (() => void) | null = null
     let poll: NodeJS.Timeout | null = null
-    const finalize = () => {
+    let keepalive: NodeJS.Timeout | null = null
+    const finalize = (frames: readonly ReconnectRelayFrame[]) => {
       if (closed) return
       closed = true
       if (poll) clearInterval(poll)
+      if (keepalive) clearInterval(keepalive)
       unsubscribe?.()
-      send('done', {})
+      for (const frame of frames) send(frame.event, frame.data)
       res.end()
     }
 
@@ -1485,31 +1552,43 @@ export function sessionRoutes(opts: SessionRouteOptions = {}): Router {
       userId: jwtUserId,
       name: null,
       cb: (event: SessionEvent) => {
-        if (event.kind === 'turn_stream') {
-          send('snapshot', event.payload)
-        } else if (event.kind === 'turn_completed') {
-          finalize()
+        const relay = reconnectRelayFrames(event)
+        if (relay.finalize) {
+          finalize(relay.frames)
+          return
         }
+        for (const frame of relay.frames) send(frame.event, frame.data)
       },
     })
 
     // Backstop: the bus event can be missed (a turn that ended on another
     // instance, a dropped NOTIFY). Poll the authoritative DB status so the
     // client never hangs on "working" past the turn. The stuck-session-sweeper
-    // flips an abandoned turn to 'timeout', which is also caught here.
+    // flips an abandoned turn to 'timeout', which is also caught here. There
+    // is no bus payload to relay, so the backstop sends the bare pair.
     poll = setInterval(() => {
       void findSessionById(req.params.id)
         .then((s) => {
-          if (!s || s.status !== 'running') finalize()
+          if (!s || s.status !== 'running') finalize(RECONNECT_BACKSTOP_FRAMES)
         })
         .catch(() => {})
     }, 5_000)
     poll.unref?.()
 
+    // A long tool call writes nothing for minutes and a proxy cuts an idle
+    // response at 100s; now that every turn can be followed here, not just a
+    // comment reply, that idle window is ordinary (2026-08-24). A comment line
+    // every 25s keeps the relay non-idle; SSE parsers ignore ':' lines.
+    keepalive = setInterval(() => {
+      if (!res.writableEnded) res.write(': keepalive\n\n')
+    }, 25_000)
+    keepalive.unref?.()
+
     req.on('close', () => {
       if (closed) return
       closed = true
       if (poll) clearInterval(poll)
+      if (keepalive) clearInterval(keepalive)
       unsubscribe?.()
     })
   })

--- a/packages/chat-ui/src/__tests__/useMessageStream.test.ts
+++ b/packages/chat-ui/src/__tests__/useMessageStream.test.ts
@@ -1,0 +1,159 @@
+/**
+ * [COMP:chat-ui/use-message-stream] `runStream` close semantics.
+ *
+ * The load-bearing contract: a body that closes AFTER a terminal event
+ * (`done` / `error`) is a finished turn and lands in `onDone`; a body that
+ * closes with NO terminal event is a transport disconnect — the turn is very
+ * likely still running server-side — and lands in `onDisconnect`. Before
+ * 2026-08-24 both cases landed in `onDone`, so Cloud Run's request-timeout
+ * cut painted a finished turn over a live one and the user's re-send was
+ * refused with `turn_in_flight`. Hosts that do not pass `onDisconnect` keep
+ * the historical `onDone` fallback.
+ *
+ * chat-ui's vitest is node-only; `runStream` is driven with a fake
+ * `authFetch` that returns a `Response` over a hand-built `ReadableStream`.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { runStream, TERMINAL_STREAM_EVENTS, type StreamOptions } from '../useMessageStream'
+
+function sseResponse(frames: string[], opts: { fail?: boolean } = {}): Response {
+  const encoder = new TextEncoder()
+  // Pull-based so a `fail` stream delivers its frames BEFORE erroring —
+  // `controller.error()` discards anything still queued.
+  const pending = [...frames]
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      const next = pending.shift()
+      if (next !== undefined) controller.enqueue(encoder.encode(next))
+      else if (opts.fail) controller.error(new Error('socket reset'))
+      else controller.close()
+    },
+  })
+  return new Response(body, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+}
+
+function frame(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
+}
+
+type Calls = { events: string[]; done: number; disconnect: Array<{ lastEvent: string | null }>; errors: unknown[] }
+
+function drive(
+  response: Response,
+  extra: Partial<Pick<StreamOptions, 'onDisconnect'>> & { signal?: AbortSignal } = {},
+): { calls: Calls; run: Promise<void> } {
+  const calls: Calls = { events: [], done: 0, disconnect: [], errors: [] }
+  const run = runStream(
+    {
+      url: 'http://api.example/api/chat',
+      body: { message: 'hi' },
+      authFetch: async () => response,
+      onEvent: (e) => calls.events.push(e.event),
+      onDone: () => { calls.done += 1 },
+      onError: (err) => calls.errors.push(err),
+      ...(extra.onDisconnect ? { onDisconnect: extra.onDisconnect } : {}),
+    },
+    extra.signal ?? new AbortController().signal,
+  )
+  return { calls, run }
+}
+
+describe('[COMP:chat-ui/use-message-stream] runStream close semantics', () => {
+  it('names done and error as the terminal events', () => {
+    expect([...TERMINAL_STREAM_EVENTS].sort()).toEqual(['done', 'error'])
+  })
+
+  it('a close after `done` is a completed turn: onDone, never onDisconnect', async () => {
+    const disconnects: Array<{ lastEvent: string | null }> = []
+    const { calls, run } = drive(
+      sseResponse([frame('text_delta', { text: 'hel' }), frame('text_delta', { text: 'lo' }), frame('done', {})]),
+      { onDisconnect: (i) => disconnects.push(i) },
+    )
+    await run
+    expect(calls.events).toEqual(['text_delta', 'text_delta', 'done'])
+    expect(calls.done).toBe(1)
+    expect(disconnects).toEqual([])
+    expect(calls.errors).toEqual([])
+  })
+
+  it('a close after an `error` event is terminal too (the route ends the response right after it)', async () => {
+    const disconnects: Array<{ lastEvent: string | null }> = []
+    const { calls, run } = drive(
+      sseResponse([frame('error', { code: 'turn_in_flight', error: 'busy' })]),
+      { onDisconnect: (i) => disconnects.push(i) },
+    )
+    await run
+    expect(calls.events).toEqual(['error'])
+    expect(calls.done).toBe(1)
+    expect(disconnects).toEqual([])
+  })
+
+  it('a close with NO terminal event is a disconnect: onDisconnect with the last event, no onDone', async () => {
+    const disconnects: Array<{ lastEvent: string | null }> = []
+    const { calls, run } = drive(
+      sseResponse([frame('session', { id: 's1' }), frame('text_delta', { text: 'working' })]),
+      { onDisconnect: (i) => disconnects.push(i) },
+    )
+    await run
+    expect(calls.events).toEqual(['session', 'text_delta'])
+    expect(calls.done).toBe(0)
+    expect(disconnects).toEqual([{ lastEvent: 'text_delta' }])
+    expect(calls.errors).toEqual([])
+  })
+
+  it('a bare close with no events at all reports lastEvent null', async () => {
+    const disconnects: Array<{ lastEvent: string | null }> = []
+    const { calls, run } = drive(sseResponse([]), { onDisconnect: (i) => disconnects.push(i) })
+    await run
+    expect(calls.done).toBe(0)
+    expect(disconnects).toEqual([{ lastEvent: null }])
+  })
+
+  it('without onDisconnect a bare close falls back to onDone (host compatibility)', async () => {
+    const { calls, run } = drive(sseResponse([frame('text_delta', { text: 'x' })]))
+    await run
+    expect(calls.done).toBe(1)
+    expect(calls.errors).toEqual([])
+  })
+
+  it('a transport error mid-body goes to onError, not onDisconnect or onDone', async () => {
+    const disconnects: Array<{ lastEvent: string | null }> = []
+    const { calls, run } = drive(
+      sseResponse([frame('text_delta', { text: 'x' })], { fail: true }),
+      { onDisconnect: (i) => disconnects.push(i) },
+    )
+    await run
+    expect(calls.events).toEqual(['text_delta'])
+    expect(calls.done).toBe(0)
+    expect(disconnects).toEqual([])
+    expect(calls.errors).toHaveLength(1)
+  })
+
+  it('an aborted stream fires none of the completion callbacks', async () => {
+    const controller = new AbortController()
+    const disconnects: Array<{ lastEvent: string | null }> = []
+    let firstEventSeen = false
+    const calls: Calls = { events: [], done: 0, disconnect: [], errors: [] }
+    const run = runStream(
+      {
+        url: 'http://api.example/api/chat',
+        body: {},
+        authFetch: async () => sseResponse([frame('text_delta', { text: 'a' }), frame('text_delta', { text: 'b' })]),
+        onEvent: (e) => {
+          calls.events.push(e.event)
+          if (!firstEventSeen) { firstEventSeen = true; controller.abort() }
+        },
+        onDone: () => { calls.done += 1 },
+        onDisconnect: (i) => disconnects.push(i),
+        onError: (err) => calls.errors.push(err),
+      },
+      controller.signal,
+    )
+    await run
+    expect(calls.events).toEqual(['text_delta'])
+    expect(calls.done).toBe(0)
+    expect(disconnects).toEqual([])
+    expect(calls.errors).toEqual([])
+  })
+})

--- a/packages/chat-ui/src/index.ts
+++ b/packages/chat-ui/src/index.ts
@@ -21,6 +21,8 @@ export { useChatSession, type UseChatSessionResult } from './useChatSession.js'
 
 export {
   useMessageStream,
+  runStream,
+  TERMINAL_STREAM_EVENTS,
   type AuthFetch,
   type StreamOptions,
   type StartStream,

--- a/packages/chat-ui/src/useMessageStream.ts
+++ b/packages/chat-ui/src/useMessageStream.ts
@@ -20,11 +20,36 @@ export type StreamOptions = {
   authFetch: AuthFetch
   /** Per-event callback. Caller dispatches reducer actions from here. */
   onEvent: (event: SSEEvent) => void
-  /** Called once when the stream ends (network closed, body drained). */
+  /**
+   * Called once when the stream ends AFTER the server said it was over — a
+   * terminal event (`done` or `error`) was seen before the body closed.
+   *
+   * Compatibility: when `onDisconnect` is not supplied, a body that closes
+   * WITHOUT a terminal event also lands here, exactly as it always did.
+   */
   onDone?: () => void
+  /**
+   * Called when the transport closed with NO terminal event: a request or
+   * proxy timeout, a deploy, a network blip. The turn is very likely still
+   * running on the server — Cloud Run cut every chat stream at its request
+   * cap on 2026-08-24 while the turn kept working, and treating that close
+   * as `onDone` painted a finished turn over a live one. A caller that can
+   * re-attach (the chat surface's session follow stream) does so here.
+   * `lastEvent` is the last event name received, for diagnostics.
+   */
+  onDisconnect?: (info: { lastEvent: string | null }) => void
   /** Called on transport errors. Aborted streams do not call this. */
   onError?: (err: unknown) => void
 }
+
+/**
+ * Event names that mean "the server has finished with this stream". A body
+ * that closes after one of these is a completed turn; a body that closes
+ * before any of them is a disconnect. `error` is terminal because the route
+ * always `res.end()`s right after it (`turn_in_flight`, `pending_question_exists`,
+ * the generic crash banner) — the caller's `onEvent` has already reacted.
+ */
+export const TERMINAL_STREAM_EVENTS: ReadonlySet<string> = new Set(['done', 'error'])
 
 export type StartStream = (opts: StreamOptions) => Promise<void>
 
@@ -52,9 +77,11 @@ export type UseMessageStreamResult = {
 
 /**
  * Run one POST + SSE-parse loop against `signal`. Shared by `start` (which
- * owns the abort registration) and `sideStream` (which has none).
+ * owns the abort registration) and `sideStream` (which has none). Exported
+ * for the hook's tests, which drive it with a fake `authFetch` — the
+ * close-without-`done` distinction is the whole contract and needs no React.
  */
-async function runStream(opts: StreamOptions, signal: AbortSignal): Promise<void> {
+export async function runStream(opts: StreamOptions, signal: AbortSignal): Promise<void> {
   let res: Response
   try {
     res = await opts.authFetch(opts.url, {
@@ -77,6 +104,13 @@ async function runStream(opts: StreamOptions, signal: AbortSignal): Promise<void
   const reader = res.body.getReader()
   const decoder = new TextDecoder()
   const buffer = createSSEBuffer()
+  let lastEvent: string | null = null
+  let sawTerminal = false
+  const deliver = (event: SSEEvent) => {
+    lastEvent = event.event
+    if (TERMINAL_STREAM_EVENTS.has(event.event)) sawTerminal = true
+    opts.onEvent(event)
+  }
 
   try {
     while (true) {
@@ -86,7 +120,7 @@ async function runStream(opts: StreamOptions, signal: AbortSignal): Promise<void
       const chunk = decoder.decode(value, { stream: true })
       for (const event of parseSSEStream(chunk, buffer)) {
         if (signal.aborted) break
-        opts.onEvent(event)
+        deliver(event)
       }
     }
     // Drain any trailing event captured but not yet flushed.
@@ -94,10 +128,18 @@ async function runStream(opts: StreamOptions, signal: AbortSignal): Promise<void
     if (tail) {
       for (const event of parseSSEStream(tail, buffer)) {
         if (signal.aborted) break
-        opts.onEvent(event)
+        deliver(event)
       }
     }
-    if (!signal.aborted) opts.onDone?.()
+    if (signal.aborted) return
+    // The body closed. Only the server's own terminal event makes that a
+    // completed turn; a bare close is the transport giving up on a stream
+    // the server may still be writing to (request-timeout cut, deploy,
+    // network). Hand that to `onDisconnect` when the caller can re-attach;
+    // otherwise keep the historical `onDone` so existing hosts behave as
+    // before.
+    if (sawTerminal || !opts.onDisconnect) opts.onDone?.()
+    else opts.onDisconnect({ lastEvent })
   } catch (err) {
     if (signal.aborted) return
     opts.onError?.(err)


### PR DESCRIPTION
## Why

On 2026-08-24 Cloud Run severed a personal chat's `POST /api/chat` stream at its request cap while the turn kept running: the container gets no close event at a proxy cut, the client painted the closed body as a finished turn, personal sessions had no follow stream, the Live card and Stop vanished, and a write-tool confirmation raised three minutes after the cut was written to the dead socket and parked for its 24h web timeout, locking the session (`turn_in_flight` on every re-send). The hosted timeout is now 1800s (platform PR); this is the product fix.

## What

- **chat-ui** `useMessageStream`: `done` / `error` are the terminal events. A close after one is `onDone`; a bare close is the new `onDisconnect({ lastEvent })`. Hosts without `onDisconnect` keep the old `onDone` fallback. Tests: `[COMP:chat-ui/use-message-stream]`.
- **api** `POST /api/chat`: every turn is a background turn (`req.on('close')` only sets `clientGone`; the explicit cancel is `POST /api/chat/stop`). Activity + confirmation mirror publishes for any session once its direct stream is dead; `/confirm` publishes `tool_confirmation_resolved` for every session; `turn_client_disconnected` analytics.
- **api** `GET /api/sessions/:id/stream` reconnect mode: relays `snapshot`, `activity`, then `turn_completed` + `done`; 5s backstop; 25s keepalive. `reconnectRelayFrames` is the pure relay. Tests: `[COMP:api/session-turn-reconnect]`.
- **app-web** chat surface: `onDisconnect` moves the turn onto the room mirror, opens the session stream, `case "done"`, reconnect on hydrate (reload mid-turn re-attaches), `directTurnSessionRef` for every session, composer Stop posts `/api/chat/stop`, `turnReconnecting` notice (en/ja/zh). `shouldOpenSessionStream` / `shouldReopenSessionStream` are the pure lifecycle decisions (a personal session never reopens after `done`). Tests: `[COMP:app-web/turn-reconnect]`.
- **app-web** floating dock re-attaches to learn when the turn ends; dock / Knowledge / Feed-tuning Stops also post `/api/chat/stop`.

Spec (platform): `docs/architecture/features/chat-app.md` -> "Disconnect is not a stop".

## Verification

- `pnpm typecheck` (all packages): clean.
- `@use-brian/chat-ui` 54/54, `app-web` 3318/3318, `@use-brian/api` 6178/6179 with the one failure (`knowledge.test.ts`, unrelated, known-flaky) passing in isolation 41/41.
- `pnpm smoke`: green.

Known gap, deliberate: a confirmation raised before the client re-attached (reload during a pending card) is not replayed (rows carry no `toolCallId`); the Approvals panel resolves it by `approvalId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkFovJjHNgny3nBHqKHSo8
