### PR TITLE
fix(browser): preserve preapproval across relay loss

### DIFF
--- a/apps/browser-extension/src/__tests__/task-gate.test.ts
+++ b/apps/browser-extension/src/__tests__/task-gate.test.ts
@@ -199,6 +199,42 @@ describe('[COMP:ext/agent] Per-task consent gate (P1.7)', () => {
     expect(gate.isStopped()).toBe(false)
   })
 
+  it('allows pre-approval after relay loss ends the active task', async () => {
+    const preapprovalStates: boolean[] = []
+    const gate = new TaskGate({
+      prompt: async ({ allowPreApproval }) => {
+        preapprovalStates.push(allowPreApproval)
+        return { allowed: true, tabId: 5 }
+      },
+    })
+
+    await gate.requireTab()
+    gate.registerCreatedTab(6)
+    expect(gate.endTask()).toEqual([6])
+    expect(gate.currentTab()).toBeNull()
+
+    await gate.requireTab()
+    expect(preapprovalStates).toEqual([true, true])
+    expect(gate.isStopped()).toBe(false)
+  })
+
+  it('does not let an Allow from an ended relay task restore authorization', async () => {
+    let allow: (() => void) | null = null
+    const gate = new TaskGate({
+      prompt: () => new Promise((resolve) => {
+        allow = () => resolve({ allowed: true, tabId: 5 })
+      }),
+    })
+
+    const pending = gate.requireTab()
+    gate.endTask()
+    allow?.()
+
+    await expect(pending).rejects.toMatchObject({ code: 'stopped' })
+    expect(gate.currentTab()).toBeNull()
+    expect(gate.isStopped()).toBe(false)
+  })
+
   it('a DECLINED prompt leaves Stop latched (declining is not a release)', async () => {
     const gate = new TaskGate({ prompt: async () => ({ allowed: false, reason: 'denied' }) })
     gate.stop()

--- a/apps/browser-extension/src/background.ts
+++ b/apps/browser-extension/src/background.ts
@@ -77,7 +77,10 @@ const gate = new TaskGate({ prompt: promptForConsent })
 let relayWasReady = false
 
 async function stopTask(): Promise<void> {
-  const createdTabIds = gate.stop()
+  await clearTask(gate.stop())
+}
+
+async function clearTask(createdTabIds: number[]): Promise<void> {
   await executor.detach()
   if (createdTabIds.length > 0) {
     await chrome.tabs.remove(createdTabIds).catch(() => undefined)
@@ -108,7 +111,10 @@ const client = new RelayClient({
       // A lost control plane must revoke browser control even if the relay
       // process restarts and forgets a queued Stop.
       relayWasReady = false
-      void stopTask()
+      // A transport interruption ends the active task, but it is not the
+      // user's Stop action. Once the relay recovers, local pre-approval may
+      // authorize the next task as configured.
+      void clearTask(gate.endTask())
     }
     void chrome.action.setBadgeText({ text: state === 'ready' ? 'ON' : '' })
     void chrome.action.setBadgeBackgroundColor({ color: '#16a34a' })

--- a/apps/browser-extension/src/firefox-background.ts
+++ b/apps/browser-extension/src/firefox-background.ts
@@ -78,7 +78,7 @@ const client = new RelayClient({
       relayWasReady = true
     } else if (relayWasReady) {
       relayWasReady = false
-      gate.stop()
+      gate.endTask()
       boundTabId = null
       void native.request('stop').catch(() => {})
     }

--- a/apps/browser-extension/src/task-gate.ts
+++ b/apps/browser-extension/src/task-gate.ts
@@ -55,10 +55,10 @@ export class TaskGate {
   private mode: LocalControlMode = 'task_tabs'
   private stopped = false
   private manualApprovalRequired = false
-  private stopGeneration = 0
+  private taskGeneration = 0
   private lastCommandAt = 0
   private promptInFlight: Promise<ConsentOutcome> | null = null
-  private promptStopGeneration = 0
+  private promptTaskGeneration = 0
   private readonly prompt: ConsentPrompter
   private readonly now: () => number
 
@@ -81,21 +81,21 @@ export class TaskGate {
     // usable while no tab is selected; a fresh Allow reactivates the task.
     this.clearAuthorization(true)
     if (!this.promptInFlight) {
-      this.promptStopGeneration = this.stopGeneration
+      this.promptTaskGeneration = this.taskGeneration
       this.promptInFlight = this.prompt({
         allowPreApproval: !this.stopped && !this.manualApprovalRequired,
       }).finally(() => {
         this.promptInFlight = null
       })
     }
-    const stopGeneration = this.promptStopGeneration
+    const taskGeneration = this.promptTaskGeneration
     const outcome = await this.promptInFlight
     if (!outcome.allowed) {
       const { code, message } = DENIAL_ERRORS[outcome.reason]
       throw Object.assign(new Error(message), { code })
     }
-    if (this.stopGeneration !== stopGeneration) {
-      throw Object.assign(new Error('The task stopped while browser permission was pending.'), {
+    if (this.taskGeneration !== taskGeneration) {
+      throw Object.assign(new Error('The task ended while browser permission was pending.'), {
         code: 'stopped',
       })
     }
@@ -183,10 +183,16 @@ export class TaskGate {
 
   /** Persistent Stop. Returns only task-created tabs for caller-side cleanup. */
   stop(): number[] {
-    const created = this.createdTabIds()
-    this.stopGeneration += 1
     this.stopped = true
+    return this.endTask()
+  }
+
+  /** End the active task without turning relay loss into an explicit user Stop. */
+  endTask(): number[] {
+    const created = this.createdTabIds()
+    this.taskGeneration += 1
     this.clearAuthorization(false)
+    this.lastCommandAt = 0
     return created
   }
 

--- a/docs/plans/browser-extension-consent.md
+++ b/docs/plans/browser-extension-consent.md
@@ -14,7 +14,8 @@ Pre-approval does not widen browser access:
 
 - restricted, privileged, and incognito pages remain ineligible;
 - the server-supplied `task_tabs` or `full_browser` profile policy still bounds available tabs;
-- relay disconnect still revokes the active task;
+- relay disconnect still revokes the active task, but reconnecting does not count as pressing Stop;
+  the stored pre-approval preference governs the next task;
 - the popup Stop action still ends the active task and task-created tabs;
 - after Stop, automatic approval is suppressed until the user manually allows a new task.
 - cancelling the browser's own control indicator also requires a fresh manual Allow.

--- a/packages/shared/src/browser-extension-build.ts
+++ b/packages/shared/src/browser-extension-build.ts
@@ -19,7 +19,7 @@
  * Do not hand-edit. `pnpm check` (`invariants/browser-extension-build-stamp`)
  * prints the value to paste when extension source moves.
  */
-export const CURRENT_EXTENSION_BUILD = '47a10e524cb3'
+export const CURRENT_EXTENSION_BUILD = '2f4f37a5cb04'
 
 /**
  * A reported build is stale unless it matches exactly.


### PR DESCRIPTION
## Summary
- distinguish relay task termination from the user-triggered persistent Stop action
- revoke active browser authorization and clean task-owned tabs without disabling preapproval after reconnect
- invalidate pending consent responses when their task has ended
- update the extension build stamp and consent documentation

## Verification
- `corepack pnpm --filter @use-brian/browser-extension test` (142 tests passed)
- `corepack pnpm --filter @use-brian/browser-extension typecheck`
- browser extension build hash verified as `7c6e10d2a423`