### PR TITLE
feat(approvals): show human-readable tool actions

### DIFF
--- a/apps/app-web/src/components/chrome/__tests__/chat-confirmation-card.test.tsx
+++ b/apps/app-web/src/components/chrome/__tests__/chat-confirmation-card.test.tsx
@@ -212,6 +212,40 @@ describe("[COMP:app-web/chat-confirmation-card] ChatConfirmationCard", () => {
     expect(text).toContain("Memory: office wifi password location");
   });
 
+  it("shows an unrecognised call as readable fields with exact input collapsed", () => {
+    renderCard(
+      confirmation({
+        toolName: "customPublishAction",
+        displayName: "Publish release",
+        input: {
+          releaseTitle: "August update",
+          notifySubscribers: true,
+          destination: { channelName: "Product news", visibility: "Public" },
+        },
+        description: undefined,
+        displayLines: undefined,
+      }),
+    );
+
+    const text = host!.textContent ?? "";
+    expect(text).toContain("Release Title");
+    expect(text).toContain("August update");
+    expect(text).toContain("Notify Subscribers");
+    expect(text).toContain("Yes");
+    expect(text).toContain("Channel Name: Product news");
+    expect(text).toContain("View tool input");
+    expect(host!.querySelector("pre")).toBeNull();
+
+    act(() =>
+      Array.from(host!.querySelectorAll("button"))
+        .find((button) => button.textContent === "View tool input")!
+        .click(),
+    );
+    expect(host!.querySelector("pre")?.textContent).toContain(
+      '"notifySubscribers": true',
+    );
+  });
+
   it("renders an updateKnowledgeEntry diff as a styled monospace block, prose lines intact", () => {
     // The KB update preview: the server appends a unified diff after a
     // `Changes:` marker (knowledge-base.md → "Update previews are diffs").

--- a/apps/app-web/src/components/chrome/chat-confirmation-card.tsx
+++ b/apps/app-web/src/components/chrome/chat-confirmation-card.tsx
@@ -19,9 +19,14 @@
 import { useState, type ReactNode } from "react";
 import { TriangleAlert } from "lucide-react";
 import type { PendingConfirmation } from "@use-brian/chat-ui";
+import { buildConfirmationPreview } from "@use-brian/shared";
 import { useT } from "@/lib/i18n/client";
 import { cn } from "@/lib/utils";
-import { ToolPreview } from "@/components/doc/panels/approval-tool-previews";
+import {
+  GenericToolPreview,
+  ToolInputToggle,
+  ToolPreview,
+} from "@/components/doc/panels/approval-tool-previews";
 import {
   extractAttachmentLines,
   extractEmailSender,
@@ -182,9 +187,14 @@ export function ChatConfirmationCard({
                 toolName={confirmation.toolName}
                 lines={confirmation.displayLines}
               />
-            ) : null}
+            ) : (
+              <GenericToolPreview
+                preview={buildConfirmationPreview(confirmation.input)}
+              />
+            )}
           </>
         )}
