### PR TITLE
ci: publish component images to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+.env
+.env.*
+**/node_modules
+**/dist
+**/.next
+**/.turbo
+**/coverage

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,0 +1,121 @@
+# Build every deployable container on pull requests and publish images from
+# trusted refs to the GitHub Container Registry.
+name: Docker images
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".dockerignore"
+      - ".github/workflows/docker-images.yml"
+      - "apps/auth-web/**"
+      - "apps/browser-relay/**"
+      - "apps/discord-connector/**"
+      - "apps/doc-sync/**"
+      - "apps/feishu-connector/**"
+      - "apps/wa-connector/**"
+      - "apps/wechat-connector/**"
+      - "apps/wechat-desktop-bridge/**"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "tsconfig.base.json"
+      - "turbo.json"
+  push:
+    branches: [main, develop]
+    tags: ["v*"]
+    paths:
+      - ".dockerignore"
+      - ".github/workflows/docker-images.yml"
+      - "apps/auth-web/**"
+      - "apps/browser-relay/**"
+      - "apps/discord-connector/**"
+      - "apps/doc-sync/**"
+      - "apps/feishu-connector/**"
+      - "apps/wa-connector/**"
+      - "apps/wechat-connector/**"
+      - "apps/wechat-desktop-bridge/**"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "tsconfig.base.json"
+      - "turbo.json"
+
+concurrency:
+  group: docker-images-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: auth-web
+            context: .
+            dockerfile: apps/auth-web/Dockerfile
+          - image: browser-relay
+            context: .
+            dockerfile: apps/browser-relay/Dockerfile
+          - image: discord-connector
+            context: .
+            dockerfile: apps/discord-connector/Dockerfile
+          - image: doc-sync
+            context: .
+            dockerfile: apps/doc-sync/Dockerfile
+          - image: feishu-connector
+            context: .
+            dockerfile: apps/feishu-connector/Dockerfile
+          - image: wa-connector
+            context: .
+            dockerfile: apps/wa-connector/Dockerfile
+          - image: wechat-connector
+            context: .
+            dockerfile: apps/wechat-connector/Dockerfile
+          - image: wechat-desktop-bridge
+            context: apps/wechat-desktop-bridge
+            dockerfile: apps/wechat-desktop-bridge/Dockerfile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}

--- a/README.md
+++ b/README.md
@@ -67,6 +67,32 @@ database under `~/.usebrian/`; point `DATABASE_URL` at a local Postgres if you
 prefer a container. Files live in the durable `~/.usebrian/files` directory.
 Every self-host override is documented in [`.env.example`](./.env.example).
 
+### Container images
+
+Prebuilt images for the independently deployable services are published to the
+[GitHub Container Registry](https://github.com/orgs/use-brian/packages). Pull a
+service with:
+
+```bash
+docker pull ghcr.io/use-brian/doc-sync:latest
+```
+
+| Service | Image |
+|---|---|
+| Auth web | `ghcr.io/use-brian/auth-web` |
+| Browser relay | `ghcr.io/use-brian/browser-relay` |
+| Discord connector | `ghcr.io/use-brian/discord-connector` |
+| Document sync | `ghcr.io/use-brian/doc-sync` |
+| Feishu connector | `ghcr.io/use-brian/feishu-connector` |
+| WhatsApp connector | `ghcr.io/use-brian/wa-connector` |
+| WeChat connector | `ghcr.io/use-brian/wechat-connector` |
+| WeChat desktop bridge | `ghcr.io/use-brian/wechat-desktop-bridge` |
+
+Use `latest` for the current `main` build, `develop` for the development branch,
+`v*` tags for releases, or `sha-<commit>` to pin an exact build. These images
+cover the standalone services; use the `pnpm` quick start above to run the full
+self-hosted app locally.
+
 ### Your data stays yours
 
 The brain, the store, and the canvas stay local. Model requests go only to the

--- a/apps/feishu-connector/Dockerfile
+++ b/apps/feishu-connector/Dockerfile
@@ -5,10 +5,12 @@ WORKDIR /app
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY packages/shared/package.json packages/shared/tsconfig.json ./packages/shared/
 COPY packages/channels/package.json packages/channels/tsconfig.json ./packages/channels/
 COPY apps/feishu-connector/package.json apps/feishu-connector/tsconfig.json ./apps/feishu-connector/
 RUN pnpm install --frozen-lockfile
 
+COPY packages/shared/src ./packages/shared/src
 COPY packages/channels/src ./packages/channels/src
 COPY apps/feishu-connector/src ./apps/feishu-connector/src
 RUN pnpm --filter "@use-brian/feishu-connector..." run build


### PR DESCRIPTION
## Summary
- build all eight Dockerized components with a GitHub Actions matrix
- publish branch, tag, SHA, and default-branch tags to GHCR
- add Docker context exclusions and document image names and tags

## Testing
- `actionlint .github/workflows/docker-images.yml`
- `git diff --check`

## Deployment note
After the first publish, the component packages must be made public for anonymous pulls, or consumers must authenticate to GHCR.