### PR TITLE
feat(search): add Baidu and confirm context-changing page moves

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,6 +109,7 @@ TAVILY_API_KEY=          # Tavily search (AI-optimized results)
 BRAVE_SEARCH_API_KEY=    # Brave Search API
 SERPER_API_KEY=          # Serper (Google Search results)
 SERPAPI_API_KEY=         # SerpAPI (Google Search results; separate from Serper)
+BAIDU_SEARCH_API_KEY=    # Baidu Qianfan Search (Chinese-language and mainland-China results)
 JINA_API_KEY=            # Jina Reader for cleaner page fetches (works without a key at lower rate limits)
 
 # ── Google Maps location intelligence (optional) ────────────────────────────

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ each is a service you choose to talk to, so nothing turns on by itself.
 
 | Capability | Key(s) to set | What you get |
 |---|---|---|
-| Web search | `BRAVE_SEARCH_API_KEY`, `SERPER_API_KEY`, `SERPAPI_API_KEY`, or `TAVILY_API_KEY` | Upgrade the search tool past the free DuckDuckGo fallback |
+| Web search | `BRAVE_SEARCH_API_KEY`, `SERPER_API_KEY`, `SERPAPI_API_KEY`, `TAVILY_API_KEY`, or `BAIDU_SEARCH_API_KEY` | Upgrade the search tool past the free DuckDuckGo fallback; Baidu adds Chinese-language and mainland-China coverage |
 | Page fetches | `JINA_API_KEY` | Cleaner page reads via Jina Reader (works keyless at lower limits) |
 | Read X / Twitter | `TWITTER_BEARER_TOKEN` | Read x.com permalinks through the official X API v2 |
 | X search | `XAI_API_KEY` | Fall back to xAI Grok and enable the `xSearch` tool |

--- a/apps/app-web/src/components/doc/doc-sidebar-data.tsx
+++ b/apps/app-web/src/components/doc/doc-sidebar-data.tsx
@@ -774,6 +774,9 @@ export function DocSidebarDataProvider({
           ...(move.teamspaceId !== undefined
             ? { teamspaceId: move.teamspaceId }
             : {}),
+          ...(move.contextMoveConfirmed !== undefined
+            ? { contextMoveConfirmed: move.contextMoveConfirmed }
+            : {}),
         });
         patchActiveView(move.viewId, () => updated);
         reloadSidebar();

--- a/apps/app-web/src/components/doc/doc-sidebar.tsx
+++ b/apps/app-web/src/components/doc/doc-sidebar.tsx
@@ -91,7 +91,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { useT } from "@/lib/i18n/client";
+import { format, useT } from "@/lib/i18n/client";
 import { useIsOffline } from "@/lib/offline/use-offline-sync";
 import { useTheme, THEME_PRESETS, currentPresetId } from "@/lib/theme";
 import { useCustomThemes } from "@/lib/custom-themes";
@@ -112,8 +112,10 @@ import { PageIcon } from "./page-icon";
 import type { Teamspace } from "@/lib/api/teamspaces";
 import {
   buildTree,
+  dispatchReparentWithContextConfirmation,
   groupRowsByTeamspace,
   savedAncestorIds,
+  type ContextAwareReparentMove,
   type TreeNode,
 } from "@/lib/sidebar-tree";
 import { parseSectionDropId, sectionDropId } from "@/lib/sidebar-sections";
@@ -142,19 +144,7 @@ import { LiveActiveBadge } from "@/components/live/live-active-badge";
 import { useLiveRoster } from "@/components/live/use-live-roster";
 import { summarizeRosterItems } from "@/lib/live-roster";
 
-export type SidebarMove = {
-  viewId: string;
-  nestParentId: string | null;
-  /** Target sibling index among the new parent's children. */
-  position: number;
-  /**
-   * Target teamspace for a ROOT drop (`nestParentId: null`): a teamspace id
-   * files the page into that section, `null` files it Private, omitted keeps
-   * the current teamspace. Ignored when `nestParentId` is a page — the child
-   * adopts the parent's teamspace server-side.
-   */
-  teamspaceId?: string | null;
-};
+export type SidebarMove = ContextAwareReparentMove;
 
 /** Section-collapse localStorage key (per workspace) — the section analog of
  *  `collapseKey` below. Values: section key → collapsed (default expanded). */
@@ -486,7 +476,25 @@ export function DocSidebar(props: Props) {
     setDraggingId(String(event.active.id));
   }
 