+        <ToolInputToggle args={confirmation.input} disabled={isInFlight} />
         {commenting ? (
           <div className="space-y-2 pt-1">
             <textarea

--- a/apps/app-web/src/components/doc/panels/approval-tool-previews.tsx
+++ b/apps/app-web/src/components/doc/panels/approval-tool-previews.tsx
@@ -5,17 +5,18 @@
  *
  * `ToolPreview` switches on the parsed preview data from
  * `lib/approval-previews.ts` (the recognition + parsing lives there so it
- * stays unit-testable). One card per preview kind; tools without a card
- * keep the generic raw-input view in `approvals-panel.tsx` — the caller
- * decides the fallback, this component only renders recognised previews.
+ * stays unit-testable). One card per preview kind; tools without a card use
+ * `GenericToolPreview`, while exact input remains behind `ToolInputToggle`.
  *
  * Spec: docs/architecture/features/workflow.md → Unified approvals.
  * [COMP:app-web/approvals]
  */
 
+import { useState } from "react";
 import { Ban, Check, Mail, Paperclip, RotateCcw, X } from "lucide-react";
 import remarkGfm from "remark-gfm";
 import { ChatMarkdown } from "@use-brian/chat-ui";
+import type { ConfirmationPreview } from "@use-brian/shared";
 import { cn } from "@/lib/utils";
 import { useT } from "@/lib/i18n/client";
 import { format } from "@/lib/i18n/format";
@@ -29,6 +30,59 @@ import {
 } from "@/lib/approval-previews";
 
 const EMAIL_BODY_REMARK_PLUGINS = [remarkGfm];
+
+export function GenericToolPreview({
+  preview,
+}: {
+  preview: ConfirmationPreview;
+}) {
+  if (preview.fields.length === 0) return null;
+  return (
+    <dl className="w-full max-w-2xl mt-1 rounded-md border border-border bg-background px-3 py-2 space-y-2">
+      {preview.fields.map((field, index) => (
+        <div
+          key={`${field.label}-${index}`}
+          className="grid grid-cols-[7rem_minmax(0,1fr)] gap-2"
+        >
+          <dt className="text-[11px] text-muted-foreground">{field.label}</dt>
+          <dd className="text-xs whitespace-pre-wrap break-words">
+            {field.value}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+/** Exact frozen arguments, disclosed for auditing but never used as display copy. */
+export function ToolInputToggle({
+  args,
+  disabled = false,
+}: {
+  args: Record<string, unknown>;
+  disabled?: boolean;
+}) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  if (Object.keys(args).length === 0) return null;
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        disabled={disabled}
+        className="text-xs text-primary hover:underline disabled:opacity-50"
+      >
+        {open ? t.approvalsPage.hideToolInput : t.approvalsPage.viewToolInput}
+      </button>
+      {open && (
+        <pre className="w-full text-[11px] font-mono bg-muted/50 border border-border rounded px-2 py-1.5 max-h-40 overflow-auto whitespace-pre-wrap break-all max-w-2xl">
+          {JSON.stringify(args, null, 2)}
+        </pre>
+      )}
+    </>
+  );
+}
 
 export function ToolPreview({
   preview,

--- a/apps/app-web/src/components/doc/panels/approvals-panel.tsx
+++ b/apps/app-web/src/components/doc/panels/approvals-panel.tsx
@@ -30,7 +30,8 @@
  * the JSON view (`lib/approval-previews.ts` parses, `ToolPreview` in
  * `approval-tool-previews.tsx` renders — first: `gmailSendMessage` as a
  * mail-client-style email card), with the raw input kept one toggle away
- * and the generic view as the fallback for everything else. Reviewed
+ * and a structured human-readable projection as the fallback for everything
+ * else. Reviewed
  * workflow IMAP replies add body-only immutable revision editing and are
  * excluded from batch resolution: every save replaces the pending row,
  * while Approve and send always executes the newest frozen row. Only
@@ -51,6 +52,10 @@
  */
 
 import { useEffect, useMemo, useState } from "react";
+import {
+  buildConfirmationPreview,
+  getToolDisplayName,
+} from "@use-brian/shared";
 import { useT } from "@/lib/i18n/client";
 import { format } from "@/lib/i18n/format";
 import Link from "next/link";
@@ -98,7 +103,11 @@ import {
   parseToolPreview,
   type ToolPreviewData,
 } from "@/lib/approval-previews";
-import { ToolPreview } from "./approval-tool-previews";
+import {
+  GenericToolPreview,
+  ToolInputToggle,
+  ToolPreview,
+} from "./approval-tool-previews";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import {
@@ -706,20 +715,25 @@ function ApprovalCard({
     row.kind === "staged_skill_creation"
       ? (row.arguments as { umbrella?: { name?: string } }).umbrella?.name
       : undefined;
+  const toolDisplayName = row.toolName
+    ? getToolDisplayName(row.toolName.split("__", 1)[0]!)
+    : "";
   const headline =
     row.kind === "email_sender"
       ? row.approvalPayload.senderName?.trim() ||
         row.approvalPayload.sender ||
         t.approvalsPage.kind.email_sender
       : row.kind === "staged_write"
-      ? row.toolName
+      ? toolDisplayName
       : row.kind === "staged_skill_creation"
         ? stagedCreationName || t.approvalsPage.kind[row.kind]
         : row.kind === "staged_skill_update"
           ? skillDetail?.targetSkill?.name || t.approvalsPage.kind[row.kind]
           : row.kind === "workflow_refinement"
             ? skillDetail?.targetWorkflow?.name || t.approvalsPage.kind[row.kind]
-            : row.approvalPayload.description?.trim() || row.toolName;
+            : row.kind === "workflow_step" || row.kind === "tool_invocation"
+              ? toolDisplayName
+              : row.approvalPayload.description?.trim() || row.toolName;
 
   // A staged update can only be applied while its target skill exists —
   // block approve (reject stays available) when the snapshot says it's gone
@@ -745,7 +759,7 @@ function ApprovalCard({
   const resolvedAttachStepId = attachStepId ?? attachTo?.stepId ?? null;
 
   // Tool-specific rich preview (an email as an email), for the kinds whose
-  // `arguments` are a frozen tool input. Null → the generic raw-input view.
+  // `arguments` are a frozen tool input. Null → the generic readable projection.
   // When a preview renders, the payload displayLines are suppressed — they
   // narrate the same call the preview already shows.
   const toolPreview: ToolPreviewData | null =
@@ -876,8 +890,8 @@ function ApprovalCard({
               ))}
             {row.kind === "staged_write" && (
               <>
-                {toolPreview ? (
-                  <div className="flex flex-col items-start gap-1">
+                <div className="flex flex-col items-start gap-1">
+                  {toolPreview ? (
                     <ToolPreview
                       preview={toolPreview}
                       attachmentLines={extractAttachmentLines(
@@ -887,13 +901,13 @@ function ApprovalCard({
                         row.approvalPayload.displayLines,
                       )}
                     />
-                    <RawInputToggle args={row.arguments} />
-                  </div>
-                ) : (
-                  <pre className="mt-1.5 text-[11px] font-mono bg-muted/50 border border-border rounded px-2 py-1.5 max-h-40 overflow-auto whitespace-pre-wrap break-all max-w-2xl">
-                    {JSON.stringify(row.arguments, null, 2)}
-                  </pre>
-                )}
+                  ) : row.approvalPayload.displayLines?.length ? null : (
+                    <GenericToolPreview
+                      preview={buildConfirmationPreview(row.arguments)}
+                    />
+                  )}
+                  <ToolInputToggle args={row.arguments} />
+                </div>
                 <div className="text-xs text-muted-foreground mt-1.5">
                   {format(t.approvalsPage.stagedWrite.provenance, {
                     surface: stagedSurface ?? "",
@@ -1217,11 +1231,10 @@ function ToolCallBody({
   preview: ToolPreviewData | null;
 }) {
   const hasInput = Object.keys(row.arguments ?? {}).length > 0;
-  const described = Boolean(row.approvalPayload.description?.trim());
-  if (!(described && row.toolName) && !hasInput) return null;
+  if (!row.toolName && !hasInput) return null;
   return (
     <div className="flex flex-col items-start gap-1 mt-0.5">
-      {described && row.toolName && (
+      {row.toolName && (
         <div className="text-[11px] font-mono text-muted-foreground/80">
           {row.toolName}
         </div>
@@ -1237,32 +1250,11 @@ function ToolCallBody({
           )}
         />
       )}
-      {hasInput && <RawInputToggle args={row.arguments} />}
-    </div>
-  );
-}
-
-/** "View tool input" toggle over the frozen arguments JSON — the ground
- *  truth under every preview, and the whole view when no preview exists. */
-function RawInputToggle({ args }: { args: Record<string, unknown> }) {
-  const t = useT();
-  const [open, setOpen] = useState(false);
-  if (Object.keys(args ?? {}).length === 0) return null;
-  return (
-    <>
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="text-xs text-primary hover:underline"
-      >
-        {open ? t.approvalsPage.hideToolInput : t.approvalsPage.viewToolInput}
-      </button>
-      {open && (
-        <pre className="w-full text-[11px] font-mono bg-muted/50 border border-border rounded px-2 py-1.5 max-h-40 overflow-auto whitespace-pre-wrap break-all max-w-2xl">
-          {JSON.stringify(args, null, 2)}
-        </pre>
+      {!preview && !row.approvalPayload.displayLines?.length && (
+        <GenericToolPreview preview={buildConfirmationPreview(row.arguments)} />
       )}
-    </>
+      {hasInput && <ToolInputToggle args={row.arguments} />}
+    </div>
   );
 }
 

--- a/apps/app-web/src/lib/approval-previews.ts
+++ b/apps/app-web/src/lib/approval-previews.ts
@@ -3,14 +3,14 @@
  *
  * The approvals queue renders a rich, tool-specific preview for actions it
  * recognises (an outgoing email as an email, not a JSON blob) and falls
- * back to the generic raw-input view for everything else. This module owns
- * the recognition + argument parsing so it stays unit-testable; the render
- * layer lives in
- * `components/doc/panels/approval-tool-previews.tsx`.
+ * back to the shared generic human-readable projection for everything else,
+ * with exact input retained behind a technical-details toggle. This module
+ * owns the recognition + argument parsing so it stays unit-testable; the
+ * render layer lives in `components/doc/panels/approval-tool-previews.tsx`.
  *
  * Adding a preview for another tool: add its name → kind to
  * `TOOL_PREVIEW_KINDS`, a parse function returning `null` on any
- * unexpected shape (null = degrade to the generic view, never throw), a
+ * unexpected shape (null = degrade to the generic projection, never throw), a
  * branch in `parseToolPreview`, and a card in the render layer.
  *
  * Spec: docs/architecture/features/workflow.md → Unified approvals.
@@ -113,7 +113,7 @@ export type ToolPreviewData =
  * Recognise + parse an approval row's tool call into preview data.
  * Returns `null` when the tool has no specific preview OR its arguments
  * don't match the expected shape — the caller falls back to the generic
- * raw-input view in both cases.
+ * human-readable projection in both cases.
  */
 export function parseToolPreview(
   toolName: string | null | undefined,

--- a/packages/core/src/tasks/__tests__/tools.test.ts
+++ b/packages/core/src/tasks/__tests__/tools.test.ts
@@ -934,6 +934,51 @@ describe('[COMP:tasks/tools-bulk] bulkUpdateTasks / archiveTasks', () => {
     ).toBe(true)
   })
 
+  it('previews explicit task ids as titles and readable changes', async () => {
+    const store = makeFakeStore()
+    const { saveTask, bulkUpdateTasks } = createTaskTools(store)
+    await saveTask.execute({ title: 'Prepare release notes' }, ctx)
+    await saveTask.execute({ title: 'Review launch checklist' }, ctx)
+    const ids = store.rows.map((row) => row.id)
+
+    const lines = await bulkUpdateTasks.describeConfirmation!(
+      { filter: { ids }, set: { status: 'in_review' } },
+      ctx,
+    )
+
+    expect(lines).toEqual([
+      'Update 2 task(s):',
+      '• Prepare release notes (Todo)',
+      '• Review launch checklist (Todo)',
+      'Changes:',
+      '• Status: In review',
+    ])
+    expect(lines?.join('\n')).not.toContain(ids[0])
+    expect(lines?.join('\n')).not.toContain(ids[1])
+  })
+
+  it('previews archive targets and says when a filter currently matches nothing', async () => {
+    const store = makeFakeStore()
+    const { saveTask, archiveTasks } = createTaskTools(store)
+    await saveTask.execute({ title: 'Completed migration', status: 'done' }, ctx)
+
+    expect(
+      await archiveTasks.describeConfirmation!({ filter: { status: 'done' } }, ctx),
+    ).toEqual([
+      'Archive 1 task(s):',
+      '• Completed migration (Done)',
+      'Changes:',
+      '• Status: Archived',
+    ])
+    expect(
+      await archiveTasks.describeConfirmation!({ filter: { status: 'blocked' } }, ctx),
+    ).toEqual([
+      'No tasks currently match this filter.',
+      'Changes:',
+      '• Status: Archived',
+    ])
+  })
+
   it('errors without a workspace', async () => {
     const { archiveTasks } = createTaskTools(makeFakeStore())
     const result = await archiveTasks.execute({ filter: { status: 'todo' } }, ctxNoWorkspace)

--- a/packages/core/src/tasks/tools.ts
+++ b/packages/core/src/tasks/tools.ts
@@ -797,6 +797,24 @@ export function createTaskTools(
 
   type BulkFilter = z.infer<typeof bulkFilterSchema>
 
+  const bulkSetSchema = z
+    .object({
+      status: statusEnum.optional(),
+      assignee_id: idShape.nullable().optional().describe('workspace_members id; null unassigns.'),
+      due: isoDateOrDateTime.nullable().optional().describe('null clears the due date.'),
+      priority: z
+        .enum(['low', 'medium', 'high', 'urgent'])
+        .nullable()
+        .optional()
+        .describe('Merged into `attributes.priority`; null clears it.'),
+    })
+    .refine((set) => Object.values(set).some((value) => value !== undefined), {
+      message: 'Pass at least one field to set.',
+    })
+
+  const bulkUpdateSchema = z.object({ filter: bulkFilterSchema, set: bulkSetSchema })
+  const archiveTasksSchema = z.object({ filter: bulkFilterSchema })
+
   /** Resolve a bulk filter to its matching live rows (capped). */
   async function resolveBulkRows(
     context: Parameters<Tool['execute']>[1],
@@ -834,6 +852,42 @@ export function createTaskTools(
       rows = rows.filter((r) => wanted.has(r.id))
     }
     return rows
+  }
+
+  function readableTaskStatus(status: TaskRecordStatus): string {
+    const text = status.replace(/_/g, ' ')
+    return text.charAt(0).toUpperCase() + text.slice(1)
+  }
+
+  function bulkTargetLines(verb: string, rows: TaskListRow[]): string[] {
+    if (rows.length === 0) return ['No tasks currently match this filter.']
+    const shown = rows.slice(0, 20)
+    const lines = [
+      `${verb} ${rows.length} task(s):`,
+      ...shown.map((row) => `• ${row.title} (${readableTaskStatus(row.status)})`),
+    ]
+    if (rows.length > shown.length) lines.push(`• ${rows.length - shown.length} more task(s)`)
+    return lines
+  }
+
+  function bulkChangeLines(set: z.infer<typeof bulkSetSchema>): string[] {
+    const lines = ['Changes:']
+    if (set.status !== undefined) lines.push(`• Status: ${readableTaskStatus(set.status)}`)
+    if (set.assignee_id !== undefined) {
+      lines.push(
+        set.assignee_id === null
+          ? '• Assignee: Unassigned'
+          : `• Assignee: workspace member ${set.assignee_id.slice(0, 8)}`,
+      )
+    }
+    if (set.due !== undefined) lines.push(`• Due: ${set.due === null ? 'Clear due date' : set.due}`)
+    if (set.priority !== undefined) {
+      const priority = set.priority === null
+        ? 'Clear priority'
+        : set.priority.charAt(0).toUpperCase() + set.priority.slice(1)
+      lines.push(`• Priority: ${priority}`)
+    }
+    return lines
   }
 
   /** Loop the per-row supersession update over resolved rows. */
@@ -880,23 +934,17 @@ export function createTaskTools(
     description:
       'Update MANY tasks in one confirmed call: everything matching `filter` gets `set` applied (status / assignee / due / priority). The backlog-cleanup verb — e.g. filter `{status: "todo", unassigned: true, updated_before: <30 days ago>}` with set `{status: "archived"}` clears the stale unassigned backlog. ' +
       `Caps at ${BULK_CAP} tasks per call; requires at least one filter field (an empty filter is rejected). For archiving, \`archiveTasks\` is the shorthand. Every update supersedes its row (new task ids).`,
-    inputSchema: z.object({
-      filter: bulkFilterSchema,
-      set: z
-        .object({
-          status: statusEnum.optional(),
-          assignee_id: idShape.nullable().optional().describe('workspace_members id; null unassigns.'),
-          due: isoDateOrDateTime.nullable().optional().describe('null clears the due date.'),
-          priority: z
-            .enum(['low', 'medium', 'high', 'urgent'])
-            .nullable()
-            .optional()
-            .describe('Merged into `attributes.priority`; null clears it.'),
-        })
-        .refine((s) => Object.values(s).some((v) => v !== undefined), {
-          message: 'Pass at least one field to set.',
-        }),
-    }),
+    inputSchema: bulkUpdateSchema,
+    async describeConfirmation(input, context) {
+      if (!context.workspaceId) return null
+      const parsed = bulkUpdateSchema.safeParse(input)
+      if (!parsed.success) return null
+      const rows = await resolveBulkRows(context, parsed.data.filter)
+      return [
+        ...bulkTargetLines('Update', rows),
+        ...bulkChangeLines(parsed.data.set),
+      ]
+    },
     async execute(input, context) {
       const gate = workspaceGate(context.workspaceId)
       if (gate) return gate
@@ -929,7 +977,18 @@ export function createTaskTools(
     description:
       'Archive MANY tasks in one confirmed call — the soft-delete sweep (`status: "archived"`; archived tasks leave every default list but stay recoverable). Shorthand for `bulkUpdateTasks` with `set: {status: "archived"}`. ' +
       `Same filter shape and ${BULK_CAP}-task cap; requires at least one filter field.`,
-    inputSchema: z.object({ filter: bulkFilterSchema }),
+    inputSchema: archiveTasksSchema,
+    async describeConfirmation(input, context) {
+      if (!context.workspaceId) return null
+      const parsed = archiveTasksSchema.safeParse(input)
+      if (!parsed.success) return null
+      const rows = await resolveBulkRows(context, parsed.data.filter)
+      return [
+        ...bulkTargetLines('Archive', rows),
+        'Changes:',
+        '• Status: Archived',
+      ]
+    },
     async execute(input, context) {
       const gate = workspaceGate(context.workspaceId)
       if (gate) return gate

--- a/packages/shared/src/__tests__/tool-display-names.test.ts
+++ b/packages/shared/src/__tests__/tool-display-names.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { humanizeToolName, describeToolInput } from '../tool-display-names.js'
+import {
+  buildConfirmationPreview,
+  describeToolInput,
+  formatConfirmationInput,
+  humanizeToolName,
+} from '../tool-display-names.js'
 
 describe('[COMP:shared/tool-display-names] channel tool-status labels', () => {
   describe('describeToolInput names WHICH page for browser tools', () => {
@@ -46,5 +51,39 @@ describe('[COMP:shared/tool-display-names] channel tool-status labels', () => {
 
   it('labels the server-scoped Slack history reader plainly', () => {
     expect(humanizeToolName('readCurrentSlackThread')).toBe('Reading the Slack thread')
+  })
+
+  describe('approval projections', () => {
+    it('projects frozen arguments into labeled fields without mutating them', () => {
+      const input = {
+        taskId: 'internal-1',
+        title: 'Prepare launch',
+        notifyCustomer: false,
+        window: { startAt: '09:00', timezone: 'Asia/Hong_Kong' },
+        recipients: ['ops@example.com', 'owner@example.com'],
+      }
+      const snapshot = structuredClone(input)
+
+      expect(buildConfirmationPreview(input)).toEqual({
+        fields: [
+          { label: 'Title', value: 'Prepare launch' },
+          { label: 'Notify Customer', value: 'No' },
+          { label: 'Window', value: 'Start At: 09:00\nTimezone: Asia/Hong_Kong' },
+          { label: 'Recipients', value: 'ops@example.com, owner@example.com' },
+        ],
+      })
+      expect(input).toEqual(snapshot)
+    })
+
+    it('renders nested channel lines as readable text instead of JSON', () => {
+      const lines = formatConfirmationInput({
+        lineItems: [{ name: 'Widget', quantity: 2 }],
+      })
+
+      expect(lines).toEqual([
+        '• Line Items:\n  1.\n    Name: Widget\n    Quantity: 2',
+      ])
+      expect(lines[0]).not.toContain('{')
+    })
   })
 })

--- a/packages/shared/src/tool-display-names.ts
+++ b/packages/shared/src/tool-display-names.ts
@@ -410,6 +410,88 @@ const FIELD_LABELS: Record<string, string> = {
   parent: 'Parent',
 }
 
+export type ConfirmationPreviewField = {
+  label: string
+  value: string
+}
+
+/** Human-readable projection of one frozen tool input. Never parsed back. */
+export type ConfirmationPreview = {
+  fields: ConfirmationPreviewField[]
+}
+
+function confirmationFieldLabel(key: string): string {
+  return FIELD_LABELS[key]
+    ?? key
+      .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+      .replace(/[_-]+/g, ' ')
+      .replace(/^./, (c) => c.toUpperCase())
+}
+
+function indent(text: string): string {
+  return text.split('\n').map((line) => `  ${line}`).join('\n')
+}
+
+function confirmationValue(value: unknown, depth = 0): string {
+  if (typeof value === 'string') return value
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No'
+  if (typeof value === 'number' || typeof value === 'bigint') return String(value)
+  if (value === null) return 'None'
+  if (Array.isArray(value)) {
+    if (value.length === 0) return 'None'
+    if (value.every((item) => typeof item === 'string')) return value.join(', ')
+    return value
+      .map((item, index) => {
+        const rendered = confirmationValue(item, depth + 1)
+        return rendered.includes('\n')
+          ? `${index + 1}.\n${indent(rendered)}`
+          : `${index + 1}. ${rendered}`
+      })
+      .join('\n')
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, child]) => child !== undefined)
+    if (entries.length === 0) return 'None'
+    if (depth >= 4) return 'See technical details'
+    return entries
+      .map(([key, child]) => {
+        const rendered = confirmationValue(child, depth + 1)
+        return rendered.includes('\n')
+          ? `${confirmationFieldLabel(key)}:\n${indent(rendered)}`
+          : `${confirmationFieldLabel(key)}: ${rendered}`
+      })
+      .join('\n')
+  }
+  return String(value)
+}
+
+/**
+ * Derive a readable, structured view from exact tool arguments. This is a
+ * one-way presentation projection; callers must retain and execute `input`.
+ */
+export function buildConfirmationPreview(
+  input: Record<string, unknown>,
+): ConfirmationPreview {
+  const entries = Object.entries(input)
+    .filter(([key, value]) => value !== undefined && !HIDDEN_FIELDS.has(key))
+  const priority = ['currentTitle', 'title', 'name', 'summary', 'description', 'status', 'notes']
+  entries.sort((a, b) => {
+    const ai = priority.indexOf(a[0])
+    const bi = priority.indexOf(b[0])
+    if (ai !== -1 && bi !== -1) return ai - bi
+    if (ai !== -1) return -1
+    if (bi !== -1) return 1
+    return 0
+  })
+  return {
+    fields: entries.map(([key, value]) => ({
+      label: confirmationFieldLabel(key),
+      value: confirmationValue(value),
+    })),
+  }
+}
+
 /**
  * Sort and format tool input entries for a confirmation prompt.
  *
@@ -427,28 +509,8 @@ export function formatConfirmationInput(
   input: Record<string, unknown>,
   bullet = '• ',
 ): string[] {
-  const entries = Object.entries(input)
-    .filter(([k, v]) => v !== undefined && v !== null && !HIDDEN_FIELDS.has(k))
-  // Sort: human-readable fields first, then everything else in original order
-  const priority = ['currentTitle', 'title', 'name', 'summary', 'description', 'status', 'notes']
-  entries.sort((a, b) => {
-    const ai = priority.indexOf(a[0])
-    const bi = priority.indexOf(b[0])
-    if (ai !== -1 && bi !== -1) return ai - bi
-    if (ai !== -1) return -1
-    if (bi !== -1) return 1
-    return 0
-  })
-  return entries.map(([k, v]) => {
-    const label = FIELD_LABELS[k] ?? k.replace(/([a-z])([A-Z])/g, '$1 $2').replace(/^./, (c) => c.toUpperCase())
-    // Address lists (to/cc/bcc) and other string arrays read as a comma list,
-    // not a raw JSON blob.
-    const rendered =
-      Array.isArray(v) && v.every((x) => typeof x === 'string')
-        ? (v as string[]).join(', ')
-        : typeof v === 'object'
-          ? JSON.stringify(v)
-          : v
-    return `${bullet}${label}: ${rendered}`
+  return buildConfirmationPreview(input).fields.map(({ label, value }) => {
+    const rendered = value.includes('\n') ? `\n${indent(value)}` : ` ${value}`
+    return `${bullet}${label}:${rendered}`
   })
 }


### PR DESCRIPTION
## Summary
- derive structured, human-readable previews from frozen tool arguments
- render generic fields by default and keep exact JSON behind a technical-details toggle
- require domain-owned `describeConfirmation` hooks for opaque references rather than guessing UUID meaning
- resolve bulk task filters to task titles, current statuses, and intended changes before asking
- preserve specialized email and Shopify previews and approval binding

## Companion PRs
- Platform spec and gitlink: use-brian/brian-platform#363
- Brian KB mirror: use-brian/brian-kb#77

## Validation
- shared package tests and typecheck
- app-web typecheck and chat confirmation card tests
- core task tool tests (68 passing) and core typecheck
- core smoke