### PR TITLE
feat(desktop): add awake Brian companion

### DIFF
--- a/apps/app-desktop/scripts/copy-static.mjs
+++ b/apps/app-desktop/scripts/copy-static.mjs
@@ -1,7 +1,6 @@
 // Copy the static assets that the TypeScript build doesn't emit — the sandboxed
-// preload (`preload.cjs`) and the sign-in / offline landings (`signin.html`,
-// `offline.html`) — from src/ into dist/. Run after `tsc` by the `build` / `dev`
-// scripts.
+// preloads (`preload.cjs`, `pet-preload.cjs`) and the bundled HTML surfaces —
+// from src/ into dist/. Run after `tsc` by the `build` / `dev` scripts.
 //
 // This replaces a Unix `cp` that broke the Windows build: npm/pnpm run scripts via
 // cmd.exe on Windows, which has no `cp`, so `package:win` failed at the copy step
@@ -13,6 +12,12 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
-for (const file of ["preload.cjs", "signin.html", "offline.html"]) {
+for (const file of [
+  "preload.cjs",
+  "pet-preload.cjs",
+  "signin.html",
+  "offline.html",
+  "brian-pet.html",
+]) {
   copyFileSync(join(pkgRoot, "src", file), join(pkgRoot, "dist", file));
 }

--- a/apps/app-desktop/scripts/copy-static.mjs
+++ b/apps/app-desktop/scripts/copy-static.mjs
@@ -21,3 +21,6 @@ for (const file of [
 ]) {
   copyFileSync(join(pkgRoot, "src", file), join(pkgRoot, "dist", file));
 }
+
+// The companion displays the canonical app mark, not a reconstructed SVG.
+copyFileSync(join(pkgRoot, "build", "icon.original.png"), join(pkgRoot, "dist", "brian-logo.png"));

--- a/apps/app-desktop/scripts/copy-static.mjs
+++ b/apps/app-desktop/scripts/copy-static.mjs
@@ -22,5 +22,5 @@ for (const file of [
   copyFileSync(join(pkgRoot, "src", file), join(pkgRoot, "dist", file));
 }
 
-// The companion displays the canonical app mark, not a reconstructed SVG.
-copyFileSync(join(pkgRoot, "build", "icon.original.png"), join(pkgRoot, "dist", "brian-logo.png"));
+// The companion displays the canonical transparent app mark, not a reconstructed SVG.
+copyFileSync(join(pkgRoot, "..", "app-web", "public", "icon.png"), join(pkgRoot, "dist", "brian-logo.png"));

--- a/apps/app-desktop/src/__tests__/awake-brian.test.ts
+++ b/apps/app-desktop/src/__tests__/awake-brian.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
 
 import {
   parseAwakeBrianPreference,
@@ -22,5 +23,12 @@ describe("[COMP:app-desktop/awake-brian] preference", () => {
     expect(parseAwakeBrianPreference("")).toBe(false);
     expect(parseAwakeBrianPreference("{oops")).toBe(false);
     expect(parseAwakeBrianPreference("[]")).toBe(false);
+  });
+
+  it("renders the canonical logo asset instead of reconstructing the mark", () => {
+    const html = readFileSync(new URL("../brian-pet.html", import.meta.url), "utf8");
+    expect(html).toContain('src="./brian-logo.png"');
+    expect(html).not.toContain("<svg");
+    expect(html).not.toContain("brian-blink");
   });
 });

--- a/apps/app-desktop/src/__tests__/awake-brian.test.ts
+++ b/apps/app-desktop/src/__tests__/awake-brian.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseAwakeBrianPreference,
+  serializeAwakeBrianPreference,
+} from "../awake-brian.js";
+
+describe("[COMP:app-desktop/awake-brian] preference", () => {
+  it("round-trips enabled and disabled values", () => {
+    expect(parseAwakeBrianPreference(serializeAwakeBrianPreference(true))).toBe(true);
+    expect(parseAwakeBrianPreference(serializeAwakeBrianPreference(false))).toBe(false);
+  });
+
+  it("enables only the current explicit true record", () => {
+    expect(parseAwakeBrianPreference('{"v":1,"keepAwake":true}')).toBe(true);
+    expect(parseAwakeBrianPreference('{"v":2,"keepAwake":true}')).toBe(false);
+    expect(parseAwakeBrianPreference('{"v":1,"keepAwake":"true"}')).toBe(false);
+  });
+
+  it("falls back to disabled for missing or malformed data", () => {
+    expect(parseAwakeBrianPreference(null)).toBe(false);
+    expect(parseAwakeBrianPreference("")).toBe(false);
+    expect(parseAwakeBrianPreference("{oops")).toBe(false);
+    expect(parseAwakeBrianPreference("[]")).toBe(false);
+  });
+});

--- a/apps/app-desktop/src/__tests__/awake-brian.test.ts
+++ b/apps/app-desktop/src/__tests__/awake-brian.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 
 import {
+  clampBrianPosition,
+  parseBrianPosition,
   parseAwakeBrianPreference,
+  serializeBrianPosition,
   serializeAwakeBrianPreference,
 } from "../awake-brian.js";
 
@@ -30,5 +33,20 @@ describe("[COMP:app-desktop/awake-brian] preference", () => {
     expect(html).toContain('src="./brian-logo.png"');
     expect(html).not.toContain("<svg");
     expect(html).not.toContain("brian-blink");
+  });
+
+  it("round-trips and clamps the companion position", () => {
+    expect(parseBrianPosition(serializeBrianPosition({ x: 42.4, y: -9.6 }))).toEqual({
+      x: 42,
+      y: -10,
+    });
+    expect(parseBrianPosition('{"v":1,"x":"42","y":0}')).toBeNull();
+    expect(
+      clampBrianPosition(
+        { x: 950, y: -30 },
+        { x: 0, y: 0, width: 1_000, height: 800 },
+        { width: 150, height: 154 },
+      ),
+    ).toEqual({ x: 850, y: 0 });
   });
 });

--- a/apps/app-desktop/src/__tests__/desktop-chat.test.ts
+++ b/apps/app-desktop/src/__tests__/desktop-chat.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  companionClickFollowsChatBlur,
   desktopChatRoute,
   parseCompanionState,
   workspaceIdFromDesktopRoute,
@@ -26,5 +27,11 @@ describe("[COMP:app-desktop/awake-brian] desktop chat routing", () => {
     });
     expect(parseCompanionState({ phase: "unknown", label: "no" })).toBeNull();
     expect(parseCompanionState({ phase: "idle", label: "x".repeat(200) })?.label).toHaveLength(120);
+  });
+
+  it("treats the companion click that caused blur as a close, not a reopen", () => {
+    expect(companionClickFollowsChatBlur(1_250, 1_000)).toBe(true);
+    expect(companionClickFollowsChatBlur(1_500, 1_000)).toBe(false);
+    expect(companionClickFollowsChatBlur(1_000, 0)).toBe(false);
   });
 });

--- a/apps/app-desktop/src/__tests__/desktop-chat.test.ts
+++ b/apps/app-desktop/src/__tests__/desktop-chat.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  desktopChatRoute,
+  workspaceIdFromDesktopRoute,
+} from "../desktop-chat.js";
+
+describe("[COMP:app-desktop/awake-brian] desktop chat routing", () => {
+  it("extracts workspace ids only from canonical workspace routes", () => {
+    expect(workspaceIdFromDesktopRoute("/w/ws-1/p/page-1")).toBe("ws-1");
+    expect(workspaceIdFromDesktopRoute("/w/team%20one/brain")).toBe("team one");
+    expect(workspaceIdFromDesktopRoute("/desktop/chat/ws-1")).toBeNull();
+    expect(workspaceIdFromDesktopRoute("/workspaces/ws-1")).toBeNull();
+    expect(workspaceIdFromDesktopRoute("/w/%2F/brain")).toBeNull();
+  });
+
+  it("builds the shared live and bundled chat route", () => {
+    expect(desktopChatRoute("team one")).toBe("/desktop/chat/team%20one");
+  });
+});

--- a/apps/app-desktop/src/__tests__/desktop-chat.test.ts
+++ b/apps/app-desktop/src/__tests__/desktop-chat.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   desktopChatRoute,
+  parseCompanionState,
   workspaceIdFromDesktopRoute,
 } from "../desktop-chat.js";
 
@@ -16,5 +17,14 @@ describe("[COMP:app-desktop/awake-brian] desktop chat routing", () => {
 
   it("builds the shared live and bundled chat route", () => {
     expect(desktopChatRoute("team one")).toBe("/desktop/chat/team%20one");
+  });
+
+  it("accepts only bounded display-only companion state", () => {
+    expect(parseCompanionState({ phase: "thinking", label: "Searching\nnow" })).toEqual({
+      phase: "thinking",
+      label: "Searching now",
+    });
+    expect(parseCompanionState({ phase: "unknown", label: "no" })).toBeNull();
+    expect(parseCompanionState({ phase: "idle", label: "x".repeat(200) })?.label).toHaveLength(120);
   });
 });

--- a/apps/app-desktop/src/__tests__/menu-template.test.ts
+++ b/apps/app-desktop/src/__tests__/menu-template.test.ts
@@ -83,7 +83,7 @@ describe("[COMP:app-desktop/menu-template] buildMenuTemplate", () => {
     }
   });
 
