### PR TITLE
refactor(core): centralize confirmation event decisions

### DIFF
--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -15,7 +15,7 @@ import {
 } from '../resolve-session-pins.js'
 import { getSelfEntityId } from '../db/memories.js'
 import { getRecording, type Recording } from '../db/recordings-store.js'
-import { queryLoop, isConnectionDropError, isEndpointUnreachableError, streamErrorCode, buildMemoryContext, voicePlatformFromDraftTitle, measureDocContext, createMemoryTools, createSelfProfileTool, createMemoryRecallBuffer, createSkillInvocationBuffer, createRetrievalTools, createSessionStateTools, buildSessionStateBlock, runSessionStateDiff, buildActivePlanBlock, createPlanTools, seedPlanFromTasks, calculateCost, sanitize, shouldInline, ensureToolResultPairing, stripUnsignedToolUses, modelRequiresToolSignatures, elideStaleDocToolResults, synthesizeMissingToolResults, createConfirmationResolver, runPreflight, buildPreflightPrompt, runMemoryNudge, collectStream, classifyTopic, fetchEpisodicContext, transcribeFirstAudio, voiceUnavailableNote, TRANSCRIPTION_DISABLED_REASON, probePdfPageCount, estimateDistillTokens, PDF_CONFIRM_PAGE_THRESHOLD, DASHSCOPE_RENDER_WIDTH, filterToolsByCapabilities, modelToCompactionTier, buildWorkspaceFilesContext, buildUploadPolicyBlock, SensitivityAccumulator, CompartmentAccumulator, ContextScopeAccumulator, AttachmentCollector, runLocalMatchCheck, sanitizeTitle, AUTO_TITLE_AI_MIN_CHARS, COORDINATOR_BASE_ADDENDUM, COORDINATOR_RESEARCH_ADDENDUM, buildDocSupervisorSkillBlock, buildAmbientDocSkillBlock, detectOperateSiteIntent, EvidenceAccumulator, matchesDisputedFigure, buildDisputeContextNote, parsePresentedDocumentInput, latestWorkflowProposalReceipt, buildTool, prepareSlashCommand, resolveNativeSlashCommand, buildSlashCommandBlock, buildWorkflowSlashCommandBlock, buildEmailDraftAnchorPrompt, formatActiveEmailDraftContext, type PresentedDocumentInput, type MediaBackend } from '@use-brian/core'
+import { queryLoop, isConnectionDropError, isEndpointUnreachableError, streamErrorCode, buildMemoryContext, voicePlatformFromDraftTitle, measureDocContext, createMemoryTools, createSelfProfileTool, createMemoryRecallBuffer, createSkillInvocationBuffer, createRetrievalTools, createSessionStateTools, buildSessionStateBlock, runSessionStateDiff, buildActivePlanBlock, createPlanTools, seedPlanFromTasks, calculateCost, sanitize, shouldInline, ensureToolResultPairing, stripUnsignedToolUses, modelRequiresToolSignatures, elideStaleDocToolResults, synthesizeMissingToolResults, createConfirmationResolver, interpretConfirmationEvent, runPreflight, buildPreflightPrompt, runMemoryNudge, collectStream, classifyTopic, fetchEpisodicContext, transcribeFirstAudio, voiceUnavailableNote, TRANSCRIPTION_DISABLED_REASON, probePdfPageCount, estimateDistillTokens, PDF_CONFIRM_PAGE_THRESHOLD, DASHSCOPE_RENDER_WIDTH, filterToolsByCapabilities, modelToCompactionTier, buildWorkspaceFilesContext, buildUploadPolicyBlock, SensitivityAccumulator, CompartmentAccumulator, ContextScopeAccumulator, AttachmentCollector, runLocalMatchCheck, sanitizeTitle, AUTO_TITLE_AI_MIN_CHARS, COORDINATOR_BASE_ADDENDUM, COORDINATOR_RESEARCH_ADDENDUM, buildDocSupervisorSkillBlock, buildAmbientDocSkillBlock, detectOperateSiteIntent, EvidenceAccumulator, matchesDisputedFigure, buildDisputeContextNote, parsePresentedDocumentInput, latestWorkflowProposalReceipt, buildTool, prepareSlashCommand, resolveNativeSlashCommand, buildSlashCommandBlock, buildWorkflowSlashCommandBlock, buildEmailDraftAnchorPrompt, formatActiveEmailDraftContext, type PresentedDocumentInput, type MediaBackend } from '@use-brian/core'
 import { deliverTurnInput, registerTurnInbox } from '../turn-inbox.js'
 import { insertClaimProvenance, getClaimsForLatestAssistantMessage } from '../db/claim-provenance-store.js'
 import type { SessionStateStore, SessionStateRecord, PlanStore, AmbientSurface, CrmEmailDraftStore } from '@use-brian/core'