-  function handleDragEnd(event: DragEndEvent) {
+  async function confirmAndMove(move: SidebarMove) {
+    const moved = allRows.find((row) => row.id === move.viewId);
+    await dispatchReparentWithContextConfirmation(
+      allRows,
+      move,
+      () =>
+        confirmDialog({
+          title: t.moveContextConfirmTitle,
+          description: format(t.moveContextConfirm, {
+            name: moved?.name?.trim() || t.breadcrumbUntitled,
+          }),
+          confirmLabel: t.moveContextConfirmAction,
+          cancelLabel: t.cancel,
+        }),
+      props.onMove,
+    );
+  }
+
+  async function handleDragEnd(event: DragEndEvent) {
     setDraggingId(null);
     const { active, over } = event;
     if (!over) return;
@@ -501,7 +509,7 @@ export function DocSidebar(props: Props) {
           r.nestParentId === null &&
           (r.teamspaceId ?? null) === section.teamspaceId,
       );
-      props.onMove({
+      await confirmAndMove({
         viewId: draggedId,
         nestParentId: null,
         position: sectionRoots.length,
@@ -518,7 +526,7 @@ export function DocSidebar(props: Props) {
       // Reparent under the target; append to the end of its children. The
       // child adopts the target's teamspace server-side — no teamspaceId here.
       const siblings = allRows.filter((r) => r.nestParentId === target.nodeId);
-      props.onMove({
+      await confirmAndMove({
         viewId: draggedId,
         nestParentId: target.nodeId,
         position: siblings.length,
@@ -545,7 +553,7 @@ export function DocSidebar(props: Props) {
     const targetIdx = siblings.findIndex((r) => r.id === target.nodeId);
     // Insert after the target. The server re-packs positions, so a
     // 1-based "after" index is a safe target.
-    props.onMove({
+    await confirmAndMove({
       viewId: draggedId,
       nestParentId: parentId,
       position: targetIdx + 1,

--- a/apps/app-web/src/lib/__tests__/sidebar-tree.test.ts
+++ b/apps/app-web/src/lib/__tests__/sidebar-tree.test.ts
@@ -11,11 +11,13 @@
  * src/lib/sidebar-tree.ts header.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildBreadcrumb,
   buildTree,
+  dispatchReparentWithContextConfirmation,
   groupRowsByTeamspace,
+  reparentChangesContext,
   savedAncestorIds,
   type TreeNode,
 } from "../sidebar-tree";
@@ -31,6 +33,7 @@ function row(
     updatedAt?: string;
     state?: "draft" | "saved";
     teamspaceId?: string | null;
+    projectId?: string | null;
   } = {},
 ): ViewListRow {
   return {
@@ -47,9 +50,133 @@ function row(
     position: opts.position ?? 0,
     icon: null,
     teamspaceId: opts.teamspaceId ?? null,
-    projectId: null,
+    projectId: opts.projectId ?? null,
   };
 }
+
+describe("[COMP:app-web/sidebar-tree] reparent context preflight", () => {
+  const rows = [
+    row("moving", { teamspaceId: "general" }),
+    row("same-context-parent", { teamspaceId: "general" }),
+    row("other-teamspace-parent", { teamspaceId: "mali" }),
+    row("other-project-parent", {
+      teamspaceId: "general",
+      projectId: "project-2",
+    }),
+  ];
+
+  it("does not confirm a same-context page reparent", () => {
+    expect(
+      reparentChangesContext(rows, {
+        viewId: "moving",
+        nestParentId: "same-context-parent",
+      }),
+    ).toBe(false);
+  });
+
+  it("confirms a root drop into another Teamspace or Private", () => {
+    expect(
+      reparentChangesContext(rows, {
+        viewId: "moving",
+        nestParentId: null,
+        teamspaceId: "mali",
+      }),
+    ).toBe(true);
+    expect(
+      reparentChangesContext(rows, {
+        viewId: "moving",
+        nestParentId: null,
+        teamspaceId: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("confirms nesting under a different Teamspace or Project", () => {
+    expect(
+      reparentChangesContext(rows, {
+        viewId: "moving",
+        nestParentId: "other-teamspace-parent",
+      }),
+    ).toBe(true);
+    expect(
+      reparentChangesContext(rows, {
+        viewId: "moving",
+        nestParentId: "other-project-parent",
+      }),
+    ).toBe(true);
+  });
+
+  it("leaves stale or context-preserving root moves to the server", () => {
+    expect(
+      reparentChangesContext(rows, {
+        viewId: "missing",
+        nestParentId: null,
+        teamspaceId: "mali",
+      }),
+    ).toBe(false);
+    expect(
+      reparentChangesContext(rows, {
+        viewId: "moving",
+        nestParentId: "missing-parent",
+      }),
+    ).toBe(false);
+    expect(
+      reparentChangesContext(rows, {
+        viewId: "moving",
+        nestParentId: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("dispatches nothing when a context-changing move is cancelled", async () => {
+    const confirm = vi.fn().mockResolvedValue(false);
+    const onMove = vi.fn();
+    const move = {
+      viewId: "moving",
+      nestParentId: null,
+      position: 0,
+      teamspaceId: "mali",
+    };
+
+    await dispatchReparentWithContextConfirmation(rows, move, confirm, onMove);
+
+    expect(confirm).toHaveBeenCalledOnce();
+    expect(onMove).not.toHaveBeenCalled();
+  });
+
+  it("dispatches an accepted context-changing move with the server flag", async () => {
+    const confirm = vi.fn().mockResolvedValue(true);
+    const onMove = vi.fn();
+    const move = {
+      viewId: "moving",
+      nestParentId: "other-teamspace-parent",
+      position: 0,
+    };
+
+    await dispatchReparentWithContextConfirmation(rows, move, confirm, onMove);
+
+    expect(confirm).toHaveBeenCalledOnce();
+    expect(onMove).toHaveBeenCalledWith({
+      ...move,
+      contextMoveConfirmed: true,
+    });
+  });
+
+  it("dispatches a same-context move without opening the dialog", async () => {
+    const confirm = vi.fn().mockResolvedValue(true);
+    const onMove = vi.fn();
+    const move = {
+      viewId: "moving",
+      nestParentId: "same-context-parent",
+      position: 0,
+    };
+
+    await dispatchReparentWithContextConfirmation(rows, move, confirm, onMove);
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(onMove).toHaveBeenCalledWith(move);
+  });
+});
 
 /** Flatten a tree to `id` strings in DFS pre-order — easy to assert on. */
 function flatten(nodes: TreeNode[]): string[] {

--- a/apps/app-web/src/lib/api/__tests__/views-conversion.test.ts
+++ b/apps/app-web/src/lib/api/__tests__/views-conversion.test.ts
@@ -1,10 +1,21 @@
 /**
- * [COMP:app-web/views-sdk] Format-conversion SDK helpers (the pure parts).
- * Spec: docs/architecture/features/doc-conversion.md.
+ * [COMP:app-web/views-sdk] View SDK request and conversion contracts.
+ * Specs: docs/architecture/features/doc-conversion.md and
+ * docs/architecture/features/teamspaces.md.
  */
 
-import { describe, it, expect } from "vitest";
-import { exportUrl, exportFilename } from "../views";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth-fetch", () => ({ authFetch: vi.fn() }));
+
+import { authFetch } from "@/lib/auth-fetch";
+import { exportUrl, exportFilename, reparentView } from "../views";
+
+const mockAuthFetch = vi.mocked(authFetch);
+
+beforeEach(() => {
+  mockAuthFetch.mockReset();
+});
 
 describe("[COMP:app-web/views-sdk] export SDK helpers", () => {
   it("builds the export endpoint URL with the format query", () => {
@@ -34,5 +45,36 @@ describe("[COMP:app-web/views-sdk] export SDK helpers", () => {
   it("caps an absurdly long title", () => {
     const name = exportFilename("x".repeat(500), "md");
     expect(name.length).toBeLessThanOrEqual(103); // 100 + ".md"
+  });
+});
+
+describe("[COMP:app-web/views-sdk] reparent request", () => {
+  it("sends the explicit confirmation accepted by a context-changing drag", async () => {
+    mockAuthFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: "page-1" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await reparentView("page-1", {
+      nestParentId: null,
+      position: 0,
+      teamspaceId: "teamspace-2",
+      contextMoveConfirmed: true,
+    });
+
+    expect(mockAuthFetch).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/views\/page-1\/reparent$/),
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({
+          nestParentId: null,
+          position: 0,
+          teamspaceId: "teamspace-2",
+          contextMoveConfirmed: true,
+        }),
+      }),
+    );
   });
 });

--- a/apps/app-web/src/lib/api/views.ts
+++ b/apps/app-web/src/lib/api/views.ts
@@ -1335,8 +1335,9 @@ export async function commitPageCreatedEvent(
  * server-side regardless.
  *
  * Maps to `PATCH /api/views/:id/reparent` with body
- * `{ nestParentId, position, teamspaceId? }` → returns the updated
- * `ViewMetadata`.
+ * `{ nestParentId, position, teamspaceId?, contextMoveConfirmed? }` → returns
+ * the updated `ViewMetadata`. A context-changing move sends the confirmation
+ * flag only after the user accepts the sidebar's preflight dialog.
  */
 export async function reparentView(
   viewId: string,
@@ -1344,6 +1345,7 @@ export async function reparentView(
     nestParentId: string | null;
     position: number;
     teamspaceId?: string | null;
+    contextMoveConfirmed?: boolean;
   },
 ): Promise<ViewMetadata> {
   const res = await authFetch(`${API_URL}/api/views/${viewId}/reparent`, {

--- a/apps/app-web/src/lib/i18n/dictionaries/en.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/en.ts
@@ -1298,6 +1298,10 @@ export const en = {
     createDraftFailed: "Could not create draft: {message}",
     saveFailed: "Could not save: {message}",
     unsaveFailed: "Could not move to drafts: {message}",
+    moveContextConfirmTitle: "Move page to a different context?",
+    moveContextConfirm:
+      '"{name}" and every page inside it will inherit the destination Teamspace and Project. This can change who can access them.',
+    moveContextConfirmAction: "Move page",
     patchPageFailed: "Could not save change: {message}",
     undoFailed: "Could not undo: {message}",
     undoUnavailable: "Nothing to undo",

--- a/apps/app-web/src/lib/i18n/dictionaries/ja.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/ja.ts
@@ -1171,6 +1171,10 @@ export const ja: Dictionary = {
     createDraftFailed: "下書きの作成に失敗しました: {message}",
     saveFailed: "保存できませんでした: {message}",
     unsaveFailed: "下書きへの移動に失敗しました: {message}",
+    moveContextConfirmTitle: "ページを別のコンテキストへ移動しますか？",
+    moveContextConfirm:
+      "「{name}」とその配下のすべてのページは、移動先のチームスペースとプロジェクトを継承します。アクセスできるユーザーが変わる可能性があります。",
+    moveContextConfirmAction: "ページを移動",
     patchPageFailed: "変更を保存できませんでした: {message}",
     undoFailed: "取り消せませんでした: {message}",
     undoUnavailable: "取り消す操作がありません",

--- a/apps/app-web/src/lib/i18n/dictionaries/zh-cn.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh-cn.ts
@@ -1141,6 +1141,10 @@ export const zhCN: Dictionary = {
     createDraftFailed: "无法创建草稿：{message}",
     saveFailed: "无法保存：{message}",
     unsaveFailed: "无法移至草稿：{message}",
+    moveContextConfirmTitle: "要将页面移至其他内容范围吗？",
+    moveContextConfirm:
+      "“{name}”及其所有子页面将继承目的地的团队空间与项目。可访问这些页面的用户可能会改变。",
+    moveContextConfirmAction: "移动页面",
     patchPageFailed: "无法保存变更：{message}",
     undoFailed: "无法恢复：{message}",
     undoUnavailable: "没有可恢复的操作",

--- a/apps/app-web/src/lib/i18n/dictionaries/zh.ts
+++ b/apps/app-web/src/lib/i18n/dictionaries/zh.ts
@@ -1158,6 +1158,10 @@ export const zh: Dictionary = {
     createDraftFailed: "無法建立草稿：{message}",
     saveFailed: "無法儲存：{message}",
     unsaveFailed: "無法移至草稿：{message}",
+    moveContextConfirmTitle: "要將頁面移至其他內容範圍嗎？",
+    moveContextConfirm:
+      "「{name}」及其所有子頁面將繼承目的地的團隊空間與專案。可存取這些頁面的使用者可能會改變。",
+    moveContextConfirmAction: "移動頁面",
     patchPageFailed: "無法儲存變更：{message}",
     undoFailed: "無法復原：{message}",
     undoUnavailable: "沒有可復原的操作",

--- a/apps/app-web/src/lib/sidebar-tree.ts
+++ b/apps/app-web/src/lib/sidebar-tree.ts
@@ -52,6 +52,81 @@ export type Crumb = {
   nameOrigin: NameOrigin;
 };
 
+export type ContextAwareReparentMove = {
+  viewId: string;
+  nestParentId: string | null;
+  /** Target sibling index among the new parent's children. */
+  position: number;
+  /**
+   * Target teamspace for a root drop: an id files the page into that
+   * Teamspace, `null` files it Private, and omission keeps the current one.
+   */
+  teamspaceId?: string | null;
+  /** Explicit user acceptance when the destination changes access context. */
+  contextMoveConfirmed?: boolean;
+};
+
+/**
+ * Whether a sidebar reparent changes the moved page's Teamspace or Project.
+ *
+ * This is the client-side preflight for the server's authoritative
+ * `contextMoveConfirmed` gate. A page-parent destination inherits both
+ * context ids from that parent. A root destination may explicitly change the
+ * Teamspace; Project stays unchanged because the root-drop UI has no Project
+ * target. Missing/stale rows return false and let the server fail honestly.
+ */
+export function reparentChangesContext(
+  rows: ViewListRow[],
+  move: {
+    viewId: string;
+    nestParentId: string | null;
+    teamspaceId?: string | null;
+  },
+): boolean {
+  const moved = rows.find((row) => row.id === move.viewId);
+  if (!moved) return false;
+
+  const currentTeamspaceId = moved.teamspaceId ?? null;
+  const currentProjectId = moved.projectId ?? null;
+  let destinationTeamspaceId = currentTeamspaceId;
+  let destinationProjectId = currentProjectId;
+
+  if (move.nestParentId !== null) {
+    const parent = rows.find((row) => row.id === move.nestParentId);
+    if (!parent) return false;
+    destinationTeamspaceId = parent.teamspaceId ?? null;
+    destinationProjectId = parent.projectId ?? null;
+  } else if (move.teamspaceId !== undefined) {
+    destinationTeamspaceId = move.teamspaceId;
+  }
+
+  return (
+    destinationTeamspaceId !== currentTeamspaceId ||
+    destinationProjectId !== currentProjectId
+  );
+}
+
+/**
+ * Dispatch a sidebar reparent only after any context change is confirmed.
+ * Keeping the side-effect boundary here makes the three guarantees explicit:
+ * cancel dispatches nothing, accept carries the literal server flag, and a
+ * same-context move bypasses the dialog.
+ */
+export async function dispatchReparentWithContextConfirmation(
+  rows: ViewListRow[],
+  move: ContextAwareReparentMove,
+  confirmContextMove: () => Promise<boolean>,
+  onMove: (move: ContextAwareReparentMove) => void,
+): Promise<void> {
+  if (!reparentChangesContext(rows, move)) {
+    onMove(move);
+    return;
+  }
+
+  if (!(await confirmContextMove())) return;
+  onMove({ ...move, contextMoveConfirmed: true });
+}
+
 /**
  * Sort comparator for siblings: ascending `position`, then `updatedAt`
  * descending as a stable tiebreak (two rows colliding on the same

--- a/packages/api/src/constants/__tests__/search-provider-costs.test.ts
+++ b/packages/api/src/constants/__tests__/search-provider-costs.test.ts
@@ -17,6 +17,7 @@ describe('[COMP:api/search-provider-costs] estimateSearchCostUsd', () => {
   it('scales the per-1k rate by the call count', () => {
     expect(estimateSearchCostUsd('brave', 1000)).toBeCloseTo(SEARCH_PROVIDER_COST_PER_1K.brave)
     expect(estimateSearchCostUsd('serper', 500)).toBeCloseTo(SEARCH_PROVIDER_COST_PER_1K.serper / 2)
+    expect(estimateSearchCostUsd('baidu', 250)).toBeCloseTo(SEARCH_PROVIDER_COST_PER_1K.baidu / 4)
   })
 
   it('returns 0 for a zero-rate or unknown provider', () => {
@@ -30,6 +31,7 @@ describe('[COMP:api/search-provider-costs] estimateSearchCostUsd', () => {
 
   it('exposes the provider rate table for the cost dashboard', () => {
     expect(SEARCH_PROVIDER_COST_PER_1K.brave).toBeGreaterThan(0)
+    expect(SEARCH_PROVIDER_COST_PER_1K.baidu).toBeGreaterThan(0)
     expect(SEARCH_PROVIDER_COST_PER_1K.duckduckgo).toBe(0)
   })
 })

--- a/packages/core/src/billing/__tests__/search-provider-rates.test.ts
+++ b/packages/core/src/billing/__tests__/search-provider-rates.test.ts
@@ -7,6 +7,7 @@ describe('[COMP:billing/search-rates] SEARCH_PROVIDER_COST_PER_1K', () => {
     expect(SEARCH_PROVIDER_COST_PER_1K.serper).toBe(1.0)
     expect(SEARCH_PROVIDER_COST_PER_1K.serpapi).toBe(25.0)
     expect(SEARCH_PROVIDER_COST_PER_1K.tavily).toBe(8.0)
+    expect(SEARCH_PROVIDER_COST_PER_1K.baidu).toBe(5.04)
     expect(SEARCH_PROVIDER_COST_PER_1K.duckduckgo).toBe(0.0)
   })
 
@@ -23,6 +24,7 @@ describe('[COMP:billing/search-rates] flatSearchCostUsd', () => {
     expect(flatSearchCostUsd('serper')).toBe(0.001)
     expect(flatSearchCostUsd('serpapi')).toBe(0.025)
     expect(flatSearchCostUsd('tavily')).toBe(0.008)
+    expect(flatSearchCostUsd('baidu')).toBe(0.00504)
     expect(flatSearchCostUsd('duckduckgo')).toBe(0)
   })
 

--- a/packages/core/src/billing/search-provider-rates.ts
+++ b/packages/core/src/billing/search-provider-rates.ts
@@ -1,7 +1,7 @@
 /**
  * Per-call rates for web-search providers that don't return token counts.
  *
- * These providers charge flat per-call (Brave, Serper, SerpAPI, Tavily) or per-1k,
+ * These providers charge flat per-call (Brave, Serper, SerpAPI, Tavily, Baidu) or per-1k,
  * not per-token. For billing, the `webSearch` tool emits these rates as
  * `ExternalCost['flat']` so the chat route can write a `usage_tracking`
  * row at the true cost — matching the "External API cost tracking policy"
@@ -10,11 +10,13 @@
  * Keep the keys in sync with `SearchProvider.name` strings in
  * `packages/core/src/tools/base/search-stack.ts`.
  *
- * Last verified: 2026-08-25
+ * Last verified: 2026-08-31
  * - brave: $5.00 per 1k (AI-tier billing; user-confirmed rate).
  * - serper: $50 / 50k queries = $1.00 per 1k.
  * - serpapi: $25 / 1k searches on the Starter plan = $25.00 per 1k.
  * - tavily: $0.008 / request = $8.00 per 1k.
+ * - baidu: standard search is ¥0.036 / request; ¥36 / 1k converted
+ *   conservatively at ¥7.14 / USD = $5.04 per 1k.
  * - duckduckgo: free HTML scrape fallback, $0.
  *
  * When a rate changes (new tier, vendor switch, volume discount), update
@@ -25,6 +27,7 @@ export const SEARCH_PROVIDER_COST_PER_1K: Record<string, number> = {
   serper: 1.0,
   serpapi: 25.0,
   tavily: 8.0,
+  baidu: 5.04,
   duckduckgo: 0.0,
   // xAI's x_search is not served via this path — Grok returns token counts,
   // so it bills per-token via the PRICING table in cost-tracker.ts. Listed

--- a/packages/core/src/tools/__tests__/search-stack.test.ts
+++ b/packages/core/src/tools/__tests__/search-stack.test.ts
@@ -4,6 +4,7 @@ import { braveProvider } from '../base/search-brave.js'
 import { serperProvider } from '../base/search-serper.js'
 import { serpApiProvider } from '../base/search-serpapi.js'
 import { tavilyProvider } from '../base/search-tavily.js'
+import { baiduProvider } from '../base/search-baidu.js'
 import { duckDuckGoProvider } from '../base/search-ddg.js'
 import { webSearchTool } from '../base/web-search.js'
 import type { ToolContext } from '../types.js'
@@ -213,6 +214,16 @@ describe('[COMP:tools/search] Provider availability gates', () => {
     })
   })
 
+  it('baiduProvider gates on BAIDU_SEARCH_API_KEY and serializes exact panels', () => {
+    withEnv('BAIDU_SEARCH_API_KEY', undefined, () => {
+      expect(baiduProvider.available()).toBe(false)
+    })
+    withEnv('BAIDU_SEARCH_API_KEY', 'test-token', () => {
+      expect(baiduProvider.available()).toBe(true)
+    })
+    expect(baiduProvider.panelConcurrency).toBe(1)
+  })
+
   it('duckDuckGoProvider is always available (no-token fallback)', () => {
     expect(duckDuckGoProvider.available()).toBe(true)
   })
@@ -225,7 +236,7 @@ describe('[COMP:tools/search] Provider availability gates', () => {
 // ── webSearch tool: outage vs genuine no-results ─────────────────
 
 describe('[COMP:tools/search] webSearch outage surfacing', () => {
-  const ENV_KEYS = ['BRAVE_SEARCH_API_KEY', 'SERPER_API_KEY', 'SERPAPI_API_KEY', 'TAVILY_API_KEY'] as const
+  const ENV_KEYS = ['BRAVE_SEARCH_API_KEY', 'SERPER_API_KEY', 'SERPAPI_API_KEY', 'TAVILY_API_KEY', 'BAIDU_SEARCH_API_KEY'] as const
   let savedEnv: Record<string, string | undefined>
   let fetchSpy: MockInstance<typeof fetch>
 
@@ -236,6 +247,7 @@ describe('[COMP:tools/search] webSearch outage surfacing', () => {
     delete process.env.BRAVE_SEARCH_API_KEY
     delete process.env.SERPER_API_KEY
     delete process.env.SERPAPI_API_KEY
+    delete process.env.BAIDU_SEARCH_API_KEY
     process.env.TAVILY_API_KEY = 'test-token'
     fetchSpy = vi.spyOn(globalThis, 'fetch') as unknown as MockInstance<typeof fetch>
   })
@@ -277,7 +289,7 @@ describe('[COMP:tools/search] webSearch outage surfacing', () => {
 })
 
 describe('[COMP:tools/search] webSearch exact-provider panels', () => {
-  const ENV_KEYS = ['BRAVE_SEARCH_API_KEY', 'SERPER_API_KEY', 'SERPAPI_API_KEY', 'TAVILY_API_KEY'] as const
+  const ENV_KEYS = ['BRAVE_SEARCH_API_KEY', 'SERPER_API_KEY', 'SERPAPI_API_KEY', 'TAVILY_API_KEY', 'BAIDU_SEARCH_API_KEY'] as const
   let savedEnv: Record<string, string | undefined>
   let fetchSpy: MockInstance<typeof fetch>
 
@@ -289,6 +301,7 @@ describe('[COMP:tools/search] webSearch exact-provider panels', () => {
     process.env.SERPER_API_KEY = 'serper-token'
     process.env.SERPAPI_API_KEY = 'serpapi-token'
     process.env.TAVILY_API_KEY = 'tavily-token'
+    process.env.BAIDU_SEARCH_API_KEY = 'baidu-token'
     fetchSpy = vi.spyOn(globalThis, 'fetch') as unknown as MockInstance<typeof fetch>
   })
 
@@ -308,6 +321,7 @@ describe('[COMP:tools/search] webSearch exact-provider panels', () => {
     expect(webSearchTool.inputSchema.safeParse({ queries: ['one'] }).success).toBe(false)
     expect(webSearchTool.inputSchema.safeParse({ queries: ['one'], provider: 'serper' }).success).toBe(true)
     expect(webSearchTool.inputSchema.safeParse({ queries: ['one'], provider: 'serpapi' }).success).toBe(true)
+    expect(webSearchTool.inputSchema.safeParse({ queries: ['one'], provider: 'baidu' }).success).toBe(true)
     expect(webSearchTool.inputSchema.safeParse({ query: 'one', resultMode: 'measurement' }).success).toBe(false)
     expect(webSearchTool.inputSchema.safeParse({ query: 'one', trackDomains: ['example.com'] }).success).toBe(false)
     expect(webSearchTool.inputSchema.safeParse({
@@ -420,6 +434,45 @@ describe('[COMP:tools/search] webSearch exact-provider panels', () => {
       searchProviderUnits: 2,
       externalCost_model: 'serpapi',
       externalCost_flatCostUsd: 0.05,
+    })
+  })
+
+  it('runs exact Baidu panels serially and records the standard-search cost', async () => {
+    let active = 0
+    let maxActive = 0
+    fetchSpy.mockImplementation(async (input, init) => {
+      expect(String(input)).toBe('https://qianfan.baidubce.com/v2/ai_search/web_search')
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      await Promise.resolve()
+      const query = JSON.parse(String(init?.body)).messages[0].content as string
+      active -= 1
+      return new Response(JSON.stringify({
+        references: [{ type: 'web', title: query, url: `https://${query}.example`, snippet: `${query} result` }],
+      }), { status: 200 })
+    })
+
+    const out = await webSearchTool.execute(
+      { queries: ['q1', 'q2'], provider: 'baidu', maxResults: 10 },
+      ctx,
+    )
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    expect(maxActive).toBe(1)
+    expect(out.data).toMatchObject({
+      provider: 'baidu',
+      completed: 2,
+      failed: 0,
+      searches: [
+        { query: 'q1', status: 'ok', provider: 'baidu' },
+        { query: 'q2', status: 'ok', provider: 'baidu' },
+      ],
+    })
+    expect(out.meta).toMatchObject({
+      searchProvider: 'baidu',
+      searchProviderUnits: 2,
+      externalCost_model: 'baidu',
+      externalCost_flatCostUsd: 0.01008,
     })
   })
 
@@ -822,6 +875,55 @@ describe('[COMP:tools/search] Provider response parsers', () => {
     await withEnv('TAVILY_API_KEY', 'test-token', async () => {
       const results = await tavilyProvider.search('flights', 5)
       expect(results[0].snippet).toBe('Find cheap flights')
+    })
+  })
+
+  it('baiduProvider posts a standard web-only request and maps references', async () => {
+    fetchSpy.mockImplementationOnce(async (input, init) => {
+      expect(String(input)).toBe('https://qianfan.baidubce.com/v2/ai_search/web_search')
+      expect(init?.method).toBe('POST')
+      expect(init?.headers).toMatchObject({
+        Authorization: 'Bearer test-token',
+        'Content-Type': 'application/json',
+      })
+      expect(JSON.parse(String(init?.body))).toEqual({
+        messages: [{ role: 'user', content: '百度千帆' }],
+        edition: 'standard',
+        search_source: 'baidu_search_v2',
+        resource_type_filter: [{ type: 'web', top_k: 5 }],
+      })
+      return new Response(JSON.stringify({
+        references: [
+          {
+            type: 'web',
+            title: '<b>百度千帆</b>',
+            url: 'https://cloud.baidu.com/product-s/qianfan_home',
+            content: '百度智能云<b>千帆平台</b>',
+          },
+          { type: 'image', title: 'skip non-web', url: 'https://example.com/image' },
+          { type: 'web', title: 'skip non-http', url: 'ftp://example.com/result' },
+        ],
+      }), { status: 200 })
+    })
+
+    await withEnv('BAIDU_SEARCH_API_KEY', 'test-token', async () => {
+      const results = await baiduProvider.search('百度千帆', 5)
+      expect(results).toEqual([{
+        title: '百度千帆',
+        url: 'https://cloud.baidu.com/product-s/qianfan_home',
+        snippet: '百度智能云千帆平台',
+      }])
+    })
+  })
+
+  it('baiduProvider treats a structured API error as a failure, not an empty result', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({
+      code: 216003,
+      message: 'Authentication error',
+    }), { status: 200 }))
+
+    await withEnv('BAIDU_SEARCH_API_KEY', 'test-token', async () => {
+      await expect(baiduProvider.search('company brain', 5)).rejects.toThrow(/Baidu: 216003: Authentication error/)
     })
   })
 

--- a/packages/core/src/tools/base/search-baidu.ts
+++ b/packages/core/src/tools/base/search-baidu.ts
@@ -1,0 +1,94 @@
+/**
+ * Baidu Qianfan Search API provider.
+ *
+ * Uses Baidu's standard `baidu_search_v2` web index. The endpoint returns a
+ * `references` array whose web entries map directly to the shared search
+ * result shape.
+ *
+ * Docs: https://cloud.baidu.com/doc/qianfan/s/2mh4su4uy
+ * Endpoint: POST https://qianfan.baidubce.com/v2/ai_search/web_search
+ * Auth:     Authorization: Bearer <API Key>
+ */
+
+import type { SearchProvider, SearchResult } from './search-stack.js'
+import { retryAfterMs, SearchProviderError } from './_fetch-error.js'
+import { clampResultCount, stripHtmlTags } from './search-stack.js'
+
+const BAIDU_ENDPOINT = 'https://qianfan.baidubce.com/v2/ai_search/web_search'
+
+type BaiduReference = {
+  type?: string
+  title?: string
+  web_anchor?: string
+  website?: string
+  url?: string
+  snippet?: string
+  content?: string
+}
+
+type BaiduResponse = {
+  references?: BaiduReference[]
+  code?: string | number
+  message?: string
+}
+
+export const baiduProvider: SearchProvider = {
+  name: 'baidu',
+
+  available: () => Boolean(process.env.BAIDU_SEARCH_API_KEY),
+
+  // Baidu documents a low default QPS. Keep exact-provider panels serial so
+  // one panel does not create its own avoidable burst; 429s still use the
+  // shared bounded retry path.
+  panelConcurrency: 1,
+
+  async search(query, maxResults, signal): Promise<SearchResult[]> {
+    const token = process.env.BAIDU_SEARCH_API_KEY
+    if (!token) return []
+
+    const res = await fetch(BAIDU_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        messages: [{ role: 'user', content: query }],
+        edition: 'standard',
+        search_source: 'baidu_search_v2',
+        resource_type_filter: [{ type: 'web', top_k: clampResultCount(maxResults) }],
+      }),
+      signal,
+    })
+
+    if (!res.ok) {
+      throw new SearchProviderError({
+        provider: 'Baidu',
+        status: res.status,
+        retryAfterMs: retryAfterMs(res.headers.get('retry-after')),
+      })
+    }
+
+    const data = (await res.json()) as BaiduResponse
+    const errorCode = data.code === undefined ? '' : String(data.code).trim()
+    if (errorCode && errorCode !== '0') {
+      const detail = [errorCode, data.message?.trim()].filter(Boolean).join(': ')
+      throw new SearchProviderError({
+        provider: 'Baidu',
+        kind: 'other',
+        detail: detail.slice(0, 300),
+      })
+    }
+
+    return (data.references ?? [])
+      .filter((reference) => !reference.type || reference.type === 'web')
+      .map((reference) => ({
+        title: stripHtmlTags(reference.title ?? reference.web_anchor ?? reference.website ?? '').trim(),
+        url: reference.url ?? '',
+        snippet: stripHtmlTags(reference.snippet ?? reference.content ?? '').trim(),
+      }))
+      .filter((result) => result.url.startsWith('http'))
+      .slice(0, maxResults)
+  },
+}

--- a/packages/core/src/tools/base/search-stack.ts
+++ b/packages/core/src/tools/base/search-stack.ts
@@ -58,6 +58,8 @@ export type SearchProvider = {
    * results, so its empties prove nothing. Defaults to true.
    */
   trustEmpty?: boolean
+  /** Optional provider-specific cap for exact-provider query panels. */
+  panelConcurrency?: number
   /** Execute the search. Should throw on API error so the stack can fall through. */
   search: (query: string, maxResults: number, signal?: AbortSignal) => Promise<SearchResult[]>
 }

--- a/packages/core/src/tools/base/web-search.ts
+++ b/packages/core/src/tools/base/web-search.ts
@@ -5,12 +5,13 @@ import { braveProvider } from './search-brave.js'
 import { serperProvider } from './search-serper.js'
 import { serpApiProvider } from './search-serpapi.js'
 import { tavilyProvider } from './search-tavily.js'
+import { baiduProvider } from './search-baidu.js'
 import { duckDuckGoProvider } from './search-ddg.js'
 import { encodeExternalCostMeta } from '../../billing/external-cost.js'
 import { flatSearchCostUsd } from '../../billing/search-provider-rates.js'
 import { NO_TOOL_TIMEOUT } from '../../engine/tool-executor.js'
 
-const SEARCH_PROVIDER_NAMES = ['brave', 'serper', 'serpapi', 'tavily', 'duckduckgo'] as const
+const SEARCH_PROVIDER_NAMES = ['brave', 'serper', 'serpapi', 'tavily', 'baidu', 'duckduckgo'] as const
 type SearchProviderName = (typeof SEARCH_PROVIDER_NAMES)[number]
 
 const providersByName = {
@@ -18,6 +19,7 @@ const providersByName = {
   serper: serperProvider,
   serpapi: serpApiProvider,
   tavily: tavilyProvider,
+  baidu: baiduProvider,
   duckduckgo: duckDuckGoProvider,
 } satisfies Record<SearchProviderName, typeof braveProvider>
 
@@ -106,7 +108,7 @@ function waitForRetry(ms: number, signal: AbortSignal): Promise<boolean> {
 /**
  * Web search tool — model-driven search with provider fallback.
  *
- * Provider order: Brave → Serper → SerpAPI → Tavily → DuckDuckGo.
+ * Provider order: Brave → Serper → SerpAPI → Tavily → Baidu → DuckDuckGo.
  *
  * - Brave is first because it's fast, commerce-aware, and cheap.
  * - Serper (Google SERP) is second because Google indexes commercial sites
@@ -115,6 +117,7 @@ function waitForRetry(ms: number, signal: AbortSignal): Promise<boolean> {
  * - SerpAPI is a second Google SERP backend for exact-provider measurements
  *   and fallback when Serper rejects a request.
  * - Tavily follows for AI-optimized research queries.
+ * - Baidu adds a keyed Chinese-language and mainland-China web index.
  * - DuckDuckGo is the no-token fallback for local dev without any env set.
  *
  * This is the explicit `webSearch` tool the model calls. It replaces
@@ -140,7 +143,7 @@ const webSearchInputSchema = z
       .enum(SEARCH_PROVIDER_NAMES)
       .optional()
       .describe(
-        'Exact provider for repeatable measurement. Omit for normal Brave → Serper → SerpAPI → Tavily → DuckDuckGo fallback.',
+        'Exact provider for repeatable measurement. Omit for normal Brave → Serper → SerpAPI → Tavily → Baidu → DuckDuckGo fallback.',
       ),
     maxResults: z.number().optional().describe('Maximum results per query (default 5, max 10)'),
     resultMode: z
@@ -228,7 +231,7 @@ export const webSearchTool = buildTool({
       const measurement = input.resultMode === 'measurement'
       const trackedDomains = [...new Set((input.trackDomains ?? []).map(normalizeDomain).filter((domain): domain is string => Boolean(domain)))]
       const strictStack = createSearchStack([selected])
-      const searches = await mapPool(queries, PANEL_CONCURRENCY, async (query) => {
+      const searches = await mapPool(queries, selected.panelConcurrency ?? PANEL_CONCURRENCY, async (query) => {
         let final: {
           value: Awaited<ReturnType<typeof strictStack>>
           timedOut: boolean
@@ -396,7 +399,7 @@ export const webSearchTool = buildTool({
     )
 
     // `meta.searchProvider` carries the winning provider name (brave / serper /
-    // serpapi / tavily / duckduckgo) back to analytics via ToolResult.meta.
+    // serpapi / tavily / baidu / duckduckgo) back to analytics via ToolResult.meta.
     // `externalCost_*` keys carry the per-call USD so the chat route can
     // write a `usage_tracking` row (flat cost, 0 tokens) per billing policy.
     // Both are omitted when no provider served the call.


### PR DESCRIPTION
Summary

- add Baidu as a keyed web-search provider
- confirm page moves before changing Teamspace or Project access context
- preserve the server-side RLS and context-confirmation authority

Verification

- `pnpm test`
- `pnpm smoke`
- `pnpm --filter app-web typecheck`
- `pnpm --filter app-web build`