-  it("renders Keep Brian Awake as a checked setting and toggles through", () => {
+  it("renders Keep Brian Nearby as a checked setting and toggles through", () => {
     const onToggleKeepAwake = vi.fn();
     for (const isMac of [true, false]) {
       const items = allItems(
@@ -92,7 +92,7 @@ describe("[COMP:app-desktop/menu-template] buildMenuTemplate", () => {
           { ...handlers, onToggleKeepAwake },
         ),
       );
-      const awake = items.find((item) => item.label === "Keep Brian Awake");
+      const awake = items.find((item) => item.label === "Keep Brian Nearby");
       expect(awake?.type).toBe("checkbox");
       expect(awake?.checked).toBe(true);
       (awake?.click as () => void)();

--- a/apps/app-desktop/src/__tests__/menu-template.test.ts
+++ b/apps/app-desktop/src/__tests__/menu-template.test.ts
@@ -15,11 +15,19 @@ const handlers: MenuTemplateHandlers = {
   onSwitchTarget: () => {},
   onUninstall: () => {},
   onStartFirefoxControl: () => {},
+  onToggleKeepAwake: () => {},
 };
 
 /** Default options; spread + override per test. */
 function opts(over: Partial<MenuTemplateOptions> = {}): MenuTemplateOptions {
-  return { isMac: true, isDev: false, appName: "Use Brian", update: null, ...over };
+  return {
+    isMac: true,
+    isDev: false,
+    appName: "Use Brian",
+    update: null,
+    keepBrianAwake: false,
+    ...over,
+  };
 }
 
 /** Collect every `role` string in a template tree (top level + one submenu deep). */
@@ -73,6 +81,23 @@ describe("[COMP:app-desktop/menu-template] buildMenuTemplate", () => {
       const record = allItems(t).find((i) => i.label === "Start Recording");
       expect(record?.accelerator).toBe("CommandOrControl+Shift+R");
     }
+  });
+
+  it("renders Keep Brian Awake as a checked setting and toggles through", () => {
+    const onToggleKeepAwake = vi.fn();
+    for (const isMac of [true, false]) {
+      const items = allItems(
+        buildMenuTemplate(
+          opts({ isMac, keepBrianAwake: true }),
+          { ...handlers, onToggleKeepAwake },
+        ),
+      );
+      const awake = items.find((item) => item.label === "Keep Brian Awake");
+      expect(awake?.type).toBe("checkbox");
+      expect(awake?.checked).toBe(true);
+      (awake?.click as () => void)();
+    }
+    expect(onToggleKeepAwake).toHaveBeenCalledTimes(2);
   });
 
   it("starts Firefox browser control from both platform menus", () => {

--- a/apps/app-desktop/src/awake-brian.ts
+++ b/apps/app-desktop/src/awake-brian.ts
@@ -1,0 +1,28 @@
+/**
+ * Persisted preference for the ambient Brian desktop companion.
+ *
+ * The Electron IO lives in `main.ts`; this module owns only the tolerant
+ * serialization boundary so a damaged userData file can never keep the machine
+ * awake unexpectedly.
+ *
+ * Spec: docs/plans/desktop-awake-brian.md
+ * [COMP:app-desktop/awake-brian]
+ */
+
+export const AWAKE_BRIAN_FILE_NAME = "awake-brian.json";
+
+export function parseAwakeBrianPreference(raw: string | null | undefined): boolean {
+  if (!raw) return false;
+  try {
+    const value = JSON.parse(raw) as unknown;
+    if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+    const record = value as Record<string, unknown>;
+    return record.v === 1 && record.keepAwake === true;
+  } catch {
+    return false;
+  }
+}
+
+export function serializeAwakeBrianPreference(keepAwake: boolean): string {
+  return JSON.stringify({ v: 1, keepAwake });
+}

--- a/apps/app-desktop/src/awake-brian.ts
+++ b/apps/app-desktop/src/awake-brian.ts
@@ -10,6 +10,9 @@
  */
 
 export const AWAKE_BRIAN_FILE_NAME = "awake-brian.json";
+export const BRIAN_POSITION_FILE_NAME = "brian-position.json";
+
+export type BrianPosition = { x: number; y: number };
 
 export function parseAwakeBrianPreference(raw: string | null | undefined): boolean {
   if (!raw) return false;
@@ -25,4 +28,38 @@ export function parseAwakeBrianPreference(raw: string | null | undefined): boole
 
 export function serializeAwakeBrianPreference(keepAwake: boolean): string {
   return JSON.stringify({ v: 1, keepAwake });
+}
+
+export function parseBrianPosition(raw: string | null | undefined): BrianPosition | null {
+  if (!raw) return null;
+  try {
+    const value = JSON.parse(raw) as { v?: unknown; x?: unknown; y?: unknown };
+    if (
+      value?.v !== 1 ||
+      typeof value.x !== "number" ||
+      typeof value.y !== "number" ||
+      !Number.isFinite(value.x) ||
+      !Number.isFinite(value.y)
+    ) {
+      return null;
+    }
+    return { x: Math.round(value.x), y: Math.round(value.y) };
+  } catch {
+    return null;
+  }
+}
+
+export function serializeBrianPosition(position: BrianPosition): string {
+  return JSON.stringify({ v: 1, x: Math.round(position.x), y: Math.round(position.y) });
+}
+
+export function clampBrianPosition(
+  position: BrianPosition,
+  area: { x: number; y: number; width: number; height: number },
+  size: { width: number; height: number },
+): BrianPosition {
+  return {
+    x: Math.max(area.x, Math.min(area.x + area.width - size.width, position.x)),
+    y: Math.max(area.y, Math.min(area.y + area.height - size.height, position.y)),
+  };
 }

--- a/apps/app-desktop/src/brian-pet.html
+++ b/apps/app-desktop/src/brian-pet.html
@@ -8,12 +8,8 @@
     />
     <meta name="color-scheme" content="dark" />
     <style>
-      :root {
-        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-      }
-
+      :root { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
       * { box-sizing: border-box; }
-
       html, body {
         width: 100%;
         height: 100%;
@@ -21,13 +17,7 @@
         overflow: hidden;
         background: transparent;
       }
-
-      body {
-        display: grid;
-        place-items: end center;
-        padding: 6px;
-      }
-
+      body { display: grid; place-items: end center; padding: 6px; }
       button {
         position: relative;
         width: 138px;
@@ -40,12 +30,13 @@
         cursor: pointer;
         -webkit-app-region: no-drag;
       }
-
       .prompt {
         position: absolute;
         top: 1px;
         left: 50%;
-        z-index: 2;
+        z-index: 4;
+        max-width: 136px;
+        overflow: hidden;
         padding: 7px 10px;
         border: 1px solid rgba(21, 213, 238, 0.68);
         border-radius: 8px;
@@ -54,12 +45,12 @@
         font-size: 11px;
         font-weight: 700;
         letter-spacing: 0.02em;
+        text-overflow: ellipsis;
         white-space: nowrap;
         opacity: 0;
         transform: translate(-50%, 5px) scale(0.96);
         transition: opacity 130ms ease, transform 130ms ease;
       }
-
       .prompt::after {
         content: "";
         position: absolute;
@@ -72,23 +63,63 @@
         background: #071629;
         transform: translateX(-50%) rotate(45deg);
       }
-
       button:hover .prompt,
-      button:focus-visible .prompt {
+      button:focus-visible .prompt,
+      body:not([data-state="idle"]) .prompt {
         opacity: 1;
         transform: translate(-50%, 0) scale(1);
       }
-
-      .pet {
+      .pet-wrap {
         position: absolute;
         left: 17px;
         bottom: 5px;
         width: 104px;
         height: 104px;
-        object-fit: contain;
         filter: drop-shadow(0 9px 10px rgba(0, 21, 40, 0.38));
+        transform-origin: 50% 85%;
       }
-
+      .pet { display: block; width: 100%; height: 100%; object-fit: contain; }
+      .lid, .mouth, .thought, .action-badge { position: absolute; pointer-events: none; }
+      .lid {
+        top: 40%;
+        width: 7%;
+        height: 7%;
+        background: #10d4eb;
+        opacity: 0;
+        animation: blink 4.6s steps(1, end) infinite;
+      }
+      .lid.left { left: 33%; }
+      .lid.right { right: 33%; }
+      .mouth {
+        left: 46%;
+        top: 58%;
+        width: 8%;
+        height: 8%;
+        background: #07172b;
+        opacity: 0;
+      }
+      .thought {
+        right: 3%;
+        top: 8%;
+        display: flex;
+        gap: 3px;
+        opacity: 0;
+      }
+      .thought i { width: 5px; height: 5px; border-radius: 50%; background: #eaf5ff; }
+      .action-badge {
+        right: 0;
+        top: 4%;
+        display: grid;
+        width: 24px;
+        height: 24px;
+        place-items: center;
+        border: 2px solid #07172b;
+        border-radius: 50%;
+        color: #07172b;
+        background: #ffca3a;
+        font: 900 16px/1 system-ui, sans-serif;
+        opacity: 0;
+      }
       .halo {
         position: absolute;
         left: 50%;
@@ -100,14 +131,41 @@
         filter: blur(8px);
         transform: translateX(-50%);
       }
-
+      body[data-state="loading"] .pet-wrap { animation: loading 900ms ease-in-out infinite alternate; }
+      body[data-state="thinking"] .pet-wrap { animation: thinking 800ms steps(2, end) infinite alternate; }
+      body[data-state="thinking"] .thought { opacity: 1; }
+      body[data-state="thinking"] .thought i { animation: thought 900ms ease-in-out infinite; }
+      body[data-state="thinking"] .thought i:nth-child(2) { animation-delay: 150ms; }
+      body[data-state="thinking"] .thought i:nth-child(3) { animation-delay: 300ms; }
+      body[data-state="responding"] .mouth { opacity: 1; animation: talk 320ms steps(2, end) infinite; }
+      body[data-state="responding"] .pet-wrap { animation: respond 420ms ease-in-out infinite alternate; }
+      body[data-state="action-required"] .action-badge { opacity: 1; animation: attention 900ms ease-in-out infinite; }
+      body[data-state="complete"] .pet-wrap { animation: complete 700ms ease-out both; }
+      @keyframes blink { 0%, 45%, 49%, 100% { opacity: 0; } 46%, 48% { opacity: 1; } }
+      @keyframes loading { from { opacity: 0.62; transform: translateY(2px); } to { opacity: 1; transform: translateY(-2px); } }
+      @keyframes thinking { from { transform: rotate(-2deg); } to { transform: rotate(3deg) translateY(-3px); } }
+      @keyframes thought { 0%, 100% { transform: translateY(0); opacity: 0.35; } 50% { transform: translateY(-5px); opacity: 1; } }
+      @keyframes talk { from { height: 3%; transform: translateY(2px); } to { height: 10%; transform: translateY(0); } }
+      @keyframes respond { from { transform: translateY(0); } to { transform: translateY(-3px); } }
+      @keyframes attention { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.16); } }
+      @keyframes complete { 0% { transform: scale(1); } 45% { transform: translateY(-10px) scale(1.06); } 100% { transform: scale(1); } }
+      @media (prefers-reduced-motion: reduce) {
+        .pet-wrap, .lid, .mouth, .thought i, .action-badge { animation: none !important; }
+      }
     </style>
   </head>
   <body>
     <button id="message-brian" type="button" aria-label="Message Brian" title="Message Brian">
-      <span class="prompt">Message Brian</span>
+      <span id="status" class="prompt">Message Brian</span>
       <span class="halo" aria-hidden="true"></span>
-      <img class="pet" src="./brian-logo.png" alt="" aria-hidden="true" />
+      <span class="pet-wrap" aria-hidden="true">
+        <img class="pet" src="./brian-logo.png" alt="" />
+        <span class="lid left"></span>
+        <span class="lid right"></span>
+        <span class="mouth"></span>
+        <span class="thought"><i></i><i></i><i></i></span>
+        <span class="action-badge">!</span>
+      </span>
     </button>
   </body>
 </html>

--- a/apps/app-desktop/src/brian-pet.html
+++ b/apps/app-desktop/src/brian-pet.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; style-src 'unsafe-inline'; img-src data:"
+    />
+    <meta name="color-scheme" content="dark" />
+    <style>
+      :root {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      }
+
+      * { box-sizing: border-box; }
+
+      html, body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        overflow: hidden;
+        background: transparent;
+      }
+
+      body {
+        display: grid;
+        place-items: end center;
+        padding: 6px;
+      }
+
+      button {
+        position: relative;
+        width: 138px;
+        height: 142px;
+        padding: 0;
+        border: 0;
+        outline: 0;
+        color: #eaf5ff;
+        background: transparent;
+        cursor: pointer;
+        -webkit-app-region: no-drag;
+      }
+
+      .prompt {
+        position: absolute;
+        top: 1px;
+        left: 50%;
+        z-index: 2;
+        padding: 7px 10px;
+        border: 1px solid rgba(21, 213, 238, 0.68);
+        border-radius: 8px;
+        background: rgba(7, 22, 41, 0.94);
+        box-shadow: 0 8px 22px rgba(3, 12, 27, 0.34);
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+        white-space: nowrap;
+        opacity: 0;
+        transform: translate(-50%, 5px) scale(0.96);
+        transition: opacity 130ms ease, transform 130ms ease;
+      }
+
+      .prompt::after {
+        content: "";
+        position: absolute;
+        left: 50%;
+        bottom: -5px;
+        width: 8px;
+        height: 8px;
+        border-right: 1px solid rgba(21, 213, 238, 0.68);
+        border-bottom: 1px solid rgba(21, 213, 238, 0.68);
+        background: #071629;
+        transform: translateX(-50%) rotate(45deg);
+      }
+
+      button:hover .prompt,
+      button:focus-visible .prompt {
+        opacity: 1;
+        transform: translate(-50%, 0) scale(1);
+      }
+
+      .pet {
+        position: absolute;
+        left: 17px;
+        bottom: 5px;
+        width: 104px;
+        height: 104px;
+        filter: drop-shadow(0 9px 10px rgba(0, 21, 40, 0.38));
+        transform-origin: 50% 100%;
+        animation: brian-breathe 2.8s steps(2, end) infinite;
+      }
+
+      .halo {
+        position: absolute;
+        left: 50%;
+        bottom: 2px;
+        width: 90px;
+        height: 18px;
+        border-radius: 50%;
+        background: rgba(14, 210, 235, 0.18);
+        filter: blur(8px);
+        transform: translateX(-50%);
+      }
+
+      .eye { animation: brian-blink 4.4s steps(1, end) infinite; }
+
+      button:hover .pet,
+      button:focus-visible .pet {
+        animation: brian-wave 420ms steps(2, end) infinite alternate;
+      }
+
+      button:active .pet { transform: translateY(3px) scale(0.96); }
+
+      @keyframes brian-breathe {
+        0%, 100% { transform: translateY(0); }
+        50% { transform: translateY(-4px); }
+      }
+
+      @keyframes brian-wave {
+        from { transform: translateY(-4px) rotate(-2deg); }
+        to { transform: translateY(-8px) rotate(3deg); }
+      }
+
+      @keyframes brian-blink {
+        0%, 46%, 50%, 100% { opacity: 1; }
+        47%, 49% { opacity: 0; }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .pet, .eye { animation: none; }
+      }
+    </style>
+  </head>
+  <body>
+    <button id="message-brian" type="button" aria-label="Message Brian" title="Message Brian">
+      <span class="prompt">Message Brian</span>
+      <span class="halo" aria-hidden="true"></span>
+      <svg class="pet" viewBox="0 0 7 7" aria-hidden="true" shape-rendering="crispEdges">
+        <g fill="#10d4eb">
+          <rect x="2" y="0" width="3" height="1" />
+          <rect x="1" y="1" width="5" height="1" />
+          <rect x="0" y="2" width="7" height="2" />
+          <rect x="1" y="4" width="5" height="1" />
+          <rect x="2" y="5" width="1" height="1" />
+          <rect x="4" y="5" width="1" height="1" />
+        </g>
+        <g class="eye" fill="#07172b">
+          <rect x="2" y="2" width="0.55" height="0.55" />
+          <rect x="4.45" y="2" width="0.55" height="0.55" />
+        </g>
+        <rect x="3" y="3.35" width="1" height="0.25" fill="#85f4ff" opacity="0.85" />
+      </svg>
+    </button>
+  </body>
+</html>

--- a/apps/app-desktop/src/brian-pet.html
+++ b/apps/app-desktop/src/brian-pet.html
@@ -28,6 +28,8 @@
         color: #eaf5ff;
         background: transparent;
         cursor: pointer;
+        touch-action: none;
+        user-select: none;
         -webkit-app-region: no-drag;
       }
       .prompt {
@@ -78,7 +80,13 @@
         filter: drop-shadow(0 9px 10px rgba(0, 21, 40, 0.38));
         transform-origin: 50% 85%;
       }
-      .pet { display: block; width: 100%; height: 100%; object-fit: contain; }
+      .pet {
+        display: block;
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+        -webkit-user-drag: none;
+      }
       .lid, .mouth, .thought, .action-badge { position: absolute; pointer-events: none; }
       .lid {
         top: 40%;

--- a/apps/app-desktop/src/brian-pet.html
+++ b/apps/app-desktop/src/brian-pet.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; style-src 'unsafe-inline'; img-src data:"
+      content="default-src 'none'; style-src 'unsafe-inline'; img-src 'self'"
     />
     <meta name="color-scheme" content="dark" />
     <style>
@@ -85,9 +85,8 @@
         bottom: 5px;
         width: 104px;
         height: 104px;
+        object-fit: contain;
         filter: drop-shadow(0 9px 10px rgba(0, 21, 40, 0.38));
-        transform-origin: 50% 100%;
-        animation: brian-breathe 2.8s steps(2, end) infinite;
       }
 
       .halo {
@@ -102,54 +101,13 @@
         transform: translateX(-50%);
       }
 
-      .eye { animation: brian-blink 4.4s steps(1, end) infinite; }
-
-      button:hover .pet,
-      button:focus-visible .pet {
-        animation: brian-wave 420ms steps(2, end) infinite alternate;
-      }
-
-      button:active .pet { transform: translateY(3px) scale(0.96); }
-
-      @keyframes brian-breathe {
-        0%, 100% { transform: translateY(0); }
-        50% { transform: translateY(-4px); }
-      }
-
-      @keyframes brian-wave {
-        from { transform: translateY(-4px) rotate(-2deg); }
-        to { transform: translateY(-8px) rotate(3deg); }
-      }
-
-      @keyframes brian-blink {
-        0%, 46%, 50%, 100% { opacity: 1; }
-        47%, 49% { opacity: 0; }
-      }
-
-      @media (prefers-reduced-motion: reduce) {
-        .pet, .eye { animation: none; }
-      }
     </style>
   </head>
   <body>
     <button id="message-brian" type="button" aria-label="Message Brian" title="Message Brian">
       <span class="prompt">Message Brian</span>
       <span class="halo" aria-hidden="true"></span>
-      <svg class="pet" viewBox="0 0 7 7" aria-hidden="true" shape-rendering="crispEdges">
-        <g fill="#10d4eb">
-          <rect x="2" y="0" width="3" height="1" />
-          <rect x="1" y="1" width="5" height="1" />
-          <rect x="0" y="2" width="7" height="2" />
-          <rect x="1" y="4" width="5" height="1" />
-          <rect x="2" y="5" width="1" height="1" />
-          <rect x="4" y="5" width="1" height="1" />
-        </g>
-        <g class="eye" fill="#07172b">
-          <rect x="2" y="2" width="0.55" height="0.55" />
-          <rect x="4.45" y="2" width="0.55" height="0.55" />
-        </g>
-        <rect x="3" y="3.35" width="1" height="0.25" fill="#85f4ff" opacity="0.85" />
-      </svg>
+      <img class="pet" src="./brian-logo.png" alt="" aria-hidden="true" />
     </button>
   </body>
 </html>

--- a/apps/app-desktop/src/desktop-chat.ts
+++ b/apps/app-desktop/src/desktop-chat.ts
@@ -30,6 +30,15 @@ export function desktopChatRoute(workspaceId: string): string {
   return `/desktop/chat/${encodeURIComponent(workspaceId)}`;
 }
 
+/** A companion click immediately following panel blur is the outside click itself. */
+export function companionClickFollowsChatBlur(
+  nowMs: number,
+  blurredAtMs: number,
+  windowMs = 400,
+): boolean {
+  return blurredAtMs > 0 && nowMs >= blurredAtMs && nowMs - blurredAtMs <= windowMs;
+}
+
 /** Accept only the small display-only state surface sent by the chat renderer. */
 export function parseCompanionState(value: unknown): CompanionState | null {
   if (!value || typeof value !== "object") return null;

--- a/apps/app-desktop/src/desktop-chat.ts
+++ b/apps/app-desktop/src/desktop-chat.ts
@@ -2,6 +2,17 @@
 
 const WORKSPACE_ROUTE = /^\/w\/([^/?#]+)(?:\/|$)/;
 
+export const COMPANION_PHASES = [
+  "idle",
+  "loading",
+  "thinking",
+  "responding",
+  "action-required",
+] as const;
+
+export type CompanionPhase = (typeof COMPANION_PHASES)[number];
+export type CompanionState = { phase: CompanionPhase; label?: string };
+
 /** Extract a workspace id only from a canonical in-app workspace route. */
 export function workspaceIdFromDesktopRoute(route: string): string | null {
   const match = WORKSPACE_ROUTE.exec(route);
@@ -17,4 +28,21 @@ export function workspaceIdFromDesktopRoute(route: string): string | null {
 /** Route shared by the live Next app and bundled HashRouter build. */
 export function desktopChatRoute(workspaceId: string): string {
   return `/desktop/chat/${encodeURIComponent(workspaceId)}`;
+}
+
+/** Accept only the small display-only state surface sent by the chat renderer. */
+export function parseCompanionState(value: unknown): CompanionState | null {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as { phase?: unknown; label?: unknown };
+  if (
+    typeof candidate.phase !== "string" ||
+    !COMPANION_PHASES.includes(candidate.phase as CompanionPhase)
+  ) {
+    return null;
+  }
+  const label =
+    typeof candidate.label === "string"
+      ? candidate.label.replace(/[\u0000-\u001f\u007f]/g, " ").trim().slice(0, 120)
+      : "";
+  return { phase: candidate.phase as CompanionPhase, ...(label ? { label } : {}) };
 }

--- a/apps/app-desktop/src/desktop-chat.ts
+++ b/apps/app-desktop/src/desktop-chat.ts
@@ -1,0 +1,20 @@
+/** Pure route helpers for the companion's dedicated chat window. */
+
+const WORKSPACE_ROUTE = /^\/w\/([^/?#]+)(?:\/|$)/;
+
+/** Extract a workspace id only from a canonical in-app workspace route. */
+export function workspaceIdFromDesktopRoute(route: string): string | null {
+  const match = WORKSPACE_ROUTE.exec(route);
+  if (!match?.[1]) return null;
+  try {
+    const workspaceId = decodeURIComponent(match[1]);
+    return workspaceId && !workspaceId.includes("/") ? workspaceId : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Route shared by the live Next app and bundled HashRouter build. */
+export function desktopChatRoute(workspaceId: string): string {
+  return `/desktop/chat/${encodeURIComponent(workspaceId)}`;
+}

--- a/apps/app-desktop/src/main.ts
+++ b/apps/app-desktop/src/main.ts
@@ -53,8 +53,13 @@ import electronUpdater from "electron-updater";
 import { resolveConfig } from "./config.js";
 import {
   AWAKE_BRIAN_FILE_NAME,
+  BRIAN_POSITION_FILE_NAME,
+  clampBrianPosition,
+  parseBrianPosition,
   parseAwakeBrianPreference,
+  serializeBrianPosition,
   serializeAwakeBrianPreference,
+  type BrianPosition,
 } from "./awake-brian.js";
 import {
   DEFAULT_LOCAL_APP_URL,
@@ -101,6 +106,7 @@ import {
 import { resolveDeepLink } from "./deep-link.js";
 import { quickCaptureUrl, recordTargetUrl } from "./quick-capture.js";
 import {
+  companionClickFollowsChatBlur,
   desktopChatRoute,
   parseCompanionState,
   workspaceIdFromDesktopRoute,
@@ -260,6 +266,9 @@ let desktopChatWindow: BrowserWindow | null = null;
 let awakeBrianBlockerId: number | null = null;
 let keepBrianAwake = false;
 let lastWorkspaceId: string | null = null;
+let desktopChatBlurredAt = 0;
+let brianPetPosition: BrianPosition | null = null;
+let brianPetDragOffset: BrianPosition | null = null;
 /** The PKCE verifier for an in-flight sign-in; held until the callback returns. */
 let pendingVerifier: string | null = null;
 /** Whether the in-flight sign-in adds a second account (stash) vs replaces the active one. */
@@ -297,10 +306,19 @@ function awakeBrianFile(): string {
   return join(app.getPath("userData"), AWAKE_BRIAN_FILE_NAME);
 }
 
+function brianPositionFile(): string {
+  return join(app.getPath("userData"), BRIAN_POSITION_FILE_NAME);
+}
+
 try {
   keepBrianAwake = parseAwakeBrianPreference(readFileSync(awakeBrianFile(), "utf8"));
 } catch {
   keepBrianAwake = false;
+}
+try {
+  brianPetPosition = parseBrianPosition(readFileSync(brianPositionFile(), "utf8"));
+} catch {
+  brianPetPosition = null;
 }
 
 /** Electron-session transport: HttpOnly deployment-gateway cookies stay on-device. */
@@ -622,6 +640,7 @@ function messageBrian(): void {
       desktopChatWindow.hide();
       return;
     }
+    if (companionClickFollowsChatBlur(Date.now(), desktopChatBlurredAt)) return;
     positionDesktopChat();
     desktopChatWindow.show();
     desktopChatWindow.focus();
@@ -679,6 +698,11 @@ function messageBrian(): void {
       win.hide();
     }
   });
+  win.on("blur", () => {
+    if (win.isDestroyed() || !win.isVisible()) return;
+    desktopChatBlurredAt = Date.now();
+    win.hide();
+  });
   win.webContents.setWindowOpenHandler(({ url }) => {
     void shell.openExternal(url);
     return { action: "deny" };
@@ -698,6 +722,7 @@ function messageBrian(): void {
   });
   win.on("closed", () => {
     if (desktopChatWindow === win) desktopChatWindow = null;
+    desktopChatBlurredAt = 0;
     publishCompanionState({ phase: "idle" });
   });
 
@@ -735,13 +760,50 @@ function positionDesktopChat(): void {
 
 function positionBrianPet(): void {
   if (!brianPetWindow || brianPetWindow.isDestroyed()) return;
-  const area = screen.getPrimaryDisplay().workArea;
-  brianPetWindow.setPosition(
-    area.x + area.width - BRIAN_PET_WIDTH - BRIAN_PET_GUTTER,
-    area.y + area.height - BRIAN_PET_HEIGHT - BRIAN_PET_GUTTER,
-    false,
+  const fallbackArea = screen.getPrimaryDisplay().workArea;
+  const desired =
+    brianPetPosition ??
+    {
+      x: fallbackArea.x + fallbackArea.width - BRIAN_PET_WIDTH - BRIAN_PET_GUTTER,
+      y: fallbackArea.y + fallbackArea.height - BRIAN_PET_HEIGHT - BRIAN_PET_GUTTER,
+    };
+  const area = screen.getDisplayMatching({
+    x: desired.x,
+    y: desired.y,
+    width: BRIAN_PET_WIDTH,
+    height: BRIAN_PET_HEIGHT,
+  }).workArea;
+  brianPetPosition = clampBrianPosition(
+    desired,
+    area,
+    { width: BRIAN_PET_WIDTH, height: BRIAN_PET_HEIGHT },
   );
+  brianPetWindow.setPosition(brianPetPosition.x, brianPetPosition.y, false);
   positionDesktopChat();
+}
+
+function moveBrianPet(screenX: number, screenY: number): void {
+  if (!brianPetWindow || brianPetWindow.isDestroyed() || !brianPetDragOffset) return;
+  const display = screen.getDisplayNearestPoint({ x: Math.round(screenX), y: Math.round(screenY) });
+  brianPetPosition = clampBrianPosition(
+    {
+      x: Math.round(screenX - brianPetDragOffset.x),
+      y: Math.round(screenY - brianPetDragOffset.y),
+    },
+    display.workArea,
+    { width: BRIAN_PET_WIDTH, height: BRIAN_PET_HEIGHT },
+  );
+  brianPetWindow.setPosition(brianPetPosition.x, brianPetPosition.y, false);
+  positionDesktopChat();
+}
+
+function persistBrianPetPosition(): void {
+  if (!brianPetPosition) return;
+  try {
+    writeFileSync(brianPositionFile(), serializeBrianPosition(brianPetPosition));
+  } catch (error) {
+    console.warn("Failed to persist Brian companion position:", error);
+  }
 }
 
 function showBrianPet(): void {
@@ -2844,6 +2906,46 @@ if (!gotLock) {
     ) {
       messageBrian();
     }
+  });
+  ipcMain.on("Use Brian:companion-drag", (event, raw: unknown) => {
+    if (
+      !brianPetWindow ||
+      brianPetWindow.isDestroyed() ||
+      event.sender.id !== brianPetWindow.webContents.id ||
+      !raw ||
+      typeof raw !== "object"
+    ) {
+      return;
+    }
+    const input = raw as {
+      phase?: unknown;
+      screenX?: unknown;
+      screenY?: unknown;
+      moved?: unknown;
+    };
+    if (input.phase === "end") {
+      if (input.moved === true) persistBrianPetPosition();
+      brianPetDragOffset = null;
+      return;
+    }
+    if (
+      (input.phase !== "start" && input.phase !== "move") ||
+      typeof input.screenX !== "number" ||
+      typeof input.screenY !== "number" ||
+      !Number.isFinite(input.screenX) ||
+      !Number.isFinite(input.screenY)
+    ) {
+      return;
+    }
+    if (input.phase === "start") {
+      const bounds = brianPetWindow.getBounds();
+      brianPetDragOffset = {
+        x: input.screenX - bounds.x,
+        y: input.screenY - bounds.y,
+      };
+      return;
+    }
+    moveBrianPet(input.screenX, input.screenY);
   });
   ipcMain.on("Use Brian:companion-state", (event, rawState: unknown) => {
     if (

--- a/apps/app-desktop/src/main.ts
+++ b/apps/app-desktop/src/main.ts
@@ -102,7 +102,9 @@ import { resolveDeepLink } from "./deep-link.js";
 import { quickCaptureUrl, recordTargetUrl } from "./quick-capture.js";
 import {
   desktopChatRoute,
+  parseCompanionState,
   workspaceIdFromDesktopRoute,
+  type CompanionState,
 } from "./desktop-chat.js";
 import {
   isTrustedCaptureOrigin,
@@ -589,6 +591,8 @@ function createWindow(): BrowserWindow {
 const BRIAN_PET_WIDTH = 150;
 const BRIAN_PET_HEIGHT = 154;
 const BRIAN_PET_GUTTER = 18;
+const DESKTOP_CHAT_WIDTH = 436;
+const DESKTOP_CHAT_HEIGHT = 640;
 
 function isAppPage(win: BrowserWindow): boolean {
   try {
@@ -614,6 +618,11 @@ function rememberWorkspace(win: BrowserWindow): void {
 function messageBrian(): void {
   if (!lastWorkspaceId) return;
   if (desktopChatWindow && !desktopChatWindow.isDestroyed()) {
+    if (desktopChatWindow.isVisible()) {
+      desktopChatWindow.hide();
+      return;
+    }
+    positionDesktopChat();
     desktopChatWindow.show();
     desktopChatWindow.focus();
     desktopChatWindow.webContents.focus();
@@ -621,12 +630,19 @@ function messageBrian(): void {
   }
 
   const win = new BrowserWindow({
-    width: 420,
-    height: 640,
-    minWidth: 360,
-    minHeight: 480,
+    width: DESKTOP_CHAT_WIDTH,
+    height: DESKTOP_CHAT_HEIGHT,
     title: "Message Brian",
-    backgroundColor: "#ffffff",
+    frame: false,
+    transparent: true,
+    resizable: false,
+    maximizable: false,
+    minimizable: false,
+    fullscreenable: false,
+    skipTaskbar: true,
+    alwaysOnTop: true,
+    hasShadow: false,
+    backgroundColor: "#00000000",
     show: false,
     webPreferences: {
       preload: PRELOAD_PATH,
@@ -641,6 +657,10 @@ function messageBrian(): void {
     },
   });
   desktopChatWindow = win;
+  positionDesktopChat();
+  publishCompanionState({ phase: "loading" });
+  win.setAlwaysOnTop(true, "floating");
+  win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
 
   win.once("ready-to-show", () => {
     if (win.isDestroyed()) return;
@@ -651,6 +671,12 @@ function messageBrian(): void {
   win.webContents.on("did-finish-load", () => {
     if (!win.webContents.isDestroyed()) {
       void win.webContents.insertCSS(DESKTOP_CHROME_SAFETY_CSS);
+    }
+  });
+  win.webContents.on("before-input-event", (event, input) => {
+    if (input.type === "keyDown" && input.key === "Escape") {
+      event.preventDefault();
+      win.hide();
     }
   });
   win.webContents.setWindowOpenHandler(({ url }) => {
@@ -672,12 +698,39 @@ function messageBrian(): void {
   });
   win.on("closed", () => {
     if (desktopChatWindow === win) desktopChatWindow = null;
+    publishCompanionState({ phase: "idle" });
   });
 
   void loadApp(win, { route: desktopChatRoute(lastWorkspaceId) }).catch((error) => {
     console.warn("Failed to open the Brian chat window:", error);
     if (!win.isDestroyed()) win.close();
   });
+}
+
+function publishCompanionState(state: CompanionState): void {
+  if (!brianPetWindow || brianPetWindow.isDestroyed() || brianPetWindow.webContents.isDestroyed()) {
+    return;
+  }
+  brianPetWindow.webContents.send("Use Brian:companion-state", state);
+}
+
+function positionDesktopChat(): void {
+  if (
+    !desktopChatWindow ||
+    desktopChatWindow.isDestroyed() ||
+    !brianPetWindow ||
+    brianPetWindow.isDestroyed()
+  ) {
+    return;
+  }
+  const pet = brianPetWindow.getBounds();
+  const area = screen.getDisplayMatching(pet).workArea;
+  const x = Math.max(area.x, pet.x - DESKTOP_CHAT_WIDTH + 8);
+  const y = Math.max(
+    area.y,
+    Math.min(area.y + area.height - DESKTOP_CHAT_HEIGHT, pet.y + pet.height - DESKTOP_CHAT_HEIGHT),
+  );
+  desktopChatWindow.setPosition(x, y, false);
 }
 
 function positionBrianPet(): void {
@@ -688,6 +741,7 @@ function positionBrianPet(): void {
     area.y + area.height - BRIAN_PET_HEIGHT - BRIAN_PET_GUTTER,
     false,
   );
+  positionDesktopChat();
 }
 
 function showBrianPet(): void {
@@ -729,6 +783,7 @@ function showBrianPet(): void {
   win.once("ready-to-show", () => win.showInactive());
   win.on("closed", () => {
     if (brianPetWindow === win) brianPetWindow = null;
+    if (desktopChatWindow && !desktopChatWindow.isDestroyed()) desktopChatWindow.close();
   });
   void win.loadFile(BRIAN_PET_PAGE);
 }
@@ -753,6 +808,8 @@ function syncAwakeBrianMode(): void {
   stopAwakeBrianBlocker();
   if (brianPetWindow && !brianPetWindow.isDestroyed()) brianPetWindow.destroy();
   brianPetWindow = null;
+  if (desktopChatWindow && !desktopChatWindow.isDestroyed()) desktopChatWindow.close();
+  desktopChatWindow = null;
 }
 
 function toggleKeepBrianAwake(): void {
@@ -2787,6 +2844,17 @@ if (!gotLock) {
     ) {
       messageBrian();
     }
+  });
+  ipcMain.on("Use Brian:companion-state", (event, rawState: unknown) => {
+    if (
+      !desktopChatWindow ||
+      desktopChatWindow.isDestroyed() ||
+      event.sender.id !== desktopChatWindow.webContents.id
+    ) {
+      return;
+    }
+    const state = parseCompanionState(rawState);
+    if (state) publishCompanionState(state);
   });
   // Dock live recording: show/close the floating overlay with the capture.
   ipcMain.on("Use Brian:recording-state", (_event, on: unknown) => {

--- a/apps/app-desktop/src/main.ts
+++ b/apps/app-desktop/src/main.ts
@@ -101,6 +101,10 @@ import {
 import { resolveDeepLink } from "./deep-link.js";
 import { quickCaptureUrl, recordTargetUrl } from "./quick-capture.js";
 import {
+  desktopChatRoute,
+  workspaceIdFromDesktopRoute,
+} from "./desktop-chat.js";
+import {
   isTrustedCaptureOrigin,
   selectPrimaryDisplaySource,
 } from "./system-audio-policy.js";
@@ -250,9 +254,10 @@ type SwitchResult = { ok: true } | { ok: false; error: "switch" | "reauth" };
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let brianPetWindow: BrowserWindow | null = null;
+let desktopChatWindow: BrowserWindow | null = null;
 let awakeBrianBlockerId: number | null = null;
 let keepBrianAwake = false;
-let pendingMessageBrian = false;
+let lastWorkspaceId: string | null = null;
 /** The PKCE verifier for an in-flight sign-in; held until the callback returns. */
 let pendingVerifier: string | null = null;
 /** Whether the in-flight sign-in adds a second account (stash) vs replaces the active one. */
@@ -493,8 +498,11 @@ function createWindow(): BrowserWindow {
   win.webContents.on("did-finish-load", () => {
     if (!win.webContents.isDestroyed()) void win.webContents.insertCSS(DESKTOP_CHROME_SAFETY_CSS);
     if (cfg.target === "local") void detectLoadedGatewayChallenge(win);
-    flushMessageBrian(win);
+    rememberWorkspace(win);
   });
+
+  win.webContents.on("did-navigate", () => rememberWorkspace(win));
+  win.webContents.on("did-navigate-in-page", () => rememberWorkspace(win));
 
   // §2.3 visible target indicator: a local target suffixes every page title so
   // the two brains can never be mistaken for each other. Cloud keeps titles
@@ -592,17 +600,84 @@ function isAppPage(win: BrowserWindow): boolean {
   }
 }
 
-function flushMessageBrian(win: BrowserWindow): void {
-  if (!pendingMessageBrian || win.isDestroyed() || !isAppPage(win)) return;
-  focusWindow(win);
-  win.webContents.send("Use Brian:message-brian");
+function rememberWorkspace(win: BrowserWindow): void {
+  if (win.isDestroyed() || !isAppPage(win)) return;
+  try {
+    const current = new URL(win.webContents.getURL());
+    const route = current.protocol === "file:" ? current.hash.slice(1) : current.pathname;
+    lastWorkspaceId = workspaceIdFromDesktopRoute(route) ?? lastWorkspaceId;
+  } catch {
+    // A transient blank or malformed navigation cannot replace the last target.
+  }
 }
 
 function messageBrian(): void {
-  pendingMessageBrian = true;
-  const win = ensureWindow();
-  focusWindow(win);
-  flushMessageBrian(win);
+  if (!lastWorkspaceId) return;
+  if (desktopChatWindow && !desktopChatWindow.isDestroyed()) {
+    desktopChatWindow.show();
+    desktopChatWindow.focus();
+    desktopChatWindow.webContents.focus();
+    return;
+  }
+
+  const win = new BrowserWindow({
+    width: 420,
+    height: 640,
+    minWidth: 360,
+    minHeight: 480,
+    title: "Message Brian",
+    backgroundColor: "#ffffff",
+    show: false,
+    webPreferences: {
+      preload: PRELOAD_PATH,
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+      webSecurity: true,
+      additionalArguments: [
+        ...(cfg.bundled ? ["--usebrian-bundled"] : []),
+        ...(cfg.target === "local" ? ["--usebrian-local-target"] : []),
+      ],
+    },
+  });
+  desktopChatWindow = win;
+
+  win.once("ready-to-show", () => {
+    if (win.isDestroyed()) return;
+    win.show();
+    win.focus();
+    win.webContents.focus();
+  });
+  win.webContents.on("did-finish-load", () => {
+    if (!win.webContents.isDestroyed()) {
+      void win.webContents.insertCSS(DESKTOP_CHROME_SAFETY_CSS);
+    }
+  });
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    void shell.openExternal(url);
+    return { action: "deny" };
+  });
+  win.webContents.on("will-navigate", (event, url) => {
+    try {
+      const target = new URL(url);
+      const trusted =
+        target.origin === cfg.appOrigin ||
+        (bundledAvailable() && target.pathname === pathToFileURL(BUNDLE_INDEX).pathname);
+      if (trusted) return;
+    } catch {
+      // Reject malformed navigation below.
+    }
+    event.preventDefault();
+    void shell.openExternal(url);
+  });
+  win.on("closed", () => {
+    if (desktopChatWindow === win) desktopChatWindow = null;
+  });
+
+  void loadApp(win, { route: desktopChatRoute(lastWorkspaceId) }).catch((error) => {
+    console.warn("Failed to open the Brian chat window:", error);
+    if (!win.isDestroyed()) win.close();
+  });
 }
 
 function positionBrianPet(): void {
@@ -2713,12 +2788,6 @@ if (!gotLock) {
       messageBrian();
     }
   });
-  ipcMain.on("Use Brian:message-brian-consumed", (event) => {
-    if (mainWindow && !mainWindow.isDestroyed() && event.sender.id === mainWindow.webContents.id) {
-      pendingMessageBrian = false;
-    }
-  });
-
   // Dock live recording: show/close the floating overlay with the capture.
   ipcMain.on("Use Brian:recording-state", (_event, on: unknown) => {
     if (on === true) showRecorderOverlay();

--- a/apps/app-desktop/src/main.ts
+++ b/apps/app-desktop/src/main.ts
@@ -5,8 +5,9 @@
  * (or the deployed web app in development compatibility mode) and adds the
  * native capabilities a browser cannot: a global quick-capture hotkey, a tray,
  * OS-level menus, a `usebrian://` deep-link protocol, and a system-browser
- * sign-in flow (RFC 8252 + PKCE). It owns no product UI and no backend — every
- * pixel comes from apps/app-web. All decisions are delegated to the pure helpers
+ * sign-in flow (RFC 8252 + PKCE). Product UI is served by apps/app-web; the
+ * only shell-owned interactive surface is the bundled ambient Brian companion.
+ * It owns no backend. All decisions are delegated to the pure helpers
  * (config / window-policy / deep-link / quick-capture / desktop-auth) so this
  * file stays thin and they stay tested.
  *
@@ -14,7 +15,7 @@
  * [COMP:app-desktop/main]
  */
 
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, join, resolve } from "node:path";
 import { existsSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { spawn } from "node:child_process";
@@ -30,6 +31,7 @@ import {
   safeStorage,
   dialog,
   powerMonitor,
+  powerSaveBlocker,
   screen,
   systemPreferences,
   net,
@@ -49,6 +51,11 @@ import {
 import electronUpdater from "electron-updater";
 
 import { resolveConfig } from "./config.js";
+import {
+  AWAKE_BRIAN_FILE_NAME,
+  parseAwakeBrianPreference,
+  serializeAwakeBrianPreference,
+} from "./awake-brian.js";
 import {
   DEFAULT_LOCAL_APP_URL,
   TARGET_FILE_NAME,
@@ -211,6 +218,8 @@ const cfg = resolveConfig(process.env, readPersistedTargetRaw(), app.isPackaged)
 const isDev = !app.isPackaged;
 
 const PRELOAD_PATH = join(__dirname, "preload.cjs");
+const PET_PRELOAD_PATH = join(__dirname, "pet-preload.cjs");
+const BRIAN_PET_PAGE = join(__dirname, "brian-pet.html");
 const SIGNIN_PAGE = join(__dirname, "signin.html");
 /**
  * The offline landing — shown (instead of the sign-in landing) when a signed-in
@@ -240,6 +249,10 @@ type SwitchResult = { ok: true } | { ok: false; error: "switch" | "reauth" };
 
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
+let brianPetWindow: BrowserWindow | null = null;
+let awakeBrianBlockerId: number | null = null;
+let keepBrianAwake = false;
+let pendingMessageBrian = false;
 /** The PKCE verifier for an in-flight sign-in; held until the callback returns. */
 let pendingVerifier: string | null = null;
 /** Whether the in-flight sign-in adds a second account (stash) vs replaces the active one. */
@@ -272,6 +285,16 @@ let activeAccessGrant: CloudflareAccessGrant | null = null;
 let accessReauthorizationNeeded = false;
 
 const GATEWAY_RECHECK_INTERVAL_MS = 1000;
+
+function awakeBrianFile(): string {
+  return join(app.getPath("userData"), AWAKE_BRIAN_FILE_NAME);
+}
+
+try {
+  keepBrianAwake = parseAwakeBrianPreference(readFileSync(awakeBrianFile(), "utf8"));
+} catch {
+  keepBrianAwake = false;
+}
 
 /** Electron-session transport: HttpOnly deployment-gateway cookies stay on-device. */
 const gatewayProbeFetch: GatewayProbeFetch = (input, init) => {
@@ -470,6 +493,7 @@ function createWindow(): BrowserWindow {
   win.webContents.on("did-finish-load", () => {
     if (!win.webContents.isDestroyed()) void win.webContents.insertCSS(DESKTOP_CHROME_SAFETY_CSS);
     if (cfg.target === "local") void detectLoadedGatewayChallenge(win);
+    flushMessageBrian(win);
   });
 
   // §2.3 visible target indicator: a local target suffixes every page title so
@@ -550,6 +574,130 @@ function createWindow(): BrowserWindow {
     destroyRecorderOverlay();
   });
   return win;
+}
+
+// ── Awake Brian companion ─────────────────────────────────────
+
+const BRIAN_PET_WIDTH = 150;
+const BRIAN_PET_HEIGHT = 154;
+const BRIAN_PET_GUTTER = 18;
+
+function isAppPage(win: BrowserWindow): boolean {
+  try {
+    const current = new URL(win.webContents.getURL());
+    if (current.origin === cfg.appOrigin) return true;
+    return bundledAvailable() && current.pathname === pathToFileURL(BUNDLE_INDEX).pathname;
+  } catch {
+    return false;
+  }
+}
+
+function flushMessageBrian(win: BrowserWindow): void {
+  if (!pendingMessageBrian || win.isDestroyed() || !isAppPage(win)) return;
+  focusWindow(win);
+  win.webContents.send("Use Brian:message-brian");
+}
+
+function messageBrian(): void {
+  pendingMessageBrian = true;
+  const win = ensureWindow();
+  focusWindow(win);
+  flushMessageBrian(win);
+}
+
+function positionBrianPet(): void {
+  if (!brianPetWindow || brianPetWindow.isDestroyed()) return;
+  const area = screen.getPrimaryDisplay().workArea;
+  brianPetWindow.setPosition(
+    area.x + area.width - BRIAN_PET_WIDTH - BRIAN_PET_GUTTER,
+    area.y + area.height - BRIAN_PET_HEIGHT - BRIAN_PET_GUTTER,
+    false,
+  );
+}
+
+function showBrianPet(): void {
+  if (brianPetWindow && !brianPetWindow.isDestroyed()) {
+    positionBrianPet();
+    brianPetWindow.showInactive();
+    return;
+  }
+
+  const win = new BrowserWindow({
+    width: BRIAN_PET_WIDTH,
+    height: BRIAN_PET_HEIGHT,
+    frame: false,
+    transparent: true,
+    resizable: false,
+    maximizable: false,
+    minimizable: false,
+    fullscreenable: false,
+    skipTaskbar: true,
+    alwaysOnTop: true,
+    hasShadow: false,
+    show: false,
+    webPreferences: {
+      preload: PET_PRELOAD_PATH,
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+      webSecurity: true,
+      devTools: false,
+      spellcheck: false,
+    },
+  });
+  brianPetWindow = win;
+  positionBrianPet();
+  win.setAlwaysOnTop(true, "floating");
+  win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+  win.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+  win.webContents.on("will-navigate", (event) => event.preventDefault());
+  win.once("ready-to-show", () => win.showInactive());
+  win.on("closed", () => {
+    if (brianPetWindow === win) brianPetWindow = null;
+  });
+  void win.loadFile(BRIAN_PET_PAGE);
+}
+
+function stopAwakeBrianBlocker(): void {
+  if (awakeBrianBlockerId === null) return;
+  if (powerSaveBlocker.isStarted(awakeBrianBlockerId)) {
+    powerSaveBlocker.stop(awakeBrianBlockerId);
+  }
+  awakeBrianBlockerId = null;
+}
+
+function syncAwakeBrianMode(): void {
+  if (keepBrianAwake) {
+    if (awakeBrianBlockerId === null || !powerSaveBlocker.isStarted(awakeBrianBlockerId)) {
+      awakeBrianBlockerId = powerSaveBlocker.start("prevent-app-suspension");
+    }
+    showBrianPet();
+    return;
+  }
+
+  stopAwakeBrianBlocker();
+  if (brianPetWindow && !brianPetWindow.isDestroyed()) brianPetWindow.destroy();
+  brianPetWindow = null;
+}
+
+function toggleKeepBrianAwake(): void {
+  const next = !keepBrianAwake;
+  try {
+    writeFileSync(awakeBrianFile(), serializeAwakeBrianPreference(next));
+  } catch (error) {
+    console.warn("Failed to persist Keep Brian Awake preference:", error);
+    refreshAppMenu();
+    refreshTrayMenu();
+    dialog.showErrorBox(
+      "Could not update Keep Brian Awake",
+      "Use Brian could not save this setting. Check that its application data folder is writable and try again.",
+    );
+    return;
+  }
+  keepBrianAwake = next;
+  syncAwakeBrianMode();
+  refreshAppMenu();
+  refreshTrayMenu();
 }
 
 // ── Recorder overlay (docs/architecture/media/live-capture.md) ─────────
@@ -2446,12 +2594,14 @@ function refreshAppMenu(): void {
       onSwitchTarget: () => void switchTargetFromMenu(),
       onUninstall: () => void confirmAndUninstall(),
       onStartFirefoxControl: () => void startFirefoxForControl(),
+      onToggleKeepAwake: toggleKeepBrianAwake,
       isDev,
       update: updateMenuItem(),
       target: { kind: cfg.target, label: cfg.targetLabel },
       // Packaged macOS only: Windows has the NSIS uninstaller; a dev run has
       // no bundle (and its exe lives in node_modules/electron).
       uninstall: process.platform === "darwin" && app.isPackaged,
+      keepBrianAwake,
     }),
   );
 }
@@ -2467,6 +2617,12 @@ function buildTrayMenu(): Menu {
     { label: "Open Use Brian", click: () => focusWindow(ensureWindow()) },
     { label: "Quick Capture", click: () => summonAndCapture() },
     { label: "Start Recording", click: () => summonAndRecord() },
+    {
+      label: "Keep Brian Awake",
+      type: "checkbox",
+      checked: keepBrianAwake,
+      click: () => toggleKeepBrianAwake(),
+    },
     { label: "Start Firefox for My Browser…", click: () => void startFirefoxForControl() },
   ];
   // A local target has no login — the tray mirrors the app menu (§2.3).
@@ -2548,6 +2704,20 @@ if (!gotLock) {
 
   // The sign-in landing's button asks the main process to start the flow.
   ipcMain.on("Use Brian:sign-in", () => startSignIn());
+  ipcMain.on("Use Brian:message-brian", (event) => {
+    if (
+      brianPetWindow &&
+      !brianPetWindow.isDestroyed() &&
+      event.sender.id === brianPetWindow.webContents.id
+    ) {
+      messageBrian();
+    }
+  });
+  ipcMain.on("Use Brian:message-brian-consumed", (event) => {
+    if (mainWindow && !mainWindow.isDestroyed() && event.sender.id === mainWindow.webContents.id) {
+      pendingMessageBrian = false;
+    }
+  });
 
   // Dock live recording: show/close the floating overlay with the capture.
   ipcMain.on("Use Brian:recording-state", (_event, on: unknown) => {
@@ -2886,6 +3056,10 @@ if (!gotLock) {
     mainWindow = createWindow();
     refreshAppMenu();
     tray = createTray();
+    syncAwakeBrianMode();
+    screen.on("display-added", positionBrianPet);
+    screen.on("display-removed", positionBrianPet);
+    screen.on("display-metrics-changed", positionBrianPet);
 
     const ok = globalShortcut.register(cfg.quickCaptureHotkey, summonAndCapture);
     if (!ok) console.warn(`Failed to register hotkey: ${cfg.quickCaptureHotkey}`);
@@ -2910,7 +3084,10 @@ if (!gotLock) {
     // intentional no-op — stay resident until the user quits explicitly.
   });
 
-  app.on("will-quit", () => globalShortcut.unregisterAll());
+  app.on("will-quit", () => {
+    globalShortcut.unregisterAll();
+    stopAwakeBrianBlocker();
+  });
 }
 
 // Keep the tray reference alive for the GC.

--- a/apps/app-desktop/src/main.ts
+++ b/apps/app-desktop/src/main.ts
@@ -604,7 +604,7 @@ function createWindow(): BrowserWindow {
   return win;
 }
 
-// ── Awake Brian companion ─────────────────────────────────────
+// ── Brian companion ───────────────────────────────────────────
 
 const BRIAN_PET_WIDTH = 150;
 const BRIAN_PET_HEIGHT = 154;
@@ -879,11 +879,11 @@ function toggleKeepBrianAwake(): void {
   try {
     writeFileSync(awakeBrianFile(), serializeAwakeBrianPreference(next));
   } catch (error) {
-    console.warn("Failed to persist Keep Brian Awake preference:", error);
+    console.warn("Failed to persist Keep Brian Nearby preference:", error);
     refreshAppMenu();
     refreshTrayMenu();
     dialog.showErrorBox(
-      "Could not update Keep Brian Awake",
+      "Could not update Keep Brian Nearby",
       "Use Brian could not save this setting. Check that its application data folder is writable and try again.",
     );
     return;
@@ -2812,7 +2812,7 @@ function buildTrayMenu(): Menu {
     { label: "Quick Capture", click: () => summonAndCapture() },
     { label: "Start Recording", click: () => summonAndRecord() },
     {
-      label: "Keep Brian Awake",
+      label: "Keep Brian Nearby",
       type: "checkbox",
       checked: keepBrianAwake,
       click: () => toggleKeepBrianAwake(),

--- a/apps/app-desktop/src/menu-template.ts
+++ b/apps/app-desktop/src/menu-template.ts
@@ -47,6 +47,8 @@ export interface MenuTemplateOptions {
    * Ignored off-mac. See `uninstall.ts`.
    */
   readonly uninstall?: boolean;
+  /** Whether the persisted awake companion mode is currently enabled. */
+  readonly keepBrianAwake: boolean;
 }
 
 export interface MenuTemplateHandlers {
@@ -66,6 +68,8 @@ export interface MenuTemplateHandlers {
   onUninstall: () => void;
   /** Start Firefox with its loopback Remote Agent enabled for My Browser. */
   onStartFirefoxControl: () => void;
+  /** Toggle the persisted power blocker + ambient Brian companion. */
+  onToggleKeepAwake: () => void;
 }
 
 /** Build the platform-appropriate menu template (pure). */
@@ -108,6 +112,12 @@ export function buildMenuTemplate(
       label: "Start Recording",
       accelerator: "CommandOrControl+Shift+R",
       click: () => handlers.onRecord(),
+    },
+    {
+      label: "Keep Brian Awake",
+      type: "checkbox",
+      checked: opts.keepBrianAwake,
+      click: () => handlers.onToggleKeepAwake(),
     },
     {
       label: "Start Firefox for My Browser…",

--- a/apps/app-desktop/src/menu-template.ts
+++ b/apps/app-desktop/src/menu-template.ts
@@ -114,7 +114,7 @@ export function buildMenuTemplate(
       click: () => handlers.onRecord(),
     },
     {
-      label: "Keep Brian Awake",
+      label: "Keep Brian Nearby",
       type: "checkbox",
       checked: opts.keepBrianAwake,
       click: () => handlers.onToggleKeepAwake(),

--- a/apps/app-desktop/src/menu.ts
+++ b/apps/app-desktop/src/menu.ts
@@ -32,6 +32,8 @@ export interface MenuHandlers {
   onUninstall: () => void;
   /** Start Firefox with its loopback Remote Agent enabled for My Browser. */
   onStartFirefoxControl: () => void;
+  /** Toggle the persisted power blocker + ambient Brian companion. */
+  onToggleKeepAwake: () => void;
   /** Whether DevTools / reload affordances should be shown (dev only). */
   isDev: boolean;
   /** Show "Uninstall …" in the macOS app menu (packaged macOS builds only). */
@@ -40,6 +42,8 @@ export interface MenuHandlers {
   update: { readonly label: string; readonly enabled: boolean } | null;
   /** The active target for the indicator + switch items (see menu-template.ts). */
   target: { readonly kind: "cloud" | "local"; readonly label: string } | null;
+  /** Whether the persisted awake companion mode is currently enabled. */
+  keepBrianAwake: boolean;
 }
 
 export function buildAppMenu(handlers: MenuHandlers): Menu {
@@ -51,6 +55,7 @@ export function buildAppMenu(handlers: MenuHandlers): Menu {
       update: handlers.update,
       target: handlers.target,
       uninstall: handlers.uninstall,
+      keepBrianAwake: handlers.keepBrianAwake,
     },
     handlers,
   );

--- a/apps/app-desktop/src/pet-preload.cjs
+++ b/apps/app-desktop/src/pet-preload.cjs
@@ -1,0 +1,9 @@
+// Sandboxed preload for the bundled Brian companion. The page receives no
+// privileged API; activating its one button emits one fixed intent to main.
+const { ipcRenderer } = require("electron");
+
+window.addEventListener("DOMContentLoaded", () => {
+  document.getElementById("message-brian")?.addEventListener("click", () => {
+    ipcRenderer.send("Use Brian:message-brian");
+  });
+});

--- a/apps/app-desktop/src/pet-preload.cjs
+++ b/apps/app-desktop/src/pet-preload.cjs
@@ -2,8 +2,37 @@
 // privileged API; activating its one button emits one fixed intent to main.
 const { ipcRenderer } = require("electron");
 
+const labels = {
+  idle: "Message Brian",
+  loading: "Loading…",
+  thinking: "Thinking…",
+  responding: "Responding…",
+  "action-required": "I need your input",
+};
+let currentState = "idle";
+let completionTimer;
+
 window.addEventListener("DOMContentLoaded", () => {
+  const status = document.getElementById("status");
+  document.body.dataset.state = currentState;
   document.getElementById("message-brian")?.addEventListener("click", () => {
     ipcRenderer.send("Use Brian:message-brian");
+  });
+  ipcRenderer.on("Use Brian:companion-state", (_event, next) => {
+    if (!next || typeof next !== "object" || !(next.phase in labels)) return;
+    clearTimeout(completionTimer);
+    const prior = currentState;
+    currentState = next.phase;
+    if (next.phase === "idle" && (prior === "thinking" || prior === "responding")) {
+      document.body.dataset.state = "complete";
+      if (status) status.textContent = "Ready";
+      completionTimer = setTimeout(() => {
+        document.body.dataset.state = "idle";
+        if (status) status.textContent = labels.idle;
+      }, 900);
+      return;
+    }
+    document.body.dataset.state = next.phase;
+    if (status) status.textContent = next.label || labels[next.phase];
   });
 });

--- a/apps/app-desktop/src/pet-preload.cjs
+++ b/apps/app-desktop/src/pet-preload.cjs
@@ -61,18 +61,25 @@ window.addEventListener("DOMContentLoaded", () => {
   });
   ipcRenderer.on("Use Brian:companion-state", (_event, next) => {
     if (!next || typeof next !== "object" || !(next.phase in labels)) return;
-    clearTimeout(completionTimer);
     const prior = currentState;
-    currentState = next.phase;
     if (next.phase === "idle" && (prior === "thinking" || prior === "responding")) {
+      clearTimeout(completionTimer);
+      currentState = "complete";
       document.body.dataset.state = "complete";
       if (status) status.textContent = "Ready";
       completionTimer = setTimeout(() => {
+        currentState = "idle";
         document.body.dataset.state = "idle";
         if (status) status.textContent = labels.idle;
       }, 900);
       return;
     }
+    // FloatingChat can publish more than one equivalent idle snapshot while it
+    // clears its stream/tool buffers. Keep the completion reaction visible for
+    // its full duration instead of letting the duplicate erase it immediately.
+    if (next.phase === "idle" && prior === "complete") return;
+    clearTimeout(completionTimer);
+    currentState = next.phase;
     document.body.dataset.state = next.phase;
     if (status) status.textContent = next.label || labels[next.phase];
   });

--- a/apps/app-desktop/src/pet-preload.cjs
+++ b/apps/app-desktop/src/pet-preload.cjs
@@ -14,8 +14,49 @@ let completionTimer;
 
 window.addEventListener("DOMContentLoaded", () => {
   const status = document.getElementById("status");
+  const button = document.getElementById("message-brian");
+  let pointerStart;
+  let dragged = false;
+  let suppressClick = false;
   document.body.dataset.state = currentState;
-  document.getElementById("message-brian")?.addEventListener("click", () => {
+  button?.addEventListener("pointerdown", (event) => {
+    if (event.button !== 0) return;
+    pointerStart = { x: event.screenX, y: event.screenY, id: event.pointerId };
+    dragged = false;
+    button.setPointerCapture(event.pointerId);
+    ipcRenderer.send("Use Brian:companion-drag", {
+      phase: "start",
+      screenX: event.screenX,
+      screenY: event.screenY,
+    });
+  });
+  button?.addEventListener("pointermove", (event) => {
+    if (!pointerStart || event.pointerId !== pointerStart.id) return;
+    if (Math.hypot(event.screenX - pointerStart.x, event.screenY - pointerStart.y) >= 4) {
+      dragged = true;
+    }
+    if (!dragged) return;
+    ipcRenderer.send("Use Brian:companion-drag", {
+      phase: "move",
+      screenX: event.screenX,
+      screenY: event.screenY,
+    });
+  });
+  const finishDrag = (event) => {
+    if (!pointerStart || event.pointerId !== pointerStart.id) return;
+    suppressClick = dragged;
+    ipcRenderer.send("Use Brian:companion-drag", { phase: "end", moved: dragged });
+    pointerStart = undefined;
+    dragged = false;
+    if (button.hasPointerCapture(event.pointerId)) button.releasePointerCapture(event.pointerId);
+  };
+  button?.addEventListener("pointerup", finishDrag);
+  button?.addEventListener("pointercancel", finishDrag);
+  button?.addEventListener("click", () => {
+    if (suppressClick) {
+      suppressClick = false;
+      return;
+    }
     ipcRenderer.send("Use Brian:message-brian");
   });
   ipcRenderer.on("Use Brian:companion-state", (_event, next) => {

--- a/apps/app-desktop/src/preload.cjs
+++ b/apps/app-desktop/src/preload.cjs
@@ -123,6 +123,9 @@ const bridge = {
     return () => messageBrianListeners.delete(callback);
   },
   acknowledgeMessageBrian: () => ipcRenderer.send("Use Brian:message-brian-consumed"),
+  // The dedicated chat renderer mirrors its display-only lifecycle onto the
+  // local companion. Main validates both sender identity and payload shape.
+  setCompanionState: (state) => ipcRenderer.send("Use Brian:companion-state", state),
 };
 
 if (process.argv.includes("--usebrian-bundled")) {

--- a/apps/app-desktop/src/preload.cjs
+++ b/apps/app-desktop/src/preload.cjs
@@ -21,6 +21,16 @@
 //       docs/plans/canvas-desktop-bundled-offline.md → Phase 1 ("Remaining wiring").
 const { contextBridge, ipcRenderer, webFrame } = require("electron");
 
+const messageBrianListeners = new Set();
+let messageBrianPending = false;
+ipcRenderer.on("Use Brian:message-brian", () => {
+  if (messageBrianListeners.size === 0) {
+    messageBrianPending = true;
+    return;
+  }
+  for (const listener of messageBrianListeners) listener();
+});
+
 /** @type {Record<string, unknown>} */
 const bridge = {
   // The host OS, so app-web can gate macOS-only chrome (e.g. the traffic-light
@@ -98,6 +108,21 @@ const bridge = {
   // an RFC 8252 loopback flow and navigates back to the connectors page on done.
   // Spec: docs/plans/desktop-connector-oauth-return.md.
   connectConnector: (req) => ipcRenderer.send("Use Brian:connect-connector", req),
+  // The always-on-top Brian companion asks the already-mounted workspace
+  // chrome to reveal its existing composer. Queue one intent until hydration
+  // subscribes so a cold window can never drop the click.
+  onMessageBrian: (callback) => {
+    if (typeof callback !== "function") return () => {};
+    messageBrianListeners.add(callback);
+    if (messageBrianPending) {
+      messageBrianPending = false;
+      queueMicrotask(() => {
+        callback();
+      });
+    }
+    return () => messageBrianListeners.delete(callback);
+  },
+  acknowledgeMessageBrian: () => ipcRenderer.send("Use Brian:message-brian-consumed"),
 };
 
 if (process.argv.includes("--usebrian-bundled")) {

--- a/apps/app-web/desktop/app.tsx
+++ b/apps/app-web/desktop/app.tsx
@@ -57,6 +57,7 @@ import { DocSidebarDataProvider } from "@/components/doc/doc-sidebar-data";
 import { BrainSurfaceProvider } from "@/contexts/brain-surface-context";
 import { PrimaryAssistantProvider } from "@/contexts/primary-assistant";
 import { WorkspaceChrome } from "@/components/doc/workspace-chrome";
+import { DesktopChatWindow } from "@/components/chrome/desktop-chat-window";
 import { WorkspacePicker } from "@/components/workspace-picker";
 import {
   usesScalableWorkspacePicker,
@@ -238,6 +239,7 @@ export function App() {
                 create-workspace affordance yet — that gap is desktop-wide,
                 not introduced by this alias. */}
             <Route path="/teams" element={<Boot />} />
+            <Route path="/desktop/chat/:workspaceId" element={<DesktopChatRoute />} />
             {/* Layout route: WorkspaceShell (providers + persistent chrome)
                 stays mounted across every `/w/[id]/*` surface change — only the
                 `<Outlet/>` swaps — mirroring the Next workspace layout. */}
@@ -330,6 +332,11 @@ export function App() {
       </I18nProvider>
     </ThemeProvider>
   );
+}
+
+function DesktopChatRoute() {
+  const { workspaceId = "" } = useParams();
+  return workspaceId ? <DesktopChatWindow workspaceId={workspaceId} /> : <Navigate to="/" replace />;
 }
 
 // ── Boot / workspace picker ────────────────────────────────────

--- a/apps/app-web/src/app/desktop/chat/[workspaceId]/page.tsx
+++ b/apps/app-web/src/app/desktop/chat/[workspaceId]/page.tsx
@@ -1,0 +1,10 @@
+import { DesktopChatWindow } from "@/components/chrome/desktop-chat-window";
+
+export default async function DesktopChatPage({
+  params,
+}: {
+  params: Promise<{ workspaceId: string }>;
+}) {
+  const { workspaceId } = await params;
+  return <DesktopChatWindow workspaceId={workspaceId} />;
+}

--- a/apps/app-web/src/components/chrome/desktop-chat-window.tsx
+++ b/apps/app-web/src/components/chrome/desktop-chat-window.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useLayoutEffect } from "react";
 import { FloatingChat } from "@/components/chrome/floating-chat";
 import type { ChatActivity } from "@/components/chrome/floating-chat";
 import {
@@ -23,6 +23,27 @@ function DesktopChatContent({ workspaceId }: { workspaceId: string }) {
   const { assistantId } = usePrimaryAssistant();
   const t = useT().chat;
 
+  useLayoutEffect(() => {
+    const elements = [document.documentElement, document.body];
+    const previous = elements.map((element) => ({
+      value: element.style.getPropertyValue("background-color"),
+      priority: element.style.getPropertyPriority("background-color"),
+    }));
+    for (const element of elements) {
+      element.style.setProperty("background-color", "transparent", "important");
+    }
+    return () => {
+      elements.forEach((element, index) => {
+        const prior = previous[index];
+        if (prior?.value) {
+          element.style.setProperty("background-color", prior.value, prior.priority);
+        } else {
+          element.style.removeProperty("background-color");
+        }
+      });
+    };
+  }, []);
+
   useEffect(() => {
     if (!assistantId) desktopBridge()?.setCompanionState?.({ phase: "loading" });
     return () => desktopBridge()?.setCompanionState?.({ phase: "idle" });
@@ -42,7 +63,7 @@ function DesktopChatContent({ workspaceId }: { workspaceId: string }) {
 
   return (
     <main className="relative h-dvh w-full overflow-hidden bg-transparent py-2 pr-4">
-      <section className="h-full overflow-hidden rounded-2xl border border-border bg-background shadow-2xl">
+      <section className="h-full overflow-hidden rounded-2xl border border-border bg-background">
         {assistantId ? (
           <FloatingChat
             workspaceId={workspaceId}

--- a/apps/app-web/src/components/chrome/desktop-chat-window.tsx
+++ b/apps/app-web/src/components/chrome/desktop-chat-window.tsx
@@ -1,10 +1,14 @@
 "use client";
 
+import { useEffect } from "react";
 import { FloatingChat } from "@/components/chrome/floating-chat";
+import type { ChatActivity } from "@/components/chrome/floating-chat";
 import {
   PrimaryAssistantProvider,
   usePrimaryAssistant,
 } from "@/contexts/primary-assistant";
+import { desktopBridge } from "@/lib/desktop-auth-source";
+import { useT } from "@/lib/i18n/client";
 
 /** Chat-only renderer hosted by the companion's dedicated Electron window. */
 export function DesktopChatWindow({ workspaceId }: { workspaceId: string }) {
@@ -17,18 +21,43 @@ export function DesktopChatWindow({ workspaceId }: { workspaceId: string }) {
 
 function DesktopChatContent({ workspaceId }: { workspaceId: string }) {
   const { assistantId } = usePrimaryAssistant();
+  const t = useT().chat;
+
+  useEffect(() => {
+    if (!assistantId) desktopBridge()?.setCompanionState?.({ phase: "loading" });
+    return () => desktopBridge()?.setCompanionState?.({ phase: "idle" });
+  }, [assistantId]);
+
+  const mirrorActivity = (activity: ChatActivity) => {
+    const label =
+      activity.phase === "action-required"
+        ? t.pendingQuestion.heading
+        : activity.phase === "thinking"
+          ? (activity.activeTool?.description ?? t.thinking)
+          : activity.phase === "loading"
+            ? t.pendingQuestion.resuming
+            : undefined;
+    desktopBridge()?.setCompanionState?.({ phase: activity.phase, ...(label ? { label } : {}) });
+  };
 
   return (
-    <main className="h-dvh w-full overflow-hidden bg-background">
-      {assistantId ? (
-        <FloatingChat
-          workspaceId={workspaceId}
-          assistantId={assistantId}
-          mode="side-panel"
-          origin="doc"
-          messageBrianRequest={1}
-        />
-      ) : null}
+    <main className="relative h-dvh w-full overflow-hidden bg-transparent py-2 pr-4">
+      <section className="h-full overflow-hidden rounded-2xl border border-border bg-background shadow-2xl">
+        {assistantId ? (
+          <FloatingChat
+            workspaceId={workspaceId}
+            assistantId={assistantId}
+            mode="side-panel"
+            origin="doc"
+            messageBrianRequest={1}
+            onActivityChange={mirrorActivity}
+          />
+        ) : null}
+      </section>
+      <span
+        aria-hidden
+        className="absolute bottom-16 right-1 size-6 rotate-45 border-r border-t border-border bg-background"
+      />
     </main>
   );
 }

--- a/apps/app-web/src/components/chrome/desktop-chat-window.tsx
+++ b/apps/app-web/src/components/chrome/desktop-chat-window.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { FloatingChat } from "@/components/chrome/floating-chat";
+import {
+  PrimaryAssistantProvider,
+  usePrimaryAssistant,
+} from "@/contexts/primary-assistant";
+
+/** Chat-only renderer hosted by the companion's dedicated Electron window. */
+export function DesktopChatWindow({ workspaceId }: { workspaceId: string }) {
+  return (
+    <PrimaryAssistantProvider workspaceId={workspaceId}>
+      <DesktopChatContent workspaceId={workspaceId} />
+    </PrimaryAssistantProvider>
+  );
+}
+
+function DesktopChatContent({ workspaceId }: { workspaceId: string }) {
+  const { assistantId } = usePrimaryAssistant();
+
+  return (
+    <main className="h-dvh w-full overflow-hidden bg-background">
+      {assistantId ? (
+        <FloatingChat
+          workspaceId={workspaceId}
+          assistantId={assistantId}
+          mode="side-panel"
+          origin="doc"
+          messageBrianRequest={1}
+        />
+      ) : null}
+    </main>
+  );
+}

--- a/apps/app-web/src/components/chrome/floating-chat.tsx
+++ b/apps/app-web/src/components/chrome/floating-chat.tsx
@@ -237,6 +237,7 @@ import {
   type StagedRecording,
 } from "@/lib/recordings/use-recording-upload";
 import { dispatchRecordingParticipantsUpdated } from "@/lib/recordings/recording-events";
+import { companionChatPhase } from "@/lib/companion-chat-state";
 import { useDockRecorder } from "@/lib/recorder/use-dock-recorder";
 import { useLiveRecordingPage } from "@/lib/recordings/use-live-recording-page";
 import {
@@ -409,6 +410,7 @@ type InlineNotice = {
 export type ChatActivity = {
   isStreaming: boolean;
   streamingText: string;
+  phase: "idle" | "loading" | "thinking" | "responding" | "action-required";
   activeTool: {
     name: string;
     description?: string;
@@ -1268,8 +1270,20 @@ export function FloatingChat({
   const isStreaming = session.state.isStreaming;
   const streamingText = session.state.streamingText;
   const activity = useMemo<ChatActivity>(() => {
+    const requiresAction =
+      Boolean(pendingQuestion) ||
+      session.state.pendingConfirmations.some(
+        (confirmation) =>
+          confirmation.status === "pending" || confirmation.status === "approving",
+      );
+    const phase = companionChatPhase({
+      isStreaming,
+      hasStreamingText: Boolean(streamingText),
+      requiresAction,
+      isLoading: resumePolling,
+    });
     if (!isStreaming) {
-      return { isStreaming: false, streamingText: "", activeTool: null };
+      return { isStreaming: false, streamingText: "", phase, activeTool: null };
     }
     const running = toolTimeline.find((t) => t.status === "running");
     const last =
@@ -1280,6 +1294,7 @@ export function FloatingChat({
     return {
       isStreaming: true,
       streamingText,
+      phase,
       activeTool: last
         ? {
             name: last.name,
@@ -1288,7 +1303,7 @@ export function FloatingChat({
           }
         : null,
     };
-  }, [isStreaming, streamingText, toolTimeline]);
+  }, [isStreaming, pendingQuestion, resumePolling, session.state.pendingConfirmations, streamingText, toolTimeline]);
 
   const onActivityChangeRef = useRef(onActivityChange);
   useEffect(() => {

--- a/apps/app-web/src/components/chrome/floating-chat.tsx
+++ b/apps/app-web/src/components/chrome/floating-chat.tsx
@@ -493,6 +493,10 @@ type FloatingChatProps = {
    * instruction at the same page. Soft by design — it warns, it doesn't block.
    */
   othersRun?: AssistantRunState | null;
+  /** Reveal and focus the already-mounted composer when this token changes. */
+  messageBrianRequest?: number;
+  /** Called after the requested composer is mounted, visible, and focused. */
+  onMessageBrianRevealed?: () => void;
 };
 
 const CLIENT_TIMEZONE: string | null = (() => {
@@ -513,6 +517,8 @@ export function FloatingChat({
   activePage = null,
   seedRequest,
   othersRun = null,
+  messageBrianRequest,
+  onMessageBrianRevealed,
 }: FloatingChatProps) {
   // 'side-panel' fills its parent column and stays open (no pill); 'floating'
   // is the bottom-right collapsible dock. Drives positioning + the pill below.
@@ -548,6 +554,20 @@ export function FloatingChat({
   const [pendingSurfaceSeed, setPendingSurfaceSeed] =
     useState<SurfaceChatSeed | null>(null);
   const surfaceSeedAttemptRef = useRef<SurfaceChatSeed | null>(null);
+
+  useEffect(() => {
+    if (messageBrianRequest === undefined || isSidePanel) return;
+    setExpanded(true);
+  }, [isSidePanel, messageBrianRequest]);
+
+  const acknowledgedMessageBrianRef = useRef<number | undefined>(undefined);
+  useEffect(() => {
+    if (messageBrianRequest === undefined) return;
+    if (!isSidePanel && !expanded) return;
+    if (acknowledgedMessageBrianRef.current === messageBrianRequest) return;
+    acknowledgedMessageBrianRef.current = messageBrianRequest;
+    onMessageBrianRevealed?.();
+  }, [expanded, isSidePanel, messageBrianRequest, onMessageBrianRevealed]);
 
   // ── Assistant switcher ───────────────────────────────────────────────────
   // The chat talks to the workspace PRIMARY by default (the `assistantId`
@@ -3537,6 +3557,7 @@ export function FloatingChat({
             onKeyDown={slashCommands.handleKeyDown}
             highlightRanges={slashCommands.highlightRanges}
             inputWrapClassName="flex-1 min-w-0 rounded-md border border-border bg-background focus-within:border-ring [&_:focus-visible]:shadow-none"
+            focusRequest={messageBrianRequest}
             // While a turn streams, Send QUEUES: the message is handed to the
             // running turn, which takes it at its next safe boundary.
             // Cmd/Ctrl+Enter steers instead — take it as soon as possible.

--- a/apps/app-web/src/components/doc/mobile-chat-drawer.tsx
+++ b/apps/app-web/src/components/doc/mobile-chat-drawer.tsx
@@ -97,6 +97,10 @@ type Props = {
   };
   /** Soft double-text guard — forwarded to the inner `<FloatingChat>`. */
   othersRun?: AssistantRunState | null;
+  /** Reveal and focus the composer when the desktop companion is activated. */
+  messageBrianRequest?: number;
+  /** Called after the inner composer confirms it is visible. */
+  onMessageBrianRevealed?: () => void;
 };
 
 /** Vertical pixel threshold (downward swipe) that dismisses the bottom sheet. */
@@ -109,6 +113,8 @@ export function MobileChatDrawer({
   activePage = null,
   seed,
   othersRun = null,
+  messageBrianRequest,
+  onMessageBrianRevealed,
 }: Props) {
   const t = useT().docPage;
   const [open, setOpen] = useState(false);
@@ -138,6 +144,11 @@ export function MobileChatDrawer({
     setMounted(true);
     setOpen(true);
   }, []);
+
+  useEffect(() => {
+    if (messageBrianRequest === undefined) return;
+    openDrawer();
+  }, [messageBrianRequest, openDrawer]);
 
   // Chat-seed: when the shell routes a seed to this (mobile) surface, make
   // `<FloatingChat>` available and forward the seed to it (as `seedRequest`)
@@ -322,6 +333,8 @@ export function MobileChatDrawer({
               activePage={activePage}
               seedRequest={seed}
               othersRun={othersRun}
+              messageBrianRequest={messageBrianRequest}
+              onMessageBrianRevealed={onMessageBrianRevealed}
             />
           ) : null}
         </div>

--- a/apps/app-web/src/components/doc/workspace-chrome.tsx
+++ b/apps/app-web/src/components/doc/workspace-chrome.tsx
@@ -68,7 +68,11 @@ import { useOfflineSync } from "@/lib/offline/use-offline-sync";
 import { useWorkspaceEvents } from "@/lib/workspace-events";
 import { cn } from "@/lib/utils";
 import { CHAT_SEED_EVENT, type ChatSeed } from "@/lib/chat-seed";
-import { desktopBridge } from "@/lib/desktop-auth-source";
+import {
+  acknowledgeDesktopMessageBrian,
+  desktopBridge,
+  onDesktopMessageBrian,
+} from "@/lib/desktop-auth-source";
 import {
   desktopTitlebarInsetCssPx,
   resolveDesktopZoomFactor,
@@ -277,6 +281,11 @@ export function WorkspaceChrome({
   // (Moved up from `DocShell` with the dock; the publishers still fire the
   // same event from inside the page surface.)
   const [seed, setSeed] = useState<RoutedSeed | null>(null);
+  const [messageBrianRequest, setMessageBrianRequest] = useState<{
+    nonce: number;
+    target: "desktop" | "mobile";
+  }>();
+  const pendingMessageBrianRef = useRef(false);
   const seedNonceRef = useRef(0);
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -302,6 +311,32 @@ export function WorkspaceChrome({
     window.addEventListener(CHAT_SEED_EVENT, onSeed);
     return () => window.removeEventListener(CHAT_SEED_EVENT, onSeed);
   }, []);
+
+  const revealMessageBrian = useCallback(() => {
+    setMessageBrianRequest((current) => ({
+      nonce: (current?.nonce ?? 0) + 1,
+      target: window.matchMedia("(min-width: 1024px)").matches ? "desktop" : "mobile",
+    }));
+  }, []);
+
+  useEffect(() => {
+    if (dockSuppressed || !pendingMessageBrianRef.current) return;
+    pendingMessageBrianRef.current = false;
+    revealMessageBrian();
+  }, [dockSuppressed, revealMessageBrian]);
+
+  useEffect(
+    () =>
+      onDesktopMessageBrian(() => {
+        if (!dockSuppressed) {
+          revealMessageBrian();
+          return;
+        }
+        pendingMessageBrianRef.current = true;
+        router.push(docPagePath(workspaceId));
+      }),
+    [dockSuppressed, revealMessageBrian, router, workspaceId],
+  );
 
   // Soft-navigate to a page's canonical URL. On `/p` the shell's URL→tabs effect
   // adopts it into the tab history; from another surface it opens the doc
@@ -664,6 +699,10 @@ export function WorkspaceChrome({
               origin="doc"
               seedRequest={seed?.target === "desktop" ? seed : undefined}
               othersRun={docOthersRun}
+              messageBrianRequest={
+                messageBrianRequest?.target === "desktop" ? messageBrianRequest.nonce : undefined
+              }
+              onMessageBrianRevealed={acknowledgeDesktopMessageBrian}
             />
           </div>
           <MobileChatDrawer
@@ -672,6 +711,10 @@ export function WorkspaceChrome({
             className="lg:hidden"
             seed={seed?.target === "mobile" ? seed : undefined}
             othersRun={docOthersRun}
+            messageBrianRequest={
+              messageBrianRequest?.target === "mobile" ? messageBrianRequest.nonce : undefined
+            }
+            onMessageBrianRevealed={acknowledgeDesktopMessageBrian}
           />
         </div>
       )}

--- a/apps/app-web/src/lib/__tests__/companion-chat-state.test.ts
+++ b/apps/app-web/src/lib/__tests__/companion-chat-state.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { companionChatPhase } from "../companion-chat-state";
+
+describe("[COMP:app-web/desktop-chat-window] companion chat state", () => {
+  it("maps the chat lifecycle and gives required action highest priority", () => {
+    expect(
+      companionChatPhase({
+        isStreaming: true,
+        hasStreamingText: true,
+        requiresAction: true,
+        isLoading: false,
+      }),
+    ).toBe("action-required");
+    expect(
+      companionChatPhase({
+        isStreaming: true,
+        hasStreamingText: false,
+        requiresAction: false,
+        isLoading: false,
+      }),
+    ).toBe("thinking");
+    expect(
+      companionChatPhase({
+        isStreaming: true,
+        hasStreamingText: true,
+        requiresAction: false,
+        isLoading: false,
+      }),
+    ).toBe("responding");
+    expect(
+      companionChatPhase({
+        isStreaming: false,
+        hasStreamingText: false,
+        requiresAction: false,
+        isLoading: true,
+      }),
+    ).toBe("loading");
+    expect(
+      companionChatPhase({
+        isStreaming: false,
+        hasStreamingText: false,
+        requiresAction: false,
+        isLoading: false,
+      }),
+    ).toBe("idle");
+  });
+});

--- a/apps/app-web/src/lib/__tests__/desktop-auth-source.test.ts
+++ b/apps/app-web/src/lib/__tests__/desktop-auth-source.test.ts
@@ -13,6 +13,8 @@ import {
   desktopSignOut,
   classifyRefreshStatus,
   usesGatewayCredentials,
+  onDesktopMessageBrian,
+  acknowledgeDesktopMessageBrian,
 } from "../desktop-auth-source";
 
 const realFetch = globalThis.fetch;
@@ -50,6 +52,30 @@ describe("[COMP:app-web/desktop-auth-source] usesGatewayCredentials", () => {
     expect(usesGatewayCredentials()).toBe(false);
     setBridge({ signIn: () => {}, gatewayCredentials: true });
     expect(usesGatewayCredentials()).toBe(true);
+  });
+});
+
+describe("[COMP:app-web/desktop-auth-source] onDesktopMessageBrian", () => {
+  it("is a no-op outside Electron", () => {
+    expect(onDesktopMessageBrian(() => {})).toBeTypeOf("function");
+  });
+
+  it("subscribes through the shell bridge and returns its cleanup", () => {
+    const cleanup = vi.fn();
+    const subscribe = vi.fn(() => cleanup);
+    const callback = vi.fn();
+    setBridge({ signIn: () => {}, onMessageBrian: subscribe });
+
+    expect(onDesktopMessageBrian(callback)).toBe(cleanup);
+    expect(subscribe).toHaveBeenCalledWith(callback);
+  });
+
+  it("acknowledges consumption only when the shell exposes it", () => {
+    acknowledgeDesktopMessageBrian();
+    const acknowledgeMessageBrian = vi.fn();
+    setBridge({ signIn: () => {}, acknowledgeMessageBrian });
+    acknowledgeDesktopMessageBrian();
+    expect(acknowledgeMessageBrian).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/app-web/src/lib/__tests__/site-hosts.test.ts
+++ b/apps/app-web/src/lib/__tests__/site-hosts.test.ts
@@ -69,6 +69,7 @@ describe("[COMP:app-web/site-route] Custom-domain host classification", () => {
       expect(isGuardedPath("/settings/profile")).toBe(true);
       expect(isGuardedPath("/knowledge-base/x")).toBe(true);
       expect(isGuardedPath("/cloud-link")).toBe(true);
+      expect(isGuardedPath("/desktop/chat/ws-1")).toBe(true);
     });
 
     it("passes public and auth paths through unguarded", () => {

--- a/apps/app-web/src/lib/companion-chat-state.ts
+++ b/apps/app-web/src/lib/companion-chat-state.ts
@@ -1,0 +1,19 @@
+export type CompanionChatPhase =
+  | "idle"
+  | "loading"
+  | "thinking"
+  | "responding"
+  | "action-required";
+
+/** Map the existing chat lifecycle onto the companion's small visual vocabulary. */
+export function companionChatPhase(input: {
+  isStreaming: boolean;
+  hasStreamingText: boolean;
+  requiresAction: boolean;
+  isLoading: boolean;
+}): CompanionChatPhase {
+  if (input.requiresAction) return "action-required";
+  if (input.isStreaming) return input.hasStreamingText ? "responding" : "thinking";
+  if (input.isLoading) return "loading";
+  return "idle";
+}

--- a/apps/app-web/src/lib/desktop-auth-source.ts
+++ b/apps/app-web/src/lib/desktop-auth-source.ts
@@ -112,6 +112,11 @@ export interface DesktopBridge {
   onMessageBrian?: (callback: () => void) => () => void;
   /** Confirm that the workspace composer has consumed the companion intent. */
   acknowledgeMessageBrian?: () => void;
+  /** Mirror the dedicated chat window's display-only lifecycle onto the companion. */
+  setCompanionState?: (state: {
+    phase: "idle" | "loading" | "thinking" | "responding" | "action-required";
+    label?: string;
+  }) => void;
 }
 
 /** The connector-connect handoff payload (see `DesktopBridge.connectConnector`). */

--- a/apps/app-web/src/lib/desktop-auth-source.ts
+++ b/apps/app-web/src/lib/desktop-auth-source.ts
@@ -108,6 +108,10 @@ export interface DesktopBridge {
    * docs/plans/desktop-connector-oauth-return.md.
    */
   connectConnector?: (req: ConnectConnectorRequest) => void;
+  /** Subscribe to the shell companion's open-composer intent. */
+  onMessageBrian?: (callback: () => void) => () => void;
+  /** Confirm that the workspace composer has consumed the companion intent. */
+  acknowledgeMessageBrian?: () => void;
 }
 
 /** The connector-connect handoff payload (see `DesktopBridge.connectConnector`). */
@@ -143,6 +147,16 @@ declare global {
 export function desktopBridge(): DesktopBridge | undefined {
   if (typeof window === "undefined") return undefined;
   return window.usebrianDesktop ?? window.sidanclawDesktop;
+}
+
+/** Subscribe to companion clicks when hosted by the Electron shell. */
+export function onDesktopMessageBrian(callback: () => void): () => void {
+  return desktopBridge()?.onMessageBrian?.(callback) ?? (() => {});
+}
+
+/** Clear the shell's durable companion intent after the composer is visible. */
+export function acknowledgeDesktopMessageBrian(): void {
+  desktopBridge()?.acknowledgeMessageBrian?.();
 }
 
 /** True only in the thin shell while it fronts a local/self-hosted target. */

--- a/apps/app-web/src/lib/site-hosts.ts
+++ b/apps/app-web/src/lib/site-hosts.ts
@@ -74,6 +74,7 @@ const GUARDED_PREFIXES = [
   "/knowledge-base",
   "/memories",
   "/cloud-link",
+  "/desktop/chat",
 ];
 
 export function isGuardedPath(pathname: string): boolean {

--- a/docs/plans/desktop-awake-brian.md
+++ b/docs/plans/desktop-awake-brian.md
@@ -2,17 +2,18 @@
 
 ## Goal
 
-The Electron app can keep Brian available while its main window is closed. A user-controlled **Keep Brian Awake** setting keeps the app from being suspended and shows a small Brian companion above normal windows. Clicking the companion summons Use Brian and opens the message composer.
+The Electron app can keep Brian available while its main window is closed. A user-controlled **Keep Brian Awake** setting keeps the app from being suspended and shows a small Brian companion above normal windows. Clicking the companion opens a dedicated chat-only window backed by the existing workspace chat popup.
 
-The companion borrows the useful parts of Codex pets: an ambient pixel character, a quiet idle animation, and a direct interaction. It is not a general pet runtime or a third-party sprite-pack loader.
+The companion uses the canonical Use Brian logo image without reconstructing, recoloring, blinking, or deforming it. It is not a general pet runtime or a third-party sprite-pack loader.
 
 ## User Contract
 
 - **Keep Brian Awake** is an explicit, persisted checkbox in both the application menu and tray menu. It is off by default.
 - Enabling it starts Electron's `prevent-app-suspension` power-save blocker. The operating system may still turn off the display; Use Brian must not request `prevent-display-sleep`.
-- While enabled, a transparent, always-on-top Brian companion is visible near the lower-right corner of the primary display. It stays available when the main window is closed.
-- Clicking or keyboard-activating the companion focuses or recreates the main window and opens the existing workspace chat composer. It does not create a second chat implementation or send an empty message automatically.
-- If the active surface deliberately suppresses the shared dock because it owns another embedded chat, the click navigates to the workspace page surface before revealing the canonical dock.
+- While enabled, a transparent, always-on-top Brian companion is visible near the lower-right corner of the primary display. The visible character is the canonical `apps/app-desktop/build/icon.original.png` asset copied byte-for-byte into the app bundle. It stays available when the main window is closed.
+- Clicking or keyboard-activating the companion opens or focuses a small dedicated Electron chat window. It must not show, focus, navigate, or recreate the main application window.
+- The chat window mounts the existing app-web `FloatingChat` in side-panel mode for the last workspace observed by the desktop shell. It does not create a second chat implementation or send an empty message automatically.
+- Closing the chat window leaves the main app and the always-awake companion unchanged. A later companion activation recreates only the chat window.
 - Disabling the setting immediately closes the companion and stops the power-save blocker.
 - Quitting the app stops any active blocker. A malformed or unreadable preference file safely falls back to disabled.
 
@@ -20,18 +21,19 @@ The companion borrows the useful parts of Codex pets: an ambient pixel character
 
 - The companion loads only a bundled local HTML file.
 - Its sandboxed preload exposes no renderer API. It may send only the fixed `Use Brian:message-brian` IPC event after the bundled button is activated.
-- The main window receives a one-shot message intent through its existing preload bridge. The web app consumes it in `WorkspaceChrome`, which already owns the single persistent chat dock.
-- The main process retains that intent until `WorkspaceChrome` subscribes and the preload acknowledges delivery. Sign-in and other full-page reloads therefore cannot drop a cold-start click.
-- No message content, credentials, workspace identifiers, or assistant identifiers cross the new IPC boundary.
+- The main process accepts only the fixed companion activation event, derives the last workspace from trusted same-app navigation, and loads the dedicated app-web desktop-chat route in a hardened window using the shared Electron session.
+- The dedicated route mounts `FloatingChat`; no message content, credentials, assistant identifiers, or arbitrary URL crosses the companion preload IPC boundary.
+- If no trusted workspace has been observed yet, activation does nothing rather than opening the main application or guessing a workspace.
 
 ## Components
 
 | COMP tag | Source | Test |
 | --- | --- | --- |
-| `[COMP:app-desktop/awake-brian]` | `apps/app-desktop/src/awake-brian.ts`, `apps/app-desktop/src/main.ts`, `apps/app-desktop/src/brian-pet.html` | `apps/app-desktop/src/__tests__/awake-brian.test.ts` |
+| `[COMP:app-desktop/awake-brian]` | `apps/app-desktop/src/awake-brian.ts`, `apps/app-desktop/src/desktop-chat.ts`, `apps/app-desktop/src/main.ts`, `apps/app-desktop/src/brian-pet.html` | `apps/app-desktop/src/__tests__/awake-brian.test.ts`, `apps/app-desktop/src/__tests__/desktop-chat.test.ts` |
 | `[COMP:app-desktop/menu-template]` | `apps/app-desktop/src/menu-template.ts` | `apps/app-desktop/src/__tests__/menu-template.test.ts` |
 | `[COMP:app-web/desktop-auth-source]` | `apps/app-web/src/lib/desktop-auth-source.ts` | `apps/app-web/src/lib/__tests__/desktop-auth-source.test.ts` |
 | `[COMP:app-web/views-shell]` | `apps/app-web/src/components/doc/workspace-chrome.tsx` | Bridge behavior is covered through `desktop-auth-source.test.ts`; workspace rendering remains covered by existing shell tests. |
+| `[COMP:app-web/desktop-chat-window]` | `apps/app-web/src/components/chrome/desktop-chat-window.tsx`, `apps/app-web/src/app/desktop/chat/[workspaceId]/page.tsx`, `apps/app-web/desktop/app.tsx` | `apps/app-web/src/lib/__tests__/site-hosts.test.ts` guards the live route; component behavior reuses the existing floating-chat tests. |
 
 ## Persistence
 

--- a/docs/plans/desktop-awake-brian.md
+++ b/docs/plans/desktop-awake-brian.md
@@ -4,16 +4,17 @@
 
 The Electron app can keep Brian available while its main window is closed. A user-controlled **Keep Brian Awake** setting keeps the app from being suspended and shows a small Brian companion above normal windows. Clicking the companion opens a dedicated chat-only window backed by the existing workspace chat popup.
 
-The companion uses the canonical Use Brian logo image without reconstructing, recoloring, blinking, or deforming it. It is not a general pet runtime or a third-party sprite-pack loader.
+The companion uses the canonical transparent Use Brian logo image as its base. Small state overlays may blink the eyes, open a mouth, show thinking motion, celebrate a completed response, or call attention to required user action; the underlying mark is never reconstructed or placed on an artificial background. It is not a general pet runtime or a third-party sprite-pack loader.
 
 ## User Contract
 
 - **Keep Brian Awake** is an explicit, persisted checkbox in both the application menu and tray menu. It is off by default.
 - Enabling it starts Electron's `prevent-app-suspension` power-save blocker. The operating system may still turn off the display; Use Brian must not request `prevent-display-sleep`.
-- While enabled, a transparent, always-on-top Brian companion is visible near the lower-right corner of the primary display. The visible character is the canonical `apps/app-desktop/build/icon.original.png` asset copied byte-for-byte into the app bundle. It stays available when the main window is closed.
-- Clicking or keyboard-activating the companion opens or focuses a small dedicated Electron chat window. It must not show, focus, navigate, or recreate the main application window.
+- While enabled, a transparent, always-on-top Brian companion is visible near the lower-right corner of the primary display. The visible character is the canonical transparent `apps/app-web/public/icon.png` asset copied byte-for-byte into the app bundle. It stays available when the main window is closed and has no black tile behind it.
+- Clicking or keyboard-activating the companion toggles a frameless chat panel attached to the companion's left edge. The panel must not show, focus, navigate, or recreate the main application window, and must move with the companion when the primary display changes.
 - The chat window mounts the existing app-web `FloatingChat` in side-panel mode for the last workspace observed by the desktop shell. It does not create a second chat implementation or send an empty message automatically.
 - Closing the chat window leaves the main app and the always-awake companion unchanged. A later companion activation recreates only the chat window.
+- The companion mirrors the chat's real lifecycle: loading while the workspace assistant resolves, thinking before reply text, responding while text streams, action-required while a confirmation or question waits, and a short completion reaction when a response finishes. Active tool descriptions use the same localized narration emitted by `FloatingChat`.
 - Disabling the setting immediately closes the companion and stops the power-save blocker.
 - Quitting the app stops any active blocker. A malformed or unreadable preference file safely falls back to disabled.
 
@@ -21,8 +22,9 @@ The companion uses the canonical Use Brian logo image without reconstructing, re
 
 - The companion loads only a bundled local HTML file.
 - Its sandboxed preload exposes no renderer API. It may send only the fixed `Use Brian:message-brian` IPC event after the bundled button is activated.
-- The main process accepts only the fixed companion activation event, derives the last workspace from trusted same-app navigation, and loads the dedicated app-web desktop-chat route in a hardened window using the shared Electron session.
+- The main process accepts only the fixed companion activation event, derives the last workspace from trusted same-app navigation, and loads the dedicated app-web desktop-chat route in a hardened attached window using the shared Electron session.
 - The dedicated route mounts `FloatingChat`; no message content, credentials, assistant identifiers, or arbitrary URL crosses the companion preload IPC boundary.
+- The app renderer may send only a bounded companion phase and short display label. The main process accepts that state only from the dedicated chat window and forwards it to the local companion page; arbitrary renderer IPC cannot animate the companion.
 - If no trusted workspace has been observed yet, activation does nothing rather than opening the main application or guessing a workspace.
 
 ## Components
@@ -33,7 +35,7 @@ The companion uses the canonical Use Brian logo image without reconstructing, re
 | `[COMP:app-desktop/menu-template]` | `apps/app-desktop/src/menu-template.ts` | `apps/app-desktop/src/__tests__/menu-template.test.ts` |
 | `[COMP:app-web/desktop-auth-source]` | `apps/app-web/src/lib/desktop-auth-source.ts` | `apps/app-web/src/lib/__tests__/desktop-auth-source.test.ts` |
 | `[COMP:app-web/views-shell]` | `apps/app-web/src/components/doc/workspace-chrome.tsx` | Bridge behavior is covered through `desktop-auth-source.test.ts`; workspace rendering remains covered by existing shell tests. |
-| `[COMP:app-web/desktop-chat-window]` | `apps/app-web/src/components/chrome/desktop-chat-window.tsx`, `apps/app-web/src/app/desktop/chat/[workspaceId]/page.tsx`, `apps/app-web/desktop/app.tsx` | `apps/app-web/src/lib/__tests__/site-hosts.test.ts` guards the live route; component behavior reuses the existing floating-chat tests. |
+| `[COMP:app-web/desktop-chat-window]` | `apps/app-web/src/components/chrome/desktop-chat-window.tsx`, `apps/app-web/src/app/desktop/chat/[workspaceId]/page.tsx`, `apps/app-web/src/lib/companion-chat-state.ts`, `apps/app-web/desktop/app.tsx` | `apps/app-web/src/lib/__tests__/site-hosts.test.ts`, `apps/app-web/src/lib/__tests__/companion-chat-state.test.ts` |
 
 ## Persistence
 

--- a/docs/plans/desktop-awake-brian.md
+++ b/docs/plans/desktop-awake-brian.md
@@ -1,0 +1,44 @@
+# Awake Brian Desktop Companion
+
+## Goal
+
+The Electron app can keep Brian available while its main window is closed. A user-controlled **Keep Brian Awake** setting keeps the app from being suspended and shows a small Brian companion above normal windows. Clicking the companion summons Use Brian and opens the message composer.
+
+The companion borrows the useful parts of Codex pets: an ambient pixel character, a quiet idle animation, and a direct interaction. It is not a general pet runtime or a third-party sprite-pack loader.
+
+## User Contract
+
+- **Keep Brian Awake** is an explicit, persisted checkbox in both the application menu and tray menu. It is off by default.
+- Enabling it starts Electron's `prevent-app-suspension` power-save blocker. The operating system may still turn off the display; Use Brian must not request `prevent-display-sleep`.
+- While enabled, a transparent, always-on-top Brian companion is visible near the lower-right corner of the primary display. It stays available when the main window is closed.
+- Clicking or keyboard-activating the companion focuses or recreates the main window and opens the existing workspace chat composer. It does not create a second chat implementation or send an empty message automatically.
+- If the active surface deliberately suppresses the shared dock because it owns another embedded chat, the click navigates to the workspace page surface before revealing the canonical dock.
+- Disabling the setting immediately closes the companion and stops the power-save blocker.
+- Quitting the app stops any active blocker. A malformed or unreadable preference file safely falls back to disabled.
+
+## Security Boundary
+
+- The companion loads only a bundled local HTML file.
+- Its sandboxed preload exposes no renderer API. It may send only the fixed `Use Brian:message-brian` IPC event after the bundled button is activated.
+- The main window receives a one-shot message intent through its existing preload bridge. The web app consumes it in `WorkspaceChrome`, which already owns the single persistent chat dock.
+- The main process retains that intent until `WorkspaceChrome` subscribes and the preload acknowledges delivery. Sign-in and other full-page reloads therefore cannot drop a cold-start click.
+- No message content, credentials, workspace identifiers, or assistant identifiers cross the new IPC boundary.
+
+## Components
+
+| COMP tag | Source | Test |
+| --- | --- | --- |
+| `[COMP:app-desktop/awake-brian]` | `apps/app-desktop/src/awake-brian.ts`, `apps/app-desktop/src/main.ts`, `apps/app-desktop/src/brian-pet.html` | `apps/app-desktop/src/__tests__/awake-brian.test.ts` |
+| `[COMP:app-desktop/menu-template]` | `apps/app-desktop/src/menu-template.ts` | `apps/app-desktop/src/__tests__/menu-template.test.ts` |
+| `[COMP:app-web/desktop-auth-source]` | `apps/app-web/src/lib/desktop-auth-source.ts` | `apps/app-web/src/lib/__tests__/desktop-auth-source.test.ts` |
+| `[COMP:app-web/views-shell]` | `apps/app-web/src/components/doc/workspace-chrome.tsx` | Bridge behavior is covered through `desktop-auth-source.test.ts`; workspace rendering remains covered by existing shell tests. |
+
+## Persistence
+
+The shell stores `awake-brian.json` under Electron's `userData` directory:
+
+```json
+{"v":1,"keepAwake":true}
+```
+
+Only `{ v: 1, keepAwake: true }` enables the feature. Missing, stale, malformed, and false values resolve to disabled.

--- a/docs/plans/desktop-awake-brian.md
+++ b/docs/plans/desktop-awake-brian.md
@@ -1,14 +1,14 @@
-# Awake Brian Desktop Companion
+# Brian Companion
 
 ## Goal
 
-The Electron app can keep Brian available while its main window is closed. A user-controlled **Keep Brian Awake** setting keeps the app from being suspended and shows a small Brian companion above normal windows. Clicking the companion opens a dedicated chat-only window backed by the existing workspace chat popup.
+The Electron app can keep Brian available while its main window is closed. A user-controlled **Keep Brian Nearby** setting keeps the app ready in the background and shows a small Brian companion above normal windows. Clicking the companion opens a dedicated chat-only window backed by the existing workspace chat popup.
 
 The companion uses the canonical transparent Use Brian logo image as its base. Small state overlays may blink the eyes, open a mouth, show thinking motion, celebrate a completed response, or call attention to required user action; the underlying mark is never reconstructed or placed on an artificial background. It is not a general pet runtime or a third-party sprite-pack loader.
 
 ## User Contract
 
-- **Keep Brian Awake** is an explicit, persisted checkbox in both the application menu and tray menu. It is off by default.
+- **Keep Brian Nearby** is an explicit, persisted checkbox in both the application menu and tray menu. It is off by default.
 - Enabling it starts Electron's `prevent-app-suspension` power-save blocker. The operating system may still turn off the display; Use Brian must not request `prevent-display-sleep`.
 - While enabled, a transparent, always-on-top Brian companion is visible near the lower-right corner of the primary display. The visible character is the canonical transparent `apps/app-web/public/icon.png` asset copied byte-for-byte into the app bundle. It stays available when the main window is closed and has no black tile behind it.
 - Dragging the companion relocates it without opening chat; a stationary click still toggles chat. The shell persists the position, clamps it to an available display on launch or monitor changes, and keeps the attached panel aligned while dragging.

--- a/docs/plans/desktop-awake-brian.md
+++ b/docs/plans/desktop-awake-brian.md
@@ -11,7 +11,8 @@ The companion uses the canonical transparent Use Brian logo image as its base. S
 - **Keep Brian Awake** is an explicit, persisted checkbox in both the application menu and tray menu. It is off by default.
 - Enabling it starts Electron's `prevent-app-suspension` power-save blocker. The operating system may still turn off the display; Use Brian must not request `prevent-display-sleep`.
 - While enabled, a transparent, always-on-top Brian companion is visible near the lower-right corner of the primary display. The visible character is the canonical transparent `apps/app-web/public/icon.png` asset copied byte-for-byte into the app bundle. It stays available when the main window is closed and has no black tile behind it.
-- Clicking or keyboard-activating the companion toggles a frameless chat panel attached to the companion's left edge. The panel must not show, focus, navigate, or recreate the main application window, and must move with the companion when the primary display changes.
+- Dragging the companion relocates it without opening chat; a stationary click still toggles chat. The shell persists the position, clamps it to an available display on launch or monitor changes, and keeps the attached panel aligned while dragging.
+- Clicking or keyboard-activating the companion toggles a frameless chat panel attached to the companion's left edge. Clicking anywhere outside the panel, including the companion itself, hides it. The route clears the global page canvas to transparent while mounted, so no app background or shadow paints outside the rounded panel and its connector. The panel must not show, focus, navigate, or recreate the main application window, and must move with the companion when the primary display changes.
 - The chat window mounts the existing app-web `FloatingChat` in side-panel mode for the last workspace observed by the desktop shell. It does not create a second chat implementation or send an empty message automatically.
 - Closing the chat window leaves the main app and the always-awake companion unchanged. A later companion activation recreates only the chat window.
 - The companion mirrors the chat's real lifecycle: loading while the workspace assistant resolves, thinking before reply text, responding while text streams, action-required while a confirmation or question waits, and a short completion reaction when a response finishes. Active tool descriptions use the same localized narration emitted by `FloatingChat`.
@@ -46,3 +47,5 @@ The shell stores `awake-brian.json` under Electron's `userData` directory:
 ```
 
 Only `{ v: 1, keepAwake: true }` enables the feature. Missing, stale, malformed, and false values resolve to disabled.
+
+The last dragged position is stored separately in `brian-position.json` as `{ "v": 1, "x": number, "y": number }`. Invalid or off-screen values fall back or clamp to an available display.

--- a/packages/chat-ui/src/ChatComposer.tsx
+++ b/packages/chat-ui/src/ChatComposer.tsx
@@ -185,6 +185,11 @@ export type ChatComposerProps = {
    * image paste and let a plain text paste fall through untouched.
    */
   onPaste?: (event: ClipboardEvent<HTMLTextAreaElement>) => void
+  /**
+   * Focus the textarea whenever this token changes. Hosts use this when an
+   * already-mounted composer is revealed by an external launcher.
+   */
+  focusRequest?: string | number
 }
 
 /**
@@ -281,6 +286,11 @@ export function ChatComposer(props: ChatComposerProps) {
     ro.observe(el)
     return () => ro.disconnect()
   }, [])
+
+  useEffect(() => {
+    if (props.focusRequest === undefined) return
+    textareaRef.current?.focus()
+  }, [props.focusRequest])
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {

--- a/packages/chat-ui/src/__tests__/chat-composer.test.tsx
+++ b/packages/chat-ui/src/__tests__/chat-composer.test.tsx
@@ -63,6 +63,10 @@ describe('[COMP:chat-ui/chat-composer] ChatComposer disable semantics', () => {
     expect(textareaTag(html)).not.toContain('disabled')
     expect(sendButtonTag(html)).toContain('disabled')
   })
+
+  it('accepts an external focus token without changing static composer markup', () => {
+    expect(textareaTag(render({ focusRequest: 1 }))).toContain('data-testid="chat-composer-input"')
+  })
 })
 
 describe('[COMP:chat-ui/chat-composer] Enter intent', () => {


### PR DESCRIPTION
## Summary
- add a persisted Keep Brian Awake mode with a transparent, draggable companion
- attach the existing workspace chat UI in a frameless panel without reopening the main window
- mirror loading, thinking, responding, completion, and action-required states onto companion animations
- dismiss chat on outside click, preserve the companion position across launches, and clamp it to available displays
- support both live Next.js and bundled desktop routes with sender-validated IPC boundaries

## Verification
- 288 app-desktop tests pass
- focused app-web companion lifecycle and route tests pass
- app-desktop and app-web typechecks pass
- app-desktop build passes
- bundled app-web desktop renderer build passes
- bundled companion logo matches the canonical transparent asset byte-for-byte