@@ -8690,26 +8690,33 @@ export function chatRoutes(options: WebChatOptions): Router {
 
   // ── POST /confirm — resolve a pending tool confirmation ──────
   router.post('/confirm', async (req, res) => {
-    const { sessionId, toolCallId, decision, comment } = req.body as {
-      sessionId?: string
-      toolCallId?: string
-      decision?: ConfirmationDecision
-      comment?: string
+    const { sessionId, toolCallId: rawToolCallId, decision: rawDecision, comment } = req.body as {
+      sessionId?: unknown
+      toolCallId?: unknown
+      decision?: unknown
+      comment?: unknown
     }
-
-    if (!sessionId || !toolCallId || !decision) {
+    if (typeof sessionId !== 'string' || !sessionId) {
       res.status(400).json({ error: 'Missing sessionId, toolCallId, or decision' })
       return
     }
+    const confirmation = interpretConfirmationEvent({
+      kind: 'decision',
+      toolCallId: rawToolCallId,
+      decision: rawDecision,
+      comment,
+    })
+    if (confirmation.status !== 'decision' || !confirmation.toolCallId) {
+      res.status(400).json({ error: 'Invalid toolCallId, decision, or comment' })
+      return
+    }
+    const { toolCallId, decision } = confirmation
 
     // "Deny with comment" — the user's note travels with the decision to the
     // model-facing `declinedToolResult` so the assistant revises rather than
     // just re-asks. Arbitrary user text, so cap it (mirrors the approvals
     // panel's `reason` slice) before it lands in `session_messages`.
-    const note =
-      typeof comment === 'string' && comment.trim()
-        ? comment.trim().slice(0, 1000)
-        : undefined
+    const note = confirmation.comment?.slice(0, 1000)
 
     const jwtUserId = (req as { userId?: string }).userId
     if (!jwtUserId) { res.status(401).json({ error: 'Unauthorized' }); return }

--- a/packages/api/src/routes/custom-channel-bridge.ts
+++ b/packages/api/src/routes/custom-channel-bridge.ts
@@ -51,6 +51,7 @@ import {
 import type { IncomingMessage } from '@use-brian/channels'
 import {
   composeVoiceTurnText,
+  interpretConfirmationEvent,
   parseFileContent,
   sanitize as sanitizeAnalytics,
   transcribeFirstAudio,
@@ -58,7 +59,7 @@ import {
   type MediaBackend,
   type TokenUsage,
 } from '@use-brian/core'
-import type { ConfirmationDecision, ConfirmationResolver, ContentBlock } from '@use-brian/core'
+import type { ConfirmationResolver, ContentBlock } from '@use-brian/core'
 import type { LLMProvider, Tool, MemoryStore, UsageStore, AnalyticsLogger, McpSettingsStore } from '@use-brian/core'
 import { getToolDisplayName, formatConfirmationInput } from '@use-brian/shared'
 import { findAssistantById } from '../db/users.js'
@@ -140,15 +141,6 @@ export type CustomChannelBridgeRouteOptions = {
   }
   /** Injectable clock/sleep for the long-poll (tests). */
   sleep?: (ms: number) => Promise<void>
-}
-
-// Natural-language → decision mapping for text-based confirmation (a bridge
-// has no buttons — text is the only path). Mirrors routes/wechat.ts.
-const DECISION_MAP: Record<string, ConfirmationDecision> = {
-  yes: 'allow', y: 'allow', allow: 'allow', approve: 'allow', ok: 'allow',
-  no: 'deny', n: 'deny', deny: 'deny', reject: 'deny',
-  always: 'always_allow', 'always allow': 'always_allow',
-  never: 'always_deny', 'always deny': 'always_deny',
 }
 
 /** Long-poll ceiling (ms) — `wait` is clamped to this. */
@@ -744,16 +736,18 @@ export function customChannelBridgeRoutes(options: CustomChannelBridgeRouteOptio
       const confirmKey = `${channelId}:${peerId}`
       const pending = pendingConfirmations.get(confirmKey)
       if (pending) {
-        const decision = DECISION_MAP[incoming.text.trim().toLowerCase()]
+        const confirmation = interpretConfirmationEvent(
+          { kind: 'text', text: incoming.text },
+          pending.toolCallId,
+        )
         pendingConfirmations.delete(confirmKey)
-        if (decision) {
-          pending.resolver.resolve(pending.toolCallId, decision)
-          return
+        if (confirmation.status === 'decision') {
+          pending.resolver.resolve(pending.toolCallId, confirmation.decision)
+          if (confirmation.consume) return
         }
-        pending.resolver.resolve(pending.toolCallId, 'deny')
       } else {
-        const decision = DECISION_MAP[incoming.text.trim().toLowerCase()]
-        if (decision && options.deferredConfirmationStore) {
+        const confirmation = interpretConfirmationEvent({ kind: 'text', text: incoming.text })
+        if (confirmation.status === 'decision' && options.deferredConfirmationStore) {
           // A custom peer id is only unique inside its routed assistant/channel
           // (many WeChat accounts have the same `filehelper` peer). Scope the
           // DB lookup by assistant, then carry the trusted deferred-row user
@@ -763,12 +757,12 @@ export function customChannelBridgeRoutes(options: CustomChannelBridgeRouteOptio
             peerId,
             routing.assistantId,
           )
-          if (deferred && tryResolveSchedulerConfirmation(deferred.toolCallId, decision, {
+          if (deferred && tryResolveSchedulerConfirmation(deferred.toolCallId, confirmation.decision, {
             userId: deferred.userId,
             channelType: 'custom',
             channelId: peerId,
           })) {
-            await options.deferredConfirmationStore.markResolved(deferred.toolCallId, decision)
+            await options.deferredConfirmationStore.markResolved(deferred.toolCallId, confirmation.decision)
             return
           }
         }
@@ -1237,7 +1231,7 @@ export function customChannelBridgeRoutes(options: CustomChannelBridgeRouteOptio
         },
         async onConfirmationRequired(req, resolver) {
           // Text-only confirmation: park the resolver; the peer's next
-          // message resolves it via DECISION_MAP (step 7 above).
+          // message resolves it through the shared confirmation interpreter.
           pendingConfirmations.set(confirmKey, { resolver, toolCallId: req.toolCallId })
           const lines = req.displayLines && req.displayLines.length > 0
             ? req.displayLines

--- a/packages/api/src/routes/discord.ts
+++ b/packages/api/src/routes/discord.ts
@@ -25,14 +25,20 @@
 import { timingSafeEqual } from 'node:crypto'
 import { Router } from 'express'
 import { createDiscordAdapter, DiscordApiError, respondToInteraction } from '@use-brian/channels'
-import type { IncomingMessage, OutgoingAction } from '@use-brian/channels'
+import type { IncomingMessage } from '@use-brian/channels'
 import { findAssistantById } from '../db/users.js'
 import { withChatLock } from '../db/chat-lock.js'
 import { resolveChannelUser, type ChannelUserStore } from '../db/channel-user-store.js'
 import { resolveRoutingForSurface, getChannelForWebhook } from '../db/channels-store.js'
-import { parseFileContent, buildTool } from '@use-brian/core'
+import {
+  buildConfirmationActions,
+  buildTool,
+  confirmationDecisionLabel,
+  interpretConfirmationEvent,
+  parseFileContent,
+} from '@use-brian/core'
 import { z } from 'zod'
-import type { ConfirmationDecision, ConfirmationResolver, ContentBlock } from '@use-brian/core'
+import type { ConfirmationResolver, ContentBlock } from '@use-brian/core'
 import type { LLMProvider, Tool, MemoryStore, UsageStore, AnalyticsLogger, McpSettingsStore } from '@use-brian/core'
 import type { ChannelIntegrationStore, ChannelIntegrationConfig, DiscordCredentials } from '../db/channel-integrations.js'
 import type { ConnectorStore } from '../db/connector-store.js'
@@ -108,20 +114,7 @@ export type DiscordRouteOptions = {
   capabilityStore: import('@use-brian/core').CapabilityStore
 }
 
-// Natural-language → decision mapping for Discord text-based confirmation.
-const DECISION_MAP: Record<string, ConfirmationDecision> = {
-  yes: 'allow', y: 'allow', allow: 'allow', approve: 'allow', ok: 'allow',
-  no: 'deny', n: 'deny', deny: 'deny', reject: 'deny',
-  always: 'always_allow', 'always allow': 'always_allow',
-  never: 'always_deny', 'always deny': 'always_deny',
-}
-
 const STATUS_THROTTLE_MS = 1200
-
-// Decision label shown back in the morphed prompt after a button press.
-const DECISION_LABEL: Record<ConfirmationDecision, string> = {
-  allow: 'Allowed', deny: 'Denied', always_allow: 'Always allowed', always_deny: 'Always denied',
-}
 
 const interactionSchema = z.object({
   // Internal `channels` row id (forwarded for symmetry; resolution keys off the
@@ -395,19 +388,15 @@ export function discordRoutes(options: DiscordRouteOptions): Router {
       //    as a yes/no/always/never decision.
       const pending = pendingConfirmations.get(incoming.channelId)
       if (pending) {
-        const decision = DECISION_MAP[incoming.text.trim().toLowerCase()]
-        if (decision) {
-          pendingConfirmations.delete(incoming.channelId)
-          pending.resolver.resolve(pending.toolCallId, decision)
-          return
-        }
-        // Not a decision keyword: treat as deny so the in-flight turn (which
-        // holds the per-channel chat lock while it waits on this resolver)
-        // unblocks immediately instead of stalling until the 300s timeout —
-        // then fall through to process this message as a fresh turn. Mirrors
-        // slack.ts. Resolving an already-resolved/timed-out call is a no-op.
-        pending.resolver.resolve(pending.toolCallId, 'deny')
+        const confirmation = interpretConfirmationEvent(
+          { kind: 'text', text: incoming.text },
+          pending.toolCallId,
+        )
         pendingConfirmations.delete(incoming.channelId)
+        if (confirmation.status === 'decision') {
+          pending.resolver.resolve(pending.toolCallId, confirmation.decision)
+          if (confirmation.consume) return
+        }
       }
 
       // 7. Sequentialize per Discord channel.
@@ -449,12 +438,9 @@ export function discordRoutes(options: DiscordRouteOptions): Router {
     res.status(200).json({ ok: true })
 
     const { interaction } = parsed.data
-    // custom_id = mcp_confirm:<toolCallId>:<decision>
-    const parts = interaction.customId.split(':')
-    if (parts[0] !== 'mcp_confirm' || parts.length < 3) return
-    const toolCallId = parts[1]
-    const decision = parts[2] as ConfirmationDecision
-    if (!(decision in DECISION_LABEL)) return
+    const confirmation = interpretConfirmationEvent({ kind: 'action', data: interaction.customId })
+    if (confirmation.status !== 'decision' || !confirmation.toolCallId) return
+    const { toolCallId, decision } = confirmation
 
     const pending = pendingConfirmations.get(interaction.channelId)
     const matched = !!pending && pending.toolCallId === toolCallId
@@ -467,7 +453,7 @@ export function discordRoutes(options: DiscordRouteOptions): Router {
       await respondToInteraction(interaction.id, interaction.token, {
         type: 7,
         data: {
-          content: matched ? `Tool action: ${DECISION_LABEL[decision]}` : 'Expired or already handled.',
+          content: matched ? `Tool action: ${confirmationDecisionLabel(decision)}` : 'Expired or already handled.',
           components: [],
           allowed_mentions: { parse: [] },
         },
@@ -736,7 +722,7 @@ export function discordRoutes(options: DiscordRouteOptions): Router {
         async onConfirmationRequired(req, resolver) {
           // Park the resolver so BOTH paths can answer: an atomic button press
           // (relayed back as an INTERACTION_CREATE → POST /interaction) and the
-          // text fallback (the next message on this channel → DECISION_MAP). The
+          // text fallback (the next normalized message on this channel). The
           // key includes toolCallId so a button echoing a stale id is rejected.
           pendingConfirmations.set(channelId, { resolver, toolCallId: req.toolCallId })
           const lines = req.displayLines && req.displayLines.length > 0
@@ -747,16 +733,7 @@ export function discordRoutes(options: DiscordRouteOptions): Router {
 
           // custom_id = mcp_confirm:<toolCallId>:<decision> (≤100 chars, the
           // Discord button limit). Mirrors the Telegram inline-keyboard payload.
-          const actions: OutgoingAction[] = [
-            { id: 'allow', label: 'Allow', data: `mcp_confirm:${req.toolCallId}:allow` },
-            { id: 'deny', label: 'Deny', data: `mcp_confirm:${req.toolCallId}:deny` },
-          ]
-          if (req.allowPersistentApproval) {
-            actions.push(
-              { id: 'always', label: 'Always Allow', data: `mcp_confirm:${req.toolCallId}:always_allow` },
-              { id: 'never', label: 'Always Deny', data: `mcp_confirm:${req.toolCallId}:always_deny` },
-            )
-          }
+          const actions = buildConfirmationActions(req.toolCallId, req.allowPersistentApproval)
           const replyHint = req.allowPersistentApproval
             ? 'Tap a button, or reply: yes / no / always / never'
             : 'Tap a button, or reply: yes / no'

--- a/packages/api/src/routes/feishu.ts
+++ b/packages/api/src/routes/feishu.ts
@@ -17,16 +17,17 @@ import {
   type FeishuCardAction,
   type FeishuNormalizedMessage,
   type IncomingMessage,
-  type OutgoingAction,
 } from '@use-brian/channels'
 import {
+  buildConfirmationActions,
   buildTool,
+  confirmationDecisionLabel,
   composeVoiceTurnText,
   describeTranscriptionFailure,
+  interpretConfirmationEvent,
   parseFileContent,
   transcribeFirstAudio,
   TRANSCRIPTION_DISABLED_REASON,
-  type ConfirmationDecision,
   type ConfirmationResolver,
   type ContentBlock,
   type MediaBackend,
@@ -111,20 +112,6 @@ export type FeishuRouteOptions = Omit<DiscordRouteOptions, 'ingestChannelMediaRe
     backend?: MediaBackend
     model?: string
   }
-}
-
-const DECISION_MAP: Record<string, ConfirmationDecision> = {
-  yes: 'allow', y: 'allow', allow: 'allow', approve: 'allow', ok: 'allow',
-  no: 'deny', n: 'deny', deny: 'deny', reject: 'deny',
-  always: 'always_allow', 'always allow': 'always_allow',
-  never: 'always_deny', 'always deny': 'always_deny',
-}
-
-const DECISION_LABEL: Record<ConfirmationDecision, string> = {
-  allow: 'Allowed',
-  deny: 'Denied',
-  always_allow: 'Always allowed',
-  always_deny: 'Always denied',
 }
 
 const STATUS_THROTTLE_MS = 1200
@@ -524,9 +511,9 @@ export function feishuRoutes(options: FeishuRouteOptions): Router {
     if (!interaction.chatId || !interaction.messageId || !interaction.action) return
     const data = actionData(interaction)
     if (!data) return
-    const [prefix, toolCallId, rawDecision] = data.split(':')
-    if (prefix !== 'mcp_confirm' || !toolCallId || !(rawDecision in DECISION_LABEL)) return
-    const decision = rawDecision as ConfirmationDecision
+    const confirmation = interpretConfirmationEvent({ kind: 'action', data })
+    if (confirmation.status !== 'decision' || !confirmation.toolCallId) return
+    const { toolCallId, decision } = confirmation
     const pending = pendingConfirmations.get(interaction.chatId)
     let matched = !!pending && pending.toolCallId === toolCallId
     if (matched) {
@@ -555,7 +542,7 @@ export function feishuRoutes(options: FeishuRouteOptions): Router {
     if (integration) {
       const api = createFeishuApi(credentialsForApi(integration.credentials as FeishuCredentials))
       await api.updateCard(interaction.messageId, {
-        elements: [{ tag: 'markdown', content: matched ? `Tool action: ${DECISION_LABEL[decision]}` : 'Expired or already handled.' }],
+        elements: [{ tag: 'markdown', content: matched ? `Tool action: ${confirmationDecisionLabel(decision)}` : 'Expired or already handled.' }],
       }).catch(() => {})
     }
   }
@@ -616,17 +603,18 @@ export function feishuRoutes(options: FeishuRouteOptions): Router {
 
     const pending = pendingConfirmations.get(incoming.channelId)
     if (pending) {
-      const decision = DECISION_MAP[incoming.text.trim().toLowerCase()]
-      if (decision) {
-        pendingConfirmations.delete(incoming.channelId)
-        pending.resolver.resolve(pending.toolCallId, decision)
-        return
-      }
-      pending.resolver.resolve(pending.toolCallId, 'deny')
+      const confirmation = interpretConfirmationEvent(
+        { kind: 'text', text: incoming.text },
+        pending.toolCallId,
+      )
       pendingConfirmations.delete(incoming.channelId)
+      if (confirmation.status === 'decision') {
+        pending.resolver.resolve(pending.toolCallId, confirmation.decision)
+        if (confirmation.consume) return
+      }
     } else if (options.deferredConfirmationStore) {
-      const decision = DECISION_MAP[incoming.text.trim().toLowerCase()]
-      if (decision) {
+      const confirmation = interpretConfirmationEvent({ kind: 'text', text: incoming.text })
+      if (confirmation.status === 'decision') {
         const deferred = await options.deferredConfirmationStore.findPendingByChannel(
           'feishu',
           incoming.channelId,
@@ -634,12 +622,12 @@ export function feishuRoutes(options: FeishuRouteOptions): Router {
         )
         if (
           deferred
-          && tryResolveSchedulerConfirmation(deferred.toolCallId, decision, {
+          && tryResolveSchedulerConfirmation(deferred.toolCallId, confirmation.decision, {
             channelType: 'feishu',
             channelId: incoming.channelId,
           })
         ) {
-          await options.deferredConfirmationStore.markResolved(deferred.toolCallId, decision)
+          await options.deferredConfirmationStore.markResolved(deferred.toolCallId, confirmation.decision)
           return
         }
       }
@@ -1080,16 +1068,7 @@ export function feishuRoutes(options: FeishuRouteOptions): Router {
           const lines = request.displayLines?.length
             ? request.displayLines
             : formatConfirmationInput(request.input)
-          const actions: OutgoingAction[] = [
-            { id: 'allow', label: 'Allow', data: `mcp_confirm:${request.toolCallId}:allow` },
-            { id: 'deny', label: 'Deny', data: `mcp_confirm:${request.toolCallId}:deny` },
-          ]
-          if (request.allowPersistentApproval) {
-            actions.push(
-              { id: 'always', label: 'Always Allow', data: `mcp_confirm:${request.toolCallId}:always_allow` },
-              { id: 'never', label: 'Always Deny', data: `mcp_confirm:${request.toolCallId}:always_deny` },
-            )
-          }
+          const actions = buildConfirmationActions(request.toolCallId, request.allowPersistentApproval)
           await adapter.sendMessage(incoming.channelId, {
             text: `${getToolDisplayName(request.toolName)}${lines.length ? `\n${lines.join('\n')}` : ''}\n\n${request.allowPersistentApproval ? 'Tap a button, or reply: yes / no / always / never' : 'Tap a button, or reply: yes / no'}`,
             actions,

--- a/packages/api/src/routes/msteams.ts
+++ b/packages/api/src/routes/msteams.ts
@@ -30,8 +30,8 @@ import { findAssistantById } from '../db/users.js'
 import { withChatLock } from '../db/chat-lock.js'
 import { resolveChannelUser, type ChannelUserStore } from '../db/channel-user-store.js'
 import { resolveRoutingForSurface, resolveAssistantForSurface, getChannelForWebhook } from '../db/channels-store.js'
-import { parseFileContent } from '@use-brian/core'
-import type { ConfirmationDecision, ConfirmationResolver, ContentBlock } from '@use-brian/core'
+import { interpretConfirmationEvent, parseFileContent } from '@use-brian/core'
+import type { ConfirmationResolver, ContentBlock } from '@use-brian/core'
 import type { LLMProvider, Tool, MemoryStore, UsageStore, AnalyticsLogger, McpSettingsStore } from '@use-brian/core'
 import type {
   ChannelIntegrationStore,
@@ -124,15 +124,6 @@ export type MsTeamsRouteOptions = {
    * Absent → ingest degrades to a no-op (OSS, or before the closed impl wires).
    */
   msteamsWebhookIngestor?: MsTeamsWebhookIngestor
-}
-
-// Natural-language → decision mapping for Teams text-based confirmation
-// (no Adaptive Card buttons yet — that is the P5 parity fast-follow).
-const DECISION_MAP: Record<string, ConfirmationDecision> = {
-  yes: 'allow', y: 'allow', allow: 'allow', approve: 'allow', ok: 'allow',
-  no: 'deny', n: 'deny', deny: 'deny', reject: 'deny',
-  always: 'always_allow', 'always allow': 'always_allow',
-  never: 'always_deny', 'always deny': 'always_deny',
 }
 
 const STATUS_THROTTLE_MS = 1200
@@ -281,12 +272,15 @@ export function msteamsRoutes(options: MsTeamsRouteOptions): Router {
       //    Card buttons are P5).
       const pending = pendingConfirmations.get(incoming.channelId)
       if (pending) {
-        const decision = DECISION_MAP[incoming.text.trim().toLowerCase()]
+        const confirmation = interpretConfirmationEvent(
+          { kind: 'text', text: incoming.text },
+          pending.toolCallId,
+        )
         pendingConfirmations.delete(incoming.channelId)
-        pending.resolver.resolve(pending.toolCallId, decision ?? 'deny')
-        if (decision) return
-        // Not a decision keyword: we unblocked the parked turn above; fall
-        // through and process this message as a fresh turn.
+        if (confirmation.status === 'decision') {
+          pending.resolver.resolve(pending.toolCallId, confirmation.decision)
+          if (confirmation.consume) return
+        }
       }
 
       // 10. Sequentialize per Teams conversation.

--- a/packages/api/src/routes/slack.ts
+++ b/packages/api/src/routes/slack.ts
@@ -50,11 +50,12 @@ import { resolveAssistantForSurface, resolveRoutingForSurface, getChannelForWebh
 import {
   parseFileContent,
   buildTool,
+  interpretConfirmationEvent,
   resolveRealtimeThreadAddressing,
   sanitize as sanitizeAnalytics,
 } from '@use-brian/core'
 import { z } from 'zod'
-import type { ConfirmationDecision, ConfirmationResolver, ContentBlock } from '@use-brian/core'
+import type { ConfirmationResolver, ContentBlock } from '@use-brian/core'
 import type { LLMProvider, Tool, MemoryStore, UsageStore, AnalyticsLogger, McpSettingsStore, WorkflowEventDispatcher } from '@use-brian/core'
 import type { ChannelIntegrationStore } from '../db/channel-integrations.js'
 import type { ConnectorStore } from '../db/connector-store.js'
@@ -231,14 +232,6 @@ type SlackRouteOptions = {
    * See docs/architecture/brain/ingest-pipeline.md → "Source adapters".
    */
   slackWebhookIngestor?: SlackWebhookIngestor
-}
-
-// Natural language → decision mapping for Slack text-based confirmation
-const DECISION_MAP: Record<string, ConfirmationDecision> = {
-  yes: 'allow', y: 'allow', allow: 'allow', approve: 'allow', ok: 'allow',
-  no: 'deny', n: 'deny', deny: 'deny', reject: 'deny',
-  always: 'always_allow', 'always allow': 'always_allow',
-  never: 'always_deny', 'always deny': 'always_deny',
 }
 
 /** The in-flight query loop for one Slack channel: its abort handle and the
@@ -756,25 +749,22 @@ export function slackRoutes(options: SlackRouteOptions): Router {
     // ── Check if this message is a confirmation response ──────
     const pendingConf = pendingSlackConfirmations.get(sessionChannelId)
     if (pendingConf) {
-      const normalized = incoming.text.trim().toLowerCase()
-      const decision = DECISION_MAP[normalized]
-      if (decision) {
-        pendingConf.resolver.resolve(pendingConf.toolCallId, decision)
-        pendingSlackConfirmations.delete(sessionChannelId)
-        return
-      }
-      // If the text doesn't match any decision keyword, treat as deny
-      // and process as a new message
-      pendingConf.resolver.resolve(pendingConf.toolCallId, 'deny')
+      const confirmation = interpretConfirmationEvent(
+        { kind: 'text', text: incoming.text },
+        pendingConf.toolCallId,
+      )
       pendingSlackConfirmations.delete(sessionChannelId)
+      if (confirmation.status === 'decision') {
+        pendingConf.resolver.resolve(pendingConf.toolCallId, confirmation.decision)
+        if (confirmation.consume) return
+      }
     } else if (options.deferredConfirmationStore) {
       // Check for a deferred confirmation from a scheduled job
-      const normalized = incoming.text.trim().toLowerCase()
-      const decision = DECISION_MAP[normalized]
-      if (decision) {
+      const confirmation = interpretConfirmationEvent({ kind: 'text', text: incoming.text })
+      if (confirmation.status === 'decision') {
         const deferred = await options.deferredConfirmationStore.findPendingByChannel('slack', incoming.channelId)
-        if (deferred && tryResolveSchedulerConfirmation(deferred.toolCallId, decision)) {
-          options.deferredConfirmationStore.markResolved(deferred.toolCallId, decision)
+        if (deferred && tryResolveSchedulerConfirmation(deferred.toolCallId, confirmation.decision)) {
+          options.deferredConfirmationStore.markResolved(deferred.toolCallId, confirmation.decision)
             .catch((err) => console.error('[slack] deferred confirmation DB update failed:', err))
           return
         }

--- a/packages/api/src/routes/telegram-byo.ts
+++ b/packages/api/src/routes/telegram-byo.ts
@@ -48,9 +48,9 @@ import { mergeShadowUser, type LinkedAccountStore } from '../db/linked-accounts.
 import type { LinkCodeStore } from '../db/link-codes.js'
 import { withChatLock } from '../db/chat-lock.js'
 import { buildAlbumFiledReply, buildDocumentFiledReply, buildOversizeDocReply, classifyMedia, summarizeAlbumIntake } from '../ingest/channel-media-intake.js'
-import type { ConfirmationDecision, ConfirmationResolver, ContentBlock } from '@use-brian/core'
+import type { ConfirmationResolver, ContentBlock } from '@use-brian/core'
 import type { LLMProvider, Tool, MemoryStore, UsageStore, AnalyticsLogger, McpSettingsStore, KnowledgeStoreInterface, GDriveFilesStore, TokenUsage } from '@use-brian/core'
-import { transcribeFirstAudio, describeTranscriptionFailure, composeVoiceTurnText, TRANSCRIPTION_DISABLED_REASON, sanitize as sanitizeAnalytics, type MediaBackend } from '@use-brian/core'
+import { buildConfirmationActions, confirmationDecisionLabel, interpretConfirmationEvent, transcribeFirstAudio, describeTranscriptionFailure, composeVoiceTurnText, TRANSCRIPTION_DISABLED_REASON, sanitize as sanitizeAnalytics, type MediaBackend } from '@use-brian/core'
 import type { ChannelIntegrationStore, ChannelIntegrationConfig, TelegramCredentials, SeenChat } from '../db/channel-integrations.js'
 import type { ConnectorStore } from '../db/connector-store.js'
 import type { AssistantConnectorStore } from '../db/assistant-connector-store.js'
@@ -554,16 +554,12 @@ export function telegramByoRoutes(options: TelegramByoRouteOptions): Router {
           return
         }
 
-        // Parse: mcp_confirm:<toolCallId>:<decision>
-        if (parts[0] !== 'mcp_confirm' || parts.length < 3) return
-
-        const toolCallId = parts[1]
-        const decision = parts[2] as ConfirmationDecision
+        const confirmation = interpretConfirmationEvent({ kind: 'action', data: query.data })
+        if (confirmation.status !== 'decision' || !confirmation.toolCallId) return
+        const { toolCallId, decision } = confirmation
         const confKey = `${query.chatId}:${toolCallId}`
         const pending = pendingConfResolvers.get(confKey)
-
-        const label = decision === 'allow' ? 'Allowed' : decision === 'deny' ? 'Denied'
-          : decision === 'always_allow' ? 'Always allowed' : 'Always denied'
+        const label = confirmationDecisionLabel(decision)
 
         if (pending) {
           pending.resolver.resolve(toolCallId, decision)
@@ -1762,16 +1758,7 @@ async function processMessage(params: ProcessMessageParams): Promise<void> {
           : formatConfirmationInput(req.input)
         const inputSummary = lines.length > 0 ? '\n\n' + lines.join('\n') : ''
 
-        const actions = [
-          { id: 'allow', label: 'Allow', data: `mcp_confirm:${req.toolCallId}:allow` },
-          { id: 'deny', label: 'Deny', data: `mcp_confirm:${req.toolCallId}:deny` },
-        ]
-        if (req.allowPersistentApproval) {
-          actions.push(
-            { id: 'always', label: 'Always Allow', data: `mcp_confirm:${req.toolCallId}:always_allow` },
-            { id: 'never', label: 'Always Deny', data: `mcp_confirm:${req.toolCallId}:always_deny` },
-          )
-        }
+        const actions = buildConfirmationActions(req.toolCallId, req.allowPersistentApproval)
 
         const displayName = getToolDisplayName(req.toolName)
         await adapter.sendMessage(incoming.channelId, {

--- a/packages/api/src/routes/wechat.ts
+++ b/packages/api/src/routes/wechat.ts
@@ -41,8 +41,8 @@ import {
 } from '@use-brian/channels'
 import type { IncomingMessage } from '@use-brian/channels'
 import { z } from 'zod'
-import { parseFileContent } from '@use-brian/core'
-import type { ConfirmationDecision, ConfirmationResolver, ContentBlock } from '@use-brian/core'
+import { interpretConfirmationEvent, parseFileContent } from '@use-brian/core'
+import type { ConfirmationResolver, ContentBlock } from '@use-brian/core'
 import type { LLMProvider, Tool, MemoryStore, UsageStore, AnalyticsLogger, McpSettingsStore } from '@use-brian/core'
 import { findAssistantById } from '../db/users.js'
 import { withChatLock } from '../db/chat-lock.js'
@@ -106,15 +106,6 @@ export type WechatRouteOptions = {
   crmEmailDraftStore?: import('@use-brian/core').CrmEmailDraftStore
   capabilityStore: import('@use-brian/core').CapabilityStore
   archiveMedia?: ChatArchiveLiveMedia
-}
-
-// Natural-language → decision mapping for WeChat text-based confirmation
-// (no buttons on this platform — text is the only path).
-const DECISION_MAP: Record<string, ConfirmationDecision> = {
-  yes: 'allow', y: 'allow', allow: 'allow', approve: 'allow', ok: 'allow',
-  no: 'deny', n: 'deny', deny: 'deny', reject: 'deny',
-  always: 'always_allow', 'always allow': 'always_allow',
-  never: 'always_deny', 'always deny': 'always_deny',
 }
 
 // Refuse media downloads above this — matches the document cap elsewhere.
@@ -426,14 +417,15 @@ export function wechatRoutes(options: WechatRouteOptions): Router {
       const confirmKey = `${channelId}:${peerId}`
       const pending = pendingConfirmations.get(confirmKey)
       if (pending) {
-        const decision = DECISION_MAP[incoming.text.trim().toLowerCase()]
-        if (decision) {
-          pendingConfirmations.delete(confirmKey)
-          pending.resolver.resolve(pending.toolCallId, decision)
-          return
-        }
-        pending.resolver.resolve(pending.toolCallId, 'deny')
+        const confirmation = interpretConfirmationEvent(
+          { kind: 'text', text: incoming.text },
+          pending.toolCallId,
+        )
         pendingConfirmations.delete(confirmKey)
+        if (confirmation.status === 'decision') {
+          pending.resolver.resolve(pending.toolCallId, confirmation.decision)
+          if (confirmation.consume) return
+        }
       }
 
       // 7. Sequentialize per DM peer.
@@ -730,7 +722,7 @@ export function wechatRoutes(options: WechatRouteOptions): Router {
         },
         async onConfirmationRequired(req, resolver) {
           // Text-only confirmation: park the resolver; the peer's next
-          // message resolves it via DECISION_MAP (step 6 above).
+          // message resolves it through the shared confirmation interpreter.
           pendingConfirmations.set(confirmKey, { resolver, toolCallId: req.toolCallId })
           const lines = req.displayLines && req.displayLines.length > 0
             ? req.displayLines

--- a/packages/api/src/routes/whatsapp-cloud.ts
+++ b/packages/api/src/routes/whatsapp-cloud.ts
@@ -9,10 +9,9 @@ import {
   whatsappCloudMediaId,
 } from '@use-brian/channels'
 import type { IncomingMessage } from '@use-brian/channels'
-import { parseFileContent } from '@use-brian/core'
+import { interpretConfirmationEvent, parseFileContent } from '@use-brian/core'
 import type {
   AnalyticsLogger,
-  ConfirmationDecision,
   ConfirmationResolver,
   ContentBlock,
   LLMProvider,
@@ -49,11 +48,6 @@ import {
 export { whatsappCloudUserAllowed } from '../whatsapp/cloud-access.js'
 
 const MAX_MEDIA_BYTES = 25 * 1024 * 1024
-const DECISIONS: Record<string, ConfirmationDecision> = {
-  yes: 'allow', y: 'allow', allow: 'allow', approve: 'allow', ok: 'allow',
-  no: 'deny', n: 'deny', deny: 'deny', reject: 'deny',
-  always: 'always_allow', never: 'always_deny',
-}
 
 export type WhatsAppCloudRouteOptions = {
   backgroundModel?: string
@@ -317,10 +311,15 @@ export function whatsappCloudRoutes(options: WhatsAppCloudRouteOptions): Router 
       const confirmKey = `${conversationKey}:${incoming.userId}`
       const parked = pending.get(confirmKey)
       if (parked) {
-        const decision = DECISIONS[incoming.text.trim().toLowerCase()]
+        const confirmation = interpretConfirmationEvent(
+          { kind: 'text', text: incoming.text },
+          parked.toolCallId,
+        )
         pending.delete(confirmKey)
-        parked.resolver.resolve(parked.toolCallId, decision ?? 'deny')
-        if (decision) return
+        if (confirmation.status === 'decision') {
+          parked.resolver.resolve(parked.toolCallId, confirmation.decision)
+          if (confirmation.consume) return
+        }
       }
 
       await withChatLock(`whatsapp-cloud:${conversationKey}`, () => processMessage({

--- a/packages/api/src/scheduling/confirmation-prompt.ts
+++ b/packages/api/src/scheduling/confirmation-prompt.ts
@@ -17,7 +17,7 @@
  * Component tag: [COMP:scheduling/confirmation-prompt].
  */
 
-import type { ToolConfirmationRequest } from '@use-brian/core'
+import { buildConfirmationActions, type ToolConfirmationRequest } from '@use-brian/core'
 import {
   createSlackAdapter,
   createFeishuAdapter,
@@ -154,16 +154,7 @@ export async function sendConfirmationPrompt(
       }
       {
         const adapter = createTelegramAdapter({ token: botToken })
-        const actions = [
-          { id: 'allow', label: 'Allow', data: `mcp_confirm:${req.toolCallId}:allow` },
-          { id: 'deny', label: 'Deny', data: `mcp_confirm:${req.toolCallId}:deny` },
-        ]
-        if (allowPersist) {
-          actions.push(
-            { id: 'always', label: 'Always Allow', data: `mcp_confirm:${req.toolCallId}:always_allow` },
-            { id: 'never', label: 'Always Deny', data: `mcp_confirm:${req.toolCallId}:always_deny` },
-          )
-        }
+        const actions = buildConfirmationActions(req.toolCallId, allowPersist)
         await adapter.sendMessage(target.channelId, {
           text: `${displayName}${inputSummary}\n\nAllow this action?`,
           actions,
@@ -228,16 +219,7 @@ export async function sendConfirmationPrompt(
         }),
         botOpenId: integration.botUserId ?? undefined,
       })
-      const actions = [
-        { id: 'allow', label: 'Allow', data: `mcp_confirm:${req.toolCallId}:allow` },
-        { id: 'deny', label: 'Deny', data: `mcp_confirm:${req.toolCallId}:deny` },
-      ]
-      if (allowPersist) {
-        actions.push(
-          { id: 'always', label: 'Always Allow', data: `mcp_confirm:${req.toolCallId}:always_allow` },
-          { id: 'never', label: 'Always Deny', data: `mcp_confirm:${req.toolCallId}:always_deny` },
-        )
-      }
+      const actions = buildConfirmationActions(req.toolCallId, allowPersist)
       await adapter.sendMessage(target.channelId, {
         text: `${displayName}${inputSummary}\n\nAllow this action?`,
         actions,

--- a/packages/api/src/whatsapp/byon-runtime.ts
+++ b/packages/api/src/whatsapp/byon-runtime.ts
@@ -1,7 +1,6 @@
 import { createWhatsAppAdapter } from '@use-brian/channels'
 import type {
   AnalyticsLogger,
-  ConfirmationDecision,
   ConfirmationResolver,
   CrmStore,
   EntityLinksStore,
@@ -11,6 +10,7 @@ import type {
   TaskStore,
   UsageStore,
 } from '@use-brian/core'
+import { interpretConfirmationEvent } from '@use-brian/core'
 import { getToolDisplayName } from '@use-brian/shared'
 import { query } from '../db/client.js'
 import type { DbEpisodesStore } from '../db/episodes-store.js'
@@ -126,11 +126,6 @@ export function createWhatsappByonRuntime(deps: WhatsappByonRuntimeDeps) {
   }
 
   const pending = new Map<string, { resolver: ConfirmationResolver; toolCallId: string }>()
-  const decisions: Record<string, ConfirmationDecision> = {
-    allow: 'allow', yes: 'allow', y: 'allow', ok: 'allow',
-    deny: 'deny', no: 'deny', n: 'deny',
-    always: 'always_allow', never: 'always_deny',
-  }
 
   const bot = createWhatsappBot({
     resolveBotChannel: async (channelId) => {
@@ -201,11 +196,16 @@ export function createWhatsappByonRuntime(deps: WhatsappByonRuntimeDeps) {
         connectionId: input.channelId,
       })
       const parked = pending.get(input.chatJid)
-      const decision = parked && decisions[input.text.trim().toLowerCase()]
-      if (parked && decision) {
-        parked.resolver.resolve(parked.toolCallId, decision)
+      if (parked) {
+        const confirmation = interpretConfirmationEvent(
+          { kind: 'text', text: input.text },
+          parked.toolCallId,
+        )
         pending.delete(input.chatJid)
-        return
+        if (confirmation.status === 'decision') {
+          parked.resolver.resolve(parked.toolCallId, confirmation.decision)
+          if (confirmation.consume) return
+        }
       }
       const hooks: ChannelHooks = {
         onProcessingStart: async () => {

--- a/packages/core/src/engine/tool-executor.ts
+++ b/packages/core/src/engine/tool-executor.ts
@@ -629,7 +629,10 @@ export function createToolExecutor(options: ToolExecutorOptions) {
           options.confirmationTimeoutMs ?? 300_000,
         ).finally(() => options.context.progress?.resume())
 
-        if (decision === 'deny' || decision === 'always_deny') {
+        // Fail closed at the execution boundary. Normalized event handlers
+        // validate decisions before resolving, but an invalid runtime value
+        // from any future caller must never fall through into tool execution.
+        if (decision !== 'allow' && decision !== 'always_allow') {
           deniedTools.add(t.name)
           t.result = {
             type: 'tool_result',
@@ -642,7 +645,7 @@ export function createToolExecutor(options: ToolExecutorOptions) {
           wake()
           return
         }
-        // 'allow' or 'always_allow' — fall through to execution
+        // 'allow' or 'always_allow' - fall through to execution
       } catch {
         // Timeout — treat as deny for this session
         deniedTools.add(t.name)

--- a/packages/core/src/mcp/__tests__/confirmation-events.test.ts
+++ b/packages/core/src/mcp/__tests__/confirmation-events.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildConfirmationActions,
+  confirmationDecisionLabel,
+  encodeConfirmationAction,
+  interpretConfirmationEvent,
+  isConfirmationDecision,
+} from '../confirmation-events.js'
+
+describe('[COMP:mcp/confirmation-events] normalized confirmation events', () => {
+  it.each([
+    ['yes', 'allow'],
+    [' Y ', 'allow'],
+    ['approve', 'allow'],
+    ['OK', 'allow'],
+    ['no', 'deny'],
+    [' reject ', 'deny'],
+    ['always', 'always_allow'],
+    ['Always Allow', 'always_allow'],
+    ['never', 'always_deny'],
+    ['always deny', 'always_deny'],
+  ] as const)('maps text %j to %s', (text, decision) => {
+    expect(interpretConfirmationEvent({ kind: 'text', text }, 'tool-1')).toEqual({
+      status: 'decision',
+      decision,
+      toolCallId: 'tool-1',
+      consume: true,
+    })
+  })
+
+  it('denies a parked request but preserves unrelated text as a new message', () => {
+    expect(interpretConfirmationEvent({ kind: 'text', text: 'change the recipient' }, 'tool-1')).toEqual({
+      status: 'decision',
+      decision: 'deny',
+      toolCallId: 'tool-1',
+      consume: false,
+    })
+  })
+
+  it('leaves unrelated text alone when no confirmation is parked', () => {
+    expect(interpretConfirmationEvent({ kind: 'text', text: 'hello' })).toEqual({
+      status: 'not_confirmation',
+    })
+  })
+
+  it.each(['allow', 'deny', 'always_allow', 'always_deny'] as const)(
+    'round-trips the %s action',
+    (decision) => {
+      const data = encodeConfirmationAction('tool-1', decision)
+      expect(interpretConfirmationEvent({ kind: 'action', data })).toEqual({
+        status: 'decision',
+        toolCallId: 'tool-1',
+        decision,
+        consume: true,
+      })
+    },
+  )
+
+  it.each([
+    undefined,
+    42,
+    '',
+    'mcp_confirm',
+    'mcp_confirm::allow',
+    'mcp_confirm:tool-1',
+    'mcp_confirm:tool-1:approve',
+    'mcp_confirm:tool-1:constructor',
+    'mcp_confirm:tool-1:allow:extra',
+    'other:tool-1:allow',
+  ])('rejects malformed action data %j', (data) => {
+    expect(interpretConfirmationEvent({ kind: 'action', data })).toEqual({ status: 'invalid' })
+  })
+
+  it('validates and trims a direct web decision', () => {
+    expect(interpretConfirmationEvent({
+      kind: 'decision',
+      toolCallId: ' tool-1 ',
+      decision: 'deny',
+      comment: ' use the draft instead ',
+    })).toEqual({
+      status: 'decision',
+      toolCallId: 'tool-1',
+      decision: 'deny',
+      comment: 'use the draft instead',
+      consume: true,
+    })
+  })
+
+  it.each([
+    { toolCallId: '', decision: 'allow' },
+    { toolCallId: 'tool-1', decision: 'approved' },
+    { toolCallId: 'tool-1', decision: 'constructor' },
+    { toolCallId: 'tool-1', decision: 'deny', comment: 42 },
+  ])('rejects an invalid direct decision %#', (event) => {
+    expect(interpretConfirmationEvent({ kind: 'decision', ...event })).toEqual({ status: 'invalid' })
+  })
+
+  it('builds the common two- or four-action prompt', () => {
+    expect(buildConfirmationActions('tool-1')).toEqual([
+      { id: 'allow', label: 'Allow', data: 'mcp_confirm:tool-1:allow' },
+      { id: 'deny', label: 'Deny', data: 'mcp_confirm:tool-1:deny' },
+    ])
+    expect(buildConfirmationActions('tool-1', true)).toHaveLength(4)
+  })
+
+  it('exposes labels and a fail-closed decision guard', () => {
+    expect(confirmationDecisionLabel('always_deny')).toBe('Always denied')
+    expect(isConfirmationDecision('allow')).toBe(true)
+    expect(isConfirmationDecision('constructor')).toBe(false)
+    expect(isConfirmationDecision('approved')).toBe(false)
+  })
+})

--- a/packages/core/src/mcp/confirmation-events.ts
+++ b/packages/core/src/mcp/confirmation-events.ts
@@ -1,0 +1,154 @@
+import type { ConfirmationDecision } from './types.js'
+
+export const CONFIRMATION_DECISIONS = [
+  'allow',
+  'deny',
+  'always_allow',
+  'always_deny',
+] as const satisfies readonly ConfirmationDecision[]
+
+const CONFIRMATION_DECISION_SET: ReadonlySet<unknown> = new Set(CONFIRMATION_DECISIONS)
+
+const TEXT_DECISIONS = new Map<string, ConfirmationDecision>([
+  ['yes', 'allow'],
+  ['y', 'allow'],
+  ['allow', 'allow'],
+  ['approve', 'allow'],
+  ['ok', 'allow'],
+  ['no', 'deny'],
+  ['n', 'deny'],
+  ['deny', 'deny'],
+  ['reject', 'deny'],
+  ['always', 'always_allow'],
+  ['always allow', 'always_allow'],
+  ['never', 'always_deny'],
+  ['always deny', 'always_deny'],
+])
+
+const DECISION_LABELS: Record<ConfirmationDecision, string> = {
+  allow: 'Allowed',
+  deny: 'Denied',
+  always_allow: 'Always allowed',
+  always_deny: 'Always denied',
+}
+
+export type NormalizedConfirmationEvent =
+  | { kind: 'text'; text: string }
+  | { kind: 'action'; data: unknown }
+  | {
+    kind: 'decision'
+    toolCallId: unknown
+    decision: unknown
+    comment?: unknown
+  }
+
+export type ConfirmationEventResult =
+  | {
+    status: 'decision'
+    decision: ConfirmationDecision
+    toolCallId?: string
+    comment?: string
+    /** Whether this event is only a confirmation response, not a new message. */
+    consume: boolean
+  }
+  | { status: 'not_confirmation' }
+  | { status: 'invalid' }
+
+export type ConfirmationAction = {
+  id: string
+  label: string
+  data: string
+}
+
+export function isConfirmationDecision(value: unknown): value is ConfirmationDecision {
+  return CONFIRMATION_DECISION_SET.has(value)
+}
+
+export function confirmationDecisionLabel(decision: ConfirmationDecision): string {
+  return DECISION_LABELS[decision]
+}
+
+export function encodeConfirmationAction(
+  toolCallId: string,
+  decision: ConfirmationDecision,
+): string {
+  return `mcp_confirm:${toolCallId}:${decision}`
+}
+
+export function buildConfirmationActions(
+  toolCallId: string,
+  allowPersistentApproval = false,
+): ConfirmationAction[] {
+  const actions: ConfirmationAction[] = [
+    { id: 'allow', label: 'Allow', data: encodeConfirmationAction(toolCallId, 'allow') },
+    { id: 'deny', label: 'Deny', data: encodeConfirmationAction(toolCallId, 'deny') },
+  ]
+  if (allowPersistentApproval) {
+    actions.push(
+      { id: 'always', label: 'Always Allow', data: encodeConfirmationAction(toolCallId, 'always_allow') },
+      { id: 'never', label: 'Always Deny', data: encodeConfirmationAction(toolCallId, 'always_deny') },
+    )
+  }
+  return actions
+}
+
+/**
+ * Interpret a provider-neutral confirmation event.
+ *
+ * Transports extract text or opaque action data; this function alone maps that
+ * normalized input to an executor decision. If unrelated text arrives while a
+ * request is parked, the request is denied and the text continues as a fresh
+ * message so the suspended turn cannot hold the conversation lock until timeout.
+ */
+export function interpretConfirmationEvent(
+  event: NormalizedConfirmationEvent,
+  pendingToolCallId?: string,
+): ConfirmationEventResult {
+  if (event.kind === 'text') {
+    const decision = TEXT_DECISIONS.get(event.text.trim().toLowerCase())
+    if (decision) {
+      return {
+        status: 'decision',
+        decision,
+        ...(pendingToolCallId ? { toolCallId: pendingToolCallId } : {}),
+        consume: true,
+      }
+    }
+    if (pendingToolCallId) {
+      return {
+        status: 'decision',
+        decision: 'deny',
+        toolCallId: pendingToolCallId,
+        consume: false,
+      }
+    }
+    return { status: 'not_confirmation' }
+  }
+
+  if (event.kind === 'action') {
+    if (typeof event.data !== 'string') return { status: 'invalid' }
+    const parts = event.data.split(':')
+    if (parts.length !== 3 || parts[0] !== 'mcp_confirm') return { status: 'invalid' }
+    const toolCallId = parts[1]
+    const decision = parts[2]
+    if (!toolCallId || !isConfirmationDecision(decision)) return { status: 'invalid' }
+    return { status: 'decision', toolCallId, decision, consume: true }
+  }
+
+  if (
+    typeof event.toolCallId !== 'string'
+    || !event.toolCallId.trim()
+    || !isConfirmationDecision(event.decision)
+    || (event.comment !== undefined && typeof event.comment !== 'string')
+  ) {
+    return { status: 'invalid' }
+  }
+  const comment = event.comment?.trim()
+  return {
+    status: 'decision',
+    toolCallId: event.toolCallId.trim(),
+    decision: event.decision,
+    ...(comment ? { comment } : {}),
+    consume: true,
+  }
+}

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -6,3 +6,16 @@ export { wrapMcpTools } from './connector.js'
 export { createMcpGateway } from './gateway.js'
 export { buildToolIndex, createMcpSearchTools, legacyMcpToolName } from './tool-search.js'
 export type { McpToolIndex, ToolSource, RemoteSource, LocalSource } from './tool-search.js'
+export {
+  CONFIRMATION_DECISIONS,
+  buildConfirmationActions,
+  confirmationDecisionLabel,
+  encodeConfirmationAction,
+  interpretConfirmationEvent,
+  isConfirmationDecision,
+} from './confirmation-events.js'
+export type {
+  ConfirmationAction,
+  ConfirmationEventResult,
+  NormalizedConfirmationEvent,
+} from './confirmation-events.js'


### PR DESCRIPTION
## Summary
- add a provider-neutral core confirmation event interpreter for text, action callbacks, and direct web decisions
- migrate channel routes and deferred prompts to shared decision parsing, labels, and action payload construction
- reject malformed decisions at runtime and fail closed at the tool execution boundary

## Testing
- 
> @use-brian/core@0.0.1 typecheck /workspace/brian/brian-platform/use-brian-shared-confirmation-actions/packages/core
> tsc --noEmit && tsc --noEmit -p scripts/tsconfig.json
- 
> @use-brian/api@0.0.1 typecheck /workspace/brian/brian-platform/use-brian-shared-confirmation-actions/packages/api
> tsc --noEmit
- undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "vitest" not found (40 tests)
- undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "vitest" not found (71 tests)