### PR TITLE
fix(app-web): preserve hosted build-time configuration

### DIFF
--- a/apps/app-web/next.config.ts
+++ b/apps/app-web/next.config.ts
@@ -48,9 +48,9 @@ function resolveOssGitCommitSha(): string {
 // Load .env from monorepo root
 dotenv.config({ path: resolve(import.meta.dirname, "..", "..", ".env") });
 
-const API_URL = process.env.API_URL ?? "http://localhost:4000";
+const API_URL = process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
 const APP_DEV_HOST = (() => {
-  const configured = process.env.AUTHED_APP_URL;
+  const configured = process.env.AUTHED_APP_URL ?? process.env.NEXT_PUBLIC_AUTHED_APP_URL;
   if (!configured) return null;
   try {
     return new URL(configured).hostname;
@@ -80,6 +80,14 @@ const nextConfig: NextConfig = {
     // Public build provenance for Settings. Prefer OSS_GIT_COMMIT_SHA when a
     // source archive omits .git; ordinary checkout builds resolve HEAD.
     NEXT_PUBLIC_OSS_GIT_COMMIT_SHA: OSS_GIT_COMMIT_SHA,
+    // Preserve hosted build-only public provider metadata. Runtime config can
+    // override these fallbacks; never inline server URLs or client secrets.
+    NEXT_PUBLIC_GOOGLE_CLIENT_ID:
+      process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ?? process.env.GOOGLE_CLIENT_ID ?? "",
+    NEXT_PUBLIC_GOOGLE_API_KEY:
+      process.env.NEXT_PUBLIC_GOOGLE_API_KEY ?? process.env.GOOGLE_API_KEY ?? "",
+    NEXT_PUBLIC_GOOGLE_PROJECT_NUMBER:
+      process.env.NEXT_PUBLIC_GOOGLE_PROJECT_NUMBER ?? process.env.GOOGLE_PROJECT_NUMBER ?? "",
     // NOTE: no NEXT_PUBLIC_MSGRAPH_* here. The Entra app for Microsoft Teams is
     // resolved per WORKSPACE in the API (its own registration first, then
     // MSGRAPH_CLIENT_ID / MSGRAPH_CLIENT_SECRET from this deployment), and a

--- a/apps/app-web/src/app/login/__tests__/route.test.ts
+++ b/apps/app-web/src/app/login/__tests__/route.test.ts
@@ -47,6 +47,10 @@ describe("[COMP:app-web/login-delegation] GET /login", () => {
   });
 
   it("server-redirects hosted users to the canonical login without rendering HTML", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("USEBRIAN_EDITION", "hosted");
+    vi.stubEnv("PUBLIC_PRIMARY_AUTH_URL", "");
+    mockedWebAppUrl.mockReturnValue("https://app.usebrian.ai");
     const res = GET(new Request("https://app.usebrian.ai/login"));
     const target = new URL(res.headers.get("location")!);
 
@@ -54,6 +58,17 @@ describe("[COMP:app-web/login-delegation] GET /login", () => {
     expect(target.origin).toBe("https://usebrian.ai");
     expect(target.pathname).toBe("/login");
     expect(target.searchParams.get("next")).toBe("https://app.usebrian.ai/");
+    expect(mockedWebAppUrl).not.toHaveBeenCalled();
+  });
+
+  it("honors the legacy hosted primary and canonical app origin", () => {
+    vi.stubEnv("USEBRIAN_EDITION", "hosted");
+    vi.stubEnv("NEXT_PUBLIC_PRIMARY_AUTH_URL", "https://auth.preview.example");
+    vi.stubEnv("NEXT_PUBLIC_AUTHED_APP_URL", "https://app.preview.example");
+    const res = GET(new Request("http://localhost:3003/login?next=%2Fw%2Fone"));
+    const target = new URL(res.headers.get("location")!);
+    expect(target.origin).toBe("https://auth.preview.example");
+    expect(target.searchParams.get("next")).toBe("https://app.preview.example/w/one");
   });
 
   it("preserves a same-origin return, add-account intent, and a safe error", () => {

--- a/apps/app-web/src/lib/__tests__/google-connector-build-config.test.ts
+++ b/apps/app-web/src/lib/__tests__/google-connector-build-config.test.ts
@@ -18,9 +18,12 @@ describe("[COMP:app-web/connector-oauth-callbacks] Google connector deployment c
     expect(runtimeConfig).toContain("env.GOOGLE_CLIENT_ID");
     expect(runtimeConfig).toContain("env.PUBLIC_GOOGLE_API_KEY");
     expect(runtimeConfig).toContain("env.GOOGLE_PROJECT_NUMBER");
-    expect(nextConfig).not.toContain("NEXT_PUBLIC_GOOGLE_CLIENT_ID:");
-    expect(nextConfig).not.toContain("NEXT_PUBLIC_GOOGLE_API_KEY:");
-    expect(nextConfig).not.toContain("NEXT_PUBLIC_GOOGLE_PROJECT_NUMBER:");
+    expect(nextConfig).toContain("NEXT_PUBLIC_GOOGLE_CLIENT_ID:");
+    expect(nextConfig).toContain("NEXT_PUBLIC_GOOGLE_API_KEY:");
+    expect(nextConfig).toContain("NEXT_PUBLIC_GOOGLE_PROJECT_NUMBER:");
+    expect(turbo.tasks.build.env).toEqual(expect.arrayContaining([
+      "NEXT_PUBLIC_*", "GOOGLE_CLIENT_ID", "GOOGLE_API_KEY", "GOOGLE_PROJECT_NUMBER",
+    ]));
     expect(nextConfig).not.toContain("GOOGLE_CLIENT_SECRET");
     expect(turbo.tasks.build.env).not.toContain("GOOGLE_CLIENT_SECRET");
     expect(callback).toContain("process.env.PUBLIC_GOOGLE_CLIENT_ID");

--- a/apps/app-web/src/lib/__tests__/runtime-public-config.test.ts
+++ b/apps/app-web/src/lib/__tests__/runtime-public-config.test.ts
@@ -70,6 +70,39 @@ describe("[COMP:app-web/runtime-public-config] runtime public config", () => {
     expect(resolveRuntimePublicConfig({ NODE_ENV: "production" }).apiUrl).toBe("");
   });
 
+  it("preserves hosted build-only public configuration", () => {
+    expect(resolveRuntimePublicConfig({}, {
+      NEXT_PUBLIC_API_URL: "https://api.usebrian.ai",
+      NEXT_PUBLIC_DOC_SYNC_URL: "wss://docs.usebrian.ai",
+      NEXT_PUBLIC_PRIMARY_AUTH_URL: "https://usebrian.ai",
+      NEXT_PUBLIC_GOOGLE_API_KEY: "browser-picker-key",
+    })).toMatchObject({
+      apiUrl: "https://api.usebrian.ai",
+      docSyncUrl: "wss://docs.usebrian.ai",
+      primaryAuthUrl: "https://usebrian.ai",
+      googleApiKey: "browser-picker-key",
+      edition: "hosted",
+    });
+  });
+
+  it("lets runtime values, including same-origin, override hosted build defaults", () => {
+    const build = { NEXT_PUBLIC_API_URL: "https://api.usebrian.ai" };
+    expect(resolveRuntimePublicConfig({ PUBLIC_API_URL: "" }, build).apiUrl).toBe("");
+    expect(resolveRuntimePublicConfig({ PUBLIC_API_URL: "https://api.customer.example" }, build).apiUrl)
+      .toBe("https://api.customer.example");
+    expect(resolveRuntimePublicConfig({ NEXT_PUBLIC_API_URL: "https://api.preview.example" }, build).apiUrl)
+      .toBe("https://api.preview.example");
+  });
+
+  it("retains the hosted Drive Picker key alias without serializing secrets", () => {
+    const config = resolveRuntimePublicConfig({
+      GOOGLE_API_KEY: "browser-picker-key",
+      GOOGLE_CLIENT_SECRET: "private-secret",
+    });
+    expect(config.googleApiKey).toBe("browser-picker-key");
+    expect(runtimePublicConfigScript(config)).not.toContain("private-secret");
+  });
+
   it("prefers runtime provider ids over compatibility build values", () => {
     const config = resolveRuntimePublicConfig({
       GOOGLE_CLIENT_ID: "runtime-google",

--- a/apps/app-web/src/lib/__tests__/site-hosts.test.ts
+++ b/apps/app-web/src/lib/__tests__/site-hosts.test.ts
@@ -60,6 +60,24 @@ describe("[COMP:app-web/site-route] Custom-domain host classification", () => {
         },
       );
     });
+
+    it("preserves hosted legacy app hosts and prefers an explicit runtime override", async () => {
+      await withEnv(
+        { NEXT_PUBLIC_APP_HOSTS: "app.usebrian.ai,.vercel.app", NODE_ENV: "production" },
+        (m) => {
+          expect(m.isAppHost("app.usebrian.ai")).toBe(true);
+          expect(m.isAppHost("preview.vercel.app")).toBe(true);
+          expect(m.isAppHost("docs.customer.example")).toBe(false);
+        },
+      );
+      await withEnv(
+        { APP_HOSTS: "app.customer.example", NEXT_PUBLIC_APP_HOSTS: "app.usebrian.ai", NODE_ENV: "production" },
+        (m) => {
+          expect(m.isAppHost("app.customer.example")).toBe(true);
+          expect(m.isAppHost("app.usebrian.ai")).toBe(false);
+        },
+      );
+    });
   });
 
   describe("normalizeHostHeader", () => {

--- a/apps/app-web/src/lib/api/__tests__/channel-slash-commands.test.ts
+++ b/apps/app-web/src/lib/api/__tests__/channel-slash-commands.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/auth-fetch", () => ({ authFetch: vi.fn() }));
 
@@ -11,7 +11,27 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
 describe("syncChannelSlashCommands", () => {
+  it.each(["PUBLIC_API_URL", "NEXT_PUBLIC_API_URL"])("uses the configured hosted API via %s", async (name) => {
+    vi.stubEnv(name, "https://api.usebrian.ai");
+    vi.resetModules();
+    const { authFetch: hostedFetch } = await import("@/lib/auth-fetch");
+    const { syncChannelSlashCommands: hostedSync } = await import("../channels");
+    vi.mocked(hostedFetch).mockResolvedValue(new Response(JSON.stringify({ commandCount: 1, omittedCount: 0 })));
+
+    await hostedSync("workspace/one", "channel/two");
+
+    expect(hostedFetch).toHaveBeenCalledWith(
+      "https://api.usebrian.ai/api/workspaces/workspace%2Fone/channels/channel%2Ftwo/slash-commands/sync",
+      { method: "POST" },
+    );
+  });
+
   it("POSTs to the same-origin encoded channel route and parses the receipt", async () => {
     mockAuthFetch.mockResolvedValue(
       new Response(JSON.stringify({ commandCount: 7, omittedCount: 2 }), {

--- a/apps/app-web/src/lib/primary-auth.ts
+++ b/apps/app-web/src/lib/primary-auth.ts
@@ -43,7 +43,7 @@ export function primaryAuthUrl(): string | null {
  */
 export function publicAppUrl(
   requestUrl: string | URL,
-  configured = process.env.AUTHED_APP_URL,
+  configured = process.env.AUTHED_APP_URL ?? process.env.NEXT_PUBLIC_AUTHED_APP_URL,
 ): URL {
   const request = new URL(requestUrl);
   if (!configured?.trim()) return request;

--- a/apps/app-web/src/lib/runtime-public-config.ts
+++ b/apps/app-web/src/lib/runtime-public-config.ts
@@ -41,7 +41,9 @@ function publicUrl(
 
 export function resolveRuntimePublicConfig(
   env: PublicConfigEnv,
+  buildEnv: PublicConfigEnv = {},
 ): RuntimePublicConfig {
+  env = { ...buildEnv, ...env };
   const apiUrl =
     publicUrl(env.PUBLIC_API_URL, env.API_DOMAIN, "https") ??
     env.NEXT_PUBLIC_API_URL ??
@@ -78,6 +80,7 @@ export function resolveRuntimePublicConfig(
       "",
     googleApiKey:
       env.PUBLIC_GOOGLE_API_KEY ??
+      env.GOOGLE_API_KEY ??
       env.NEXT_PUBLIC_GOOGLE_API_KEY ??
       "",
     googleProjectNumber:
@@ -121,6 +124,23 @@ export function publicRuntimeConfig(): RuntimePublicConfig {
 
   return resolveRuntimePublicConfig(
     typeof process !== "undefined" ? process.env : {},
+    // Next only inlines literal NEXT_PUBLIC references. Keep hosted build-time
+    // configuration as a fallback; server runtime values still take precedence.
+    {
+      NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+      NEXT_PUBLIC_DISPLAY_API_URL: process.env.NEXT_PUBLIC_DISPLAY_API_URL,
+      NEXT_PUBLIC_DOC_SYNC_URL: process.env.NEXT_PUBLIC_DOC_SYNC_URL,
+      NEXT_PUBLIC_USEBRIAN_EDITION: process.env.NEXT_PUBLIC_USEBRIAN_EDITION,
+      NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+      NEXT_PUBLIC_PRIMARY_AUTH_URL: process.env.NEXT_PUBLIC_PRIMARY_AUTH_URL,
+      NEXT_PUBLIC_BROWSER_EXTENSION_ID: process.env.NEXT_PUBLIC_BROWSER_EXTENSION_ID,
+      NEXT_PUBLIC_GOOGLE_CLIENT_ID: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
+      NEXT_PUBLIC_GOOGLE_API_KEY: process.env.NEXT_PUBLIC_GOOGLE_API_KEY,
+      NEXT_PUBLIC_GOOGLE_PROJECT_NUMBER: process.env.NEXT_PUBLIC_GOOGLE_PROJECT_NUMBER,
+      NEXT_PUBLIC_NOTION_CLIENT_ID: process.env.NEXT_PUBLIC_NOTION_CLIENT_ID,
+      NEXT_PUBLIC_FATHOM_CLIENT_ID: process.env.NEXT_PUBLIC_FATHOM_CLIENT_ID,
+      NEXT_PUBLIC_FATHOM_AUTHORIZE_URL: process.env.NEXT_PUBLIC_FATHOM_AUTHORIZE_URL,
+    },
   );
 }
 

--- a/apps/app-web/src/lib/site-hosts.ts
+++ b/apps/app-web/src/lib/site-hosts.ts
@@ -22,7 +22,7 @@
  * anything else = customer site" so local testing needs no setup.
  */
 const APP_HOSTS = [
-  process.env.APP_HOSTS,
+  process.env.APP_HOSTS ?? process.env.NEXT_PUBLIC_APP_HOSTS,
   process.env.APP_DOMAIN,
 ]
   .filter((value): value is string => Boolean(value))

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,10 @@
       "env": [
         "NODE_ENV",
         "OSS_GIT_COMMIT_SHA",
-        "NEXT_PUBLIC_OSS_GIT_COMMIT_SHA"
+        "NEXT_PUBLIC_*",
+        "GOOGLE_CLIENT_ID",
+        "GOOGLE_API_KEY",
+        "GOOGLE_PROJECT_NUMBER"
       ]
     },
     "dev": {


### PR DESCRIPTION
## Summary
- Preserve literal NEXT_PUBLIC_* build-time fallbacks while keeping explicit runtime configuration authoritative, including same-origin API URLs.
- Restore legacy hosted app-host, canonical app URL, and public Google metadata aliases.
- Track public build settings in Turbo without exposing OAuth client secrets.
- Add hosted API, login, host-routing, and configuration-precedence regression coverage.

## Validation
- All 3,590 frontend tests across 455 files passed locally.
- app-web TypeScript checks passed.
- git diff --check passed.
- Live hosted preview and a fresh production image smoke test have not been performed.

Follow-up to #284; this PR contains only the additional hosted-compatibility changes.